### PR TITLE
ADR-0169: populate Symbol.ContainingType on the SemanticModel surface, so a translated syntax-node analyzer stops silently reporting nothing (#3795)

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -356,14 +356,38 @@ Order: GSA0001 → GSA0003 → GSA0004 → GSA0002 → GSA0005; harness and pari
     `CS2GS-ANALYZER-SNIPPET`. Note this also makes one *negative* test pass
     vacuously, for the same reason.
   - **2** — `GSA0005` (rewriter clone preservation) fires on the C# but not on
-    the translated G# shapes: an analyzer-translation parity gap, not a snippet
-    one. The markers are correctly placed.
+    the translated G# shapes. **Fixed by issue #3795**, see below.
   - **1** — the marked text `typeof(int) != type` becomes `typeof(int32) !=
     type` in G#, so the marker cannot be re-placed by text; dropped and
     reported.
   - **1** — the migrated `GSA0003` reports on a G# field symbol whose
     `Location` is empty, so the verifier cannot check the marker. It now names
     that cause instead of throwing a `NullReferenceException`.
+
+  **GSA0005 detection parity (2026-09-02, issue #3795).** The two `GSA0005`
+  failures above were a FRAMEWORK gap, not a translation one: `Symbol.
+  ContainingType` — the ADR-0169 counterpart of Roslyn's
+  `ISymbol.ContainingType` — was filled in only on the analyzer driver's
+  SYMBOL-action path, which early-returns when no symbol action is registered.
+  GSA0005 is a syntax-node analyzer; it reaches its member symbols through
+  `SemanticModel.GetDeclaredSymbol`, saw `null`, and returned before its
+  base-type walk, so it reported **nothing at all** — the failure mode that
+  passes every negative test. Anchoring now runs while the semantic model
+  indexes declared symbols (`SymbolContainment.AnchorMembers`), so both
+  surfaces agree. Every other adapted shape GSA0005 relies on (the
+  `MethodKind.Constructor`/`Ordinary` → `.ctor` rewrite, the
+  `GetMembers().Concat(GetConstructors())` augmentation, `OverriddenMethod`,
+  `DeclaringSyntaxNodes`) was already correct.
+
+  Same 2-app migration: test-parity **6 failing / 10 passing → 4 failing /
+  12 passing** (translate, compile, ILVerify stay PASS on both sides). The four
+  that remain are #3794 (×2, namespace collapse), #3796 and #3797 — the same
+  tests, failing the same way.
+
+  The corpus parity harness now covers GSA0005 as well as GSA0001
+  (`Adr0169Gsa0005ParityTests`), which is what stops a rule that quietly stops
+  firing from passing again: its negatives share one parameterised path with
+  positives that demand a diagnostic.
 - **M6 Parity + self-migration** — `AnalyzerParityStage`; extend the
   Issue3347-style self-migration ratchet to translate
   `InternalAnalyzers.csproj` live. Exit criterion: all five translated

--- a/src/Core/CodeAnalysis/Analyzers/GSharpAnalyzerDriver.cs
+++ b/src/Core/CodeAnalysis/Analyzers/GSharpAnalyzerDriver.cs
@@ -225,32 +225,29 @@ public sealed class GSharpAnalyzerDriver
 
         foreach (var declaredStruct in program.Structs)
         {
-            yield return declaredStruct;
-
             // ADR-0169: anchor member containment as symbols surface, so
             // analyzers can walk ContainingType/ContainingNamespace the way
-            // Roslyn analyzers do (fill-once, like syntax anchoring).
+            // Roslyn analyzers do (fill-once, like syntax anchoring). Issue
+            // #3795 moved the anchoring itself into SymbolContainment so the
+            // SemanticModel — the surface a syntax-node analyzer actually uses
+            // — anchors identically.
+            SymbolContainment.AnchorMembers(declaredStruct);
+
+            yield return declaredStruct;
+
             foreach (var field in declaredStruct.Fields.Concat(declaredStruct.StaticFields).Concat(declaredStruct.ConstFields))
             {
-                field.AnchorContainingType(declaredStruct);
                 yield return field;
             }
 
             foreach (var property in declaredStruct.Properties.Concat(declaredStruct.StaticProperties))
             {
-                property.AnchorContainingType(declaredStruct);
                 yield return property;
             }
 
             foreach (var declaredEvent in declaredStruct.Events.Concat(declaredStruct.StaticEvents))
             {
-                declaredEvent.AnchorContainingType(declaredStruct);
                 yield return declaredEvent;
-            }
-
-            foreach (var method in declaredStruct.Methods.Concat(declaredStruct.StaticMethods))
-            {
-                method.AnchorContainingType(declaredStruct);
             }
         }
     }

--- a/src/Core/CodeAnalysis/SemanticModel.cs
+++ b/src/Core/CodeAnalysis/SemanticModel.cs
@@ -203,6 +203,15 @@ public sealed class SemanticModel
 
         foreach (var declaredStruct in program.Structs)
         {
+            // ADR-0169 / issue #3795: anchor member containment as the model's
+            // symbols surface, not only on the analyzer driver's SYMBOL-action
+            // path. A syntax-node analyzer reaches a member symbol through
+            // GetDeclaredSymbol/GetSymbolInfo and registers no symbol action,
+            // so without this its `ContainingType` is null where Roslyn's is
+            // always populated -- and every containment-keyed rule silently
+            // reports nothing.
+            SymbolContainment.AnchorMembers(declaredStruct);
+
             yield return declaredStruct;
             foreach (var property in declaredStruct.Properties.Concat(declaredStruct.StaticProperties))
             {

--- a/src/Core/CodeAnalysis/Symbols/SymbolContainment.cs
+++ b/src/Core/CodeAnalysis/Symbols/SymbolContainment.cs
@@ -1,0 +1,82 @@
+// <copyright file="SymbolContainment.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Fills in <see cref="Symbol.ContainingType"/> for the members of a
+/// user-defined type (ADR-0169). G# binds members into per-kind collections on
+/// <see cref="StructSymbol"/> rather than threading a containing-type back-link
+/// through every symbol, so the Roslyn <c>ISymbol.ContainingType</c> analogue
+/// is anchored fill-once when symbols surface on an analyzer-facing surface.
+/// </summary>
+/// <remarks>
+/// Issue #3795: this used to run only on the analyzer driver's SYMBOL-action
+/// path, which a syntax-node analyzer never reaches. Such an analyzer obtains
+/// the same symbols through <see cref="SemanticModel.GetDeclaredSymbol"/> and
+/// saw <c>ContainingType == null</c> where Roslyn always populates it, so every
+/// rule keyed on containment (a base-type walk, a "declared on type X" test)
+/// silently reported nothing rather than failing. Anchoring is idempotent and
+/// never overwrites containment the binder already set, so calling it from both
+/// surfaces is safe.
+/// </remarks>
+internal static class SymbolContainment
+{
+    /// <summary>
+    /// Anchors every member of <paramref name="type"/> to it.
+    /// </summary>
+    /// <param name="type">The declaring type.</param>
+    public static void AnchorMembers(StructSymbol type)
+    {
+        foreach (FieldSymbol field in type.Fields)
+        {
+            field.AnchorContainingType(type);
+        }
+
+        foreach (FieldSymbol field in type.StaticFields)
+        {
+            field.AnchorContainingType(type);
+        }
+
+        foreach (FieldSymbol field in type.ConstFields)
+        {
+            field.AnchorContainingType(type);
+        }
+
+        foreach (PropertySymbol property in type.Properties)
+        {
+            property.AnchorContainingType(type);
+        }
+
+        foreach (PropertySymbol property in type.StaticProperties)
+        {
+            property.AnchorContainingType(type);
+        }
+
+        foreach (EventSymbol declaredEvent in type.Events)
+        {
+            declaredEvent.AnchorContainingType(type);
+        }
+
+        foreach (EventSymbol declaredEvent in type.StaticEvents)
+        {
+            declaredEvent.AnchorContainingType(type);
+        }
+
+        foreach (FunctionSymbol method in type.Methods)
+        {
+            method.AnchorContainingType(type);
+        }
+
+        foreach (FunctionSymbol method in type.StaticMethods)
+        {
+            method.AnchorContainingType(type);
+        }
+
+        foreach (ConstructorSymbol constructor in type.EffectiveExplicitConstructors)
+        {
+            constructor.Function.AnchorContainingType(type);
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Issue3795SymbolContainmentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3795SymbolContainmentTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="Issue3795SymbolContainmentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.CodeAnalysis.Analyzers.Testing;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Analyzers;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3795: <see cref="Symbol.ContainingType"/> — the ADR-0169 counterpart
+/// of Roslyn's <c>ISymbol.ContainingType</c> — used to be filled in only on the
+/// analyzer driver's SYMBOL-action path. A syntax-node analyzer reaches the same
+/// member symbols through <see cref="SemanticModel.GetDeclaredSymbol"/> and
+/// registers no symbol action, so it saw <c>null</c> where Roslyn always has a
+/// value, and every rule keyed on containment (a base-type walk, an "is declared
+/// on type X" test) returned early and reported NOTHING. That is the worst
+/// failure mode for an analyzer: silent under-reporting is indistinguishable
+/// from having nothing to report.
+/// </summary>
+public class Issue3795SymbolContainmentTests
+{
+    private const string Source = @"package App
+
+open class BoundTreeRewriter {
+    protected open func Rewrite(node int32) int32 {
+        return node
+    }
+}
+
+open class Broken : BoundTreeRewriter {
+    protected open override func Rewrite(node int32) int32 {
+        return node
+    }
+}
+
+class Unrelated {
+    func Rewrite(node int32) int32 {
+        return node
+    }
+}
+";
+
+    /// <summary>
+    /// The contract itself, with no analyzer in the way: a method declared in a
+    /// class reports the class as its containing type through the semantic
+    /// model. This is the assertion that fails on the pre-fix framework.
+    /// </summary>
+    [Fact]
+    public void GetDeclaredSymbol_PopulatesContainingType()
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(Source, "containment.gs"));
+        Assert.True(tree.Diagnostics.IsEmpty, string.Join("\n", tree.Diagnostics.Select(d => d.Message)));
+        var compilation = new Core.CodeAnalysis.Compilation.Compilation(tree);
+        var model = compilation.GetSemanticModel(tree);
+
+        FunctionDeclarationSyntax declaration = tree.Root
+            .DescendantNodes()
+            .OfType<FunctionDeclarationSyntax>()
+            .Single(function => function.Identifier.Text == "Rewrite" && function.IsOverride);
+
+        var method = Assert.IsType<FunctionSymbol>(model.GetDeclaredSymbol(declaration));
+        Assert.NotNull(method.ContainingType);
+        Assert.Equal("Broken", method.ContainingType.Name);
+        Assert.Equal("BoundTreeRewriter", method.ContainingType.BaseType?.Name);
+    }
+
+    /// <summary>
+    /// The same fact as an analyzer sees it. The analyzer registers ONLY a
+    /// syntax-node action — the shape #3795's GSA0005 has — and reports when the
+    /// declaring type derives from <c>BoundTreeRewriter</c>. It fires on
+    /// <c>Broken.Rewrite</c>, which is what makes the companion negative below
+    /// mean something.
+    /// </summary>
+    [Fact]
+    public void SyntaxNodeAnalyzer_SeesContainingType_AndReports()
+    {
+        GSharpAnalyzerVerifier<ContainingTypeAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+open class BoundTreeRewriter {
+    protected open func Rewrite(node int32) int32 {
+        return node
+    }
+}
+
+open class Broken : BoundTreeRewriter {
+    protected open override func [|Rewrite|](node int32) int32 {
+        return node
+    }
+}
+",
+            "TESTGSA3795");
+    }
+
+    /// <summary>
+    /// Anti-vacuity companion: the same analyzer stays silent when the
+    /// declaring type does NOT derive from <c>BoundTreeRewriter</c>. Silence
+    /// here is evidence of the containment test discriminating, not of the
+    /// analyzer never running — the test above proves it runs and fires.
+    /// </summary>
+    [Fact]
+    public void SyntaxNodeAnalyzer_StaysSilentWhenContainingTypeDoesNotDerive()
+    {
+        GSharpAnalyzerVerifier<ContainingTypeAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+open class Other {
+    open func Rewrite(node int32) int32 {
+        return node
+    }
+}
+
+open class Unrelated : Other {
+    override func Rewrite(node int32) int32 {
+        return node
+    }
+}
+");
+    }
+
+    /// <summary>
+    /// Reports an override whose declaring type derives from
+    /// <c>BoundTreeRewriter</c> — reduced to the one framework fact #3795 turns
+    /// on, reached the way a syntax-node analyzer reaches it.
+    /// </summary>
+    [GSharpDiagnosticAnalyzer]
+    public sealed class ContainingTypeAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA3795",
+            "Override inside a rewriter",
+            "The declaring type derives from BoundTreeRewriter.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.FunctionDeclaration);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var declaration = (FunctionDeclarationSyntax)context.Node;
+            if (!declaration.IsOverride
+                || context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken) is not FunctionSymbol method)
+            {
+                return;
+            }
+
+            for (var current = method.ContainingType?.BaseType; current is not null; current = current.BaseType)
+            {
+                if (current.Name == "BoundTreeRewriter")
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, declaration.Identifier.Location));
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169Gsa0005ParityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169Gsa0005ParityTests.cs
@@ -1,0 +1,309 @@
+// <copyright file="Adr0169Gsa0005ParityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Analyzers;
+using Cs2Gs.Translator.Loading;
+using GSharp.InternalAnalyzers;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// ADR-0169 §Parity for GSA0005 (issue #3795). The corpus-level parity harness
+/// covered GSA0001 only, so a translated rule that stopped firing altogether
+/// passed every negative test and was caught only by a full migration run —
+/// which is exactly how #3795 escaped. This class runs the REAL Roslyn
+/// <see cref="RewriterClonePreservationAnalyzer"/> over each snippet of
+/// <c>test/InternalAnalyzers.Tests</c>, translates BOTH the snippet and the
+/// analyzer with cs2gs, compiles the translated analyzer with the real G#
+/// compiler, runs it over the translated snippet through the same host gsc
+/// uses, and requires the two diagnostic sets to match.
+/// </summary>
+/// <remarks>
+/// The negatives are non-vacuous BY CONSTRUCTION: they share one parameterised
+/// path with the positives, and the positives assert the translated analyzer
+/// really fires. A rule that reports nothing fails the positives, so "no
+/// diagnostics" can no longer pass for the wrong reason.
+/// </remarks>
+public sealed class Adr0169Gsa0005ParityTests : IDisposable
+{
+    /// <summary>
+    /// The two-form union the fixture shares: a variable-receiver constructor
+    /// and an interface-static one, the latter omitting <c>Receiver</c> and
+    /// carrying <c>InterfaceType</c> instead. Copied verbatim from
+    /// <c>RewriterClonePreservationAnalyzerTests</c> so parity is measured on
+    /// the shapes the migrated suite actually runs.
+    /// </summary>
+    private const string Model = """
+class Node { }
+
+class FieldNode : Node
+{
+    public FieldNode(Node receiver, string field, Node value) { Receiver = receiver; Field = field; Value = value; }
+
+    public FieldNode(string field, string interfaceType, Node value) { Field = field; InterfaceType = interfaceType; Value = value; }
+
+    public Node Receiver { get; }
+
+    public string InterfaceType { get; }
+
+    public string Field { get; }
+
+    public Node Value { get; }
+}
+
+class BoundTreeRewriter
+{
+    protected virtual Node RewriteFieldNode(FieldNode node)
+    {
+        var value = node.Value;
+        return node.InterfaceType != null
+            ? new FieldNode(node.Field, node.InterfaceType, value)
+            : new FieldNode(node.Receiver, node.Field, value);
+    }
+}
+""";
+
+    private const string RebuildsWithoutDiscriminator = """
+
+class Broken : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        return new FieldNode(node.Receiver, node.Field, node.Value);
+    }
+}
+""";
+
+    private const string BranchesOnDiscriminator = """
+
+class Fixed : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        return node.InterfaceType != null
+            ? new FieldNode(node.Field, node.InterfaceType, node.Value)
+            : new FieldNode(node.Receiver, node.Field, node.Value);
+    }
+}
+""";
+
+    private const string DoesNotRebuild = """
+
+class Delegating : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        return node.Field == "skip" ? node : base.RewriteFieldNode(node);
+    }
+}
+""";
+
+    private const string DelegatesOnOnePathOnly = """
+
+class PartlyDelegating : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        if (node.Field == "skip")
+        {
+            return base.RewriteFieldNode(node);
+        }
+
+        return new FieldNode(node.Receiver, node.Field, node.Value);
+    }
+}
+""";
+
+    private const string ReplacesEveryFormsMember = """
+
+class Replacing : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        return node.InterfaceType != null
+            ? new FieldNode(node.Field, node.InterfaceType, new Node())
+            : new FieldNode(node.Receiver, node.Field, new Node());
+    }
+}
+""";
+
+    private const string ReadsThroughAHelper = """
+
+class ViaHelper : BoundTreeRewriter
+{
+    private static string Discriminator(FieldNode node) => node.InterfaceType;
+
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        var owner = Discriminator(node);
+        return owner != null
+            ? new FieldNode(node.Field, owner, node.Value)
+            : new FieldNode(node.Receiver, node.Field, node.Value);
+    }
+}
+""";
+
+    private const string ReadsThroughTheRewrittenBaseResult = """
+
+class ViaBaseResult : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        var rewritten = (FieldNode)base.RewriteFieldNode(node);
+        return rewritten.InterfaceType != null
+            ? new FieldNode(rewritten.Field, rewritten.InterfaceType, rewritten.Value)
+            : new FieldNode(rewritten.Receiver, rewritten.Field, rewritten.Value);
+    }
+}
+""";
+
+    private readonly DirectoryInfo workDirectory = Directory.CreateTempSubdirectory("cs2gs-gsa0005-parity");
+
+    /// <summary>
+    /// The fixture's snippets, each with the number of GSA0005 diagnostics the
+    /// REAL Roslyn analyzer produces. The count is asserted against Roslyn too,
+    /// so a wrong expectation fails on the C# side rather than silently
+    /// weakening the G# side.
+    /// </summary>
+    /// <returns>Snippet name, source, expected diagnostic count.</returns>
+    public static TheoryData<string, string, int> Snippets() => new()
+    {
+        { "ReportsAnOverrideThatRebuildsWithoutTheDiscriminator", Model + RebuildsWithoutDiscriminator, 1 },
+        { "DelegatingOnOnePathDoesNotExcuseDroppingOnAnother", Model + DelegatesOnOnePathOnly, 1 },
+        { "AcceptsAnOverrideThatBranchesOnTheDiscriminator", Model + BranchesOnDiscriminator, 0 },
+        { "AcceptsAnOverrideThatDoesNotRebuild", Model + DoesNotRebuild, 0 },
+        { "IgnoresMembersEveryConstructorRequires", Model + ReplacesEveryFormsMember, 0 },
+        { "AcceptsReadsReachedThroughAHelper", Model + ReadsThroughAHelper, 0 },
+        { "AcceptsReadsThroughTheRewrittenBaseResult", Model + ReadsThroughTheRewrittenBaseResult, 0 },
+    };
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try
+        {
+            workDirectory.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Roslyn GSA0005 and the cs2gs-translated GSA0005 must agree on every
+    /// snippet of the fixture — including the negatives, which are only
+    /// meaningful because the positives on this same path demand a diagnostic.
+    /// </summary>
+    /// <param name="name">The fixture test the snippet comes from.</param>
+    /// <param name="csharpSource">The C# snippet.</param>
+    /// <param name="expected">The expected GSA0005 count.</param>
+    [Theory]
+    [MemberData(nameof(Snippets))]
+    public void TranslatedGsa0005_MatchesRoslynGsa0005(string name, string csharpSource, int expected)
+    {
+        Assert.Equal(expected, RunRoslynGsa0005(csharpSource));
+
+        SnippetTranslationResult snippet = SnippetTranslator.Translate(csharpSource);
+        Assert.NotNull(snippet.GsWithMarkers);
+        Assert.Empty(snippet.UnplacedMarkers);
+
+        int produced = RunTranslatedGsa0005(snippet.GsWithMarkers);
+        Assert.True(
+            expected == produced,
+            $"{name}: Roslyn GSA0005 produced {expected} diagnostic(s), the translated analyzer produced {produced}.");
+    }
+
+    private static int RunRoslynGsa0005(string csharpSource)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", csharpSource) });
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        return project.Compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new RewriterClonePreservationAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult()
+            .Count(d => d.Id == "GSA0005");
+    }
+
+    private int RunTranslatedGsa0005(string gsWithMarkers)
+    {
+        string analyzerDll = CompileTranslatedGsa0005();
+        string gs = gsWithMarkers.Replace("[|", string.Empty, StringComparison.Ordinal)
+            .Replace("|]", string.Empty, StringComparison.Ordinal);
+
+        var tree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+            GSharp.Core.CodeAnalysis.Text.SourceText.From(gs, "snippet.gs"));
+        Assert.True(tree.Diagnostics.IsEmpty, string.Join("\n", tree.Diagnostics.Select(d => d.Message)));
+
+        using var resolver = GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.WithRuntimeReferences(
+            Array.Empty<string>());
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(resolver, tree) { IsLibrary = true };
+        var errors = compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(d => d.IsError)
+            .ToList();
+        Assert.True(errors.Count == 0, string.Join("\n", errors.Select(d => d.Message)) + "\n---\n" + gs);
+
+        var produced = GSharp.Core.CodeAnalysis.Analyzers.GSharpAnalyzerHost.Run(compilation, new[] { analyzerDll });
+        Assert.DoesNotContain(produced, d => d.Id is "GS9300" or "GS9301" or "GS9304");
+        return produced.Count(d => d.Id == "GSA0005");
+    }
+
+    /// <summary>
+    /// Translates the real GSA0005 source in analyzer mode and compiles it into
+    /// a loadable G# analyzer assembly.
+    /// </summary>
+    /// <returns>The analyzer assembly path.</returns>
+    private string CompileTranslatedGsa0005()
+    {
+        string repoRoot = Adr0169TranslatedAnalyzerHarness.FindRepoRoot();
+        string analyzerDirectory = Path.Combine(repoRoot, "src", "Analyzers", "InternalAnalyzers");
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            ("RewriterClonePreservationAnalyzer.cs", File.ReadAllText(Path.Combine(analyzerDirectory, "RewriterClonePreservationAnalyzer.cs"))),
+            ("DiagnosticDescriptors.cs", File.ReadAllText(Path.Combine(analyzerDirectory, "DiagnosticDescriptors.cs"))),
+        });
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        Assert.True(AnalyzerProjectDetector.IsAnalyzerProject(project.Compilation));
+
+        var translator = new CSharpToGSharpTranslator(analyzerApiMode: true);
+        var trees = new List<GSharp.Core.CodeAnalysis.Syntax.SyntaxTree>();
+        foreach (LoadedDocument document in project.Documents.Where(d => Path.GetFileName(d.FilePath) != "GlobalUsings.cs"))
+        {
+            var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+            string printed = GSharpPrinter.Print(translator.TranslateDocument(document, context));
+            Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+            trees.Add(GSharp.Core.CodeAnalysis.Syntax.SyntaxTree.Parse(
+                GSharp.Core.CodeAnalysis.Text.SourceText.From(printed, Path.GetFileName(document.FilePath) + ".gs")));
+        }
+
+        Assert.All(trees, tree => Assert.True(tree.Diagnostics.IsEmpty, string.Join("\n", tree.Diagnostics.Select(d => d.Message))));
+
+        using var resolver = GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.WithRuntimeReferences(
+            new[] { typeof(GSharp.Core.CodeAnalysis.Diagnostic).Assembly.Location });
+        var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(resolver, trees.ToArray())
+        {
+            IsLibrary = true,
+            AssemblyName = "TranslatedGsa0005",
+        };
+
+        string dllPath = Path.Combine(workDirectory.FullName, "TranslatedGsa0005.dll");
+        using (var peStream = File.Create(dllPath))
+        {
+            var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "TranslatedGsa0005");
+            Assert.True(
+                result.Success,
+                "Translated GSA0005 should compile:\n" + string.Join("\n", result.Diagnostics.Where(d => d.IsError).Select(d => d.Message)));
+        }
+
+        return dllPath;
+    }
+}


