### PR TITLE
gsc: honour [NotNullIfNotNull] at imported call sites (#3802)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
@@ -42,13 +42,18 @@ public sealed class BoundImportedCallExpression : BoundExpression
         ArgumentRefKinds = argumentRefKinds.IsDefault ? default : argumentRefKinds;
         TypeArgumentSymbols = typeArgumentSymbols.IsDefault ? default : typeArgumentSymbols;
         StaticContainerType = staticContainerType;
+
+        // Issue #3802: a `[return: NotNullIfNotNull(nameof(p))]` post-condition
+        // is a fact about THIS call, so it narrows the node's type, never the
+        // declared `Function.Type`.
+        Type = ConditionalReturnNarrowing.Apply(function.Method, arguments, function.Type);
     }
 
     /// <inheritdoc/>
     public override BoundNodeKind Kind => BoundNodeKind.ImportedCallExpression;
 
     /// <inheritdoc/>
-    public override TypeSymbol Type => Function.Type;
+    public override TypeSymbol Type { get; }
 
     /// <summary>
     /// Gets the imported function symbol.

--- a/src/Core/CodeAnalysis/Binding/BoundImportedInstanceCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedInstanceCallExpression.cs
@@ -68,7 +68,11 @@ public sealed class BoundImportedInstanceCallExpression : BoundExpression
     {
         Receiver = receiver;
         Method = method;
-        Type = returnType;
+
+        // Issue #3802: a `[return: NotNullIfNotNull(nameof(p))]` post-condition
+        // is a fact about THIS call, so it narrows the node's type, never the
+        // declared return type read from metadata.
+        Type = ConditionalReturnNarrowing.Apply(method, arguments, returnType);
         Arguments = arguments;
         ArgumentRefKinds = argumentRefKinds.IsDefault ? default : argumentRefKinds;
         TypeArgumentSymbols = typeArgumentSymbols.IsDefault ? default : typeArgumentSymbols;

--- a/src/Core/CodeAnalysis/Binding/ConditionalReturnNarrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/ConditionalReturnNarrowing.cs
@@ -1,0 +1,131 @@
+// <copyright file="ConditionalReturnNarrowing.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3802: applies the <c>[return: NotNullIfNotNull(nameof(p))]</c>
+/// conditional post-condition of an imported (CLR) method at a CALL SITE.
+///
+/// <para>
+/// The BCL declares members such as
+/// <c>[return: NotNullIfNotNull(nameof(path))] static string? ChangeExtension(string? path, string? extension)</c>.
+/// The declared return type really is nullable — narrowing it in the
+/// declaration reader would restore the imported-nullability unsoundness that
+/// #3705 family 2 removed — but at any call whose <c>path</c> argument is known
+/// non-null, the result is known non-null too. That makes this a FLOW FACT
+/// about one call, which is why it lives here and is applied to the bound call
+/// node's type rather than to <see cref="ImportedFunctionSymbol.Type"/>.
+/// </para>
+///
+/// <para>
+/// The narrowing is deliberately conservative: it fires only when the argument
+/// bound at the named parameter's position has a statically non-nullable type.
+/// A nullable argument (including one that has not been flow-narrowed to
+/// non-null) leaves the declared nullable return in place, so
+/// <c>Path.ChangeExtension(maybeNil, ".gs")</c> is still rejected where a
+/// non-nullable <c>string</c> is required.
+/// </para>
+/// </summary>
+internal static class ConditionalReturnNarrowing
+{
+    /// <summary>
+    /// Returns <paramref name="declaredReturn"/> stripped of its top-level
+    /// nullable annotation when <paramref name="method"/> carries a
+    /// <c>[return: NotNullIfNotNull]</c> naming a parameter whose argument at
+    /// this call site is known non-null; otherwise returns
+    /// <paramref name="declaredReturn"/> unchanged.
+    /// </summary>
+    /// <param name="method">The imported method being called.</param>
+    /// <param name="arguments">The bound arguments, in parameter order.</param>
+    /// <param name="declaredReturn">The declared (reader-derived) return type.</param>
+    /// <returns>The call-site return type.</returns>
+    public static TypeSymbol Apply(
+        MethodInfo? method,
+        ImmutableArray<BoundExpression> arguments,
+        TypeSymbol declaredReturn)
+    {
+        // Only a declared-nullable reference return has anything to narrow.
+        if (method == null || declaredReturn is not NullableTypeSymbol nullableReturn)
+        {
+            return declaredReturn;
+        }
+
+        if (arguments.IsDefaultOrEmpty)
+        {
+            return declaredReturn;
+        }
+
+        var names = ClrNullability.GetNotNullIfNotNullParameters(method);
+        if (names.Count == 0)
+        {
+            return declaredReturn;
+        }
+
+        var parameters = method.GetParameters();
+        foreach (var name in names)
+        {
+            for (var i = 0; i < parameters.Length && i < arguments.Length; i++)
+            {
+                if (!string.Equals(parameters[i].Name, name, System.StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (IsKnownNonNull(arguments[i]))
+                {
+                    return nullableReturn.UnderlyingType;
+                }
+
+                break;
+            }
+        }
+
+        return declaredReturn;
+    }
+
+    private static bool IsKnownNonNull(BoundExpression argument)
+    {
+        if (StatementBinder.IsNilLiteral(argument))
+        {
+            return false;
+        }
+
+        // Peel a pure ANNOTATION widening (`T` converted to `T?`, which is how a
+        // non-nil argument reaches a `T?`-typed parameter — including a generic
+        // parameter whose type argument inference already closed over `T?`, as
+        // in `Interlocked.Exchange(&slot, v)` where `slot` is `T?`). Such a
+        // conversion changes the annotation, never the value, so a non-nullable
+        // operand underneath it is still known non-nil. Only this exact shape is
+        // peeled: a user-defined or representation-changing conversion could
+        // legitimately produce nil from a non-nil operand.
+        while (argument is BoundConversionExpression conversion
+            && conversion.Type is NullableTypeSymbol widened
+            && conversion.Expression.Type != null
+            && widened.UnderlyingType == conversion.Expression.Type)
+        {
+            argument = conversion.Expression;
+        }
+
+        var type = argument.Type;
+
+        // A `ref`/`out` argument's nullability is the POINTEE's — issue #3727's
+        // `Volatile.Read(&r)` is annotated `[return: NotNullIfNotNull(nameof(location))]`
+        // and passes `ref Result?`, which must NOT narrow: the location holds
+        // nil. Reading the byref wrapper as "not a NullableTypeSymbol" would
+        // narrow every such call and re-break `Volatile.Read(&r) != nil`.
+        while (type is ByRefTypeSymbol byRef)
+        {
+            type = byRef.PointeeType;
+        }
+
+        return type != null
+            && type is not NullableTypeSymbol
+            && !ReferenceEquals(type, TypeSymbol.Null);
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrNullability.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
@@ -28,6 +29,16 @@ public static class ClrNullability
     private const string MaybeNullWhenAttributeFullName = "System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute";
     private const string MemberNotNullAttributeFullName = "System.Diagnostics.CodeAnalysis.MemberNotNullAttribute";
     private const string MemberNotNullWhenAttributeFullName = "System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute";
+    private const string NotNullIfNotNullAttributeFullName = "System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute";
+
+    /// <summary>
+    /// Issue #3802: cache of the parameter names carried by
+    /// <c>[return: NotNullIfNotNull(...)]</c> per method. Reading custom
+    /// attribute data through a <see cref="MetadataLoadContext"/> is expensive
+    /// and every imported call site asks the same question, so the answer is
+    /// memoised. An empty array means "no conditional post-condition".
+    /// </summary>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<MethodInfo, string[]> NotNullIfNotNullCache = new();
 
     /// <summary>
     /// Returns the GSharp <see cref="TypeSymbol"/> for a property's
@@ -163,6 +174,35 @@ public static class ClrNullability
             && mapped is not NullableTypeSymbol
                 ? NullableTypeSymbol.Get(mapped)
                 : mapped;
+    }
+
+    /// <summary>
+    /// Issue #3802: collects the parameter names named by every
+    /// <c>[return: NotNullIfNotNull(name)]</c> on <paramref name="method"/>.
+    /// The attribute states a CONDITIONAL post-condition — the (declared
+    /// nullable) return value is non-null whenever the named argument is
+    /// non-null — so this reader deliberately reports only the names. Deciding
+    /// whether the post-condition actually holds is a fact about a particular
+    /// call site's arguments and belongs with the binder's narrowing
+    /// machinery, not with the declaration reader: narrowing the DECLARED
+    /// return type here would restore the very unsoundness that #3705 family 2
+    /// removed.
+    /// </summary>
+    /// <param name="method">The method to inspect.</param>
+    /// <returns>
+    /// The named parameters, in attribute order; empty when the method carries
+    /// no conditional return post-condition.
+    /// </returns>
+    internal static IReadOnlyList<string> GetNotNullIfNotNullParameters(MethodInfo method)
+    {
+        if (NotNullIfNotNullCache.TryGetValue(method, out var cached))
+        {
+            return cached;
+        }
+
+        var names = ReadNotNullIfNotNullParameters(method);
+        NotNullIfNotNullCache.AddOrUpdate(method, names);
+        return names;
     }
 
     internal static bool TryGetNotNullWhen(ParameterInfo parameter, out bool returnValue)
@@ -821,6 +861,51 @@ public static class ClrNullability
 
             layoutOffset += layoutCount;
         }
+    }
+
+    private static string[] ReadNotNullIfNotNullParameters(MethodInfo method)
+    {
+        // Prefer the open metadata definition: on a constructed generic the
+        // reflected `ReturnParameter` may not surface the attribute data.
+        var definition = GetMetadataDefinition(method) as MethodInfo ?? method;
+        var names = ReadNotNullIfNotNullParameters(definition.ReturnParameter);
+        if (names.Length == 0 && !ReferenceEquals(definition, method))
+        {
+            names = ReadNotNullIfNotNullParameters(method.ReturnParameter);
+        }
+
+        return names;
+    }
+
+    private static string[] ReadNotNullIfNotNullParameters(ParameterInfo? returnParameter)
+    {
+        if (returnParameter == null)
+        {
+            return Array.Empty<string>();
+        }
+
+        var attrs = SafeGetCustomAttributesData(returnParameter);
+        if (attrs == null)
+        {
+            return Array.Empty<string>();
+        }
+
+        ImmutableArray<string>.Builder? builder = null;
+        foreach (var ad in attrs)
+        {
+            if (ad.AttributeType?.FullName != NotNullIfNotNullAttributeFullName
+                || ad.ConstructorArguments.Count == 0)
+            {
+                continue;
+            }
+
+            foreach (var arg in ad.ConstructorArguments)
+            {
+                CollectStringOrArray(arg, ref builder);
+            }
+        }
+
+        return builder == null ? Array.Empty<string>() : builder.ToArray();
     }
 
     private static MethodBase? GetMetadataDefinition(MethodBase method)

--- a/test/Compiler.Tests/Issue3802NotNullIfNotNullTests.cs
+++ b/test/Compiler.Tests/Issue3802NotNullIfNotNullTests.cs
@@ -1,0 +1,435 @@
+// <copyright file="Issue3802NotNullIfNotNullTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3802: gsc must honour <c>[return: NotNullIfNotNull(nameof(p))]</c> on
+/// imported (BCL) members. <c>Path.ChangeExtension</c> is declared
+/// <c>string? ChangeExtension(string? path, string? extension)</c> with that
+/// conditional post-condition, so C# accepts
+/// <c>string DestinationRelativePath(string source) =&gt; Path.ChangeExtension(source, ".gs");</c>.
+/// <para>
+/// Before this fix gsc reported <c>GS0155: Cannot convert type 'string?' to
+/// 'string'</c> at every such site, which is what dropped the #3501
+/// self-migration gate to 40/51 (<c>Cs2Gs.Pipeline</c> plus its three
+/// consumers) once #3705 family 2 made imported nullability read correctly.
+/// </para>
+/// <para>
+/// Every positive case EXECUTES: compile, IL-verify, run, assert the program's
+/// own stdout. The narrowing is a bind-time type fact but a wrong
+/// implementation (for example one that unconditionally strips the
+/// annotation) is only visible at runtime, so binding-only assertions would
+/// not be evidence.
+/// </para>
+/// </summary>
+public class Issue3802NotNullIfNotNullTests
+{
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        // The exact reduction of the gate regression:
+        // tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.DestinationRelativePath.
+        yield return new object[]
+        {
+            "change-extension-non-null-argument",
+            @"
+package P
+import System
+import System.IO
+
+func DestinationRelativePath(source string) string {
+    return Path.ChangeExtension(source, "".gs"")
+}
+
+Console.WriteLine(DestinationRelativePath(""tools/cs2gs/Foo.cs""))
+",
+            new[] { "tools/cs2gs/Foo.gs" },
+        };
+
+        // Two more BCL carriers on the same type.
+        yield return new object[]
+        {
+            "get-file-name-and-extension",
+            @"
+package P
+import System
+import System.IO
+
+func Leaf(p string) string {
+    return Path.GetFileName(p)
+}
+
+func Ext(p string) string {
+    return Path.GetExtension(p)
+}
+
+Console.WriteLine(Leaf(""a/b/c.cs""))
+Console.WriteLine(Ext(""a/b/c.cs""))
+",
+            new[] { "c.cs", ".cs" },
+        };
+
+        // ANTI-VACUITY / CONDITIONAL GUARD, runtime half: when the named
+        // argument IS nil the result really is nil, so the narrowed shape must
+        // never be relied on to be non-nil. Binding this to `string?` still
+        // works, and the value observed at runtime is nil.
+        yield return new object[]
+        {
+            "nil-argument-still-yields-nil-at-runtime",
+            @"
+package P
+import System
+import System.IO
+
+func Dest(source string?) string? {
+    return Path.ChangeExtension(source, "".gs"")
+}
+
+let r = Dest(nil)
+Console.WriteLine(if r == nil { ""nil"" } else { ""not-nil"" })
+Console.WriteLine(Dest(""x.cs"")!!)
+",
+            new[] { "nil", "x.gs" },
+        };
+
+
+        // CONDITIONAL GUARD, by-ref half. `Volatile.Read[T](ref T location)` is
+        // annotated `[return: NotNullIfNotNull(nameof(location))]`. The bound
+        // argument is a BYREF, whose own type symbol is not a nullable one even
+        // when it points at a nullable location — reading it naively narrows
+        // the result and breaks issue #3727's `Volatile.Read(&r) != nil`. The
+        // nullability that counts is the POINTEE's, and here it is nil.
+        yield return new object[]
+        {
+            "byref-argument-uses-the-pointee-nullability",
+            @"
+package P
+import System
+import System.Threading
+
+class Result {
+    var Value int32 = 0
+}
+
+func Guard() bool {
+    var r Result? = nil
+    return Volatile.Read(&r) == nil
+}
+
+Console.WriteLine(if Guard() { ""nil"" } else { ""not-nil"" })
+",
+            new[] { "nil" },
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void NotNullIfNotNull_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3802_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, name + ".dll");
+            var (compileExit, compileLog) = Compile(tempDir, source, outPath);
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed for '{name}' (a GS0155 here is the #3802 defect):\n{compileLog}");
+
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(exit == 0, $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// CONDITIONAL GUARD, compile half. The post-condition is CONDITIONAL: a
+    /// nullable argument must still produce a nullable result. A fix that
+    /// narrowed unconditionally would reintroduce exactly the unsoundness that
+    /// #3705 family 2 removed — an imported <c>string?</c> silently binding as
+    /// non-null <c>string</c> — so this case must still be REJECTED after the
+    /// fix, and it fails on <c>origin/main</c> too (it is not the regression).
+    /// </summary>
+    [Fact]
+    public void NullableArgument_StillYieldsNullableResult()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3802_neg_").FullName;
+        try
+        {
+            var source = @"
+package P
+import System
+import System.IO
+
+func Dest(source string?) string {
+    return Path.ChangeExtension(source, "".gs"")
+}
+
+Console.WriteLine(Dest(""x.cs""))
+";
+            var outPath = Path.Combine(tempDir, "neg.dll");
+            var (compileExit, compileLog) = Compile(tempDir, source, outPath);
+
+            Assert.True(
+                compileExit != 0,
+                "a NULLABLE argument must NOT narrow the result: [NotNullIfNotNull] is a "
+                    + "conditional post-condition, and narrowing it unconditionally would "
+                    + "restore the #3705 family 2 unsoundness. Compile log:\n" + compileLog);
+            Assert.Contains("GS0155", compileLog, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// ANTI-VACUITY: a method with NO conditional post-condition and a genuinely
+    /// nullable return must still be rejected when returned as non-nullable —
+    /// including <c>Path.GetDirectoryName</c>, which sits on the same type as
+    /// the annotated members and is deliberately NOT annotated (it returns
+    /// <c>null</c> for a root path even when the argument is non-null, and C#
+    /// rejects this source too). This is the behaviour #3705 family 2
+    /// established; the #3802 fix must key off the attribute, not off the type.
+    /// Passes on <c>origin/main</c> as well.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="body">The G# function body expression.</param>
+    [Theory]
+    [InlineData("environment-variable", @"Environment.GetEnvironmentVariable(p)")]
+    [InlineData("get-directory-name-is-not-annotated", @"Path.GetDirectoryName(p)")]
+    public void UnannotatedNullableReturn_IsStillRejected(string name, string body)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3802_anti_").FullName;
+        try
+        {
+            var source = @"
+package P
+import System
+import System.IO
+
+func F(p string) string {
+    return " + body + @"
+}
+
+Console.WriteLine(F(""a/b/c.cs""))
+";
+            var outPath = Path.Combine(tempDir, "anti.dll");
+            var (compileExit, compileLog) = Compile(tempDir, source, outPath);
+
+            Assert.True(
+                compileExit != 0,
+                $"'{name}': an unannotated nullable imported member must still be rejected:\n" + compileLog);
+            Assert.Contains("GS0155", compileLog, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The narrowing is wired on the imported INSTANCE call node as well as the
+    /// static one. No .NET 10 BCL instance method carries
+    /// <c>[return: NotNullIfNotNull]</c> (a reflection sweep of
+    /// System.Private.CoreLib, System.Text.RegularExpressions and System.Private.Uri
+    /// finds zero), so this case builds its own C# metadata assembly — which is
+    /// also the shape any referenced third-party library would present.
+    /// Compiles, IL-verifies and RUNS, and asserts the conditional half in the
+    /// same reference context.
+    /// </summary>
+    [Fact]
+    public void ImportedInstanceMethodCarrier_NarrowsAndStaysConditional()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3802_inst_").FullName;
+        try
+        {
+            const string metadataSource = """
+                #nullable enable
+                using System.Diagnostics.CodeAnalysis;
+
+                namespace Issue3802.Metadata
+                {
+                    public sealed class Echo
+                    {
+                        [return: NotNullIfNotNull(nameof(input))]
+                        public string? Repeat(string? input) => input == null ? null : input + input;
+                    }
+                }
+                """;
+
+            // TRUSTED_PLATFORM_ASSEMBLIES is always present under the test host;
+            // its absence would be an environment fault, not a test condition.
+            var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+                .Split(Path.PathSeparator)
+                .Where(File.Exists)
+                .Select(path => MetadataReference.CreateFromFile(path));
+            var compilation = CSharpCompilation.Create(
+                "Issue3802.Metadata",
+                new[] { CSharpSyntaxTree.ParseText(metadataSource, new CSharpParseOptions(LanguageVersion.Latest)) },
+                references,
+                new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    nullableContextOptions: NullableContextOptions.Enable));
+            var metadataPath = Path.Combine(tempDir, "Issue3802.Metadata.dll");
+            var metadataResult = compilation.Emit(metadataPath);
+            Assert.True(metadataResult.Success, string.Join(Environment.NewLine, metadataResult.Diagnostics));
+
+            const string positive = @"
+package P
+import System
+import Issue3802.Metadata
+
+func Twice(s string) string {
+    return Echo().Repeat(s)
+}
+
+Console.WriteLine(Twice(""ab""))
+";
+            var outPath = Path.Combine(tempDir, "inst.dll");
+            var (exitCode, log) = Compile(tempDir, positive, outPath, metadataPath);
+            Assert.True(exitCode == 0, "an imported INSTANCE carrier must narrow too:\n" + log);
+
+            IlVerifier.Verify(outPath, new[] { metadataPath });
+            var (runExit, output) = RunDotnet(outPath);
+            Assert.True(runExit == 0, $"instance carrier program must run. Exit {runExit}:\n{output}");
+            Assert.Equal("abab", output.Trim());
+
+            // CONDITIONAL GUARD for the instance path.
+            const string negative = @"
+package P
+import System
+import Issue3802.Metadata
+
+func Twice(s string?) string {
+    return Echo().Repeat(s)
+}
+
+Console.WriteLine(Twice(""ab""))
+";
+            var (negExit, negLog) = Compile(
+                tempDir,
+                negative,
+                Path.Combine(tempDir, "inst-neg.dll"),
+                metadataPath);
+            Assert.True(negExit != 0, "a nullable argument must not narrow the instance carrier:\n" + negLog);
+            Assert.Contains("GS0155", negLog, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static (int Exit, string Log) Compile(
+        string tempDir,
+        string source,
+        string outPath,
+        string extraReference = null)
+    {
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        if (extraReference != null)
+        {
+            args.Add("/reference:" + extraReference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        return (compileExit, "stdout:\n" + compileOut + "\nstderr:\n" + compileErr);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}


### PR DESCRIPTION
Fixes #3802. Restores the #3501 self-migration gate: `Cs2Gs.Pipeline` and its consumers `Cs2Gs.Cli` / `Cs2Gs.Report` (and `Cs2Gs.Tests`) all failed on one fingerprint.

## Confirmed mechanism

Reproduced in-process before writing any code. `tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.DestinationRelativePath` is a `string`-returning method whose body is `return Path.ChangeExtension(source, ".gs")`, and the BCL declares

```csharp
[return: NotNullIfNotNull(nameof(path))]
public static string? ChangeExtension(string? path, string? extension);
```

gsc had no `[NotNullIfNotNull]` support anywhere, so it saw the declared `string?` and reported `GS0155`. Confirmed the same fingerprint for `Path.GetFileName` and `Path.GetExtension`.

This is fallout from a **correct** fix — `281a9c278` (#3705 family 2) — which exposed the under-approximation rather than causing it. Nothing here reverts or weakens it; the declaration reader still reports `string?`.

**One correction to the issue text**: the issue named `Interlocked.Exchange` as a carrier of the same shape. It is not, in the way that matters. .NET declares it

```csharp
[return: NotNullIfNotNull(nameof(location1))]
public static T Exchange<T>([NotNullIfNotNull(nameof(value))] ref T location1, T value) where T : class?;
```

The **return**'s post-condition names `location1` (the returned value is the location's *prior* contents), and it is the `location1` **parameter** that gets a post-condition from `value`. So `Interlocked.Exchange` over a nullable location correctly does **not** narrow, and gsc rejecting it is right. The issue's suggested case was a wrong premise; there is a test asserting the by-ref behaviour instead.

The issue also refers to a reader funnel `ClrNullability.IsFlagNonNull`; the actual name is `ClrNullability.IsPositionNonNull`.

## Blast radius

Call sites of the common BCL carriers across `src/`, `tools/`, `test/`, `e2etests/` (all migration corpus):

| carrier | sites |
| --- | ---: |
| `Path.ChangeExtension` | 640 |
| `Path.GetFileName` | 260 |
| `Path.GetExtension` | 32 |
| `Path.GetDirectoryName`* | 351 |
| `Interlocked.Exchange` / `CompareExchange`* | 26 |

\* not actually `[NotNullIfNotNull]` carriers — see above; `Path.GetDirectoryName` returns `null` for a root path even with a non-null argument and C# rejects it too. So ~930 genuine sites. Far too many for a `!!` workaround, which would also cost `!!` budget and leave the compiler wrong.

## The rule, and where it lives

A **flow fact at the call**, not a declaration rewrite:

- `ClrNullability.GetNotNullIfNotNullParameters` (src/Core/CodeAnalysis/Symbols/ClrNullability.cs) reads and memoises only the parameter **names** off `[return: NotNullIfNotNull]`, preferring the open metadata definition so constructed generics resolve. It deliberately does not touch the declared return type.
- `ConditionalReturnNarrowing.Apply` (new, src/Core/CodeAnalysis/Binding/ConditionalReturnNarrowing.cs) decides per call site whether the named parameter's argument is known non-null, and narrows only the bound node's type. Applied in `BoundImportedCallExpression` and `BoundImportedInstanceCallExpression`.

Two subtleties, both pinned by tests:

- a `ref`/`out` argument's nullability is the **pointee's**. Reading the byref wrapper as "not a `NullableTypeSymbol`" narrows `Volatile.Read(&r)` over a nullable location and re-breaks #3727 — the existing Core.Tests suite caught exactly this on the first draft.
- a pure annotation widening (`T` converted to `T?` to reach a `T?` parameter) is peeled; representation-changing and user-defined conversions are not, since those can produce nil from a non-nil operand.

## Test evidence

`test/Compiler.Tests/Issue3802NotNullIfNotNullTests.cs` — every case compiles, IL-verifies, **runs**, and asserts the program's own stdout (except the two negative compile cases).

**Fails on `origin/main`, passes here (3):**
- `change-extension-non-null-argument` — the migrated `DestinationRelativePath` verbatim
- `get-file-name-and-extension`
- `ImportedInstanceMethodCarrier_NarrowsAndStaysConditional` — a C#-built metadata assembly, because a reflection sweep of System.Private.CoreLib / System.Text.RegularExpressions / System.Private.Uri finds **zero** BCL instance carriers

**Passes on `origin/main` too — anti-vacuity guard rails (5):**
- `NullableArgument_StillYieldsNullableResult` — the **conditional guard**: a nullable argument must still be rejected with `GS0155`. A fix that narrowed unconditionally would restore the #3705 family 2 unsoundness.
- `nil-argument-still-yields-nil-at-runtime` — the value really is nil at runtime
- `byref-argument-uses-the-pointee-nullability` — `Volatile.Read(&r) == nil` (#3727)
- `UnannotatedNullableReturn_IsStillRejected` × 2 — `Environment.GetEnvironmentVariable` and `Path.GetDirectoryName` (same type, deliberately unannotated) still rejected
- the instance-carrier fact also asserts its own nullable-argument half

Suites: `Core.Tests` 8570/8570 green (the first draft failed 4 there — the #3727 by-ref case, which is why that guard exists). `Compiler.Tests` full run reported separately.

`tools/cs2gs/selfmig-baseline.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs