### PR TITLE
gsc: three self-migration compile walls — embeddable-attribute scope (GS9998 ICE), nested-type initializer scope, inherited protected setters (#3811, #3812, #3813)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -3001,12 +3001,36 @@ internal sealed partial class DeclarationBinder
             // `structSymbol`, mirroring how a `shared` function body (which
             // already works) carries its `StaticOwnerType`.
             setCurrentFunction(CreateFieldInitializerAccessibilityContext(structSymbol));
-            if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
+
+            // Issue #3812: this closure runs long after BindStructDeclarationBody
+            // unwound its type-parameter scope, so the scope has to be rebuilt
+            // from scratch — and it must be rebuilt the SAME way, including the
+            // issue #1537 enclosing-type parameters. Seeding only
+            // `structSymbol.TypeParameters` left a nested type's initializer
+            // unable to name the ENCLOSING type's parameters, so
+            // `class Outer[T] { class Inner { var item T = default(T) } }` bound
+            // the field's declared type fine (that happens inside the body scope)
+            // and then failed on the initializer with GS0113 "Type 'T' doesn't
+            // exist" — an initializer-only asymmetry, invisible to any fixture
+            // whose nested field had no initializer.
+            var initializerEnclosingTypeParameters = CollectEnclosingTypeParameters(structSymbol.ContainingType);
+            if (!structSymbol.TypeParameters.IsDefaultOrEmpty || initializerEnclosingTypeParameters.Count > 0)
             {
                 binderCtx.CurrentTypeParameters = new Dictionary<string, TypeParameterSymbol>();
-                foreach (var tp in structSymbol.TypeParameters)
+
+                // Outermost-first, so an inner level shadows an outer one on a
+                // name clash — the same precedence BindStructDeclarationBody uses.
+                foreach (var tp in initializerEnclosingTypeParameters)
                 {
                     binderCtx.CurrentTypeParameters[tp.Name] = tp;
+                }
+
+                if (!structSymbol.TypeParameters.IsDefaultOrEmpty)
+                {
+                    foreach (var tp in structSymbol.TypeParameters)
+                    {
+                        binderCtx.CurrentTypeParameters[tp.Name] = tp;
+                    }
                 }
             }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -573,7 +573,7 @@ internal sealed partial class ExpressionBinder
                 inhMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, propertyName);
                 if (inhMember != null)
                 {
-                    if (!TryGetWritableClrMember(inhMember, out _, out var inhTargetSymbol, out _))
+                    if (!TryGetWritableClrMember(inhMember, out _, out var inhTargetSymbol, out _, fromDerivedType: true))
                     {
                         Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
                         _ = BindExpression(initSyntax.Value);
@@ -682,7 +682,7 @@ internal sealed partial class ExpressionBinder
             {
                 var importedBase = new ImportedClassSymbol(importedBaseClr, syntax, references: scope.References);
                 if (importedBase.TryLookupMember(fieldName, ne: null, out var inheritedStaticMember)
-                    && TryGetWritableClrMember(inheritedStaticMember, out _, out var inheritedTarget, out _))
+                    && TryGetWritableClrMember(inheritedStaticMember, out _, out var inheritedTarget, out _, fromDerivedType: true))
                 {
                     var inheritedValue = BindAssignmentRhs(syntax.Value, inheritedTarget);
                     var inheritedConverted = conversions.BindConversion(syntax.Value.Location, inheritedValue, inheritedTarget);
@@ -1079,7 +1079,7 @@ internal sealed partial class ExpressionBinder
                 clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
                 if (clrMember != null)
                 {
-                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable))
+                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable, fromDerivedType: true))
                     {
                         Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, memberName);
                         return new BoundErrorExpression(null);
@@ -2706,7 +2706,7 @@ internal sealed partial class ExpressionBinder
                 clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, fieldName);
                 if (clrMember != null)
                 {
-                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable))
+                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable, fromDerivedType: true))
                     {
                         Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                         return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1289,15 +1289,16 @@ internal sealed partial class ExpressionBinder
         return ClrTypeUtilities.IsSameAs(fnRetClr, invokeReturn);
     }
 
