### PR TITLE
cs2gs: fix the translate-stage crash on a `this` receiver in a data-row theory, and stop filing crashes as unsupported constructs (#3804)

### DIFF
--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -734,7 +734,8 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
 Fields:
 
 - `schemaVersion`, `runId`, `timestamp`, `gscVersion`, `corpusAppId` — provenance.
-- `stage` ∈ `{translate, compile, ilverify, test-parity}`; `category` ∈ `{translation-unsupported, compile-error, ilverify-failure, test-parity-failure}`.
+- `stage` ∈ `{translate, compile, ilverify, test-parity}`; `category` ∈ `{translation-unsupported, compile-error, ilverify-failure, test-parity-failure, pipeline-crash}`.
+- **`pipeline-crash` (issue #3804).** One category does not belong to a stage: `pipeline-crash` records a stage throwing an unhandled exception, which is a defect in `cs2gs` itself rather than a property of the code being migrated. It was originally filed under the crashing stage's own category, so a translator `IndexOutOfRangeException` arrived as `translation-unsupported` with the *exception type name* rendered as the offending C# construct — a tool bug published as a language gap, which reads as already-triaged and is how one sat untouched for weeks in the self-migration corpus. `diagnostic.id` still names the stage (`PipelineException`, `GS9999`, `IlVerifyError`, `STDOUT-MISMATCH`), the translate stage annotates the throw with the C# file it had on the table so `sourceLocation.csFile` is populated (positions stay `null`), and the stack trace goes to the run log.
 - `diagnostic` — the G# diagnostic id/message/severity (for stages 2–3; for stage 4 the failing test id and expected-vs-actual).
 - `sourceLocation` — both the emitted-`.gs` location **and** the originating C# location (the translator preserves a source map so a gap points back to the C# that triggered it).
 - `offendingCSharpConstruct` — the C# construct kind plus a minimal snippet.

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -800,6 +800,12 @@ public sealed class MigrationPipeline
             }
             catch (Exception ex)
             {
+                // Issue #3804: a stage crash is a cs2gs defect, and the ONLY
+                // record of where it happened is the stack. The artifact keeps
+                // the message; the log keeps the frames, so a gate run's log is
+                // enough to start a diagnosis from.
+                Console.Error.WriteLine($"cs2gs: {stageName} stage crashed for {app.Id}:");
+                Console.Error.WriteLine(ex);
                 outcome = StageOutcome.Failed(new[] { StageCrashArtifact(context.Triage, stage.Kind, ex) });
             }
 
@@ -867,15 +873,29 @@ public sealed class MigrationPipeline
         // exception's runtime type rather than its raw Message, which
         // routinely embeds run-scoped absolute paths that would otherwise
         // fingerprint the same recurring crash differently every run/machine.
-        (TriageCategory category, string diagnosticId) = stage switch
+        //
+        // Issue #3804: the category is PipelineCrash whatever the stage. A
+        // crash is a defect in the MIGRATION TOOL; filing it as the stage's
+        // own failure category made a translator IndexOutOfRangeException
+        // arrive as `translation-unsupported`, i.e. as a property of the C#
+        // being migrated, and it was triaged accordingly (which is to say, not
+        // at all). The diagnostic id still names the stage, so the two are
+        // still distinguishable at a glance.
+        string diagnosticId = stage switch
         {
-            MigrationStageKind.Compile => (TriageCategory.CompileError, "GS9999"),
-            MigrationStageKind.IlVerify => (TriageCategory.IlVerifyFailure, "IlVerifyError"),
-            MigrationStageKind.TestParity => (TriageCategory.TestParityFailure, "STDOUT-MISMATCH"),
-            _ => (TriageCategory.TranslationUnsupported, "PipelineException"),
+            MigrationStageKind.Compile => "GS9999",
+            MigrationStageKind.IlVerify => "IlVerifyError",
+            MigrationStageKind.TestParity => "STDOUT-MISMATCH",
+            _ => "PipelineException",
         };
 
-        return triage.StageCrash(stage, category, diagnosticId, ex);
+        // The wrapper (issue #3804) exists only to name the file; triage sees
+        // the exception that was actually thrown, so messages and fingerprints
+        // are unchanged by its presence.
+        string csFile = (ex as TranslationCrashException)?.SourceFilePath;
+        Exception crash = ex is TranslationCrashException wrapped ? wrapped.InnerException : ex;
+
+        return triage.StageCrash(stage, TriageCategory.PipelineCrash, diagnosticId, crash, csFile);
     }
 
     private IReadOnlyList<TriageArtifact> WriteArtifacts(

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationStageKind.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationStageKind.cs
@@ -26,7 +26,8 @@ public enum MigrationStageKind
 
 /// <summary>
 /// The triage category recorded on a failure artifact (ADR-0115 §D.1). One
-/// value per stage.
+/// value per stage, plus <see cref="PipelineCrash"/> for "the stage itself
+/// fell over", which belongs to no stage in particular.
 /// </summary>
 public enum TriageCategory
 {
@@ -41,6 +42,18 @@ public enum TriageCategory
 
     /// <summary>A ported-test parity mismatch against the C# baseline (stage 4).</summary>
     TestParityFailure,
+
+    /// <summary>
+    /// Issue #3804: a stage threw an unhandled exception — a DEFECT IN CS2GS,
+    /// not a property of the code being migrated. Crashes used to be filed
+    /// under the category of whatever stage they happened in, so a translator
+    /// <c>IndexOutOfRangeException</c> arrived as
+    /// <c>translation-unsupported</c> with the exception's type name rendered
+    /// as the "offending C# construct" — a language gap that read as triaged
+    /// and sat unexamined for weeks. A crash gets its own category so it can
+    /// never again be mistaken for a construct with no G# form.
+    /// </summary>
+    PipelineCrash,
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -963,17 +963,47 @@ public sealed class TranslateStage : IMigrationStage
                     line++;
                 }
 
-                string prior = line < priorLines.Length ? priorLines[line] : "<eof>";
-                string current = line < currentLines.Length ? currentLines[line] : "<eof>";
+                // Issue #3804: one line of each side is not enough to act on —
+                // the two renderings routinely differ in how one expression is
+                // BROKEN ACROSS lines, so the first differing line can be a
+                // bare prefix that says nothing about what actually changed.
+                // Print a short window of both.
                 throw new InvalidOperationException(
                     $"Linked source '{sourcePath}' translates differently in multiple projects. "
-                    + $"First divergence at line {line + 1}: prior `{prior.Trim()}` vs current `{current.Trim()}`.");
+                    + $"First divergence at line {line + 1}.\n"
+                    + $"  prior (as translated by the first project to reach it):\n{Window(priorLines, line)}"
+                    + $"  current (as translated by this app):\n{Window(currentLines, line)}");
             }
 
             return;
         }
 
         options.RepositoryTranslations[canonicalSourcePath] = generated;
