### PR TITLE
cs2gs: forward [NotNullIfNotNull] nullability to the named argument (#3802)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3802ConditionalNotNullPostconditionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3802ConditionalNotNullPostconditionTests.cs
@@ -1,0 +1,192 @@
+// <copyright file="Issue3802ConditionalNotNullPostconditionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3802: <c>Path.GetExtension</c>, <c>Path.GetFileName</c> and
+/// <c>Path.ChangeExtension</c> are declared <c>string?</c> with
+/// <c>[return: NotNullIfNotNull(nameof(path))]</c> — the result is non-null
+/// whenever the named argument is. Both nullability judgements in the
+/// translator ended in the same "consult the DECLARED annotation" fallback,
+/// which cannot see a CONDITIONAL post-condition.
+/// <para>
+/// The cost was concrete: migrating
+/// <c>tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.DestinationRelativePaths</c>
+/// produced <c>sequence[string?]</c> with <c>let extension string? =
+/// Path.GetExtension(source)</c> and <c>extension!!.Equals(...)</c>, and the
+/// <c>string?</c> element then flowed into a <c>Dictionary[string, string]</c>
+/// index in <c>ValidateCollisions</c>, which gsc rightly rejected with
+/// <c>GS0155</c> — the whole of the gate's 40/51 regression.
+/// </para>
+/// </summary>
+public class Issue3802ConditionalNotNullPostconditionTests
+{
+    /// <summary>
+    /// The migrated shape, reduced: the iterator element must stay
+    /// <c>string</c>, the local must stay <c>string</c>, and the dictionary
+    /// index that consumes them must bind.
+    /// </summary>
+    [Fact]
+    public void ConditionalPostcondition_KeepsTheIteratorElementNonNullable()
+    {
+        string printed = Translate(@"
+using System.Collections.Generic;
+using System.IO;
+
+namespace Demo
+{
+    public class Mirror
+    {
+        public static void ValidateCollisions(IEnumerable<string> files)
+        {
+            var destinations = new Dictionary<string, string>();
+            foreach (string source in files)
+            {
+                foreach (string destination in DestinationRelativePaths(source))
+                {
+                    destinations[destination] = source;
+                }
+            }
+        }
+
+        private static IEnumerable<string> DestinationRelativePaths(string source)
+        {
+            string extension = Path.GetExtension(source);
+            if (extension.Equals("".cs""))
+            {
+                yield return Path.ChangeExtension(source, "".gs"");
+                yield break;
+            }
+
+            yield return source;
+        }
+    }
+}");
+
+        Assert.Contains("sequence[string]", printed);
+        Assert.DoesNotContain("sequence[string?]", printed);
+        Assert.DoesNotContain("extension string?", printed);
+        Assert.DoesNotContain("extension!!", printed);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    /// <summary>
+    /// CONDITIONAL GUARD: the post-condition is conditional, so a NULLABLE
+    /// argument must still promote the result. A translator that narrowed
+    /// unconditionally would emit a <c>string</c> declaration for a value that
+    /// really can be nil and hide the nullability the migration exists to
+    /// surface.
+    /// </summary>
+    [Fact]
+    public void NullableArgument_StillPromotesTheResult()
+    {
+        string printed = Translate(@"
+using System.IO;
+
+namespace Demo
+{
+    public class Mirror
+    {
+        public static string Extension(string? source)
+        {
+            string extension = Path.GetExtension(source);
+            return extension;
+        }
+    }
+}");
+
+        Assert.Contains("string?", printed);
+    }
+
+    /// <summary>
+    /// The post-condition FORWARDS, it does not decide. When the named
+    /// argument's own declaration is promoted to <c>T?</c> by the whole-program
+    /// taint fixpoint, the call's result must be promoted with it — gsc will
+    /// not narrow a call whose argument it sees as <c>T?</c>, so answering from
+    /// the argument's C# syntax alone makes the two layers disagree.
+    /// <para>
+    /// This is the shape that broke the pinned Oahu corpus (9 of 15 apps, one
+    /// fingerprint) on the first draft of this fix:
+    /// <c>Oahu.Core/ExtensionsVarious.GetDownloadFileNameWithoutExtension</c>
+    /// came out as <c>func (downloadFileName string?) ... string</c> — a
+    /// <c>string?</c> argument feeding a <c>string</c> return.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void PromotedArgument_ForwardsItsNullabilityToTheResult()
+    {
+        string printed = Translate(@"
+using System.IO;
+
+namespace Demo
+{
+    public class Downloads
+    {
+        public static string NameWithoutExtension(string downloadFileName)
+        {
+            Report(downloadFileName == null);
+            return Path.GetFileNameWithoutExtension(downloadFileName);
+        }
+
+        private static void Report(bool missing)
+        {
+        }
+    }
+}");
+
+        // The `== null` promotes the PARAMETER; the return carries no direct
+        // null at all, so it can only be promoted by the forwarding edge.
+        Assert.Contains("downloadFileName string?", printed);
+        Assert.Contains("string? {", printed);
+        TranslationTestValidation.AssertBinds(printed);
+    }
+
+    /// <summary>
+    /// ANTI-VACUITY: an UNANNOTATED nullable-returning member on the same type
+    /// must still promote. <c>Path.GetDirectoryName</c> carries no
+    /// <c>[NotNullIfNotNull]</c> (it returns null for a root path even with a
+    /// non-null argument), so the fix must key off the attribute, not the type.
+    /// </summary>
+    [Fact]
+    public void UnannotatedNullableReturn_StillPromotes()
+    {
+        string printed = Translate(@"
+using System.IO;
+
+namespace Demo
+{
+    public class Mirror
+    {
+        public static string Directory(string source)
+        {
+            string directory = Path.GetDirectoryName(source);
+            return directory;
+        }
+    }
+}");
+
+        Assert.Contains("string?", printed);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Mirror.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " + string.Join("\n", project.ErrorDiagnostics));
+
+        LoadedDocument document = project.Documents[0];
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -801,6 +801,24 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #3802: a `[return: NotNullIfNotNull(nameof(p))]` return is
+            // declared `T?` but is exactly as nullable as its named argument,
+            // so answer for the ARGUMENT rather than reading the declared `T?`
+            // below. The argument's own EMITTED type is what gsc will see, so
+            // the taint fixpoint's promotion decision counts here as much as
+            // the syntactic one — reading only the latter is what left
+            // `Path.GetFileNameWithoutExtension(downloadFileName)` unpromoted
+            // in Oahu while `downloadFileName` itself was promoted to `string?`.
+            if (ConditionalNotNullPostcondition.TryGetForwardedArgument(
+                expression,
+                node => this.context.GetSymbolInfo(node).Symbol,
+                out ExpressionSyntax conditionalSource))
+            {
+                return this.IsNullableInitializer(conditionalSource)
+                    || this.ShouldPromoteToNullableReference(
+                        this.context.GetSymbolInfo(conditionalSource).Symbol);
+            }
+
             // Otherwise consult the bound symbol's declared annotation.
             ISymbol symbol = this.context.GetSymbolInfo(expression).Symbol;
             ITypeSymbol symbolType = symbol switch

--- a/tools/cs2gs/Cs2Gs.Translator/ConditionalNotNullPostcondition.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ConditionalNotNullPostcondition.cs
@@ -1,0 +1,179 @@
+// <copyright file="ConditionalNotNullPostcondition.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cs2Gs.Translator;
+
+/// <summary>
+/// Issue #3802: recognises <c>[return: NotNullIfNotNull(nameof(p))]</c> at a
+/// CALL SITE and hands back the argument the result's nullability is
+/// FORWARDED from.
+///
+/// <para>
+/// The BCL declares <c>Path.GetExtension</c>, <c>Path.GetFileName</c> and
+/// <c>Path.ChangeExtension</c> as <c>string?</c> with that conditional
+/// post-condition: the result is non-null whenever the named argument is.
+/// Both nullability judgements in this assembly —
+/// <c>ObliviousNullabilityAnalyzer.IsDirectlyNullable</c> and the
+/// translator's <c>IsNullableInitializer</c> — end in the same fallback,
+/// "consult the bound symbol's DECLARED annotation", which is right for a
+/// plainly nullable member and wrong for a conditional one. Left alone it
+/// promotes <c>string extension = Path.GetExtension(source)</c> to
+/// <c>string?</c>, taints every iterator that yields such a value to
+/// <c>sequence[string?]</c>, and sprays <c>!!</c> over the uses — which is
+/// how <c>Cs2Gs.Pipeline</c>'s <c>RepositoryMirror</c> came out of migration
+/// with a <c>string?</c> dictionary key gsc rightly rejected (GS0155).
+/// </para>
+///
+/// <para>
+/// The result is deliberately a FORWARDING EDGE rather than a "this is
+/// non-null" verdict. gsc refuses to narrow a call whose argument it sees as
+/// <c>T?</c>, and the argument's emitted type is decided by the same taint
+/// fixpoint this feeds — so answering "non-null" from the argument's
+/// syntactic C# shape alone makes the two layers disagree wherever the
+/// fixpoint later promotes that argument. Oahu showed exactly that:
+/// <c>Path.GetFileNameWithoutExtension(downloadFileName)</c> stayed
+/// <c>string</c> while <c>downloadFileName</c> itself became <c>string?</c>.
+/// Forwarding keeps the post-condition CONDITIONAL in both layers at once.
+/// </para>
+/// </summary>
+internal static class ConditionalNotNullPostcondition
+{
+    private const string AttributeName = "NotNullIfNotNullAttribute";
+
+    /// <summary>
+    /// When <paramref name="expression"/> is a call to a method carrying
+    /// <c>[return: NotNullIfNotNull(name)]</c>, hands back the argument bound
+    /// to the named parameter — the expression the result's nullability is
+    /// FORWARDED from.
+    /// </summary>
+    /// <param name="expression">The candidate expression.</param>
+    /// <param name="getSymbol">
+    /// The caller's symbol resolver. Passed rather than a
+    /// <see cref="SemanticModel"/> because the translator routes lookups
+    /// through a per-tree model.
+    /// </param>
+    /// <param name="forwarded">Receives the named argument.</param>
+    /// <returns>Whether a forwarded argument was found.</returns>
+    public static bool TryGetForwardedArgument(
+        ExpressionSyntax expression,
+        Func<ExpressionSyntax, ISymbol> getSymbol,
+        out ExpressionSyntax forwarded)
+    {
+        forwarded = null;
+        if (expression is not InvocationExpressionSyntax invocation || getSymbol == null)
+        {
+            return false;
+        }
+
+        if (getSymbol(invocation) is not IMethodSymbol method)
+        {
+            return false;
+        }
+
+        IReadOnlyList<string> names = NamedParameters(method);
+        if (names.Count == 0)
+        {
+            return false;
+        }
+
+        // More than one name means "non-null if ANY of these is non-null", a
+        // disjunction the caller's single-source forwarding cannot express;
+        // leaving it alone keeps the conservative declared-`T?` answer. No BCL
+        // member in the migration corpus carries more than one.
+        if (names.Count > 1)
+        {
+            return false;
+        }
+
+        forwarded = ArgumentFor(invocation, method, names[0]);
+        return forwarded != null;
+    }
+
+    // The parameter names carried by every `[return: NotNullIfNotNull]` on
+    // the method. Read off the ORIGINAL DEFINITION so a constructed generic
+    // or a reduced extension method still finds them.
+    private static IReadOnlyList<string> NamedParameters(IMethodSymbol method)
+    {
+        IMethodSymbol definition = (method.ReducedFrom ?? method).OriginalDefinition;
+        List<string> names = null;
+        foreach (AttributeData attribute in definition.GetReturnTypeAttributes())
+        {
+            if (attribute.AttributeClass?.Name != AttributeName
+                || attribute.ConstructorArguments.Length == 0)
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments[0].Value is string name)
+            {
+                (names ??= new List<string>()).Add(name);
+            }
+        }
+
+        return (IReadOnlyList<string>)names ?? Array.Empty<string>();
+    }
+
+    // The argument expression bound to the parameter called <paramref
+    // name="name"/>, honouring named arguments. Returns null when the
+    // parameter is not supplied (an omitted optional argument defaults to
+    // null far more often than not, so absence must never narrow).
+    private static ExpressionSyntax ArgumentFor(
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method,
+        string name)
+    {
+        IMethodSymbol definition = (method.ReducedFrom ?? method).OriginalDefinition;
+        int index = -1;
+        for (int i = 0; i < definition.Parameters.Length; i++)
+        {
+            if (string.Equals(definition.Parameters[i].Name, name, StringComparison.Ordinal))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            return null;
+        }
+
+        // A reduced extension invocation (`value.Ext(x)`) drops the receiver
+        // from the argument list, so the unreduced parameter positions are
+        // one ahead of the syntactic arguments. The receiver itself is
+        // parameter 0.
+        if (method.ReducedFrom != null)
+        {
+            if (index == 0)
+            {
+                return (invocation.Expression as MemberAccessExpressionSyntax)?.Expression;
+            }
+
+            index--;
+        }
+
+        SeparatedSyntaxList<ArgumentSyntax> arguments = invocation.ArgumentList.Arguments;
+        ArgumentSyntax named = arguments.FirstOrDefault(
+            a => a.NameColon?.Name.Identifier.ValueText == name);
+        if (named != null)
+        {
+            return named.Expression;
+        }
+
+        // Positional only up to the first named argument; past one, position
+        // no longer identifies the parameter.
+        if (index >= arguments.Count || arguments[index].NameColon != null)
+        {
+            return null;
+        }
+
+        return arguments[index].Expression;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -3825,6 +3825,23 @@ internal static class ObliviousNullabilityAnalyzer
                 return;
         }
 
+        // Issue #3802: a `[return: NotNullIfNotNull(nameof(p))]` call FORWARDS
+        // its named argument's nullability — it is exactly as nullable as `p`
+        // is. Recording that as an EDGE rather than a verdict is what keeps
+        // cs2gs and gsc agreeing: if the fixpoint later promotes the argument's
+        // own declaration to `T?` (which is invisible to the syntactic
+        // judgement in `IsDirectlyNullable`, since oblivious C# annotates
+        // nothing), the target is promoted with it, exactly as gsc will refuse
+        // to narrow a call whose argument it sees as `T?`.
+        if (ConditionalNotNullPostcondition.TryGetForwardedArgument(
+            value,
+            node => model.GetSymbolInfo(node).Symbol,
+            out ExpressionSyntax forwarded))
+        {
+            CollectScalarValueFlow(target, forwarded, model, tainted, edges, scalarTupleEdges, scope);
+            return;
+        }
+
         if (scope != SourceScope.CallsOnly
             && TryResolveTupleElementSource(value, model, out TupleElementKey tupleSource))
         {
@@ -4234,6 +4251,23 @@ internal static class ObliviousNullabilityAnalyzer
         if (info.Nullability.Annotation == NullableAnnotation.Annotated)
         {
             return true;
+        }
+
+        // Issue #3802: `[return: NotNullIfNotNull(nameof(p))]` makes that
+        // declared `string?` CONDITIONAL — `Path.GetExtension(source)` is
+        // exactly as nullable as `source` is, so answer for the ARGUMENT
+        // instead of reading the declared `string?` below. Promoting it
+        // unconditionally is what widened RepositoryMirror's iterator to
+        // `sequence[string?]` and left a `string?` dictionary key gsc rightly
+        // rejected. When the argument is not DIRECTLY nullable the answer here
+        // is "no", and `CollectScalarValueFlow` records a forwarding edge so
+        // the fixpoint can still promote both together.
+        if (ConditionalNotNullPostcondition.TryGetForwardedArgument(
+            expression,
+            node => model.GetSymbolInfo(node).Symbol,
+            out ExpressionSyntax conditionalSource))
+        {
+            return IsDirectlyNullable(conditionalSource, model);
         }
 
         // Otherwise consult the bound symbol's DECLARED annotation, which


### PR DESCRIPTION
Second half of #3802. The compiler half landed in #3803; the gate's four cs2gs apps stayed red on the same fingerprint, and the run artifact says why.

## The issue's premise was wrong about the failing site

I ran the gate on the #3803 branch ([33566832379](https://github.com/DavidObando/gsharp/actions/runs/33566832379)) and pulled the migrated tree. `RepositoryMirror.gs:171:34` is **not** `return Path.ChangeExtension(source, ".gs")`. Line 171 column 34 is 11 characters wide and it is `destination`:

```
private func ValidateCollisions(files IEnumerable[string]) {
    let destinations = Dictionary[string, string](StringComparer.OrdinalIgnoreCase)
    for source in files {
        for destination in DestinationRelativePaths(source)!! {
            ...
            destinations[destination] = source     // <- GS0155, line 171
```

`destination` is `string?` because the **translator** widened the producer:

```
private func DestinationRelativePaths(source string) sequence[string?] {
    let extension string? = Path.GetExtension(source)
    if extension!!.Equals(".cs", StringComparison.OrdinalIgnoreCase) {
        yield Path.ChangeExtension(source, ".gs")
```

The C# is a plain `IEnumerable<string>` iterator with `string extension = Path.GetExtension(source)`. gsc was right to reject the `string?` key; the defect is upstream, in cs2gs.

## Root cause

`Path.GetExtension`, `Path.GetFileName` and `Path.ChangeExtension` are declared `string?` with `[return: NotNullIfNotNull(nameof(path))]`. Both nullability judgements in `Cs2Gs.Translator` — `ObliviousNullabilityAnalyzer.IsDirectlyNullable` and the translator's `IsNullableInitializer` — end in the same fallback: *"otherwise consult the bound symbol's DECLARED annotation"*. That is right for a plainly nullable member and blind to a conditional one. So `extension` is promoted to `string?`, the promoted yield taints the iterator's element to `sequence[string?]`, and that element escapes into the `Dictionary[string, string]` index. One root cause, three symptoms, four red apps.

## The rule: a forwarding EDGE, not a verdict

Such a call is **exactly as nullable as its named argument**. Both analyses now answer for the argument, and `CollectScalarValueFlow` records `target ← argument` so the whole-program fixpoint carries the relationship.

The first draft answered *"non-null"* outright, and the pinned Oahu corpus proved that wrong — 9 of 15 apps, one fingerprint. I reproduced it locally and read the diagnostics rather than inferring; the mechanism is your option **(b)**, a layer disagreement, and specifically:

> gsc refuses to narrow a call whose argument it sees as `T?`, and the argument's **emitted** type is decided by the very taint fixpoint this judgement feeds. A verdict taken from the argument's *C# syntax* alone (in oblivious C# nothing is annotated, so every parameter reads as "not nullable") therefore disagrees with gsc wherever the fixpoint later promotes that argument.

Oahu's `Oahu.Core/ExtensionsVarious.GetDownloadFileNameWithoutExtension` came out as `func (downloadFileName string?) ... string` — a `string?` argument feeding a `string` return, GS0155. Its sibling line showed the inconsistency plainly: `Path.GetExtension(downloadFileName)!!` still carried a `!!` from a pass that *did* know the parameter was nullable.

Forwarding keeps the post-condition conditional in **both** layers at once. Locally, the same pinned Oahu commit now migrates **15/15 apps green** (translate + compile + ILVerify + test-parity), against 6/15 on the first draft.

## On the layer choice (cs2gs vs gsc)

Your brief asked for a flow fact in gsc, and that is what shipped — `ConditionalReturnNarrowing` in #3803, applied at the call, conditional on the argument, already merged. This PR is not an alternative to it; both are required and neither is sufficient alone. cs2gs decides the **declared** types of the G# it emits (the iterator's element, the local, the promoted parameter) before gsc ever sees the file, using its own nullability model. gsc's narrowing cannot un-declare a `sequence[string?]` that cs2gs already wrote. Conversely, with the element back at `sequence[string]`, `yield Path.ChangeExtension(source, ".gs")` needs #3803's narrowing to bind — which is exactly what this PR's test `AssertBinds` exercises.

Your inference from the blast radius was still the right instinct, and it pointed at the real bug: a taint-level answer has a much larger surface, which is why the rule here had to become a forwarding edge that defers to the fixpoint rather than a standalone verdict.

## Test evidence

`tools/cs2gs/Cs2Gs.Tests/Issue3802ConditionalNotNullPostconditionTests.cs`.

**Fails on `origin/main`, passes here:**
- `ConditionalPostcondition_KeepsTheIteratorElementNonNullable` — the reduced `RepositoryMirror` shape end to end (iterator element + local + the dictionary index that consumes them), then bound with gsc.
- `PromotedArgument_ForwardsItsNullabilityToTheResult` — the Oahu shape: the `== null` promotes the parameter, the return carries no direct null at all, so it can only become `string?` via the forwarding edge. This is the regression guard for the first draft.

**Passes on `origin/main` too — guard rails:**
- `NullableArgument_StillPromotesTheResult` — the post-condition is CONDITIONAL, so a nullable argument must still promote. Narrowing unconditionally would emit a `string` declaration for a value that really can be nil and hide the nullability the migration exists to surface — the #3705 family 2 unsoundness in translator clothing. (gsc's own conditional guard is `NullableArgument_StillYieldsNullableResult` in #3803, which compiles and asserts `GS0155`.)
- `UnannotatedNullableReturn_StillPromotes` — `Path.GetDirectoryName`, on the same type, deliberately **not** annotated (it returns null for a root path even with a non-null argument), still promotes. The rule keys off the attribute, not the type.

`tools/cs2gs/selfmig-baseline.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