-    private bool TryGetWritableClrMember(MemberInfo? member, [NotNullWhen(true)] out Type? targetType, [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol, out bool writable)
-        => TryGetWritableClrMember(member, receiverType: null, out targetType, out targetTypeSymbol, out writable);
+    private bool TryGetWritableClrMember(MemberInfo? member, [NotNullWhen(true)] out Type? targetType, [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol, out bool writable, bool fromDerivedType = false)
+        => TryGetWritableClrMember(member, receiverType: null, out targetType, out targetTypeSymbol, out writable, fromDerivedType);
 
     private bool TryGetWritableClrMember(
         MemberInfo? member,
         TypeSymbol? receiverType,
         [NotNullWhen(true)] out Type? targetType,
         [NotNullWhen(true)] out TypeSymbol? targetTypeSymbol,
-        out bool writable)
+        out bool writable,
+        bool fromDerivedType = false)
     {
         switch (member)
         {
@@ -1309,7 +1310,12 @@ internal sealed partial class ExpressionBinder
                         receiverType,
                         p,
                         projectOnlyWhenSymbolicallyRequired: true);
-                writable = p.CanWrite && GetVisibleSetter(p) != null;
+
+                // Issue #3813: `fromDerivedType` marks the inherited-CLR-base
+                // assignment paths (#319/#1582), where a `protected` setter on
+                // the base IS reachable and must not be gated away as if this
+                // were an outside caller.
+                writable = p.CanWrite && GetVisibleSetter(p, fromDerivedType) != null;
                 return writable;
             case FieldInfo f:
                 targetType = f.FieldType;
@@ -1353,6 +1359,19 @@ internal sealed partial class ExpressionBinder
     /// <returns>The callable setter, or <see langword="null"/>.</returns>
     private MethodInfo? GetVisibleSetter(PropertyInfo property)
         => ClrMemberVisibility.GetVisibleSetter(property, CanAccessInternalsOf(property.DeclaringType));
+
+    /// <summary>
+    /// Issue #3813: <see cref="GetVisibleSetter(PropertyInfo)"/>, widened to
+    /// <c>protected</c> accessors when the write is being bound inside a type
+    /// that derives from <paramref name="property"/>'s declaring type.
+    /// </summary>
+    /// <param name="property">The imported CLR property.</param>
+    /// <param name="fromDerivedType">Whether the write site derives from the declaring type.</param>
+    /// <returns>The callable setter, or <see langword="null"/>.</returns>
+    private MethodInfo? GetVisibleSetter(PropertyInfo property, bool fromDerivedType)
+        => fromDerivedType
+            ? ClrMemberVisibility.GetDerivedVisibleSetter(property, CanAccessInternalsOf(property.DeclaringType))
+            : ClrMemberVisibility.GetVisibleSetter(property, CanAccessInternalsOf(property.DeclaringType));
 
     /// <summary>
     /// Issue #3705: the shared instance-property probe for CLR member lookup.
@@ -2719,7 +2738,7 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        if (!TryGetWritableClrMember(member, out _, out var targetSymbol, out _))
+        if (!TryGetWritableClrMember(member, out _, out var targetSymbol, out _, fromDerivedType: true))
         {
             Diagnostics.ReportCannotAssign(assignLocation, name);
             _ = BindExpression(valueSyntax);

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -1394,59 +1394,46 @@ internal sealed class WellKnownReferences
     /// Issue #3811: resolves a <em>compiler-embeddable</em> attribute — one the
     /// C# compiler <b>synthesizes into the emitting assembly</b> when the target
     /// framework does not publish it (<c>NullableAttribute</c>,
-    /// <c>NullableContextAttribute</c>) — and accepts the answer only when it
-    /// comes from the <b>core library</b>.
+    /// <c>NullableContextAttribute</c>) — and accepts the answer only when it is
+    /// <b>externally visible</b>.
     /// <para>
-    /// The plain
-    /// <see cref="Symbols.ReferenceResolver.TryResolveType(string, bool, out System.Type)"/>
-    /// lookup with <c>requireExternalVisibility: false</c> is wrong for this
-    /// family. Under a TFM whose core library does not declare them (notably
-    /// <c>netstandard2.0</c>), the first declarer in the reference closure is
-    /// whichever <em>third-party package</em> csc happened to embed its own
-    /// private copy into — for <c>src/Sdk/Gsharp.NET.Sdk</c> that is
-    /// <c>Microsoft.Build.Framework</c>, which carries an <c>internal</c>
-    /// <c>NullableAttribute</c> that exists only in its <c>ref/netstandard2.0</c>
-    /// asset. Scoping the TypeRef there emits a cross-assembly reference to a
-    /// type that is neither public nor present in any other asset of that
-    /// package, so a downstream compilation that resolves the same package for a
-    /// different TFM throws
+    /// The plain lookup with <c>requireExternalVisibility: false</c> is wrong
+    /// for this family. Because csc embeds a private copy into every assembly
+    /// whose target framework lacks the type, practically every
+    /// <c>netstandard2.0</c> package assembly carries an <c>internal</c>
+    /// <c>NullableAttribute</c> of its own, and the first declarer in the
+    /// reference closure is simply whichever of those the resolver reached
+    /// first — for <c>src/Sdk/Gsharp.NET.Sdk</c> that was
+    /// <c>Microsoft.Build.Framework</c>, whose copy exists only in its
+    /// <c>ref/netstandard2.0</c> asset. Scoping the TypeRef there emits a
+    /// cross-assembly reference to a type that is neither public nor present in
+    /// that package's other assets, so a downstream compilation resolving the
+    /// same package for a different TFM throws
     /// <c>TypeLoadException: Could not find type
     /// 'System.Runtime.CompilerServices.NullableAttribute' in assembly ''</c>
     /// while reading the referencing assembly's nullability metadata — surfaced
     /// as the internal-compiler-error diagnostic <c>GS9998</c>.
     /// </para>
     /// <para>
-    /// Restricting the lookup to the core library keeps today's behaviour on
-    /// every TFM whose core library declares the attribute (where the emitted
-    /// row is resolvable by construction) and falls back to <em>omitting</em> the
-    /// attribute otherwise — the same lossy-but-sound outcome the accessors
-    /// already documented for "very old TFMs". Synthesizing our own embedded
-    /// copy, the way csc does, is the full-fidelity follow-up.
+    /// External visibility is exactly the right discriminator: an embedded copy
+    /// is <em>always</em> <c>internal</c>, while every targeting pack from
+    /// .NET 5 onwards declares
+    /// <c>System.Runtime.CompilerServices.NullableAttribute</c> as a
+    /// <b>public</b> type of <c>System.Runtime</c>. The resolver's
+    /// externally-visible overload additionally skips an inaccessible shim and
+    /// keeps searching for an accessible duplicate (issue #3445), so a closure
+    /// containing both an embedded copy and the real contract assembly resolves
+    /// to the contract assembly. When nothing public declares it — a genuinely
+    /// old TFM — the attribute is omitted, the lossy-but-sound outcome the
+    /// accessors already documented. Synthesizing our own embedded copy, the way
+    /// csc does, is the full-fidelity follow-up.
     /// </para>
     /// </summary>
     /// <param name="fullName">The attribute's fully-qualified metadata name.</param>
-    /// <param name="attributeType">The resolved attribute type, when it is declared by the core library.</param>
-    /// <returns><c>true</c> when the core library declares the attribute; otherwise <c>false</c>.</returns>
+    /// <param name="attributeType">The resolved, externally visible attribute type.</param>
+    /// <returns><c>true</c> when an externally visible declaration was found; otherwise <c>false</c>.</returns>
     private bool TryResolveEmbeddableAttribute(string fullName, [NotNullWhen(true)] out Type? attributeType)
-    {
-        attributeType = null;
-        if (!this.emitCtx.References.TryResolveType(fullName, requireExternalVisibility: false, out var resolved))
-        {
-            return false;
-        }
-
-        // The core library is whichever assembly declares System.Object in this
-        // compilation's reference closure — the targeting pack's contract
-        // assembly under a MetadataLoadContext, System.Private.CoreLib on the
-        // in-process/TPA path.
-        if (!ReferenceEquals(resolved.Assembly, this.emitCtx.CoreObjectType.Assembly))
-        {
-            return false;
-        }
-
-        attributeType = resolved;
-        return true;
-    }
+        => this.emitCtx.References.TryResolveType(fullName, requireExternalVisibility: true, out attributeType);
 
     private MemberReferenceHandle BuildObjectDefaultCtorReference()
     {

--- a/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
+++ b/src/Core/CodeAnalysis/Emit/WellKnownReferences.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -602,7 +603,7 @@ internal sealed class WellKnownReferences
             return this.nullableAttributeByteCtorRef.Value;
         }
 
-        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableAttribute", requireExternalVisibility: false, out var attrType))
+        if (!this.TryResolveEmbeddableAttribute("System.Runtime.CompilerServices.NullableAttribute", out var attrType))
         {
             return default;
         }
@@ -637,7 +638,7 @@ internal sealed class WellKnownReferences
             return this.nullableAttributeByteArrayCtorRef.Value;
         }
 
-        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableAttribute", requireExternalVisibility: false, out var attrType))
+        if (!this.TryResolveEmbeddableAttribute("System.Runtime.CompilerServices.NullableAttribute", out var attrType))
         {
             return default;
         }
@@ -747,7 +748,7 @@ internal sealed class WellKnownReferences
             return this.nullableContextAttributeByteCtorRef.Value;
         }
 
-        if (!this.emitCtx.References.TryResolveType("System.Runtime.CompilerServices.NullableContextAttribute", requireExternalVisibility: false, out var attrType))
+        if (!this.TryResolveEmbeddableAttribute("System.Runtime.CompilerServices.NullableContextAttribute", out var attrType))
         {
             return default;
         }
@@ -1387,6 +1388,64 @@ internal sealed class WellKnownReferences
             name: this.emitCtx.Metadata.GetOrAddString("Finalize"),
             signature: this.emitCtx.Metadata.GetOrAddBlob(sigBlob));
         return this.objectFinalizeRef.Value;