+    }
+
+    /// <summary>
+    /// Renders a few lines of <paramref name="lines"/> around
+    /// <paramref name="index"/>, for the linked-source divergence report
+    /// (issue #3804).
+    /// </summary>
+    /// <param name="lines">The translated file, split into lines.</param>
+    /// <param name="index">The zero-based index of the first differing line.</param>
+    /// <returns>The rendered window, one indented line per entry.</returns>
+    private static string Window(string[] lines, int index)
+    {
+        const int Context = 2;
+        var window = new System.Text.StringBuilder();
+        for (int i = Math.Max(0, index - Context); i < Math.Min(lines.Length, index + Context + 1); i++)
+        {
+            window.Append(i == index ? "  > " : "    ").Append(lines[i].TrimEnd()).Append('\n');
+        }
+
+        if (index >= lines.Length)
+        {
+            window.Append("  > <eof>\n");
+        }
+
+        return window.ToString();
     }
 
     private static string OutputPathForResx(

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -400,8 +400,23 @@ public sealed class TranslateStage : IMigrationStage
                             includeFileAttributes: unitIndex == 0,
                             analyzerApiMode: analyzerApiMode,
                             preserveEntryType: preserveEntryType);
-                    string printed = GSharpPrinter.Print(
-                        unitTranslator.TranslateDocument(document, translationContext));
+                    string printed;
+                    try
+                    {
+                        printed = GSharpPrinter.Print(
+                            unitTranslator.TranslateDocument(document, translationContext));
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException
+                        and not TranslationCrashException)
+                    {
+                        // Issue #3804: annotate, do NOT absorb. A translator
+                        // crash stays a crash — turning it into a diagnostic
+                        // here would silently drop the file from the migrated
+                        // tree and file a cs2gs defect as a language gap. All
+                        // this adds is the one fact the artifact was missing:
+                        // which source was on the table.
+                        throw new TranslationCrashException(document.FilePath, ex);
+                    }
 
                     string gsRelativePath;
                     if (unitIndex == 0)
