### PR TITLE
cs2gs + ADR-0169 M5: dispatch SnippetTranslator so migrated analyzer tests verify G# snippets (#3778)

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -168,8 +168,9 @@ consumer rewrite is a pure value substitution.
 
 ## Test-harness and snippet translation
 
-Status (2026-09-01, issue #3686): the **harness half is implemented**; the
-**snippet half is not** — see "M5 status" below.
+Status (2026-09-01, issues #3686 / #3778): the **harness half is implemented**
+(#3777) and the **snippet half is dispatched** (#3778) — see "M5 status" below
+for what is still open.
 
 The original plan here — "`AnalyzerTestHelper.cs` is ordinary C# and translates
 normally, rules 3/22 rewrite the Roslyn calls" — did not survive contact with
@@ -231,24 +232,59 @@ is itself full of unmappable cs2gs machinery — while breaking the working
 case, since `AnalyzerTestHelper.cs` instantiates no analyzer and would stop
 being claimed).
 
-The remaining half is the **embedded C# snippets** — raw strings of analyzed
-code inside tests. For functional equivalence they must become G# snippets.
+The other half is the **embedded C# snippets** — raw strings of analyzed code
+inside tests, which the migrated harness now hands to a verifier that compiles
+**G#**. `SnippetTranslator` (nested cs2gs invocation at translation time, not
+manual porting) always existed; issue #3778 is what **dispatches** it.
 
-Approach: nested cs2gs invocation at translation time, not manual porting.
+**The dispatch rule.** An expression is a snippet exactly when it is a
+compile-time constant string that *flows into the source parameter of an
+analyzer test harness entry point* — either as the initializer of a local later
+passed there, or directly as that argument
+(`CSharpToGSharpTranslator.AnalyzerSnippets.cs`). The conjunction is
+load-bearing in both directions:
 
-- New `Cs2Gs.Translator/Analyzers/SnippetTranslator.cs`:
-  `TranslateSnippet(csharpWithMarkers) → (gsharpWithMarkers, diagnostics)`.
-  Triggered by a guard on string literals flowing into a parameter the map
-  marks as analyzed-source (the translated verifier's `source` parameter).
-- Marker preservation: strip markers recording the anchor node (innermost
-  syntax node starting at each marker span), translate, re-place markers via
-  origin provenance — an optional `Origin` (source `SyntaxReference`)
-  annotation on `Cs2Gs.CodeModel` nodes surfaced by `GSharpPrinter` as an
-  origin→output-span table. Anchors with no 1:1 counterpart get a best-guess
-  position plus the new `CS2GS-ANALYZER-SNIPPET` warning → human review.
-- Golden files of translated snippets (via `test/Shared/GoldenFile.cs`) make
-  review diffable. Manual fallback (warning + TODO marker) keeps the milestone
-  shippable if provenance lands partially.
+- "a `const string` local" alone would rewrite every constant in the project;
+- "a string containing `[|…|]`" alone would miss the nine of sixteen snippets in
+  `test/InternalAnalyzers.Tests` that assert *no* diagnostic and so carry no
+  marker, and would fire on any unrelated string containing the digraph.
+
+The harness parameter is the only signal that says "this string will be
+compiled as source", which is what makes translating it correct and leaving it
+alone wrong. Neither shape the ADR originally assumed (a literal argument at the
+call site) occurs in the real tests: every snippet arrives through a local, and
+several are **composed** (`Model + """…"""` with a shared `const string` model).
+Neither operand of a composition compiles on its own, so the guard fires only on
+the *whole initializer* and takes its text from Roslyn's constant folding — the
+migrated test therefore carries the folded, translated whole and loses the
+shared-model factoring. That is the accepted trade.
+
+**Marker preservation.** Markers are re-placed by occurrence ordinal: the Nth
+occurrence of a marked text in the C# is the Nth occurrence of that text in the
+G#. The earlier "search forward from the previous marker" rule silently
+mis-placed a marker whose text also occurred *earlier* in the unit — which is
+precisely what a composed snippet produces, since the shared model declares the
+member the per-test class overrides. A marked text that does not survive
+translation verbatim is **dropped and reported** as `CS2GS-ANALYZER-SNIPPET`
+(printed by `TranslateStage`, not merely recorded); the migrated test then fails
+on a marker/id count mismatch rather than asserting a wrong span.
+
+**Markers are regions.** `GSharpAnalyzerVerifier` asserts the produced
+diagnostic's span is *contained in* the marked region, not that it starts at the
+marker. A hand-written G# test brackets exactly the construct it expects, so its
+diagnostic is span-equal and nothing relaxes; what the region admits is the
+cross-language case, where a translated marker keeps the C# extent and G#'s node
+shapes differ (its index node is narrower than C#'s element access). Containment
+in *both* directions keeps the assertion falsifiable — a marker narrower than
+the diagnostic, or on a neighbouring construct, still fails.
+
+**Known limitation: one package per unit.** A G# compilation unit declares a
+single `package`, so a C# snippet spanning several namespaces collapses into the
+first one and namespace-scoped rules (GSA0003, GSA0004) then judge the wrong
+declarations. Fixing it needs a multi-unit verifier (the harness takes one
+source string). Until then the collapse is reported as
+`CS2GS-ANALYZER-SNIPPET`, because a negative test that passes because its
+subject changed namespace is passing for the wrong reason.
 
 ## Project and consumer transform
 
@@ -273,7 +309,8 @@ Approach: nested cs2gs invocation at translation time, not manual porting.
 Two layers; test-level is the primary signal:
 
 - **Test-level**: the translated `InternalAnalyzers.Tests` run under the G#
-  verifier with exact `[|...|]` locations over translated snippets.
+  verifier, each diagnostic contained in its translated `[|...|]` region
+  (issue #3778 — the region, not an exact start, is what survives translation).
 - **Corpus-level**: a new `Cs2Gs.Pipeline/AnalyzerParityStage.cs` (sibling of
   TestParity) runs the original Roslyn analyzers over the C# corpus and the
   compiled G# analyzers over the translated corpus, diffing diagnostic
@@ -306,14 +343,27 @@ Order: GSA0001 → GSA0003 → GSA0004 → GSA0002 → GSA0005; harness and pari
   harness rewrite, the instance-based verifier entry point, and the project
   transform. Measured on `test/InternalAnalyzers.Tests`, the app was walled at
   16 `GS0154` errors (3 fingerprints) and now translates, **compiles and
-  ilverifies clean**. Not done: snippet translation. `SnippetTranslator` exists
-  and is unit-tested, but nothing dispatches it during a migration, so the
-  migrated tests still hand **C# snippets** to the G# verifier and all 16 fail
-  — loudly, with the verifier's "the test source does not compile" report, not
-  silently. Two shapes make the wiring more than plumbing: the analyzed source
-  arrives via a `const string` local rather than a literal argument, and
-  several tests compose it (`Model + """…"""`), so the unit to translate is the
-  concatenation, which cannot then be split back into its parts.
+  ilverifies clean**.
+
+  **M5 second half (2026-09-01, issue #3778).** `SnippetTranslator` is now
+  dispatched: the constant string reaching the harness's source parameter is
+  translated to G#, markers and all. Measured on the same 2-app migration,
+  test-parity went **16 failing → 6 failing / 10 passing** (translate, compile
+  and ILVerify stay PASS). Each of the six has a stated, printed cause:
+
+  - **2** — a snippet spanning several namespaces collapses into one G#
+    package, so `GSA0003`/`GSA0004` judge the wrong declarations. Reported as
+    `CS2GS-ANALYZER-SNIPPET`. Note this also makes one *negative* test pass
+    vacuously, for the same reason.
+  - **2** — `GSA0005` (rewriter clone preservation) fires on the C# but not on
+    the translated G# shapes: an analyzer-translation parity gap, not a snippet
+    one. The markers are correctly placed.
+  - **1** — the marked text `typeof(int) != type` becomes `typeof(int32) !=
+    type` in G#, so the marker cannot be re-placed by text; dropped and
+    reported.
+  - **1** — the migrated `GSA0003` reports on a G# field symbol whose
+    `Location` is empty, so the verifier cannot check the marker. It now names
+    that cause instead of throwing a `NullReferenceException`.
 - **M6 Parity + self-migration** — `AnalyzerParityStage`; extend the
   Issue3347-style self-migration ratchet to translate
   `InternalAnalyzers.csproj` live. Exit criterion: all five translated

--- a/src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/GSharpAnalyzerVerifier.cs
+++ b/src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/GSharpAnalyzerVerifier.cs
@@ -45,8 +45,12 @@ public static class GSharpAnalyzerVerifier
         string markedSource,
         params string[] diagnosticIds)
     {
-        var expectedLocations = new List<(int Line, int Column)>();
+        var expectedLocations = new List<MarkerSpan>();
         var cleanSource = StripMarkers(markedSource, expectedLocations);
+
+        // Markers are recorded when they CLOSE, so a nested pair would land out
+        // of order; produced diagnostics are compared in span order.
+        expectedLocations.Sort((left, right) => left.Start.CompareTo(right.Start));
         if (expectedLocations.Count != diagnosticIds.Length)
         {
             throw new GSharpAnalyzerVerificationException(
@@ -80,12 +84,25 @@ public static class GSharpAnalyzerVerifier
 
         for (var i = 0; i < expectedLocations.Count; i++)
         {
-            var actualLine = produced[i].Location.StartLine + 1;
-            var actualColumn = produced[i].Location.StartCharacter + 1;
-            if ((actualLine, actualColumn) != expectedLocations[i])
+            MarkerSpan expected = expectedLocations[i];
+            if (produced[i].Location.Text is null)
             {
                 throw new GSharpAnalyzerVerificationException(
-                    $"Diagnostic {i} ({produced[i].Id}) was reported at ({actualLine},{actualColumn}) but the marker expects ({expectedLocations[i].Line},{expectedLocations[i].Column}).");
+                    $"Diagnostic {i} ({produced[i].Id}) carries no source location, so the marker at "
+                    + $"({expected.Line},{expected.Column}) cannot be checked. An analyzer that reports "
+                    + "on a symbol must attribute the diagnostic to one of its declaring syntax nodes.");
+            }
+
+            var actualStart = produced[i].Location.Span.Start;
+            var actualEnd = produced[i].Location.Span.End;
+            if (actualStart < expected.Start || actualEnd > expected.End)
+            {
+                var actualLine = produced[i].Location.StartLine + 1;
+                var actualColumn = produced[i].Location.StartCharacter + 1;
+                throw new GSharpAnalyzerVerificationException(
+                    $"Diagnostic {i} ({produced[i].Id}) spans [{actualStart}..{actualEnd}) — reported at "
+                    + $"({actualLine},{actualColumn}) — which is not inside the marked region "
+                    + $"[{expected.Start}..{expected.End}) starting at ({expected.Line},{expected.Column}).");
             }
         }
     }
@@ -95,22 +112,30 @@ public static class GSharpAnalyzerVerifier
             ? $"{diagnostic.Id}: {diagnostic.Message}"
             : $"{diagnostic.Id} at ({diagnostic.Location.StartLine + 1},{diagnostic.Location.StartCharacter + 1}): {diagnostic.Message}";
 
-    private static string StripMarkers(string source, List<(int Line, int Column)> expectedLocations)
+    private static string StripMarkers(string source, List<MarkerSpan> expectedLocations)
     {
         var result = new StringBuilder(source.Length);
+        var open = new Stack<(int Start, int Line, int Column)>();
         var line = 1;
         var column = 1;
         for (var i = 0; i < source.Length; i++)
         {
             if (i + 1 < source.Length && source[i] == '[' && source[i + 1] == '|')
             {
-                expectedLocations.Add((line, column));
+                open.Push((result.Length, line, column));
                 i++;
                 continue;
             }
 
             if (i + 1 < source.Length && source[i] == '|' && source[i + 1] == ']')
             {
+                if (open.Count > 0)
+                {
+                    (int start, int startLine, int startColumn) = open.Pop();
+                    expectedLocations.Add(
+                        new MarkerSpan(start, result.Length, startLine, startColumn));
+                }
+
                 i++;
                 continue;
             }
@@ -129,6 +154,30 @@ public static class GSharpAnalyzerVerifier
 
         return result.ToString();
     }
+
+    /// <summary>
+    /// One <c>[|…|]</c> marker: the marked REGION, plus the 1-based
+    /// line/column of its first character for readable failure messages.
+    /// </summary>
+    /// <remarks>
+    /// The region, not the start point, is the assertion (ADR-0169, issue
+    /// #3778). A hand-written G# test brackets exactly the construct it
+    /// expects the diagnostic on, and a diagnostic on that construct is
+    /// span-equal to the marker, so nothing about those tests relaxes. What
+    /// the region admits is the cross-language case: a snippet TRANSLATED from
+    /// C# keeps the C# marker's extent, and G#'s syntax shapes are not always
+    /// span-identical — its index node is narrower than C#'s element access,
+    /// so <c>[|this.cache.Defs[field]|]</c> yields a diagnostic that starts
+    /// inside the marker. Requiring the diagnostic to be CONTAINED in the
+    /// marker keeps the assertion falsifiable — a diagnostic on a neighbouring
+    /// construct, or on an enclosing one, still fails — while not asserting a
+    /// span identity that does not survive translation.
+    /// </remarks>
+    /// <param name="Start">The marked region's start offset in the clean source.</param>
+    /// <param name="End">The marked region's end offset in the clean source.</param>
+    /// <param name="Line">The 1-based line of the region's first character.</param>
+    /// <param name="Column">The 1-based column of the region's first character.</param>
+    private readonly record struct MarkerSpan(int Start, int End, int Line, int Column);
 }
 
 /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
@@ -146,6 +146,97 @@ func Leak(index int32) int32 {
     }
 
     /// <summary>
+    /// Issue #3778: a <c>[|…|]</c> marker denotes a REGION, and the assertion
+    /// is that the diagnostic falls inside it. That is what lets a snippet
+    /// translated from C# keep the C# marker's extent: G#'s syntax shapes are
+    /// not always span-identical (its index node is narrower than C#'s element
+    /// access), so a translated marker is sometimes wider than the diagnostic.
+    /// Here the marker takes in one extra character.
+    /// </summary>
+    [Fact]
+    public void MarkerWiderThanTheDiagnostic_IsAccepted()
+    {
+        GSharpAnalyzerVerifier<StructFieldDefsReadAnalogueAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+var structFieldDefs = []int32{1, 2, 3}
+
+func Leak(index int32) int32 {
+    return [|structFieldDefs[index] |]
+}
+",
+            "TESTGSA0001");
+    }
+
+    /// <summary>
+    /// The anti-vacuity guard for the region rule, and the reason it is
+    /// containment rather than "starts inside": a marker NARROWER than the
+    /// diagnostic brackets a different construct — here the receiver rather
+    /// than the index expression — and must still fail. Without the end check,
+    /// this would pass, and a mis-placed marker would be indistinguishable from
+    /// a correct one.
+    /// </summary>
+    [Fact]
+    public void MarkerNarrowerThanTheDiagnostic_IsRejected()
+    {
+        Assert.Throws<GSharpAnalyzerVerificationException>(() =>
+            GSharpAnalyzerVerifier<StructFieldDefsReadAnalogueAnalyzer>.VerifyAnalyzer(
+                @"package App
+
+var structFieldDefs = []int32{1, 2, 3}
+
+func Leak(index int32) int32 {
+    return [|structFieldDefs|][index]
+}
+",
+                "TESTGSA0001"));
+    }
+
+    /// <summary>
+    /// A marker on an unrelated construct fails too: the region rule bounds
+    /// where a diagnostic may land, it does not stop checking placement.
+    /// </summary>
+    [Fact]
+    public void MarkerOnADifferentConstruct_IsRejected()
+    {
+        Assert.Throws<GSharpAnalyzerVerificationException>(() =>
+            GSharpAnalyzerVerifier<StructFieldDefsReadAnalogueAnalyzer>.VerifyAnalyzer(
+                @"package App
+
+var structFieldDefs = []int32{1, 2, 3}
+
+func Leak([|index|] int32) int32 {
+    return structFieldDefs[index]
+}
+",
+                "TESTGSA0001"));
+    }
+
+    /// <summary>
+    /// Issue #3778: an analyzer that reports without a source location used to
+    /// crash the verifier with a NullReferenceException from
+    /// <c>TextLocation.StartLine</c> — a failure that says nothing about the
+    /// analyzer. It now names the cause. (The real case: a migrated
+    /// symbol-action analyzer whose G# symbol carries no declaring location.)
+    /// </summary>
+    [Fact]
+    public void LocationLessDiagnostic_ReportsTheCauseInsteadOfCrashing()
+    {
+        GSharpAnalyzerVerificationException failure =
+            Assert.Throws<GSharpAnalyzerVerificationException>(() =>
+                GSharpAnalyzerVerifier<LocationLessAnalyzer>.VerifyAnalyzer(
+                    @"package App
+
+func Leak() int32 {
+    return [|1|]
+}
+",
+                    "TESTGSA0002"));
+
+        Assert.Contains("no source location", failure.Message, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The G# analogue of GSA0001: direct index reads of a member named
     /// <c>structFieldDefs</c> outside <c>ResolveFieldToken</c> /
     /// <c>ResolveInterfaceFieldToken</c> are flagged. Uses
@@ -196,6 +287,36 @@ func Leak(index int32) int32 {
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, indexExpression.Location));
+        }
+    }
+
+    /// <summary>
+    /// Reports one diagnostic with no source location — the shape that used to
+    /// crash the verifier (issue #3778).
+    /// </summary>
+    [GSharpDiagnosticAnalyzer]
+    public sealed class LocationLessAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA0002",
+            "Location-less",
+            "Reported with no source location.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Report, SyntaxKind.LiteralExpression);
+        }
+
+        private static void Report(SyntaxNodeAnalysisContext context)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rule, default(GSharp.Core.CodeAnalysis.Text.TextLocation)));
         }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