### PR DESCRIPTION
Fixes #3795. Part of #3501 (ADR-0169 M5, follow-up to #3798).

## The divergence, named precisely

The translated `GSA0005` (`RewriterClonePreservationAnalyzer`) reported **nothing** on the G# shapes where the Roslyn original reports. #3795 pointed at the analyzer's adapted shapes — the `MethodKind.Ordinary → ".ctor"` rewrite and `{ get; } → { get; init; }`. **Both are innocent.** I bisected the migrated analyzer step by step against the real translated snippet and the walk bails five steps earlier:

```
--- node: RewriteFieldNode isOverride=True params=1
  declaredSymbol=FunctionSymbol
  containingType=null baseType=null
  bail: RewriterBase null
```

`Symbol.ContainingType` — the ADR-0169 counterpart of Roslyn's `ISymbol.ContainingType` — is **null**, so `RewriterBase(method.ContainingType?.BaseType)` returns null and `AnalyzeMethod` returns before it ever looks at a constructor form.

**Why it was null.** Containment was anchored in exactly one place: `GSharpAnalyzerDriver.EnumerateDeclaredSymbols`, which only `DispatchSymbols` walks — and `DispatchSymbols` early-returns when no **symbol** action is registered. GSA0005 registers a **syntax-node** action and reaches its member symbols through `SemanticModel.GetDeclaredSymbol`. `SemanticModel`'s own declared-symbol enumeration never anchored anything, so the doc comment on `Symbol.ContainingType` ("Populated fill-once when symbols surface through the analyzer driver **or a `SemanticModel`**") was simply not true of the second surface.