+    }
+
+    /// <summary>
+    /// Issue #3811: resolves a <em>compiler-embeddable</em> attribute — one the
+    /// C# compiler <b>synthesizes into the emitting assembly</b> when the target
+    /// framework does not publish it (<c>NullableAttribute</c>,
+    /// <c>NullableContextAttribute</c>) — and accepts the answer only when it
+    /// comes from the <b>core library</b>.
+    /// <para>
+    /// The plain
+    /// <see cref="Symbols.ReferenceResolver.TryResolveType(string, bool, out System.Type)"/>
+    /// lookup with <c>requireExternalVisibility: false</c> is wrong for this
+    /// family. Under a TFM whose core library does not declare them (notably
+    /// <c>netstandard2.0</c>), the first declarer in the reference closure is
+    /// whichever <em>third-party package</em> csc happened to embed its own
+    /// private copy into — for <c>src/Sdk/Gsharp.NET.Sdk</c> that is
+    /// <c>Microsoft.Build.Framework</c>, which carries an <c>internal</c>
+    /// <c>NullableAttribute</c> that exists only in its <c>ref/netstandard2.0</c>
+    /// asset. Scoping the TypeRef there emits a cross-assembly reference to a
+    /// type that is neither public nor present in any other asset of that
+    /// package, so a downstream compilation that resolves the same package for a
+    /// different TFM throws
+    /// <c>TypeLoadException: Could not find type
+    /// 'System.Runtime.CompilerServices.NullableAttribute' in assembly ''</c>
+    /// while reading the referencing assembly's nullability metadata — surfaced
+    /// as the internal-compiler-error diagnostic <c>GS9998</c>.
+    /// </para>
+    /// <para>
+    /// Restricting the lookup to the core library keeps today's behaviour on
+    /// every TFM whose core library declares the attribute (where the emitted
+    /// row is resolvable by construction) and falls back to <em>omitting</em> the
+    /// attribute otherwise — the same lossy-but-sound outcome the accessors
+    /// already documented for "very old TFMs". Synthesizing our own embedded
+    /// copy, the way csc does, is the full-fidelity follow-up.
+    /// </para>
+    /// </summary>
+    /// <param name="fullName">The attribute's fully-qualified metadata name.</param>
+    /// <param name="attributeType">The resolved attribute type, when it is declared by the core library.</param>
+    /// <returns><c>true</c> when the core library declares the attribute; otherwise <c>false</c>.</returns>
+    private bool TryResolveEmbeddableAttribute(string fullName, [NotNullWhen(true)] out Type? attributeType)
+    {
+        attributeType = null;
+        if (!this.emitCtx.References.TryResolveType(fullName, requireExternalVisibility: false, out var resolved))
+        {
+            return false;
+        }
+
+        // The core library is whichever assembly declares System.Object in this
+        // compilation's reference closure — the targeting pack's contract
+        // assembly under a MetadataLoadContext, System.Private.CoreLib on the
+        // in-process/TPA path.
+        if (!ReferenceEquals(resolved.Assembly, this.emitCtx.CoreObjectType.Assembly))
+        {
+            return false;
+        }
+
+        attributeType = resolved;
+        return true;
     }
 
     private MemberReferenceHandle BuildObjectDefaultCtorReference()