@@ -151,7 +151,8 @@ func Leak(index int32) int32 {
     /// translated from C# keep the C# marker's extent: G#'s syntax shapes are
     /// not always span-identical (its index node is narrower than C#'s element
     /// access), so a translated marker is sometimes wider than the diagnostic.
-    /// Here the marker takes in one extra character.
+    /// The marker here is wider on BOTH sides, so it also fails the old
+    /// exact-start rule rather than only the end check.
     /// </summary>
     [Fact]
     public void MarkerWiderThanTheDiagnostic_IsAccepted()
@@ -162,7 +163,7 @@ func Leak(index int32) int32 {
 var structFieldDefs = []int32{1, 2, 3}
 
 func Leak(index int32) int32 {
-    return [|structFieldDefs[index] |]
+    return[| structFieldDefs[index] |]
 }
 ",
             "TESTGSA0001");

--- a/test/InternalAnalyzers.Tests/StrongStaticReflectionCacheAnalyzerTests.cs
+++ b/test/InternalAnalyzers.Tests/StrongStaticReflectionCacheAnalyzerTests.cs
@@ -39,26 +39,32 @@ class C
     [Fact]
     public Task IgnoresTypeSymbolsInstanceCachesTuplesAndNonMetadataNamespaces()
     {
+        // Two namespaces, so both are block-scoped: a second FILE-scoped
+        // namespace is CS8954, which Roslyn's analyzer driver tolerates (it
+        // only parses) but a verifier that actually COMPILES the snippet — the
+        // G# one this test migrates onto (ADR-0169 M5, issue #3778) — does not.
         const string Source = """
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-namespace GSharp.Core.CodeAnalysis.Symbols;
-
-class TypeSymbol { }
-class C
+namespace GSharp.Core.CodeAnalysis.Symbols
 {
-    private static readonly ConcurrentDictionary<TypeSymbol, string> SymbolCache = new();
-    private static readonly ConcurrentDictionary<(Type Source, Type Target), string> TupleCache = new();
-    private readonly Dictionary<Type, string> InstanceCache = new();
+    class TypeSymbol { }
+    class C
+    {
+        private static readonly ConcurrentDictionary<TypeSymbol, string> SymbolCache = new();
+        private static readonly ConcurrentDictionary<(Type Source, Type Target), string> TupleCache = new();
+        private readonly Dictionary<Type, string> InstanceCache = new();
+    }
 }
 
-namespace GSharp.Core.CodeAnalysis.Syntax;
-
-class SyntaxCache
+namespace GSharp.Core.CodeAnalysis.Syntax
 {
-    private static readonly ConcurrentDictionary<Type, string> ChildAccessorsByType = new();
+    class SyntaxCache
+    {
+        private static readonly ConcurrentDictionary<Type, string> ChildAccessorsByType = new();
+    }
 }
 """;
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -383,6 +383,14 @@ public sealed class TranslateStage : IMigrationStage
                         document.FilePath,
                         siblingCompilations,
                         repositoryCompilations);
+
+                    // ADR-0169 M5 / issue #3778: analyzer-test snippets are C#
+                    // source embedded in the tests, and the migrated verifier
+                    // compiles them as G#. The snippet translator needs a C#
+                    // project loader, so it lives one assembly above the
+                    // translator and is injected here.
+                    translationContext.TranslateAnalyzerSnippet =
+                        Cs2Gs.Translator.Analyzers.SnippetTranslator.Translate;
                     CSharpToGSharpTranslator unitTranslator = package is null
                         ? translator
                         : new CSharpToGSharpTranslator(
@@ -451,6 +459,22 @@ public sealed class TranslateStage : IMigrationStage
                         .Where(d => d.Severity == TranslationSeverity.Unsupported))
                     {
                         artifacts.Add(context.Triage.TranslationUnsupported(diagnostic));
+                    }
+
+                    // Issue #3778: an analyzer-mode adaptation that is NOT a
+                    // gate failure — a snippet whose [|…|] marker could not be
+                    // re-placed, a multi-namespace snippet collapsed into one
+                    // G# package — still changes what the migrated test
+                    // asserts, so it must reach the human running the
+                    // migration. Warnings are otherwise dropped here, which
+                    // would make "reported, never silent" untrue.
+                    foreach (TranslationDiagnostic diagnostic in translationContext.Diagnostics
+                        .Where(d => d.Severity == TranslationSeverity.Warning
+                            && d.DiagnosticId == "CS2GS-ANALYZER-SNIPPET"))
+                    {
+                        Console.WriteLine(
+                            $"cs2gs: {diagnostic.DiagnosticId}: {diagnostic.Message} "
+                            + $"[{document.FilePath}]");
                     }
 
                     RoundTripResult roundTrip = GSharpRoundTrip.Validate(printed);

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
@@ -40,7 +40,7 @@ public static class SnippetTranslator
     /// <returns>The translation result.</returns>
     public static SnippetTranslationResult Translate(string csharpWithMarkers)
     {
-        var markedTexts = new List<string>();
+        var markedTexts = new List<MarkedText>();
         string cleanSource = StripMarkers(csharpWithMarkers, markedTexts);
 
         var diagnostics = new List<TranslationDiagnostic>();
@@ -52,7 +52,10 @@ public static class SnippetTranslator
                 "The C# snippet does not compile: " + string.Join("; ", project.ErrorDiagnostics.Take(3)),
                 location: null,
                 TranslationSeverity.Unsupported));