Once containment resolves, the whole rest of the walk is already correct:

```
  overriddenMethod=RewriteFieldNode container=BoundTreeRewriter
  nodeType=FieldNode rebuilds=True
  baseReads=[Field,InterfaceType,Receiver,Value]
  overrideReads=[Field,Receiver,Value]
  GetConstructors=[.ctor(receiver,field,value),.ctor(field,interfaceType,value)]
  formDependent=[InterfaceType,Receiver]
  dropped=[InterfaceType]
```

Every adapted shape #3795 suspected — `MethodKind.Constructor`/`Ordinary` → `.ctor`, `GetMembers().Concat(GetConstructors())`, `OverriddenMethod`, `DeclaringSyntaxNodes`, the `init`-accessor property translation — behaves. **I am flagging that as a correction to the issue's premise**: it reads as a cs2gs analyzer-translation defect and is not one.

## Which layer

**ADR-0169 framework gap**, the second of the two kinds — same class as #3796, not a translation defect. Nothing in cs2gs changes in this PR.

## Overlap with the sibling issues

- **#3796** (`FieldSymbol.Location` empty) — same *family* (analyzer-facing symbol facts G# does not populate), **different root**: that one is `DeclaringSyntaxNodes`/`VariableSymbol.DeclaringSyntax`, this one is `ContainingType`. Not fixed here; its test still fails the same way.
- **#3794** (namespace collapse) and **#3797** (`typeof(int32)`) — unrelated. #3794's vacuously-passing negative (`IgnoresScopedKeysDefinitionHandlesAndNonSymbolKeys`) is untouched by this change and still passes for that issue's reason.