--- a/src/Core/CodeAnalysis/Symbols/ClrMemberVisibility.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrMemberVisibility.cs
@@ -94,6 +94,42 @@ public static class ClrMemberVisibility
     public static MethodInfo? GetVisibleSetter(PropertyInfo property, bool includeInternal)
         => Visible(property.GetSetMethod(nonPublic: true), includeInternal);
 
+    /// <summary>
+    /// Issue #3813: the setter as seen from <b>inside a type that derives from
+    /// the property's declaring type</b>, where CLR <c>family</c> accessibility
+    /// is reachable and the blanket "protected stays invisible" rule of the
+    /// other overloads does not apply.
+    /// <para>
+    /// A G# class deriving from an imported CLR base is entitled to that base's
+    /// <c>protected</c> members — the inherited-base assignment paths in
+    /// <c>ExpressionBinder</c> say so in as many words (issues #319/#1582) and
+    /// already deliver it for <c>protected</c> <em>fields</em>. Properties went
+    /// through the accessor gate instead, so a <c>{ get; protected set; }</c>
+    /// base property (e.g. <c>System.Threading.Channels.Channel&lt;T&gt;.Reader</c>)
+    /// was reported read-only (<c>GS0127</c>) in a derived type's own
+    /// constructor — a write C# accepts.
+    /// </para>
+    /// </summary>
+    /// <param name="property">The property to inspect.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The setter callable from a derived type, or <see langword="null"/>.</returns>
+    public static MethodInfo? GetDerivedVisibleSetter(PropertyInfo property, bool includeInternal)
+    {
+        var setter = property.GetSetMethod(nonPublic: true);
+        if (setter == null)
+        {
+            return null;
+        }
+
+        // `family` (protected) and `famorassem` (protected internal) are always
+        // reachable from a derived type; `famandassem` (private protected) only
+        // adds the same-assembly/friend requirement on top.
+        var reachable = setter.IsFamily
+            || setter.IsFamilyOrAssembly
+            || (includeInternal && setter.IsFamilyAndAssembly);
+        return reachable ? setter : Visible(setter, includeInternal);
+    }
+
     /// <summary>Returns the event's <c>add</c> accessor when it is visible here.</summary>
     /// <param name="eventInfo">The event to inspect.</param>
     /// <param name="includeInternal">Whether friend internals are visible.</param>

--- a/test/Compiler.Tests/Issue3811EmbeddedAttributeReferenceScopeTests.cs
+++ b/test/Compiler.Tests/Issue3811EmbeddedAttributeReferenceScopeTests.cs
@@ -55,11 +55,11 @@ package System.Runtime.CompilerServices
 
 import System
 