-            return new SnippetTranslationResult(null, diagnostics, markedTexts);
+            return new SnippetTranslationResult(
+                null,
+                diagnostics,
+                markedTexts.Select(m => m.Text).ToList());
         }
 
         var translator = new CSharpToGSharpTranslator();
@@ -60,22 +63,32 @@ public static class SnippetTranslator
         var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
         string printed = GSharpPrinter.Print(translator.TranslateDocument(document, context));
         diagnostics.AddRange(context.Diagnostics);
+        ReportNamespaceCollapse(document, diagnostics);
 
         var unplaced = new List<string>();
-        var result = new StringBuilder(printed);
 
-        // Ordered placement: member order survives translation, so each
-        // marker's text is searched after the previous marker's position.
-        int cursor = 0;
-        foreach (string markedText in markedTexts)
+        // Occurrence-ORDINAL placement (issue #3778). The previous rule —
+        // "search forward from the last marker" — silently mis-places a marker
+        // whose text also occurs EARLIER in the translated unit, and a
+        // composed snippet (`Model + """…"""`) is exactly that case: the
+        // shared model declares `RewriteFieldNode`, so the marker on the
+        // per-test override landed on the base method instead. Member order
+        // survives translation, so the truthful rule is positional: the Nth
+        // occurrence of a marked text in the C# maps to the Nth occurrence of
+        // that same text in the G#. Placements are computed against the
+        // untouched printed text and applied last, back to front, so inserting
+        // one marker cannot move another's index.
+        var placements = new List<(int Index, int Length)>();
+        foreach (MarkedText marked in markedTexts)
         {
-            int index = result.ToString().IndexOf(markedText, cursor, StringComparison.Ordinal);
+            int ordinal = OccurrenceOrdinal(cleanSource, marked.Text, marked.Start);
+            int index = NthOccurrence(printed, marked.Text, ordinal);
             if (index < 0)
             {
-                unplaced.Add(markedText);
+                unplaced.Add(marked.Text);
                 diagnostics.Add(new TranslationDiagnostic(
                     "analyzer-snippet",
-                    $"Marker text '{markedText}' does not survive translation verbatim; re-place the [|…|] marker in the G# snippet by hand.",
+                    $"Marker text '{marked.Text}' does not survive translation verbatim (occurrence {ordinal + 1} not found); re-place the [|…|] marker in the G# snippet by hand.",
                     location: null,
                     TranslationSeverity.Warning)
                 {
@@ -84,15 +97,103 @@ public static class SnippetTranslator
                 continue;
             }
 
-            result.Insert(index + markedText.Length, "|]");
+            placements.Add((index, marked.Text.Length));
+        }
+
+        var result = new StringBuilder(printed);
+        foreach ((int index, int length) in placements.OrderByDescending(p => p.Index))
+        {
+            result.Insert(index + length, "|]");
             result.Insert(index, "[|");
-            cursor = index + markedText.Length + 4;
         }
 
         return new SnippetTranslationResult(result.ToString(), diagnostics, unplaced);
     }
 
-    private static string StripMarkers(string source, List<string> markedTexts)
+    /// <summary>
+    /// A G# compilation unit declares exactly ONE package, so a C# snippet
+    /// spanning several namespaces collapses into the first one — every type
+    /// silently changes namespace, and a namespace-scoped analyzer rule
+    /// (GSA0003, GSA0004) then fires, or fails to fire, on the wrong
+    /// declarations. cs2gs's normal pipeline splits such a file per package;
+    /// a snippet has nowhere to split to because the verifier takes ONE
+    /// source. Surface it as <c>CS2GS-ANALYZER-SNIPPET</c> so the migrated
+    /// test's disagreement has a stated cause rather than looking like an
+    /// analyzer regression.
+    /// </summary>
+    /// <param name="document">The loaded snippet document.</param>
+    /// <param name="diagnostics">The diagnostic list to append to.</param>
+    private static void ReportNamespaceCollapse(
+        LoadedDocument document,
+        List<TranslationDiagnostic> diagnostics)
+    {
+        var names = document.SemanticModel.SyntaxTree.GetRoot()
+            .DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.BaseNamespaceDeclarationSyntax>()
+            .Select(declaration => declaration.Name.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (names.Count < 2)
+        {
+            return;
+        }
+
+        string message = "the snippet declares " + names.Count + " namespaces ("
+            + string.Join(", ", names)
+            + ") but a G# compilation unit declares one package, so they collapse into '"
+            + names[0] + "'. Namespace-scoped analyzer rules will disagree with the C# "
+            + "expectation; split the test or re-express the snippet in one namespace.";
+        diagnostics.Add(new TranslationDiagnostic(
+            "analyzer-snippet",
+            message,
+            location: null,
+            TranslationSeverity.Warning)
+        {
+            DiagnosticId = SnippetDiagnosticId,
+        });
+    }
+
+    /// <summary>
+    /// Counts how many non-overlapping occurrences of <paramref name="text"/>
+    /// start before <paramref name="start"/> in <paramref name="source"/>.
+    /// </summary>
+    /// <param name="source">The text to scan.</param>
+    /// <param name="text">The occurrence text.</param>
+    /// <param name="start">The offset of the occurrence being ranked.</param>
+    /// <returns>The zero-based occurrence ordinal.</returns>
+    private static int OccurrenceOrdinal(string source, string text, int start)
+    {
+        var ordinal = 0;
+        for (int i = source.IndexOf(text, StringComparison.Ordinal);
+             i >= 0 && i < start;
+             i = source.IndexOf(text, i + text.Length, StringComparison.Ordinal))
+        {
+            ordinal++;
+        }
+
+        return ordinal;
+    }
+
+    /// <summary>
+    /// Returns the index of the <paramref name="ordinal"/>-th (zero-based)
+    /// non-overlapping occurrence of <paramref name="text"/>, or -1.
+    /// </summary>
+    /// <param name="source">The text to scan.</param>
+    /// <param name="text">The occurrence text.</param>
+    /// <param name="ordinal">The zero-based occurrence to find.</param>
+    /// <returns>The index, or -1 when there are fewer occurrences.</returns>
+    private static int NthOccurrence(string source, string text, int ordinal)
+    {
+        int index = source.IndexOf(text, StringComparison.Ordinal);
+        for (var seen = 0; index >= 0 && seen < ordinal; seen++)
+        {
+            index = source.IndexOf(text, index + text.Length, StringComparison.Ordinal);
+        }
+
+        return index;
+    }
+
+    private static string StripMarkers(string source, List<MarkedText> markedTexts)
     {
         var result = new StringBuilder(source.Length);
         var markStarts = new Stack<int>();
@@ -110,7 +211,9 @@ public static class SnippetTranslator
                 if (markStarts.Count > 0)
                 {
                     int start = markStarts.Pop();
-                    markedTexts.Add(result.ToString(start, result.Length - start));
+                    markedTexts.Add(new MarkedText(
+                        result.ToString(start, result.Length - start),
+                        start));
                 }
 
                 i++;
@@ -122,15 +225,9 @@ public static class SnippetTranslator
 
         return result.ToString();
     }
-}
 
-/// <summary>
-/// The result of <see cref="SnippetTranslator.Translate"/>.
-/// </summary>
-/// <param name="GsWithMarkers">The G# snippet with re-placed markers, or null when the C# snippet did not compile.</param>
-/// <param name="Diagnostics">Translation and marker-placement diagnostics.</param>
-/// <param name="UnplacedMarkers">The marked texts that could not be re-placed automatically.</param>
-public sealed record SnippetTranslationResult(
-    string GsWithMarkers,
-    IReadOnlyList<TranslationDiagnostic> Diagnostics,
-    IReadOnlyList<string> UnplacedMarkers);
+    /// <summary>One <c>[|…|]</c> marker: its text and its offset in the marker-free C# source.</summary>
+    /// <param name="Text">The marked text.</param>
+    /// <param name="Start">The offset of the marked text in the stripped source.</param>
+    private readonly record struct MarkedText(string Text, int Start);
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3778AnalyzerSnippetDispatchTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3778AnalyzerSnippetDispatchTests.cs
@@ -1,0 +1,296 @@
+// <copyright file="Issue3778AnalyzerSnippetDispatchTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Analyzers;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// ADR-0169 M5 second half / issue #3778: <c>SnippetTranslator</c> existed and
+/// was unit-tested, but nothing DISPATCHED it during a migration, so migrated
+/// analyzer tests handed C# snippets to a verifier that compiles G#. Covered
+/// here: the dispatch rule (what is and is not a snippet), the two real shapes
+/// — a snippet arriving through a local, and a snippet composed with <c>+</c>
+/// out of a shared model — and marker fidelity, which is the part that can
+/// make a migrated test pass for the wrong reason.
+/// </summary>
+public class Issue3778AnalyzerSnippetDispatchTests
+{
+    /// <summary>
+    /// The harness shape the detector keys on (a static method taking an
+    /// analyzer and a source string), trimmed to what dispatch needs.
+    /// </summary>
+    private const string HarnessSource = @"
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Sample.Tests;
+
+internal static class AnalyzerTestHelper
+{
+    public static Task AssertDiagnosticsAsync(DiagnosticAnalyzer analyzer, string source, params string[] diagnosticIds)
+        => Task.CompletedTask;
+}
+";
+
+    private const string AnalyzerSource = @"
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Sample;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SampleAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        ""TEST0001"",
+        ""Title"",
+        ""Message"",
+        ""Testing"",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.RegisterSyntaxNodeAction(
+            c => c.ReportDiagnostic(Diagnostic.Create(Rule, c.Node.GetLocation())),
+            SyntaxKind.ElementAccessExpression);
+    }
+}
+";
+
+    /// <summary>
+    /// Shape 1 of #3778: the snippet is not a literal at the call site, it is
+    /// the initializer of a <c>const string</c> LOCAL that is passed to the
+    /// harness on the next statement. The design #3777 shipped assumed a
+    /// literal argument and therefore never fired.
+    /// </summary>
+    [Fact]
+    public void SnippetReachingTheHarnessThroughALocal_IsTranslated()
+    {
+        string printed = TranslateTests(@"
+namespace Sample.Tests.Cases;
+
+public sealed class Tests
+{
+    public System.Threading.Tasks.Task Reports()
+    {
+        const string Source = ""class C { void M(int[] a) { var x = a[0]; } }"";
+        return Sample.Tests.AnalyzerTestHelper.AssertDiagnosticsAsync(new Sample.SampleAnalyzer(), Source, ""TEST0001"");
+    }
+}
+");
+
+        // The G# spelling, not the C# one: a G# `func` with G# parameter order.
+        Assert.Contains("func M(a []int32)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("void M(int[] a)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Shape 2 of #3778: the snippet is COMPOSED — a shared <c>const string</c>
+    /// model plus a per-test literal. Neither operand is a compilable unit, so
+    /// the translatable thing is the concatenation. The migrated test carries
+    /// the folded whole and loses the shared-model factoring; that is the
+    /// trade, and this test pins it.
+    /// </summary>
+    [Fact]
+    public void ComposedSnippet_IsTranslatedAsOneFoldedUnit()
+    {
+        string printed = TranslateTests(@"
+namespace Sample.Tests.Cases;
+
+public sealed class Tests
+{
+    private const string Model = ""class Node { public int[] Values; }\n"";
+
+    public System.Threading.Tasks.Task Reports()
+    {
+        string source = Model + ""class C { void M(Node n) { var x = n.Values[0]; } }"";
+        return Sample.Tests.AnalyzerTestHelper.AssertDiagnosticsAsync(new Sample.SampleAnalyzer(), source, ""TEST0001"");
+    }
+}
+");
+
+        // Both halves are present in ONE translated unit, in G# spelling.
+        Assert.Contains("class Node", printed, StringComparison.Ordinal);
+        Assert.Contains("func M(n Node)", printed, StringComparison.Ordinal);
+
+        // The composition is gone: the initializer is a single literal, so
+        // there is no residual `Model + ` concatenation at the use site.
+        Assert.DoesNotContain("Model +", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The guard that makes the rule safe. Silently rewriting a string that was
+    /// never a snippet is the bad failure mode, so a constant string that does
+    /// NOT reach a harness source parameter must survive verbatim — even in the
+    /// same class, even when it is valid C# source text.
+    /// </summary>
+    [Fact]
+    public void ConstantStringThatNeverReachesTheHarness_IsLeftAlone()
+    {
+        string printed = TranslateTests(@"
+namespace Sample.Tests.Cases;
+
+public sealed class Tests
+{
+    public string Unrelated()
+    {
+        const string NotASnippet = ""class C { void M(int[] a) { var x = a[0]; } }"";
+        return NotASnippet;
+    }
+
+    public System.Threading.Tasks.Task Reports()
+    {
+        const string Source = ""class D { void M(int[] a) { var x = a[0]; } }"";
+        return Sample.Tests.AnalyzerTestHelper.AssertDiagnosticsAsync(new Sample.SampleAnalyzer(), Source, ""TEST0001"");
+    }
+}
+");
+
+        // Untouched, C# text and all.
+        Assert.Contains(
+            "class C { void M(int[] a) { var x = a[0]; } }",
+            printed,
+            StringComparison.Ordinal);
+
+        // …while the one that DOES reach the harness was translated. Both
+        // halves in one assertion pair: if dispatch stopped firing altogether
+        // the first assertion would still hold, so this one is the anti-vacuity
+        // guard for it.
+        Assert.Contains("class D", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("class D { void M(int[] a)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Marker fidelity, the crux. The original re-placement rule searched
+    /// forward from the previous marker, so a marked name that also occurs
+    /// EARLIER in the unit bracketed the wrong declaration — exactly what a
+    /// composed snippet produces, because the shared model declares the method
+    /// the per-test override re-declares. The rule is now positional: the Nth
+    /// occurrence in the C# is the Nth occurrence in the G#.
+    /// </summary>
+    [Fact]
+    public void MarkerOnALaterOccurrence_StaysOnThatOccurrence()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(@"
+class Base
+{
+    public virtual int Rewrite() => 0;
+}
+
+class Derived : Base
+{
+    public override int [|Rewrite|]() => 1;
+}
+");
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+
+        int markerIndex = result.GsWithMarkers.IndexOf("[|Rewrite|]", StringComparison.Ordinal);
+        int derivedIndex = result.GsWithMarkers.IndexOf("class Derived", StringComparison.Ordinal);
+        Assert.True(markerIndex > 0, "the marker must be placed: " + result.GsWithMarkers);
+        Assert.True(
+            markerIndex > derivedIndex,
+            "the marker must bracket Derived.Rewrite, not Base.Rewrite: " + result.GsWithMarkers);
+    }
+
+    /// <summary>
+    /// The other half of marker fidelity: a marked text that does NOT survive
+    /// translation is dropped and reported, never silently re-placed somewhere
+    /// plausible. The migrated test then fails on a marker/id count mismatch,
+    /// which is loud, rather than asserting the wrong span.
+    /// </summary>
+    [Fact]
+    public void MarkerWhoseTextDoesNotSurvive_IsDroppedAndReported()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(@"
+class Holder
+{
+    object Box(int value) => [|(object)value|];
+}
+");
+
+        Assert.Single(result.UnplacedMarkers);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.DiagnosticId == SnippetTranslator.SnippetDiagnosticId);
+        Assert.DoesNotContain("[|", result.GsWithMarkers, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A C# snippet spanning several namespaces cannot become one G# unit — G#
+    /// declares one package per compilation unit — so the declarations collapse
+    /// into the first namespace and a namespace-scoped rule then fires, or
+    /// fails to fire, on the wrong ones. Left unfixed (it needs a multi-unit
+    /// verifier), but it must be REPORTED: a negative test that passes because
+    /// its subject moved namespace is passing for the wrong reason.
+    /// </summary>
+    [Fact]
+    public void MultiNamespaceSnippet_ReportsTheCollapse()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(@"
+namespace One
+{
+    class A { }
+}
+
+namespace Two
+{
+    class B { }
+}
+");
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.DiagnosticId == SnippetTranslator.SnippetDiagnosticId
+                && d.Message.Contains("collapse", StringComparison.Ordinal));
+
+        // …and the collapse is real, so the report is not decorative.
+        Assert.Equal(
+            1,
+            result.GsWithMarkers.Split("package ", StringSplitOptions.None).Length - 1);
+    }
+
+    /// <summary>
+    /// Translates a two-file analyzer TEST project (harness + cases) in
+    /// analyzer mode with the snippet translator wired in, exactly as
+    /// <c>TranslateStage</c> does, and returns the printed cases file.
+    /// </summary>
+    /// <param name="testsSource">The C# test-case source.</param>
+    /// <returns>The printed G#.</returns>
+    private static string TranslateTests(string testsSource)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Harness.cs", HarnessSource), ("Analyzer.cs", AnalyzerSource), ("Tests.cs", testsSource) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Fixture should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator(analyzerApiMode: true);
+        LoadedDocument document = project.Documents.Single(d => Path.GetFileName(d.FilePath) == "Tests.cs");
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath)
+        {
+            TranslateAnalyzerSnippet = SnippetTranslator.Translate,
+        };
+        CompilationUnit unit = translator.TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/SnippetTranslationResult.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/SnippetTranslationResult.cs
@@ -1,0 +1,25 @@
+// <copyright file="SnippetTranslationResult.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Cs2Gs.Translator.Analyzers;
+
+/// <summary>
+/// The result of translating one analyzer-test snippet (ADR-0169 M5). The
+/// producer — <c>SnippetTranslator</c> — lives in <c>Cs2Gs.ProjectLoading</c>
+/// because it needs a C# project loader, but the CONSUMER is the translator
+/// itself (issue #3778: the dispatch point is a marker-bearing local in an
+/// analyzer test method). ProjectLoading already references Translator, so the
+/// contract type lives here and the hook is handed in as a delegate
+/// (<see cref="TranslationContext.TranslateAnalyzerSnippet"/>) rather than
+/// inverting the assembly dependency.
+/// </summary>
+/// <param name="GsWithMarkers">The G# snippet with re-placed markers, or null when the C# snippet did not compile.</param>
+/// <param name="Diagnostics">Translation and marker-placement diagnostics.</param>
+/// <param name="UnplacedMarkers">The marked texts that could not be re-placed automatically.</param>
+public sealed record SnippetTranslationResult(
+    string GsWithMarkers,
+    IReadOnlyList<TranslationDiagnostic> Diagnostics,
+    IReadOnlyList<string> UnplacedMarkers);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.AnalyzerSnippets.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.AnalyzerSnippets.cs
@@ -1,0 +1,275 @@
+// <copyright file="CSharpToGSharpTranslator.AnalyzerSnippets.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.Translator.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cs2Gs.Translator;
+
+/// <summary>
+/// ADR-0169 M5, issue #3778: the SNIPPET half of analyzer-test translation.
+/// #3777 put the migrated harness on <c>GSharpAnalyzerVerifier</c>, which
+/// compiles the source under analysis as <b>G#</b> — so the C# snippets the
+/// tests hand it must be translated too, markers and all.
+/// </summary>
+public sealed partial class CSharpToGSharpTranslator
+{
+    private sealed partial class DeclarationVisitor
+    {
+        /// <summary>The diagnostic id carried by snippet-dispatch reports.</summary>
+        private const string AnalyzerSnippetDiagnosticId = "CS2GS-ANALYZER-SNIPPET";
+
+        /// <summary>
+        /// Translates an analyzer-test snippet in place of the ordinary
+        /// string-literal translation.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <b>The dispatch rule.</b> An expression is a snippet exactly when it
+        /// is a compile-time constant string that <i>flows into the source
+        /// parameter of an analyzer test harness entry point</i> — either as
+        /// the initializer of a local that is later passed there, or directly
+        /// as that argument. Nothing else in the project is touched.
+        /// </para>
+        /// <para>
+        /// That conjunction is the whole point. "A <c>const string</c> local"
+        /// alone would rewrite every constant in the project; "a string
+        /// containing <c>[|…|]</c>" alone would miss the nine of sixteen
+        /// snippets in <c>test/InternalAnalyzers.Tests</c> that assert NO
+        /// diagnostic and therefore carry no marker, and would fire on any
+        /// unrelated string that happened to contain the marker digraph. The
+        /// harness parameter is the only signal that says "this string will be
+        /// compiled as source" — which is precisely what makes translating it
+        /// correct, and leaving it alone wrong. Silently rewriting a string
+        /// that was never a snippet is the bad failure mode here, so the rule
+        /// keys on the one fact that rules it out.
+        /// </para>
+        /// <para>
+        /// <b>Composed snippets.</b> Several tests build the source as
+        /// <c>Model + """…"""</c>, where <c>Model</c> is a shared
+        /// <c>const string</c> field. Neither operand is a compilable unit, so
+        /// the translatable unit is the concatenation: the guard therefore only
+        /// ever fires on the <i>whole initializer</i> (never on a sub-operand),
+        /// and takes its text from Roslyn's constant folding. The migrated test
+        /// consequently carries the folded, translated whole and loses the
+        /// shared-<c>Model</c> factoring — the trade #3778 records; a
+        /// piecewise scheme would have to translate a fragment that does not
+        /// compile on its own.
+        /// </para>
+        /// <para>
+        /// <b>Markers.</b> Re-placement is <c>SnippetTranslator</c>'s job; what
+        /// this dispatch owes is loudness. A marker whose text does not survive
+        /// translation is dropped and reported as
+        /// <c>CS2GS-ANALYZER-SNIPPET</c>; the migrated test then has fewer
+        /// markers than the ids its call site passes, so the verifier fails it
+        /// with a marker/id count mismatch instead of silently asserting the
+        /// wrong span.
+        /// </para>
+        /// </remarks>
+        /// <param name="expression">The expression being translated.</param>
+        /// <param name="translated">The G# snippet literal, when this is a snippet.</param>
+        /// <returns>True when the expression was translated as a snippet.</returns>
+        private bool TryTranslateAnalyzerSnippet(ExpressionSyntax expression, out GExpression translated)
+        {
+            translated = null;
+            if (!this.InAnalyzerApiMode
+                || this.context.TranslateAnalyzerSnippet is null
+                || !this.IsAnalyzerSnippetSource(expression))
+            {
+                return false;
+            }
+
+            Optional<object> constant = this.context.SemanticModel.GetConstantValue(expression);
+            if (!constant.HasValue || constant.Value is not string csharpSnippet)
+            {
+                string nonConstant = "the analyzer test source flowing into the harness is not a "
+                    + "compile-time constant, so it cannot be translated to G#; the migrated test "
+                    + "would hand C# to the G# verifier (ADR-0169 M5, issue #3778).";
+                this.context.Report(new TranslationDiagnostic(
+                    "analyzer-snippet",
+                    nonConstant,
+                    expression.GetLocation(),
+                    TranslationSeverity.Unsupported)
+                {
+                    DiagnosticId = AnalyzerSnippetDiagnosticId,
+                });
+                return false;
+            }
+
+            SnippetTranslationResult result = this.context.TranslateAnalyzerSnippet(csharpSnippet);
+            if (result?.GsWithMarkers is null)
+            {
+                string detail = result is null
+                    ? "no snippet translator is configured"
+                    : string.Join("; ", result.Diagnostics.Select(d => d.Message).Take(2));
+                string failure = $"the analyzer test snippet could not be translated to G#: {detail} "
+                    + "(ADR-0169 M5, issue #3778).";
+                this.context.Report(new TranslationDiagnostic(
+                    "analyzer-snippet",
+                    failure,
+                    expression.GetLocation(),
+                    TranslationSeverity.Unsupported)
+                {
+                    DiagnosticId = AnalyzerSnippetDiagnosticId,
+                });
+                return false;
+            }
+
+            // Everything the snippet translator noticed — a dropped marker, a
+            // namespace collapse — is re-reported HERE, attributed to the call
+            // site, so it lands in the migration's own diagnostics rather than
+            // being swallowed inside a nested translation the run never sees.
+            foreach (TranslationDiagnostic inner in result.Diagnostics)
+            {
+                if (inner.Severity == TranslationSeverity.Info)
+                {
+                    continue;
+                }
+
+                this.context.Report(new TranslationDiagnostic(
+                    "analyzer-snippet",
+                    inner.Message,
+                    expression.GetLocation(),
+                    TranslationSeverity.Warning)
+                {
+                    DiagnosticId = AnalyzerSnippetDiagnosticId,
+                });
+            }
+
+            string note = "analyzer test snippet translated from C# to G# with its [|…|] markers "
+                + "re-placed: the migrated harness delegates to GSharpAnalyzerVerifier, which compiles "
+                + "the source under analysis as G# (ADR-0169 M5, issue #3778).";
+
+            // Info, not Warning: the substitution itself is the intended
+            // behavior and happens once per test, so it is recorded rather than
+            // printed. The two things that CHANGE what a migrated test asserts
+            // — a dropped marker and a namespace collapse — are the warnings.
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-snippet",
+                note,
+                expression.GetLocation(),
+                TranslationSeverity.Info)
+            {
+                DiagnosticId = AnalyzerSnippetDiagnosticId,
+            });
+
+            translated = LiteralExpression.String(result.GsWithMarkers);
+            return true;
+        }
+
+        /// <summary>
+        /// True when <paramref name="expression"/> is the whole source
+        /// expression handed to an analyzer test harness entry point — the
+        /// initializer of a local later passed as its source argument, or that
+        /// argument itself.
+        /// </summary>
+        /// <param name="expression">The candidate expression.</param>
+        /// <returns>True when the expression is an analyzer-test snippet.</returns>
+        private bool IsAnalyzerSnippetSource(ExpressionSyntax expression)
+        {
+            // The literal-at-the-call-site shape the original design assumed.
+            // Restricted to a literal or a `+` composition of them: an
+            // IDENTIFIER in that position is a reference to the local handled
+            // below, and translating the reference instead of its declaration
+            // would replace `source` with the snippet text at the call site.
+            if (IsStringComposition(expression)
+                && expression.Parent is ArgumentSyntax directArgument
+                && directArgument.Parent is ArgumentListSyntax directList
+                && directList.Parent is InvocationExpressionSyntax directCall
+                && this.HarnessSourceArgument(directCall) == directArgument)
+            {
+                return true;
+            }
+
+            // The shape the real tests have (#3778): a local declaration whose
+            // value reaches the harness. Only the WHOLE initializer qualifies,
+            // so a composed `Model + """…"""` translates as one unit.
+            if (expression.Parent is not EqualsValueClauseSyntax equals
+                || equals.Parent is not VariableDeclaratorSyntax declarator
+                || declarator.Parent is not VariableDeclarationSyntax declaration
+                || declaration.Parent is not LocalDeclarationStatementSyntax
+                || this.context.GetDeclaredSymbol(declarator) is not ILocalSymbol local)
+            {
+                return false;
+            }
+
+            SyntaxNode scope = expression.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>()
+                ?? (SyntaxNode)expression.FirstAncestorOrSelf<AccessorDeclarationSyntax>();
+            if (scope is null)
+            {
+                return false;
+            }
+
+            foreach (InvocationExpressionSyntax call in scope.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (this.HarnessSourceArgument(call) is not { } argument)
+                {
+                    continue;
+                }
+
+                if (SymbolEqualityComparer.Default.Equals(
+                    this.context.GetSymbolInfo(argument.Expression).Symbol,
+                    local))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// True when <paramref name="expression"/> is spelled as a string
+        /// literal or a <c>+</c> composition of string-composition operands —
+        /// the syntactic shape of an embedded snippet, as opposed to a
+        /// reference to something holding one.
+        /// </summary>
+        /// <param name="expression">The candidate expression.</param>
+        /// <returns>True when the expression is spelled out as string text.</returns>
+        private static bool IsStringComposition(ExpressionSyntax expression)
+            => expression switch
+            {
+                LiteralExpressionSyntax literal => literal.IsKind(SyntaxKind.StringLiteralExpression)
+                    || literal.IsKind(SyntaxKind.Utf8StringLiteralExpression),
+                BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.AddExpression) =>
+                    IsStringComposition(binary.Left) || IsStringComposition(binary.Right),
+                ParenthesizedExpressionSyntax parenthesized => IsStringComposition(parenthesized.Expression),
+                _ => false,
+            };
+
+        /// <summary>
+        /// Returns the argument bound to the source (second) parameter of an
+        /// analyzer test harness entry point, or null when
+        /// <paramref name="call"/> does not target one.
+        /// </summary>
+        /// <param name="call">The candidate invocation.</param>
+        /// <returns>The source argument, or null.</returns>
+        private ArgumentSyntax HarnessSourceArgument(InvocationExpressionSyntax call)
+        {
+            if (this.context.GetSymbolInfo(call).Symbol is not IMethodSymbol method
+                || !AnalyzerProjectDetector.IsAnalyzerTestHarnessEntry(method.OriginalDefinition))
+            {
+                return null;
+            }
+
+            string sourceParameterName = method.OriginalDefinition.Parameters[1].Name;
+            IReadOnlyList<ArgumentSyntax> arguments = call.ArgumentList.Arguments;
+            ArgumentSyntax named = arguments.FirstOrDefault(
+                argument => argument.NameColon?.Name.Identifier.ValueText == sourceParameterName);
+            if (named is not null)
+            {
+                return named;
+            }
+
+            return arguments.Count > 1 && arguments[1].NameColon is null && arguments[0].NameColon is null
+                ? arguments[1]
+                : null;
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -29,6 +29,18 @@ public sealed partial class CSharpToGSharpTranslator
                 return hoistedValue;
             }
 
+            // ADR-0169 M5 / issue #3778: in an analyzer TEST project, the
+            // constant string that reaches the harness's source parameter is
+            // not data — it is C# source the migrated verifier will compile as
+            // G#. It is intercepted here, above the ordinary literal and
+            // string-concatenation paths, because a composed
+            // `Model + """…"""` must translate as ONE compilation unit and
+            // neither operand compiles alone.
+            if (this.TryTranslateAnalyzerSnippet(expression, out GExpression snippet))
+            {
+                return snippet;
+            }
+
             switch (expression)
             {
                 case LiteralExpressionSyntax literal:

--- a/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/TranslationContext.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Cs2Gs.Translator.Analyzers;
 using Cs2Gs.Translator.Coverage;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -112,6 +113,20 @@ public sealed class TranslationContext
 
     /// <summary>Gets the originating file path.</summary>
     public string FilePath { get; }
+
+    /// <summary>
+    /// Gets or sets the analyzer-test snippet translator (ADR-0169 M5, issue
+    /// #3778): given a marked C# snippet it returns the equivalent G# snippet
+    /// with its <c>[|…|]</c> markers re-placed. The implementation
+    /// (<c>Cs2Gs.Translator.Analyzers.SnippetTranslator</c>) needs a C# project
+    /// loader and therefore lives in <c>Cs2Gs.ProjectLoading</c>, which
+    /// references this assembly — so the pipeline injects it here rather than
+    /// the translator taking a dependency the wrong way round. Left
+    /// <see langword="null"/> (the default, and every in-memory unit test that
+    /// does not opt in) snippet dispatch is disabled and marked sources are
+    /// translated as ordinary string literals, exactly as before.
+    /// </summary>
+    public Func<string, SnippetTranslationResult> TranslateAnalyzerSnippet { get; set; }
 
     /// <summary>Gets the diagnostics recorded so far, in insertion order.</summary>
     public IReadOnlyList<TranslationDiagnostic> Diagnostics => this.diagnostics.ToImmutableArray();


### PR DESCRIPTION
Closes the dispatch half of #3778 (ADR-0169 **M5**, follow-up to #3777 / #3790). Part of #3501.

## The wall

`SnippetTranslator` has existed and been unit-tested since M5's first pass, but **nothing called it during a migration**. #3777 had put the migrated harness on `GSharpAnalyzerVerifier`, which compiles the source under analysis as **G#** — so all 16 tests in the migrated `test/InternalAnalyzers.Tests` handed it C# and failed with `GS0005` on `public class` / `struct`.

## The two shapes — confirmed, with one correction

Both shapes #3778 documents are real, and I re-derived them before designing:

1. **The snippet arrives through a local.** Every one of the 16 call sites is a local declaration followed by `AnalyzerTestHelper.AssertDiagnosticsAsync(analyzer, Source, …)`. #3777's design assumed a literal argument, which is why it never fired.
2. **Several snippets are composed.** 9 of 16 are `Prelude + """…"""` / `Model + """…"""`, where the left operand is a shared `private const string`. Neither operand compiles alone.

**Correction to the issue's premise:** #3778 says "Every call site is `const string Source = …` (a local const)". Seven of the sixteen — all of `RewriterClonePreservationAnalyzerTests` — are **non-const** `string source = Model + """…"""`. A rule keyed on `const` would have missed the entire composed family, i.e. exactly the half the issue calls hard. The rule below keys on neither `const` nor the literal position.

**Two things #3778 does not mention, both found by reproducing:**

- One snippet was **not valid C#**: `StrongStaticReflectionCacheAnalyzerTests.IgnoresTypeSymbols…` declares two *file-scoped* namespaces, which is `CS8954`. The old harness only `ParseText`s, so Roslyn's driver ran anyway; a verifier that actually compiles does not. Fixed in the C# fixture (block-scoped namespaces, same declarations — the C# suite still passes 16/16).
- The `[|…|]` marker on `RewriteFieldNode` was being placed on the **wrong method**. See "Marker fidelity".

## The dispatch rule

> An expression is a snippet exactly when it is a **compile-time constant string** that **flows into the source parameter of an analyzer test harness entry point** — as the initializer of a local later passed there, or directly as that argument.

Why the conjunction, in both directions:

- **"a `const string` local"** alone rewrites every constant in the project.
- **"a string containing `[|…|]`"** alone misses the nine of sixteen snippets that assert *no* diagnostic and so carry no marker, and fires on any unrelated string containing the digraph.

The harness parameter (`AnalyzerProjectDetector.IsAnalyzerTestHarnessEntry`, the same predicate #3790 made the mode key on) is the *only* signal that says "this string will be compiled as source" — which is precisely what makes translating it correct and leaving it alone wrong. Silently rewriting a string that was never a snippet is the bad failure mode here, so the rule keys on the fact that rules it out. Guarded by `ConstantStringThatNeverReachesTheHarness_IsLeftAlone`, which asserts an identical C# constant in the same class survives byte-for-byte while the one that does reach the harness is translated.

**Composed snippets** are handled by only ever firing on the *whole initializer*, never a sub-operand, and taking the text from Roslyn's constant folding. The migrated test therefore carries the folded, translated whole and loses the shared-`Model` factoring — the trade #3778 anticipated. A piecewise scheme would have to translate a fragment that does not compile.

**Where it hooks:** the top of `TranslateExpression`, above the literal and string-concatenation paths, because the concatenation must be intercepted as one unit. `SnippetTranslator` lives in `Cs2Gs.ProjectLoading` (it needs a C# project loader) which already references `Cs2Gs.Translator`, so the hook is injected as a delegate on `TranslationContext` rather than inverting the assembly dependency; `TranslateStage` wires it. Left unset — every existing in-memory unit test — dispatch is off and behaviour is exactly as before.

## Marker fidelity

This is the part that can make a migrated test pass for the wrong reason, so it has three separate mechanisms and its own tests.

**1. Occurrence ordinal, not forward search.** The old rule searched forward from the previous marker's position, which silently mis-places a marker whose text also occurs *earlier* in the unit — and a composed snippet is exactly that: the shared `Model` declares `RewriteFieldNode`, so the marker on `Broken`'s override landed on `BoundTreeRewriter`'s base method. The rule is now positional: the Nth occurrence of a marked text in the C# is the Nth occurrence in the G#. Placements are computed against the untouched printed text and applied back-to-front so one insertion cannot move another's index. Migrated output now:

```
internal open class Broken : BoundTreeRewriter {
    protected open override func [|RewriteFieldNode|](node FieldNode) Node {
```

**2. Markers are regions.** `GSharpAnalyzerVerifier` asserted an exact 1-based start; a snippet translated from C# keeps the C# marker's extent, and G#'s node shapes differ (its index node is narrower than C#'s element access), so `[|this.cache.StructFieldDefs[field]|]` produced a diagnostic at (14,32) against a marker at (14,21). The verifier now asserts the diagnostic's span is **contained in** the marked region. Containment in *both* directions keeps it falsifiable: a marker narrower than the diagnostic, or on a neighbouring construct, still fails. Hand-written G# tests bracket exactly the construct they expect, so their diagnostics are span-equal and nothing about them relaxes.

**3. Unplaceable markers are dropped and reported.** A marked text that does not survive translation verbatim is never re-placed "somewhere plausible": it is dropped, reported as `CS2GS-ANALYZER-SNIPPET`, and the migrated test then fails on a marker/id count mismatch. `TranslateStage` now **prints** `CS2GS-ANALYZER-SNIPPET` warnings — they were being dropped on the floor, which made "reported, never silent" untrue.

## Measurement — `test/InternalAnalyzers.Tests`

Targeted 2-app migration (`src/Analyzers/InternalAnalyzers` + `test/InternalAnalyzers.Tests`, whole-repo discovery with the rest excluded), Release solution rebuilt on each side, each side a real commit so the `git describe`-stamped SDK moniker differs:

| | translate | compile | ilverify | test-parity |
|---|---|---|---|---|
| before — `origin/main` `45342b455` | PASS | PASS | PASS | **FAIL — 16/16 tests failing** |
| after — `61ad8269e` | PASS | PASS | PASS | **FAIL — 6 failing, 10 passing** |

Before, verbatim: `Failed: 16, Passed: 0, Skipped: 0, Total: 16`, every one of them `GS0005 … The test source does not compile`.
After: `Failed: 6, Passed: 10, Skipped: 0, Total: 16`.

## What is NOT fixed, and how it fails

Every remaining failure has a distinct, **printed** cause; none is silent. Filed with evidence:

| # tests | failure | issue |
|---|---|---|
| 2 | snippet spanning several namespaces collapses into one G# `package`, so `GSA0003`/`GSA0004` judge the wrong declarations | #3794 |
| 2 | translated `GSA0005` produces **no** diagnostics on the translated G# shapes (markers are correct; this is analyzer-translation parity) | #3795 |
| 1 | migrated `GSA0003` reports on a G# `FieldSymbol` whose `Location` is empty | #3796 |
| 1 | marked text `typeof(int) != type` becomes `typeof(int32) != type`, so it cannot be re-placed by text | #3797 |

**One test passes for the wrong reason and I am calling it out rather than counting it as a win:** `IgnoresScopedKeysDefinitionHandlesAndNonSymbolKeys` asserts no diagnostics and gets none *because* the namespace collapse moved its subject out of `GSharp.Core.CodeAnalysis.Emit`. It is inside the 10 passing. That is recorded in #3794's acceptance criterion.

The one framework change that is not gated on those: the verifier used to throw a bare `NullReferenceException` from `TextLocation.StartLine` when an analyzer reported without a location. It now names the cause.

## Test evidence

10 new tests, all **executing** (no binding-only assertions): 6 in `Cs2Gs.Tests/Issue3778AnalyzerSnippetDispatchTests` (which really translates a two-file analyzer test project through the pipeline's own wiring) and 4 in `Core.Tests/Adr0169AnalyzerVerifierTests` (which really compile G# and run an analyzer over it).

### Failing-on-`origin/main` proof, one axis at a time

Verifier reverted to main's, tests kept — exactly 3 of the 4 new ones fail:

```
[FAIL] MarkerNarrowerThanTheDiagnostic_IsRejected
[FAIL] LocationLessDiagnostic_ReportsTheCauseInsteadOfCrashing
[FAIL] MarkerWiderThanTheDiagnostic_IsAccepted
Failed: 3, Passed: 7
```

The cs2gs tests cannot run against main at all (the `TranslationContext` hook does not exist there), so they are proved by reverting one axis each with everything else in place:

- **dispatch hook only** → exactly the 3 dispatch tests fail, the 3 marker tests pass (`Failed: 3, Passed: 3`).
- **occurrence-ordinal placement only** → exactly `MarkerOnALaterOccurrence_StaysOnThatOccurrence` fails (`Failed: 1, Passed: 5`).
- **namespace-collapse report only** → exactly `MultiNamespaceSnippet_ReportsTheCollapse` fails (`Failed: 1, Passed: 5`).

**Honest labelling.** `MarkerOnADifferentConstruct_IsRejected` and `MarkerWhoseTextDoesNotSurvive_IsDroppedAndReported` pass with and without this change — they bound the new behaviour in the other direction (a region marker must not accept a diagnostic on a neighbour; an unplaceable marker must stay loud), they are not proof of it. The app-level 16→6 above is the proof.

### Regression

- `Cs2Gs.Tests` `Adr0169*` + `Issue3686*` + `Issue3778*`: 50 passed, 0 failed.
- `Core.Tests` `Adr0169AnalyzerVerifierTests`: 10 passed, 0 failed.
- The C# `test/InternalAnalyzers.Tests` (whose fixture I edited): 16 passed, 0 failed.

### Whole-repository regression check

`build/run-cs2gs-selfmig-migrate.sh` (stage 1, every app) at `61ad8269e`: **50/51 apps translated**, the same count `origin/main` carries. The one failure is `test/Interpreter.Tests FAIL(1)` — `translate stage crashed (IndexOutOfRangeException)`, fingerprint `sha256:992ab3aeefc1…`, the identical pre-existing failure #3790 recorded as unrelated. No project outside the analyzer pair sees any snippet dispatch, by construction: the guard early-outs unless the project is in analyzer mode, which #3790 restricted to projects declaring a harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