## The fix

Anchoring moves into `SymbolContainment.AnchorMembers` and now runs while the **semantic model** indexes a compilation's declared symbols, so both analyzer-facing surfaces agree. It stays fill-once (`AnchorContainingType` never overwrites) and only touches *members* — fields, properties, events, methods, constructors. Type-level containment, which the binder sets and which the compiler's accessibility/nesting walks read, is untouched: every non-analyzer `.ContainingType` consumer in `src/Core` reads it off a `StructSymbol`/`EnumSymbol`/`InterfaceSymbol`, never off a member.

## Measurement — `test/InternalAnalyzers.Tests`

Targeted 2-app migration (whole-repo discovery, everything else excluded), Release solution rebuilt on each side, **each side a real commit** so the `git describe`-stamped SDK moniker differs and the packed nupkg is genuinely re-packed:

| | gsc | translate | compile | ilverify | test-parity |
|---|---|---|---|---|---|
| before — `origin/main` `4b5997b5e` | `0.4.380+4b5997b5eb` | PASS | PASS | PASS | **FAIL — 6 failing / 10 passing** |
| after — `59105c363` | `0.4.381+59105c363d` | PASS | PASS | PASS | **FAIL — 4 failing / 12 passing** |

Verbatim before: `Failed: 6, Passed: 10, Skipped: 0, Total: 16`. After: `Failed: 4, Passed: 12, Skipped: 0, Total: 16`.