-class NullableAttribute : Attribute {
+internal class NullableAttribute : Attribute {
     init(b uint8) {}
 }
 
-class NullableContextAttribute : Attribute {
+internal class NullableContextAttribute : Attribute {
     init(b uint8) {}
 }
 ";

--- a/test/Compiler.Tests/Issue3811EmbeddedAttributeReferenceScopeTests.cs
+++ b/test/Compiler.Tests/Issue3811EmbeddedAttributeReferenceScopeTests.cs
@@ -1,0 +1,329 @@
+// <copyright file="Issue3811EmbeddedAttributeReferenceScopeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3811: <c>NullableAttribute</c>/<c>NullableContextAttribute</c> rows
+/// must never be scoped to a third-party assembly that merely happens to carry
+/// its own embedded copy.
+/// <para>
+/// These two attributes are <em>compiler-embeddable</em>: csc synthesizes a
+/// private copy into the emitting assembly whenever the target framework does
+/// not publish them, which is why practically every <c>netstandard2.0</c>
+/// package assembly contains an <c>internal</c>
+/// <c>System.Runtime.CompilerServices.NullableAttribute</c> of its own. gsc
+/// resolved the name across its whole reference closure with
+/// <c>requireExternalVisibility: false</c> and scoped its TypeRef at whichever
+/// package declared it first — for <c>src/Sdk/Gsharp.NET.Sdk</c> that was
+/// <c>Microsoft.Build.Framework</c>. The emitted assembly then referenced a
+/// type that is neither public nor present in that package's other assets, and
+/// the NEXT gsc compilation that read the assembly's nullability metadata threw
+/// <c>TypeLoadException: Could not find type
+/// 'System.Runtime.CompilerServices.NullableAttribute' in assembly ''</c>,
+/// reported as the internal-compiler-error diagnostic <c>GS9998</c>.
+/// </para>
+/// <para>
+/// That crash is the single error walling <c>test/Sdk.Tests</c> out of the
+/// issue #3501 self-migration gate: the migrated <c>Gsharp.NET.Sdk</c>
+/// (netstandard2.0) emitted the bad rows and the migrated <c>Sdk.Tests</c>
+/// (net10.0) crashed reading them. It is the same family as #3755 — emitting a
+/// reference to a type the consuming target does not have.
+/// </para>
+/// <para>
+/// The test EXECUTES the final program: an assembly that merely "compiles" can
+/// still carry an unresolvable metadata row, so the proof has to load it.
+/// </para>
+/// </summary>
+public class Issue3811EmbeddedAttributeReferenceScopeTests
+{
+    // A third-party assembly carrying its own copy of the embeddable
+    // attributes, exactly as csc embeds one into a netstandard2.0 assembly.
+    private const string DonorSource = @"
+package System.Runtime.CompilerServices
+
+import System
+
+class NullableAttribute : Attribute {
+    init(b uint8) {}
+}
+
+class NullableContextAttribute : Attribute {
+    init(b uint8) {}
+}
+";
+
+    // A library with nullable-annotated surface, so the emitter is asked for
+    // the attribute ctors at all.
+    private const string LibrarySource = @"
+package Lib
+
+class Holder {
+    var name string?
+    func Get(input string?) string? -> input
+}
+";
+
+    private const string ConsumerSource = @"
+import System
+import Lib
+
+let h = Holder()
+Console.WriteLine(h.Get(""hello""))
+";
+
+    /// <summary>
+    /// A library compiled with the donor in its reference closure must be
+    /// consumable — and runnable — by a compilation that does NOT have the
+    /// donor. Before the fix the consumer compile died in the reference
+    /// resolver (or, when a same-named assembly WAS present without the type,
+    /// with the gate's <c>GS9998 TypeLoadException ... in assembly ''</c>).
+    /// </summary>
+    [Fact]
+    public void LibraryBuiltWithADonorAssembly_IsConsumableWithoutIt()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3811_").FullName;
+        try
+        {
+            var donorPath = Path.Combine(tempDir, "Donor.dll");
+            CompileOrThrow("donor", DonorSource, donorPath, tempDir, target: "library", extraReferences: []);
+
+            var libPath = Path.Combine(tempDir, "Lib.dll");
+
+            // The donor is listed FIRST so it wins the resolver's first-writer
+            // precedence — the position Microsoft.Build.Framework occupies for
+            // the migrated SDK, whose netstandard2.0 closure has no core
+            // library declaring the attribute at all.
+            CompileOrThrow("lib", LibrarySource, libPath, tempDir, target: "library", extraReferences: [donorPath]);
+
+            AssertNoForeignEmbeddableAttributeReference(libPath);
+
+            var appPath = Path.Combine(tempDir, "App.dll");
+            CompileOrThrow("app", ConsumerSource, appPath, tempDir, target: "exe", extraReferences: [libPath]);
+
+            IlVerifier.Verify(appPath, additionalReferences: [libPath]);
+
+            var (exit, output) = RunDotnet(appPath);
+            Assert.True(exit == 0, $"the consumer must run. Exit {exit}:\n{output}");
+            Assert.Equal("hello", output.Trim());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// ANTI-VACUITY: the fix must not have silenced nullability emission
+    /// wholesale. Compiled against the <b>targeting pack</b> — what every real
+    /// SDK build uses, and where the core contract assembly
+    /// (<c>System.Runtime</c>) genuinely declares the attributes — the rows are
+    /// still emitted, scoped there.
+    /// <para>
+    /// The targeting pack is used rather than the test host's
+    /// <c>TRUSTED_PLATFORM_ASSEMBLIES</c> precisely because the TPA set is full
+    /// of third-party <c>netstandard2.0</c> assemblies carrying their own
+    /// embedded copies — i.e. it is the defective input, not the reference one.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void AgainstTheTargetingPack_NullabilityRowsAreStillEmitted()
+    {
+        var referencePack = FindReferencePack();
+        Assert.True(
+            referencePack != null,
+            "could not locate a Microsoft.NETCore.App.Ref targeting pack; this assertion is the "
+                + "anti-vacuity guard for #3811 and must not be skipped silently.");
+
+        var tempDir = Directory.CreateTempSubdirectory("gs_3811_pos_").FullName;
+        try
+        {
+            var libPath = Path.Combine(tempDir, "Lib.dll");
+            CompileOrThrow(
+                "lib",
+                LibrarySource,
+                libPath,
+                tempDir,
+                target: "library",
+                extraReferences: [],
+                referenceSet: Directory.GetFiles(referencePack, "*.dll"));
+
+            var scopes = EmbeddableAttributeReferenceScopes(libPath);
+            Assert.NotEmpty(scopes);
+            Assert.All(scopes, scope => Assert.Equal("System.Runtime", scope));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    // <dotnet-root>/packs/Microsoft.NETCore.App.Ref/<version>/ref/<tfm>
+    private static string FindReferencePack()
+    {
+        var dotnetRoot = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        while (dotnetRoot != null && !Directory.Exists(Path.Combine(dotnetRoot, "packs")))
+        {
+            dotnetRoot = Path.GetDirectoryName(dotnetRoot);
+        }
+
+        if (dotnetRoot == null)
+        {
+            return null;
+        }
+
+        var packRoot = Path.Combine(dotnetRoot, "packs", "Microsoft.NETCore.App.Ref");
+        if (!Directory.Exists(packRoot))
+        {
+            return null;
+        }
+
+        return Directory.GetDirectories(packRoot)
+            .OrderByDescending(dir => dir, StringComparer.Ordinal)
+            .Select(dir => Path.Combine(dir, "ref"))
+            .Where(Directory.Exists)
+            .SelectMany(refDir => Directory.GetDirectories(refDir).OrderByDescending(d => d, StringComparer.Ordinal))
+            .FirstOrDefault(tfmDir => File.Exists(Path.Combine(tfmDir, "System.Runtime.dll")));
+    }
+
+    private static void AssertNoForeignEmbeddableAttributeReference(string assemblyPath)
+    {
+        var coreLibraryName = typeof(object).Assembly.GetName().Name;
+        var foreign = EmbeddableAttributeReferenceScopes(assemblyPath)
+            .Where(scope => !string.Equals(scope, coreLibraryName, StringComparison.Ordinal))
+            .ToArray();
+        Assert.True(
+            foreign.Length == 0,
+            "the emitted assembly scopes a compiler-embeddable attribute at a non-core assembly "
+                + $"({string.Join(", ", foreign)}) — the #3811 defect.");
+    }
+
+    // The declaring-assembly name of every NullableAttribute /
+    // NullableContextAttribute TypeRef in the assembly.
+    private static IReadOnlyList<string> EmbeddableAttributeReferenceScopes(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var scopes = new List<string>();
+        foreach (var handle in reader.TypeReferences)
+        {
+            var typeReference = reader.GetTypeReference(handle);
+            var name = reader.GetString(typeReference.Name);
+            if (name is not ("NullableAttribute" or "NullableContextAttribute"))
+            {
+                continue;
+            }
+
+            if (typeReference.ResolutionScope.Kind != HandleKind.AssemblyReference)
+            {
+                scopes.Add("<" + typeReference.ResolutionScope.Kind + ">");
+                continue;
+            }
+
+            var assemblyReference = reader.GetAssemblyReference(
+                (AssemblyReferenceHandle)typeReference.ResolutionScope);
+            scopes.Add(reader.GetString(assemblyReference.Name));
+        }
+
+        return scopes;
+    }
+
+    private static void CompileOrThrow(
+        string name,
+        string source,
+        string outPath,
+        string tempDir,
+        string target,
+        string[] extraReferences,
+        IEnumerable<string> referenceSet = null)
+    {
+        var srcPath = Path.Combine(tempDir, name + ".gs");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+        };
+
+        // Deliberately BEFORE the platform assemblies: the resolver keeps
+        // first-writer precedence, and this reproduces the position the donor
+        // occupies in the real reference closure.
+        foreach (var reference in extraReferences)
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        foreach (var reference in referenceSet ?? TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int exit;
+        try
+        {
+            exit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            exit == 0,
+            $"gsc failed compiling '{name}' (a GS9997/GS9998 here is the #3811 defect):\n"
+                + $"stdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}

--- a/test/Compiler.Tests/Issue3812NestedTypeInitializerScopeTests.cs
+++ b/test/Compiler.Tests/Issue3812NestedTypeInitializerScopeTests.cs
@@ -1,0 +1,265 @@
+// <copyright file="Issue3812NestedTypeInitializerScopeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3812: a nested type's field <b>initializer</b> can name the enclosing
+/// type's type parameters, the same way its field <b>declaration</b> already
+/// could.
+/// <para>
+/// Issue #1537 gave nested-type member binding the enclosing type parameters by
+/// seeding <c>binderCtx.CurrentTypeParameters</c> with
+/// <c>CollectEnclosingTypeParameters(...)</c> in
+/// <c>BindStructDeclarationBody</c>. Field initializers, however, are bound from
+/// a DEFERRED closure (issue #1194) that runs after that scope has unwound and
+/// rebuilds it from scratch — and rebuilt it from
+/// <c>structSymbol.TypeParameters</c> alone. So
+/// <c>class Outer[T] { class Inner { var item T } }</c> bound, while adding an
+/// initializer — <c>var item T = default(T)</c> — failed on the initializer
+/// only, with <c>GS0113 "Type 'T' doesn't exist"</c>.
+/// </para>
+/// <para>
+/// This is one of the two errors walling
+/// <c>bench/concurrency/clr/ClrBaseline</c> out of the issue #3501
+/// self-migration gate: its <c>Hchan&lt;T&gt;.Waiter</c> nested class carries
+/// <c>internal T item = default!;</c>.
+/// </para>
+/// <para>
+/// Every case EXECUTES: an initializer that silently bound to the WRONG
+/// type parameter (an outer/inner shadowing mistake) would still compile and
+/// still verify; only the stored value tells them apart.
+/// </para>
+/// </summary>
+public class Issue3812NestedTypeInitializerScopeTests
+{
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        // The reduction of the defect.
+        yield return new object[]
+        {
+            "nested-initializer-names-enclosing-type-parameter",
+            @"
+package P
+import System
+
+class Outer[T] {
+    class Inner {
+        var item T = default(T)
+    }
+
+    func Fresh() Inner -> Inner()
+
+    func Make(v T) Inner {
+        let i = Inner()
+        i.item = v
+        return i
+    }
+}
+
+let o = Outer[int32]()
+Console.WriteLine(o.Fresh().item.ToString())
+Console.WriteLine(o.Make(7).item.ToString())
+",
+            new[] { "0", "7" },
+        };
+
+        // The ClrBaseline shape: an enclosing-parameterised initializer sitting
+        // beside a field whose type mentions the nested type itself.
+        yield return new object[]
+        {
+            "hchan-waiter-shape",
+            @"
+package P
+import System
+import System.Collections.Generic
+
+class Hchan[T] {
+    private let q Queue[Waiter] = Queue[Waiter]()
+
+    class Waiter {
+        var next Waiter?
+        var item T = default(T)
+    }
+
+    func Push(v T) {
+        let w = Waiter()
+        w.item = v
+        q.Enqueue(w)
+    }
+
+    func Pop() T -> q.Dequeue().item
+}
+
+let h = Hchan[string]()
+h.Push(""go"")
+Console.WriteLine(h.Pop())
+",
+            new[] { "go" },
+        };
+
+        // ANTI-VACUITY: with BOTH levels generic and DIFFERENT names, each
+        // initializer must pick its own level's parameter. A scope that merely
+        // "has some type parameters" would pass the first case and fail here.
+        yield return new object[]
+        {
+            "inner-and-outer-parameters-are-distinguished",
+            @"
+package P
+import System
+
+class Outer[T] {
+    class Inner[U] {
+        var outerItem T = default(T)
+        var innerItem U = default(U)
+
+        func Describe() string -> outerItem.ToString()!! + ""|"" + (if innerItem == nil { ""nil"" } else { ""not-nil"" })
+    }
+
+    func Describe[U]() string -> Inner[U]().Describe()
+}
+
+Console.WriteLine(Outer[int32]().Describe[string]())
+",
+            new[] { "0|nil" },
+        };
+
+        // ANTI-VACUITY: an inner parameter that SHADOWS the outer's name must
+        // win inside the nested type — the outermost-first seeding order.
+        yield return new object[]
+        {
+            "inner-parameter-shadows-same-named-outer",
+            @"
+package P
+import System
+
+class Outer[T] {
+    class Inner[T] {
+        var item T = default(T)
+
+        func Describe() string -> item.ToString()!!
+    }
+
+    func Describe[U]() string -> Inner[U]().Describe()
+}
+
+Console.WriteLine(Outer[string]().Describe[int32]())
+",
+            new[] { "0" },
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void NestedTypeInitializer_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3812_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, name + ".dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed for '{name}' (a GS0113 here is the #3812 deferred-initializer "
+                    + $"scope):\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(exit == 0, $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}

--- a/test/Compiler.Tests/Issue3813InheritedProtectedSetterTests.cs
+++ b/test/Compiler.Tests/Issue3813InheritedProtectedSetterTests.cs
@@ -1,0 +1,291 @@
+// <copyright file="Issue3813InheritedProtectedSetterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3813: a G# class deriving from an imported CLR base may write that
+/// base's <c>protected</c> property, exactly as C# does.
+/// <para>
+/// <c>ClrMemberVisibility</c> (issue #3705) admits only <c>public</c> and
+/// friend-<c>internal</c> accessors, and every write path routed its
+/// settable-ness question through it — including the paths whose own comments
+/// promise inherited <c>protected</c> members (issues #319/#1582, which already
+/// delivered it for <c>protected</c> <em>fields</em>). A
+/// <c>{ get; protected set; }</c> base property was therefore reported
+/// <c>GS0127 "read-only and cannot be assigned to"</c> inside the derived type's
+/// own constructor.
+/// </para>
+/// <para>
+/// This is one of the two errors walling
+/// <c>bench/concurrency/clr/ClrBaseline</c> out of the issue #3501
+/// self-migration gate: its <c>GoChan&lt;T&gt; : Channel&lt;T&gt;</c> constructor
+/// writes <c>Reader</c> and <c>Writer</c>, whose setters
+/// <c>System.Threading.Channels.Channel&lt;T&gt;</c> declares
+/// <c>protected</c>.
+/// </para>
+/// <para>
+/// Every case EXECUTES. Binding alone cannot see whether the emitted
+/// <c>call</c>/<c>callvirt</c> to a <c>family</c> setter is the right slot, and
+/// a wrong one is still verifiable IL; only running the program observes the
+/// value that was actually stored.
+/// </para>
+/// </summary>
+public class Issue3813InheritedProtectedSetterTests
+{
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        // The ClrBaseline shape, reduced: a derived channel installs its own
+        // reader/writer through the base's `protected set` accessors, and the
+        // value written must be observable through the BASE-typed reference —
+        // i.e. the setter really wrote the base's backing slot.
+        yield return new object[]
+        {
+            "protected-setter-through-bare-name",
+            @"
+package P
+import System
+import System.Threading
+import System.Threading.Channels
+
+class Wrap : Channel[int32] {
+    init(inner Channel[int32]) {
+        Reader = inner.Reader
+        Writer = inner.Writer
+    }
+}
+
+let inner = Channel.CreateUnbounded[int32]()
+let w = Wrap(inner)
+let asBase Channel[int32] = w
+asBase.Writer.TryWrite(41)
+var got = 0
+if asBase.Reader.TryRead(&got) {
+    Console.WriteLine((got + 1).ToString())
+}
+",
+            new[] { "42" },
+        };
+
+        // The `this.`-qualified spelling takes a different binder path than the
+        // bare name; both must agree.
+        yield return new object[]
+        {
+            "protected-setter-through-this",
+            @"
+package P
+import System
+import System.Threading
+import System.Threading.Channels
+
+class Wrap : Channel[string] {
+    init(inner Channel[string]) {
+        this.Reader = inner.Reader
+        this.Writer = inner.Writer
+    }
+}
+
+let inner = Channel.CreateUnbounded[string]()
+let w = Wrap(inner)
+let asBase Channel[string] = w
+asBase.Writer.TryWrite(""hi"")
+var got = """"
+if asBase.Reader.TryRead(&got) {
+    Console.WriteLine(got)
+}
+",
+            new[] { "hi" },
+        };
+    }
+
+    /// <summary>
+    /// Gets the cases that must still be REJECTED, so the fix widens exactly
+    /// the inherited-protected hole and nothing else. Each is (name, source).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> RejectedCases()
+    {
+        // ANTI-VACUITY: a genuinely get-only inherited property is still
+        // read-only. `Task.IsCompleted` has no setter at all.
+        yield return new object[]
+        {
+            "get-only-inherited-property-still-rejected",
+            @"
+package P
+import System
+import System.Threading.Tasks
+
+class Bad : TaskCompletionSource {
+    func Break() {
+        this.Task = nil
+    }
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+
+        // ANTI-VACUITY: `protected` stays out of reach from a NON-derived type.
+        // The widening is keyed on the inherited-base write paths only.
+        yield return new object[]
+        {
+            "protected-setter-not-reachable-from-outside",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+func Break(c Channel[int32]) {
+    c.Reader = nil
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void InheritedProtectedSetter_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3813_").FullName;
+        try
+        {
+            var outPath = CompileOrThrow(tempDir, name, source);
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(
+                exit == 0,
+                $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Asserts the guard rails: writes the fix must NOT have opened up.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    [Theory]
+    [MemberData(nameof(RejectedCases))]
+    public void UnreachableSetter_IsStillRejected(string name, string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3813_neg_").FullName;
+        try
+        {
+            var (exit, stdout, stderr) = Compile(tempDir, name, source);
+            Assert.True(
+                exit != 0,
+                $"'{name}' must NOT compile — the #3813 widening is scoped to inherited "
+                    + $"protected accessors on the derived type's own base.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static string CompileOrThrow(string tempDir, string name, string source)
+    {
+        var (exit, stdout, stderr) = Compile(tempDir, name, source);
+        Assert.True(exit == 0, $"gsc failed for '{name}':\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return Path.Combine(tempDir, name + ".dll");
+    }
+
+    private static (int Exit, string Stdout, string Stderr) Compile(string tempDir, string name, string source)
+    {
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+        var outPath = Path.Combine(tempDir, name + ".dll");
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            return (Program.Main(args.ToArray()), compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}


### PR DESCRIPTION
Issue #3501 Track C. Triage of the three smallest compile-stage walls in the self-migration gate (run **33584377318**, 43/52 green), then the fixes that were tractable.

Every diagnosis below was reproduced **locally and standalone** — a two-project scratch corpus for two of them, a three-step `gsc` invocation for the third — so none of it needed a repo-scale migration to iterate on.

## Root causes

| # | cause | app | errors | layer | new / known / cascade |
|---|---|---|---|---|---|
| #3811 | `NullableAttribute`/`NullableContextAttribute` TypeRefs scoped to a third-party assembly's **embedded internal** copy; the next compilation cannot resolve them → **GS9998 ICE** | `test/Sdk.Tests` | 1 | gsc emit (`WellKnownReferences`) | **known family, new instance — a reappearance of #3755** (emitting a reference to a type the consuming target lacks) |
| #3812 | a nested type's field **initializer** binds in a deferred scope rebuilt without the enclosing type's type parameters (#1537 not mirrored into #1194's closure) | `bench/…/ClrBaseline` | 1 of 2 | gsc bind (`DeclarationBinder.Structs`) | new |
| #3813 | an imported CLR base's `protected set` accessor is invisible to the derived type, on the very paths that promise inherited protected members (#319/#1582) | `bench/…/ClrBaseline` | 1 of 2 | gsc bind (`ClrMemberVisibility` / `ExpressionBinder`) | new; a gap left by #3705's blanket "protected is never visible" rule |
| #3814 | an explicit-interface clause on an **imported generic** interface does not satisfy the contract, so cs2gs's carve-out emits two same-signature overloads | `test/Core.Tests` | 2 | gsc bind (ADR-0149) + cs2gs carve-out | **filed, not fixed** — needs the gsc half first |
| #3815 | a generic class deriving from an imported generic base sees the base's members at `object` | `bench/…/ClrBaseline` | 0 today | gsc bind | **filed, not fixed** — found by the #3813 fix; sits behind #3812/#3813 |

## Loudest finding

`test/Sdk.Tests` was an **internal compiler error**, and the empty assembly name in `in assembly ''` was the tell. Compiling the real migrated `src/Sdk/Gsharp.NET.Sdk` (netstandard2.0) and dumping its metadata:

```
--- AssemblyRefs ---
  [1] 'netstandard' 2.0.0.0
  [2] 'Microsoft.Build.Framework' 15.1.0.0
  [3] 'Microsoft.Build.Utilities.Core' 15.1.0.0
  [4] 'System.Private.CoreLib' 10.0.0.0
--- TypeRefs mentioning Nullable ---
  System.Runtime.CompilerServices.NullableAttribute         scope=asmref:Microsoft.Build.Framework
  System.Runtime.CompilerServices.NullableContextAttribute  scope=asmref:Microsoft.Build.Framework
```

Ten assemblies in that netstandard2.0 closure carry an embedded internal copy. (The `System.Private.CoreLib 10.0.0.0` ref in a netstandard2.0 assembly is **#3769**, still open, confirmed independently by the same dump.)

After the fix the two bad rows are gone and the AssemblyRef set is otherwise unchanged.

## Before / after

| app | before (gate 33584377318) | after |
|---|---|---|
| `test/Sdk.Tests` | compile FAIL(1) — GS9998 `TypeLoadException … in assembly ''` | reproduced standalone and fixed; **0 errors** in the reduced end-to-end repro |
| `bench/concurrency/clr/ClrBaseline` | compile FAIL(2) — GS0113, GS0127 | both fixed; **still not green** — #3815 is next behind them (stated, not hidden) |
| `test/Core.Tests` | compile FAIL(2) — GS0187, GS0264 | unchanged; filed as #3814 with the gsc-first ordering worked out |

Reduced-repro before/after for #3811, on the exact three-step shape (`origin/main` gsc vs this branch):

```
main:  step 2 → GS9997 Could not find assembly 'Microsoft.Build.Framework, Version=15.1.0.0…'
main:  step 3 → GS9998 TypeLoadException: Could not find type
                'System.Runtime.CompilerServices.NullableContextAttribute' in assembly ''
this:  step 2 → Wrote App.dll
this:  step 3 → Wrote App2.dll
```

## Test evidence

`test/Compiler.Tests/Issue3811…`, `Issue3812…`, `Issue3813…` — **10 cases, every one compiles + ILVerifies + runs + asserts the program's own stdout.** No binding-only assertions.

Failing-on-`origin/main` proof (source reverted, tests kept):

```
Failed!  - Failed: 6, Passed: 4, Total: 10
```

with the fixes:

```
Passed!  - Failed: 0, Passed: 10, Total: 10
```

The **4 that pass on both sides are the deliberate anti-vacuity guard rails**, labelled as such:
- nullability rows are *still emitted* against the targeting pack, scoped to `System.Runtime` (so #3811 did not simply silence emission);
- a genuinely get-only inherited property is still rejected;
- a `protected` setter is still unreachable from a **non-derived** type;
- an inner type parameter shadowing a same-named outer one already worked and must keep working.

`build/nullable_hygiene.py`: OK.

## Premise corrections

- The brief expected `test/Core.Tests` to be "an explicit interface implementation translated into an ordinary overload (or vice versa)". Half right: cs2gs *does* drop the clause — but only because of a deliberate carve-out, and **adding the clause by hand does not fix it**. gsc still reports GS0187, so the root cause is gsc's ADR-0149 interface verification, not the translator. Fixing cs2gs first would make the diagnostics worse.
- The brief suggested the `NullableAttribute` crash might be a *synthesized*-attribute emit path. It is the opposite: gsc **never** synthesizes one — that is precisely the gap — and instead borrows someone else's.
- ClrBaseline's two errors are two independent defects, as predicted, but fixing them does **not** turn the app green: a third defect (#3815) sits behind them.

## Deconfliction

No files in the cs2gs linked-source / name-spelling path were touched, so there is no overlap with the agent working #3805. `tools/cs2gs/selfmig-baseline.json` is untouched (PR #3810 is open against it) — no app moves to green in this PR, so no ratchet is due.