@@ -513,8 +528,15 @@ public sealed class TranslateStage : IMigrationStage
                     // and move on to the remaining files.
                     if (!isReferencedProject)
                     {
+                        // Issue #3804: an unreadable .resx is a tooling failure,
+                        // not a C# construct without a G# form — it gets the
+                        // crash category, and names the file it choked on.
                         artifacts.Add(context.Triage.StageCrash(
-                            MigrationStageKind.Translate, TriageCategory.TranslationUnsupported, "CS2GS0003", ex));
+                            MigrationStageKind.Translate,
+                            TriageCategory.PipelineCrash,
+                            "CS2GS0003",
+                            ex,
+                            resxPath));
                     }
 
                     continue;

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslationCrashException.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslationCrashException.cs
@@ -1,0 +1,55 @@
+// <copyright file="TranslationCrashException.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// Issue #3804: names the C# file the translator was working on when it threw.
+/// <para>
+/// A crash artifact used to carry no location at all — "translate stage crashed
+/// (IndexOutOfRangeException)", no file, no line, no construct — which made it
+/// nearly unactionable: the reader's first job was re-running the whole
+/// migration with a debugger attached just to learn WHICH of an app's several
+/// hundred sources was involved. The translate stage now re-throws inside this
+/// wrapper, which is deliberately NOT a diagnostic: the exception still
+/// propagates and still fails the stage as a crash. It only annotates it.
+/// </para>
+/// <para>
+/// The wrapper is transparent to triage: <see cref="TriageBuilder.StageCrash"/>
+/// is handed the INNER exception, so the artifact's message, its construct kind
+/// and therefore its fingerprint are exactly what they would have been without
+/// the wrapper — a crash keeps deduping against its own history across the
+/// change.
+/// </para>
+/// </summary>
+public sealed class TranslationCrashException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TranslationCrashException"/> class.
+    /// </summary>
+    /// <param name="sourceFilePath">The C# file being translated when the crash happened.</param>
+    /// <param name="inner">The exception the translator actually threw.</param>
+    public TranslationCrashException(string sourceFilePath, Exception inner)
+        : base(Describe(sourceFilePath, inner), inner)
+    {
+        this.SourceFilePath = sourceFilePath;
+    }
+
+    /// <summary>
+    /// Gets the C# file being translated when the crash happened.
+    /// </summary>
+    public string SourceFilePath { get; }
+
+    private static string Describe(string sourceFilePath, Exception inner)
+    {
+        if (inner is null)
+        {
+            throw new ArgumentNullException(nameof(inner));
+        }
+
+        return $"translating {sourceFilePath}: {inner.Message}";
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -579,8 +579,21 @@ public sealed class TriageBuilder
     /// <param name="category">The triage category to file the crash artifact under.</param>
     /// <param name="diagnosticId">The diagnostic id to stamp (stage-specific, e.g. <c>GS9999</c>).</param>
     /// <param name="ex">The exception the stage threw.</param>
+    /// <param name="csFile">
+    /// The C# file the stage was working on when it threw, when the stage knows
+    /// it (issue #3804). A crash artifact with no location at all is nearly
+    /// unactionable — "translate stage crashed", no file, no line — so the
+    /// stage annotates the throw with the source it had on the table and it is
+    /// recorded here. Deliberately NOT part of the fingerprint, for the same
+    /// reason the message is not: it is a run-scoped absolute path.
+    /// </param>
     /// <returns>The populated triage artifact.</returns>
-    public TriageArtifact StageCrash(MigrationStageKind stage, TriageCategory category, string diagnosticId, Exception ex)
+    public TriageArtifact StageCrash(
+        MigrationStageKind stage,
+        TriageCategory category,
+        string diagnosticId,
+        Exception ex,
+        string csFile = null)
     {
         if (ex is null)
         {
@@ -602,7 +615,7 @@ public sealed class TriageBuilder
             GsFile = null,
             GsLine = null,
             GsColumn = null,
-            CsFile = null,
+            CsFile = csFile,
             CsLine = null,
             CsColumn = null,
         };
@@ -619,6 +632,7 @@ public sealed class TriageBuilder
             message);
         artifact.SuggestedIssue = category switch
         {
+            TriageCategory.PipelineCrash => this.CrashIssue(artifact, stage),
             TriageCategory.CompileError => this.CompileIssue(artifact),
             TriageCategory.IlVerifyFailure => this.IlVerifyIssue(artifact),
             TriageCategory.TestParityFailure => this.TestParityIssue(artifact),
@@ -757,6 +771,51 @@ public sealed class TriageBuilder
             $"- Snippet: `{artifact.OffendingCSharpConstruct.Snippet}`",
             string.Empty,
             "**Reproduction:** run `cs2gs migrate` over the corpus; stage 1 (translate) gates on this construct.",
+            $"**Fingerprint:** `{artifact.Fingerprint}`",
+        };
+
+        var issue = new TriageSuggestedIssue
+        {
+            Title = title,
+            Body = string.Join("\n", lines),
+        };
+        issue.Labels.Add("Oats");
+        return issue;
+    }
+
+    /// <summary>
+    /// Issue #3804: the suggested issue for a stage that CRASHED. The old
+    /// rendering reused <see cref="UnsupportedIssue"/>, which titles itself
+    /// "Unsupported C# construct '<c>X</c>' has no canonical G# form" with the
+    /// exception's type name in the construct slot — so a cs2gs
+    /// <c>IndexOutOfRangeException</c> was published as a G# language gap and
+    /// read as already-triaged. This one says what actually happened, and
+    /// names the file the stage was on when it happened.
+    /// </summary>
+    /// <param name="artifact">The crash artifact.</param>
+    /// <param name="stage">The stage that crashed.</param>
+    /// <returns>The suggested issue.</returns>
+    private TriageSuggestedIssue CrashIssue(TriageArtifact artifact, MigrationStageKind stage)
+    {
+        string stageName = TriageSerialization.StageName(stage);
+        string title = $"[cs2gs] {stageName} stage crashed " +
+            $"({artifact.OffendingCSharpConstruct.Kind}) migrating {this.CorpusAppId}";
+        string fileLine = string.IsNullOrEmpty(artifact.SourceLocation.CsFile)
+            ? "- C# source: not captured (the stage crashed outside a per-file step)"
+            : $"- C# source: `{artifact.SourceLocation.CsFile}`";
+        string[] lines =
+        {
+            $"`cs2gs` itself threw while migrating **{this.CorpusAppId}** — this is a DEFECT IN THE " +
+                "MIGRATION TOOL, not a C# construct without a G# form. Fix the crash at its cause; if " +
+                "the construct really has no G# form, it needs a proper unsupported-construct report " +
+                "naming the construct, which a crash is not.",
+            string.Empty,
+            $"- Stage: `{stageName}`",
+            $"- Exception: `{artifact.OffendingCSharpConstruct.Kind}`",
+            $"- Detail: {artifact.Diagnostic.Message}",
+            fileLine,
+            string.Empty,
+            "**Reproduction:** run `cs2gs migrate` over the corpus; the stage log carries the stack trace.",
             $"**Fingerprint:** `{artifact.Fingerprint}`",
         };
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageSerialization.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageSerialization.cs
@@ -47,7 +47,7 @@ public static class TriageSerialization
 
     /// <summary>
     /// Maps a <see cref="TriageCategory"/> to its schema spelling
-    /// (<c>translation-unsupported</c>, <c>compile-error</c>, …).
+    /// (<c>translation-unsupported</c>, <c>compile-error</c>, <c>pipeline-crash</c>, …).
     /// </summary>
     /// <param name="category">The triage category.</param>
     /// <returns>The schema category string.</returns>
@@ -57,6 +57,7 @@ public static class TriageSerialization
         TriageCategory.CompileError => "compile-error",
         TriageCategory.IlVerifyFailure => "ilverify-failure",
         TriageCategory.TestParityFailure => "test-parity-failure",
+        TriageCategory.PipelineCrash => "pipeline-crash",
         _ => throw new ArgumentOutOfRangeException(nameof(category)),
     };
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3804CrashTriageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3804CrashTriageTests.cs
@@ -1,0 +1,105 @@
+// <copyright file="Issue3804CrashTriageTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3804, second half: a crash must be REPORTED as a crash. The
+/// translate-stage <see cref="IndexOutOfRangeException"/> that walled
+/// `test/Interpreter.Tests` off from the self-migration corpus reached the gate
+/// as <c>category: "translation-unsupported"</c> under a suggested issue titled
+/// <i>"Unsupported C# construct 'IndexOutOfRangeException' has no canonical G#
+/// form"</i> — with no file, no line, and no construct. An
+/// <see cref="IndexOutOfRangeException"/> is not a C# construct, and a report
+/// that says it is reads as already-triaged; that is how the crash sat
+/// unexamined for weeks.
+/// </summary>
+public class Issue3804CrashTriageTests
+{
+    [Fact]
+    public void AStageCrash_IsCategorisedAsACrash_NotAsAnUnsupportedConstruct()
+    {
+        var builder = new TriageBuilder("run_1", "2026-09-01T00:00:00Z", "0.4.0+abc", "test/Interpreter.Tests");
+
+        TriageArtifact artifact = builder.StageCrash(
+            MigrationStageKind.Translate,
+            TriageCategory.PipelineCrash,
+            "PipelineException",
+            new IndexOutOfRangeException("Index was outside the bounds of the array."));
+
+        Assert.Equal("pipeline-crash", artifact.Category);
+        Assert.Equal("translate", artifact.Stage);
+
+        // The headline must say what happened. The old rendering put the
+        // exception type in the "unsupported construct" slot.
+        Assert.DoesNotContain("Unsupported C# construct", artifact.SuggestedIssue.Title, StringComparison.Ordinal);
+        Assert.Contains("translate stage crashed", artifact.SuggestedIssue.Title, StringComparison.Ordinal);
+        Assert.Contains("IndexOutOfRangeException", artifact.SuggestedIssue.Title, StringComparison.Ordinal);
+        Assert.Contains("DEFECT IN THE MIGRATION TOOL", artifact.SuggestedIssue.Body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ACrashArtifact_NamesTheFileTheStageWasOn()
+    {
+        var builder = new TriageBuilder("run_1", "2026-09-01T00:00:00Z", "0.4.0+abc", "test/Interpreter.Tests");
+
+        TriageArtifact artifact = builder.StageCrash(
+            MigrationStageKind.Translate,
+            TriageCategory.PipelineCrash,
+            "PipelineException",
+            new IndexOutOfRangeException("Index was outside the bounds of the array."),
+            "test/Interpreter.Tests/HighlightTests.cs");
+
+        Assert.Equal("test/Interpreter.Tests/HighlightTests.cs", artifact.SourceLocation.CsFile);
+        Assert.Contains(
+            "test/Interpreter.Tests/HighlightTests.cs",
+            artifact.SuggestedIssue.Body,
+            StringComparison.Ordinal);
+
+        // Positions stay null — the annotation names a file, it does not claim
+        // a position the stage never had.
+        Assert.Null(artifact.SourceLocation.CsLine);
+        Assert.Null(artifact.SourceLocation.GsFile);
+    }
+
+    [Fact]
+    public void TheFileAnnotation_DoesNotDisturbTheCrashFingerprint()
+    {
+        // Issue #1750's dedup property must survive #3804: the file path is a
+        // run-scoped absolute path on a real run, so folding it into the
+        // fingerprint would file a fresh issue for the same crash every run.
+        var builder = new TriageBuilder("run_1", "2026-09-01T00:00:00Z", "0.4.0+abc", "test/Interpreter.Tests");
+        var crash = new IndexOutOfRangeException("Index was outside the bounds of the array.");
+
+        TriageArtifact withoutFile = builder.StageCrash(
+            MigrationStageKind.Translate, TriageCategory.PipelineCrash, "PipelineException", crash);
+        TriageArtifact withFile = builder.StageCrash(
+            MigrationStageKind.Translate,
+            TriageCategory.PipelineCrash,
+            "PipelineException",
+            crash,
+            "/tmp/run-9f8e/test/Interpreter.Tests/HighlightTests.cs");
+
+        Assert.Equal(withoutFile.Fingerprint, withFile.Fingerprint);
+    }
+
+    [Fact]
+    public void TheCrashWrapper_KeepsTheThrownExceptionIntact()
+    {
+        // TranslationCrashException annotates; it must not become the crash.
+        // The pipeline reports the INNER exception, so the construct kind (and
+        // therefore the fingerprint) is the same with or without the wrapper.
+        var inner = new IndexOutOfRangeException("Index was outside the bounds of the array.");
+        var wrapper = new TranslationCrashException("/repo/test/Interpreter.Tests/HighlightTests.cs", inner);
+
+        Assert.Same(inner, wrapper.InnerException);
+        Assert.Equal("/repo/test/Interpreter.Tests/HighlightTests.cs", wrapper.SourceFilePath);
+        Assert.Contains("HighlightTests.cs", wrapper.Message, StringComparison.Ordinal);
+        Assert.Contains(inner.Message, wrapper.Message, StringComparison.Ordinal);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3804ThisReceiverInDataRowTheoryTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3804ThisReceiverInDataRowTheoryTests.cs
@@ -1,0 +1,170 @@
+// <copyright file="Issue3804ThisReceiverInDataRowTheoryTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3804: the last translate-stage wall in the self-migration corpus was
+/// not an unsupported construct at all — it was cs2gs crashing. Issue #3726's
+/// data-row promotion looks a parameter up by ordinal in the attribute's value
+/// array, and guarded only the UPPER bound:
+/// <code>
+/// || parameter.Ordinal >= row.Values.Length) { continue; }
+/// if (row.Values[parameter.Ordinal].IsNull)
+/// </code>
+/// Roslyn models <c>this</c> as an <c>IParameterSymbol</c> on the enclosing
+/// method whose <c>Ordinal</c> is <b>-1</b>, and the semantic model hands back
+/// exactly that symbol for a <c>this</c> expression. So any <c>this.…</c>
+/// receiver inside a method carrying a data-row-shaped attribute indexed at -1
+/// and took the whole Translate stage down with an
+/// <see cref="System.IndexOutOfRangeException"/> — reported by the gate as
+/// "translation-unsupported", with no file and no line.
+/// <para>
+/// The receiver is not a row column, so the fix is to answer "no promotion" for
+/// a negative ordinal, without weakening the #3726 rule for the real columns —
+/// which the second and third tests here pin.
+/// </para>
+/// </summary>
+public class Issue3804ThisReceiverInDataRowTheoryTests
+{
+    // The same stand-in for xunit's `[InlineData]` used by the #3726 tests: the
+    // shape the rule keys off is a `params object[]` constructor, not the name.
+    private const string DataAttributeDeclarations = @"
+using System;
+
+namespace Demo
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public sealed class InlineDataAttribute : Attribute
+    {
+        public InlineDataAttribute(params object[] data)
+        {
+            this.Data = data;
+        }
+
+        public object[] Data { get; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class TheoryAttribute : Attribute
+    {
+    }
+}";
+
+    [Fact]
+    public void AThisReceiverInsideADataRowTheory_TranslatesInsteadOfCrashing()
+    {
+        // The minimal reduction of test/Interpreter.Tests' crash: a theory
+        // whose body reaches through `this`. Translating at all is the
+        // assertion that matters — before the fix this call threw
+        // IndexOutOfRangeException out of the translator.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        private readonly string name = ""n"";
+
+        [Theory]
+        [InlineData(""a"")]
+        public void Check(string text)
+        {
+            System.Console.WriteLine(this.name.Length + text.Length);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(text string)", printed);
+        Assert.Contains("this.name", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void AThisReceiverDoesNotSuppressTheNullColumnPromotion()
+    {
+        // The guard must answer only for the receiver. The declared parameters
+        // still line up with the row, so #3726's promotion has to survive it:
+        // column 0 carries a null and column 1 never does.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        private readonly string name = ""n"";
+
+        [Theory]
+        [InlineData(null, ""a"")]
+        [InlineData(""b"", ""c"")]
+        public void Check(string maybe, string always)
+        {
+            System.Console.WriteLine(this.name + maybe + always);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(maybe string?, always string)", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void AThisReceiverIsNeverPromotedByAWiderRow()
+    {
+        // The receiver's -1 is not "the last column" either: a row wide enough
+        // to cover every declared parameter must not make `this` itself
+        // nullable through some wrap-around reading of the ordinal.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        private readonly string name = ""n"";
+
+        [Theory]
+        [InlineData(null, null)]
+        public void Check(string first, string second)
+        {
+            System.Console.WriteLine(this.name.Length + (first ?? second ?? """").Length);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(first string?, second string?)", printed);
+        Assert.DoesNotContain("this!!", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    // Returns the printed consumer file, and hands back the printed attribute
+    // declarations too so callers can bind the pair.
+    private static string Translate(string source, out string printedDeclarations)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Attributes.cs", DataAttributeDeclarations), ("Tests.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " + string.Join("\n", project.ErrorDiagnostics));
+
+        printedDeclarations = Print(project, 0);
+        return Print(project, 1);
+    }
+
+    private static string Print(LoadedCSharpProject project, int documentIndex)
+    {
+        LoadedDocument document = project.Documents[documentIndex];
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -330,6 +330,22 @@ internal static class ObliviousNullabilityAnalyzer
             return false;
         }
 
+        // Issue #3804: not every IParameterSymbol hanging off a method occupies
+        // a position in that method's parameter list. Roslyn models `this` as a
+        // parameter of the enclosing method with Ordinal **-1** — and
+        // SemanticModel.GetSymbolInfo hands back exactly that symbol for a
+        // `this` expression, which the translator asks about whenever it
+        // translates a `this.…` receiver. A data row lines its values up with
+        // the declared parameters positionally, so the receiver is simply not a
+        // row column and there is nothing to look up; without this guard the
+        // row lookup below indexed at -1 and took the whole translate stage
+        // down with an IndexOutOfRangeException (the ordinal test there guards
+        // only the upper bound).
+        if (parameter.Ordinal < 0)
+        {
+            return false;
+        }
+
         foreach (AttributeData attribute in method.GetAttributes())
         {
             if (attribute.AttributeConstructor is not { Parameters.Length: 1 } constructor

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -813,6 +813,17 @@ internal static class ObliviousNullabilityAnalyzer
         if (symbol is IParameterSymbol parameter)
         {
             ISymbol remappedOwner = RemapMemberOwner(targetCompilation, parameter.ContainingSymbol);
+
+            // Issue #3804: the ordinal is bounded on BOTH sides, defensively.
+            // Roslyn's `this` parameter hangs off its method with Ordinal -1
+            // and holds no position in the parameter list, so there is nothing
+            // to remap it to; an upper-bound-only test would index at -1, the
+            // exact shape of the #3804 translate crash.
+            if (parameter.Ordinal < 0)
+            {
+                return null;
+            }
+
             return remappedOwner switch
             {
                 IMethodSymbol method when parameter.Ordinal < method.Parameters.Length =>
@@ -996,7 +1007,17 @@ internal static class ObliviousNullabilityAnalyzer
                 {
                     foreach (ISymbol inherited in InheritedDeclarations(owner))
                     {
+                        // Issue #3804: `>= 0` as well as `<`, defensively. A
+                        // `this` parameter (Ordinal -1) cannot reach here
+                        // today — HasAllowNullWriteContract's
+                        // DeclaringSyntaxReferences gate turns it away first,
+                        // which is precisely the gate HasNullDataRowArgument
+                        // applied to the METHOD rather than the parameter, and
+                        // that is how the #3804 crash got in. An ordinal
+                        // bounded on one side only is the bug shape; bound it
+                        // on both.
                         if (inherited is IMethodSymbol inheritedMethod
+                            && parameter.Ordinal >= 0
                             && parameter.Ordinal < inheritedMethod.Parameters.Length)
                         {
                             yield return inheritedMethod.Parameters[parameter.Ordinal];

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -168,6 +168,13 @@ triage artifact; later stages are reported as `skip`.
    `Gsharp.NET.Sdk`) and compares the passing/failing test set against the C#
    xUnit oracle. Failures → `test-parity-failure`.
 
+A fifth category cuts across all four: a stage that throws an unhandled
+exception is a defect in `cs2gs` itself, not a property of the code being
+migrated, and is recorded as `pipeline-crash` (issue #3804) with the C# file
+the stage was working on and the stack trace in the run log. It is deliberately
+*not* filed as `translation-unsupported`: a tool bug dressed up as a language
+gap reads as already-triaged.
+
 ### Native while-pattern bindings
 
 Positive single-binder C# while patterns use G# `while let` when translation


### PR DESCRIPTION
Fixes #3804.

`test/Interpreter.Tests` was the last app in the 51-app self-migration corpus failing the **translate** stage, and it was not failing on an unsupported construct: cs2gs crashed.

## The throwing frame

Reproduced locally at the same fingerprint the gate reports (`sha256:992ab3aeefc1`):

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.Collections.Immutable.ImmutableArray`1.get_Item(Int32 index)
   at Cs2Gs.Translator.ObliviousNullabilityAnalyzer.HasNullDataRowArgument(ISymbol)   :357
   at ...DeclarationVisitor.ShouldPromoteToNullableReference(ISymbol)                 Nullability.cs:903
   at ...DeclarationVisitor.GSharpExpressionIsStaticallyNonNull(...)                  Expressions.cs:1572
   at ...DeclarationVisitor.TranslateReceiverWithNullForgiveness(ExpressionSyntax)    Expressions.cs:871
   at ...TranslateMemberAccess -> ... -> TranslateDocument
   at Cs2Gs.Pipeline.TranslateStage.ExecuteAsync(...)
```

## Cause

Issue #3726's data-row promotion looks a parameter up by ordinal in the attribute's value array, and guarded only the **upper** bound:

```csharp
|| parameter.Ordinal >= row.Values.Length) { continue; }

if (row.Values[parameter.Ordinal].IsNull)   // throws
```

Roslyn models `this` as an `IParameterSymbol` on the enclosing method whose **`Ordinal` is `-1`**, and `SemanticModel.GetSymbolInfo` returns exactly that symbol for a `this` expression — which the translator asks about whenever it translates a `this.…` receiver. Inside a method carrying a data-row-shaped attribute (`[InlineData(…)]`, i.e. a single-`params`-array constructor) that indexes `row.Values[-1]` and takes the whole stage down.

The receiver is not a row column, so the fix answers "no promotion" for a negative ordinal. #3726's promotion of the real columns is unchanged, which two of the three new translator tests pin. Two sibling ordinal lookups in the same file are bounded on both sides defensively — a `this` parameter cannot reach them today (`HasAllowNullWriteContract`'s `DeclaringSyntaxReferences` gate turns it away, which is precisely the gate `HasNullDataRowArgument` applied to the *method* rather than the *parameter*, and that is how the crash got in).

Minimal reproducer:

```csharp
public class ProgramTests
{
    private readonly string name = "n";

    [Theory]
    [InlineData("a")]
    public void Check(string text)
    {
        System.Console.WriteLine(this.name.Length + text.Length);
    }
}
```

## The mislabelling, fixed here too

The crash reached the gate as `category: "translation-unsupported"` under a suggested issue titled *"Unsupported C# construct 'IndexOutOfRangeException' has no canonical G# form"*, with no file and no line. An exception type is not a C# construct, and a tool bug published as a language gap reads as already-triaged — which is how this sat unexamined for weeks.

- New `pipeline-crash` category (ADR-0115 §D.1 updated, plus `tools/cs2gs/README.md`): a stage that throws is a defect in **cs2gs**, not a property of the code being migrated. All stage crashes use it; the diagnostic id still names the stage.
- A crash-shaped suggested issue replaces the unsupported-construct rendering.
- `TranslationCrashException` names the C# file the translate stage was on. It **annotates, it does not absorb**: the exception still propagates and still fails the stage as a crash — no `try`/`catch` turning a crash into a silent gap. Triage is handed the inner exception, so messages, construct kinds and **fingerprints are unchanged** (pinned by a test, so #1750's dedup survives).
- The stack trace now goes to the run log, so a gate log is enough to start a diagnosis from.

## Evidence

**The crash is fixed; the app is NOT green, and the premise it came with was understated.** A whole-repository `./build/run-cs2gs-selfmig-migrate.sh` on this branch reports **51/52 apps translated**, with `test/Interpreter.Tests` still failing translate — on a *second, unrelated* defect that the crash was hiding, because the crash aborted the document loop before the linked-source cross-check ever ran:

```
System.InvalidOperationException: Linked source 'test/Shared/EmittedOracle.cs' translates
differently in multiple projects. First divergence at line 129.
  prior:   let warnings = emitResult.Diagnostics.Where((d Diagnostic) -> !d.IsError).ToImmutableArray()
  current: let warnings = emitResult
               .Diagnostics
               .Where((d GSharp.Core.CodeAnalysis.Diagnostic) -> !d.IsError)
```

The type is spelled short in `Compiler.Tests`/`Extensions.Tests` and fully qualified in `Interpreter.Tests`. Filed as #3805 with the full evidence; it is a different defect (per-project name spelling for a linked source) and is not fixed here. So the corpus goes **50/51 → 50/51 on the headline**; what changes is that the app advances past the crash to a real, named, located diagnosis. (Local denominator is 52 rather than the gate's 51 because this working tree also has `bench/concurrency/clr/ClrBaseline.csproj`; the mix of PASS/FAIL is otherwise the same.)

The improved failure surface earned its keep immediately: the second wall arrived as `pipeline-crash`, with the file named and the stack in the log, and the divergence report — widened in the second commit because one line per side showed only `current: let warnings = emitResult` — is what identified the type spelling as the cause.

### Failing-on-main proof

Reverting only the analyzer guard, on this same tree:

```
Failed  Issue3804…AThisReceiverInsideADataRowTheory_TranslatesInsteadOfCrashing
        System.IndexOutOfRangeException : Index was outside the bounds of the array.
Failed  Issue3804…AThisReceiverDoesNotSuppressTheNullColumnPromotion
        System.IndexOutOfRangeException : Index was outside the bounds of the array.
Failed  Issue3804…AThisReceiverIsNeverPromotedByAWiderRow
        System.IndexOutOfRangeException : Index was outside the bounds of the array.
Failed!  - Failed: 3, Passed: 4, Total: 7
```

All three new translator tests fail on `origin/main`'s behaviour with the reported exception. The **guard rail**: the four `Issue3726` tests in the same run pass on *both* sides — they are the anti-vacuity control, and they are also what proves the guard did not switch the data-row promotion off. `Issue3804CrashTriageTests` are new-surface tests (the `pipeline-crash` category does not exist on main), so they do not compile there; they are not offered as regression proof of the crash.

With the fix: `Issue3804` + `Issue3726` + `Issue1750` + `MigrationPipelineTests` → 39 passed, 0 failed. The whole `Cs2Gs.Tests` suite on this branch: **2644 passed, 0 failed** — no existing triage/fingerprint test moved.

The crash reproduction itself was direct, not inferred: a repository-mode translate over `test/Interpreter.Tests` before the fix produced artifact `translate-992ab3aeefc1.json` — the gate's own fingerprint — and after the fix that app's translate goes `FAIL(1)` → `PASS` in the same two-app run.

Not touched: `tools/cs2gs/selfmig-baseline.json` (the gate is red at 40/51 for #3802's reason), and nothing under `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