The delta is exactly the two GSA0005 tests. Every remaining failure is unchanged, byte-for-byte the same message, and belongs to a filed issue:

| test | failure | issue |
|---|---|---|
| `IgnoresTypeSymbolsInstanceCachesTuplesAndNonMetadataNamespaces` | `Expected diagnostics [] but the analyzer produced: GSA0003` | #3794 |
| `ReportsSymbolKeyedReferenceCachesWithoutRemapScope` | `Expected [GSA0004 ×4] but the analyzer produced: (none)` | #3794 |
| `ReportsStaticTypeAssemblyAndModuleDictionaryKeys` | `Diagnostic 0 (GSA0003) carries no source location` | #3796 |
| `ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces` | `2 [\|…\|] marker(s) but 3 diagnostic ID(s)` | #3797 |

(`bench/concurrency/clr` is discovered by both runs and fails compile identically on both; pre-existing and outside the pair.)

## Tests — and why the negatives are not vacuous

This is the failure mode the issue warns about: an analyzer that reports nothing looks exactly like an analyzer with nothing to report, and the three negative GSA0005 tests passed throughout. So the tests are built so silence can never be the reason a test passes.

**`Adr0169Gsa0005ParityTests` (7, in `Cs2Gs.Tests`)** — the corpus parity harness covered **GSA0001 only**, which is precisely why nothing was watching GSA0005. It now covers GSA0005: for each of the seven snippets of the real fixture it runs the **real Roslyn analyzer** over the C#, translates BOTH the snippet and the analyzer with cs2gs, compiles the translated analyzer with the **real G# compiler**, runs it through `GSharpAnalyzerHost` (the host gsc uses), and requires the counts to match. Positives and negatives share **one parameterised path**, so an analyzer that stops firing fails the positives — the negatives cannot pass for the wrong reason. The expected count is asserted against Roslyn first, so a wrong expectation fails on the C# side rather than quietly weakening the G# side.

**`Issue3795SymbolContainmentTests` (3, in `Core.Tests`)** — the framework contract directly: `GetDeclaredSymbol` populates `ContainingType`; a syntax-node-only analyzer sees it and **reports**; and the same analyzer stays silent when the declaring type does not derive. That third test is the anti-vacuity companion, and it is only meaningful because the second proves the analyzer runs and fires on the same path.

All ten **execute** — they compile G# and run analyzers over it. No binding-only assertions.

### Failing-on-`origin/main` proof, honestly labelled

Fix reverted (one line), everything else in place:

- `Adr0169Gsa0005ParityTests`: `Failed: 2, Passed: 5` — exactly the two positives. **The five negatives pass on main**; they bound the rule in the other direction and are not proof of the fix. The two positives are.
- `Issue3795SymbolContainmentTests`: `Failed: 2, Passed: 1` — the contract test and the reporting test. **The silence test passes on main** (vacuously — the analyzer never fires there), which is the whole point of pairing it with the reporting test.

With the fix: `7/7` and `3/3`.

## Regression

- `Core.Tests`: **8573 passed, 0 failed**.
- `Compiler.Tests`: **4638 passed, 0 failed**.
- `Cs2Gs.Tests` `Adr0169*` + `Issue3686*` + `Issue3778*`: **57 passed, 0 failed** (50 before + the 7 new).
- C# `test/InternalAnalyzers.Tests`: **16 passed, 0 failed**.
- The 2-app migration above: translate / compile / ILVerify PASS on both sides.

`tools/cs2gs/selfmig-baseline.json` is deliberately untouched.

## Known remaining edge

Anchoring covers members of classes/structs, matching what the driver already did. Members declared on `InterfaceSymbol` are still un-anchored; no analyzer in the suite hits that today, and widening it belongs with a test that needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
