### PR TITLE
cs2gs: a linked source's name-spelling decision spans every project that links it (#3805)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3805LinkedSourceHomonymTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3805LinkedSourceHomonymTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue3805LinkedSourceHomonymTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3805: a LINKED source — one <c>.cs</c> file compiled into several
+/// projects via <c>&lt;Compile Include="..\Shared\X.cs" /&gt;</c> — must
+/// translate to the SAME G# in every project. The repository mirror writes one
+/// <c>.gs</c> per source file and <c>TranslateStage</c> rejects divergent
+/// renderings ("Linked source ... translates differently in multiple
+/// projects").
+/// <para>
+/// The #1174 homonym census decides whether a bare type name is safe by
+/// looking for a same-named type declared in SOURCE anywhere in the
+/// compilation — and a project reference is a source-bearing compilation
+/// reference, so the census follows the project's reference graph.
+/// <c>test/Shared/EmittedOracle.cs</c> is linked into <c>test/Core.Tests</c>,
+/// <c>tools/cs2gs/Cs2Gs.Tests</c> and <c>test/Interpreter.Tests</c>; only the
+/// last references the Repl and through it
+/// <c>GSharp.LanguageServer.Protocol.Diagnostic</c>. Its inferred lambda
+/// parameter therefore printed <c>(d GSharp.Core.CodeAnalysis.Diagnostic)</c>
+/// while the other two printed <c>(d Diagnostic)</c>, and the whole-repository
+/// translate stage failed.
+/// </para>
+/// <para>
+/// The rule adopted here is the one the shared-document nullability taint
+/// already follows (issue #3501): a decision that can differ between the
+/// projects linking a file is answered over the WHOLE set of them, converged
+/// and order-independent. The qualified spelling binds in every project, so
+/// the union answer is the safe one.
+/// </para>
+/// </summary>
+public class Issue3805LinkedSourceHomonymTests
+{
+    /// <summary>
+    /// The type the linked file's lambda parameter is inferred as. Referenced
+    /// by both projects.
+    /// </summary>
+    private const string CoreLibrarySource = @"
+using System.Collections.Generic;
+
+namespace Corpus.Issue3805.Core
+{
+    public sealed class Diagnostic { public bool IsError { get; set; } }
+
+    public sealed class EmitResult { public IReadOnlyList<Diagnostic> Diagnostics { get; set; } }
+}
+";
+
+    /// <summary>
+    /// The <c>GSharp.LanguageServer.Protocol</c> stand-in: a second
+    /// <c>Diagnostic</c> in a namespace the linked file never imports and
+    /// never names, referenced by only ONE of the linking projects.
+    /// </summary>
+    private const string RivalLibrarySource = @"
+namespace Corpus.Issue3805.Rival
+{
+    public sealed class Diagnostic { public bool IsError { get; set; } }
+}
+";
+
+    /// <summary>
+    /// The linked file. It never SPELLS <c>Diagnostic</c> — C# infers the
+    /// lambda parameter's type — but G# always spells a lambda parameter's
+    /// type (ADR-0074), so cs2gs has to choose a spelling.
+    /// </summary>
+    private const string LinkedSource = @"
+using System.Collections.Generic;
+using System.Linq;
+using Corpus.Issue3805.Core;
+
+namespace Corpus.Issue3805.Tests
+{
+    public static class Oracle
+    {
+        public static int ErrorCount(EmitResult result)
+        {
+            return result.Diagnostics.Where(d => d.IsError).ToList().Count;
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// The repo-relative path both projects link the file under. The two
+    /// compilations parse it into distinct <see cref="SyntaxTree"/> instances,
+    /// so the linked-document set is matched by path and content.
+    /// </summary>
+    private const string LinkedPath = "test/Shared/Oracle.cs";
+
+    [Fact]
+    public void LinkedSource_TranslatesIdenticallyInEveryLinkingProject()
+    {
+        (string withoutHomonym, string withHomonym) = TranslateBothProjects();
+
+        // This is exactly what TranslateStage's cross-check compares.
+        Assert.Equal(withoutHomonym, withHomonym);
+    }
+
+    [Fact]
+    public void LinkedSource_QualifiesTheNameThatIsAmbiguousInAnyLinkingProject()
+    {
+        (string withoutHomonym, string withHomonym) = TranslateBothProjects();
+
+        // The qualified spelling binds in both projects; the bare one is the
+        // spelling the census calls unsafe in the project that also sees
+        // Corpus.Issue3805.Rival.Diagnostic.
+        Assert.Contains("(d Corpus.Issue3805.Core.Diagnostic) ->", withHomonym, StringComparison.Ordinal);
+        Assert.Contains("(d Corpus.Issue3805.Core.Diagnostic) ->", withoutHomonym, StringComparison.Ordinal);
+        Assert.DoesNotContain("(d Diagnostic) ->", withoutHomonym, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LinkedSource_WithNoHomonymAnywhere_StaysBare()
+    {
+        // Guard rail: the union answer must not qualify a name that is
+        // unambiguous in EVERY linking project, or the fix would qualify the
+        // whole corpus.
+        MetadataReference core = Reference("Corpus.Issue3805.Core", CoreLibrarySource);
+
+        LoadedCSharpProject first = LoadLinkingProject("Corpus.Issue3805.First", core);
+        LoadedCSharpProject second = LoadLinkingProject("Corpus.Issue3805.Second", core);
+        var repository = new[] { first.Compilation, second.Compilation };
+
+        string rendered = Translate(first, repository);
+
+        Assert.Contains("(d Diagnostic) ->", rendered, StringComparison.Ordinal);
+        Assert.Equal(rendered, Translate(second, repository));
+    }
+
+    /// <summary>
+    /// Translates the linked file as each of the two linking projects, with
+    /// the repository compilation set both of them would see in a
+    /// whole-repository migration.
+    /// </summary>
+    /// <returns>The rendering from the project without the rival type, then the one with it.</returns>
+    private static (string WithoutHomonym, string WithHomonym) TranslateBothProjects()
+    {
+        MetadataReference core = Reference("Corpus.Issue3805.Core", CoreLibrarySource);
+        MetadataReference rival = Reference("Corpus.Issue3805.Rival", RivalLibrarySource);
+
+        LoadedCSharpProject withoutHomonym = LoadLinkingProject(
+            "Corpus.Issue3805.WithoutHomonym", core);
+        LoadedCSharpProject withHomonym = LoadLinkingProject(
+            "Corpus.Issue3805.WithHomonym", core, rival);
+        var repository = new[] { withoutHomonym.Compilation, withHomonym.Compilation };
+
+        return (Translate(withoutHomonym, repository), Translate(withHomonym, repository));
+    }
+
+    /// <summary>
+    /// A PROJECT reference: a compilation reference, whose types carry source
+    /// locations exactly like an MSBuild <c>&lt;ProjectReference&gt;</c>'s do.
+    /// That is what puts them in the #1174 source census, and what makes the
+    /// census answer depend on the linking project's reference graph.
+    /// </summary>
+    /// <param name="assemblyName">The referenced assembly name.</param>
+    /// <param name="source">Its source.</param>
+    /// <returns>The compilation reference.</returns>
+    private static MetadataReference Reference(string assemblyName, string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Assert.Empty(compilation
+            .GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        return compilation.ToMetadataReference();
+    }
+
+    private static LoadedCSharpProject LoadLinkingProject(
+        string assemblyName,
+        params MetadataReference[] extraReferences)
+    {
+        var references = new List<MetadataReference>(CSharpProjectLoader.RuntimeReferences());
+        references.AddRange(extraReferences);
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (LinkedPath, LinkedSource) },
+            references,
+            assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+
+    private static string Translate(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> repositoryCompilations)
+    {
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            repositoryCompilations,
+            repositoryCompilations);
+        return GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -51,6 +51,15 @@ public sealed class CSharpTypeMapper
         new(BuildAnalyzerTargetTypeNames);
 
     /// <summary>
+    /// Issue #3805: the linked-source index (see <see cref="LinkedDocumentIndex"/>)
+    /// per repository compilation set, cached weakly so it is built once per
+    /// migration run instead of once per translated document.
+    /// </summary>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
+        object,
+        Dictionary<string, List<(CSharpCompilation Compilation, SyntaxTree Tree)>>> LinkedDocumentIndexes = new();
+
+    /// <summary>
     /// Issue #2211: every namespace this mapper has shortened a type reference
     /// into (via <see cref="QualifiedTypeName"/>), collected so the translator
     /// can synthesize a matching <c>import</c> for a namespace with no
@@ -135,9 +144,9 @@ public sealed class CSharpTypeMapper
     /// Nested declarations are excluded because they are not imported by their
     /// simple names.
     /// </summary>
-    private Dictionary<string, int> sourceTopLevelSimpleNameCounts;
+    private Dictionary<CSharpCompilation, Dictionary<string, HashSet<string>>> sourceTopLevelSimpleNames;
 
-    private Dictionary<string, int> sourceNestedSimpleNameCounts;
+    private Dictionary<CSharpCompilation, Dictionary<string, HashSet<string>>> sourceNestedSimpleNames;
 
     private HashSet<string> sourceDeclaredTypeNames;
 
@@ -150,6 +159,16 @@ public sealed class CSharpTypeMapper
     /// project) rather than in source.
     /// </summary>
     private HashSet<string> importedNamespaceNames;
+
+    /// <summary>
+    /// Issue #3805: the semantic models of the file being translated, one per
+    /// repository compilation that COMPILES that file. For an ordinary file
+    /// that is just <see cref="TranslationContext.SemanticModel"/>; for a
+    /// LINKED source (<c>&lt;Compile Include="..\Shared\X.cs" /&gt;</c> in
+    /// several projects) it is one model per linking project. See
+    /// <see cref="LinkedDocumentModels(TranslationContext)"/>.
+    /// </summary>
+    private Dictionary<SyntaxTree, IReadOnlyList<SemanticModel>> linkedDocumentModels;
 
     /// <summary>
     /// Issue #2509: constraint slots must disambiguate metadata/metadata
@@ -1816,41 +1835,125 @@ public sealed class CSharpTypeMapper
     /// they are reachable through their containing type, not through an import.
     /// The per-compilation simple-name census is built once and cached on this
     /// mapper instance.
+    /// <para>
+    /// Issue #3805: for a LINKED source the census runs over every compilation
+    /// that compiles the file. The census counts PROJECT-REFERENCED types too
+    /// (a project reference is a source-bearing compilation reference), so its
+    /// answer follows the project's reference graph:
+    /// <c>test/Interpreter.Tests</c> references the Repl and through it
+    /// <c>GSharp.LanguageServer.Protocol.Diagnostic</c>, while
+    /// <c>test/Core.Tests</c> and <c>tools/cs2gs/Cs2Gs.Tests</c> — which link
+    /// the very same <c>test/Shared/EmittedOracle.cs</c> — do not. That made
+    /// one lambda parameter print <c>GSharp.Core.CodeAnalysis.Diagnostic</c>
+    /// in one project and <c>Diagnostic</c> in the others, and the repository
+    /// mirror (one <c>.gs</c> per source file) rejected the divergence.
+    /// </para>
     /// </summary>
     private bool HasSourceHomonym(INamedTypeSymbol named, TranslationContext context)
     {
-        this.sourceTopLevelSimpleNameCounts ??=
-            BuildSourceTopLevelSimpleNameCounts(context.Compilation);
-        if (!this.sourceTopLevelSimpleNameCounts.TryGetValue(named.Name, out var count))
+        foreach (CSharpCompilation compilation in this.LinkedDocumentCompilations(context))
         {
-            return false;
+            if (HasHomonym(
+                this.SourceTopLevelSimpleNames(compilation),
+                named,
+                nested: false))
+            {
+                return true;
+            }
         }
 
-        // Issue #2307: for a source top-level symbol, one census entry is the
-        // symbol itself, so ambiguity starts at two. Metadata and nested source
-        // symbols are not census entries, so one same-named top-level source
-        // declaration is already a distinct homonym.
-        int selfCount = named.ContainingType == null
-            && named.Locations.Any(l => l.IsInSource)
-                ? 1
-                : 0;
-        return count > selfCount;
+        return false;
     }
 
     private bool HasSourceNestedHomonym(INamedTypeSymbol named, TranslationContext context)
     {
-        this.sourceNestedSimpleNameCounts ??=
-            BuildSourceNestedSimpleNameCounts(context.Compilation);
-        if (!this.sourceNestedSimpleNameCounts.TryGetValue(named.Name, out int count))
+        foreach (CSharpCompilation compilation in this.LinkedDocumentCompilations(context))
+        {
+            if (HasHomonym(
+                this.SourceNestedSimpleNames(compilation),
+                named,
+                nested: true))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #2307/#3805: whether <paramref name="census"/> holds a
+    /// source-declared type of <paramref name="named"/>'s simple name that is
+    /// not <paramref name="named"/> itself. Identity is compared by full name
+    /// rather than by counting entries, so the answer is the same whichever
+    /// compilation of a linked source asks it (symbols from two compilations
+    /// are never reference-equal, and the same type is source-declared in one
+    /// project's view and metadata in another's).
+    /// </summary>
+    /// <param name="census">One compilation's simple-name census.</param>
+    /// <param name="named">The type whose bare name is being considered.</param>
+    /// <param name="nested">Whether the census covers nested declarations.</param>
+    /// <returns><see langword="true"/> when a distinct same-named declaration exists.</returns>
+    private static bool HasHomonym(
+        IReadOnlyDictionary<string, HashSet<string>> census,
+        INamedTypeSymbol named,
+        bool nested)
+    {
+        if (!census.TryGetValue(named.Name, out HashSet<string> declarations))
         {
             return false;
         }
 
-        int selfCount = named.ContainingType != null
-            && named.Locations.Any(location => location.IsInSource)
-                ? 1
-                : 0;
-        return count > selfCount;
+        string self = (named.ContainingType != null) == nested
+            ? named.OriginalDefinition.ToDisplayString()
+            : null;
+        foreach (string declaration in declarations)
+        {
+            if (declaration != self)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3805: <paramref name="compilation"/>'s top-level source-declared
+    /// type names, cached per compilation on this mapper (a linked source asks
+    /// once per linking project, an ordinary file only once).
+    /// </summary>
+    /// <param name="compilation">The compilation to census.</param>
+    /// <returns>Simple name to the full names declared under it.</returns>
+    private IReadOnlyDictionary<string, HashSet<string>> SourceTopLevelSimpleNames(CSharpCompilation compilation)
+    {
+        this.sourceTopLevelSimpleNames ??= new Dictionary<CSharpCompilation, Dictionary<string, HashSet<string>>>();
+        if (!this.sourceTopLevelSimpleNames.TryGetValue(compilation, out Dictionary<string, HashSet<string>> census))
+        {
+            census = BuildSourceSimpleNames(compilation, nested: false);
+            this.sourceTopLevelSimpleNames[compilation] = census;
+        }
+
+        return census;
+    }
+
+    /// <summary>
+    /// Issue #3805: <paramref name="compilation"/>'s NESTED source-declared
+    /// type names, the nested-declaration counterpart of
+    /// <see cref="SourceTopLevelSimpleNames"/>.
+    /// </summary>
+    /// <param name="compilation">The compilation to census.</param>
+    /// <returns>Simple name to the full names declared under it.</returns>
+    private IReadOnlyDictionary<string, HashSet<string>> SourceNestedSimpleNames(CSharpCompilation compilation)
+    {
+        this.sourceNestedSimpleNames ??= new Dictionary<CSharpCompilation, Dictionary<string, HashSet<string>>>();
+        if (!this.sourceNestedSimpleNames.TryGetValue(compilation, out Dictionary<string, HashSet<string>> census))
+        {
+            census = BuildSourceSimpleNames(compilation, nested: true);
+            this.sourceNestedSimpleNames[compilation] = census;
+        }
+
+        return census;
     }
 
     private bool HasVisibleSourceNestedHomonym(
@@ -1866,22 +1969,25 @@ public sealed class CSharpTypeMapper
         int position = System.Math.Min(
             location.SourceSpan.Start,
             location.SourceTree.GetRoot().FullSpan.End - 1);
-        SemanticModel semanticModel = ReferenceEquals(
-            context.SemanticModel.SyntaxTree,
-            location.SourceTree)
-                ? context.SemanticModel
-                : context.Compilation.GetSemanticModel(location.SourceTree);
-        foreach (ISymbol symbol in semanticModel.LookupNamespacesAndTypes(position, name: named.Name))
+
+        // Issue #3805: for a LINKED source, ask every linking project's
+        // semantic model — the same lexical position, its own parse of the
+        // file — so the answer does not depend on which project is being
+        // translated. A location in some OTHER file is only the current
+        // compilation's business.
+        foreach (SemanticModel semanticModel in this.LinkedDocumentModels(context, location.SourceTree))
         {
-            if (symbol is INamedTypeSymbol candidate
-                && candidate.Arity == named.Arity
-                && candidate.ContainingType != null
-                && candidate.Locations.Any(candidateLocation => candidateLocation.IsInSource)
-                && !SymbolEqualityComparer.Default.Equals(
-                    candidate.OriginalDefinition,
-                    named.OriginalDefinition))
+            foreach (ISymbol symbol in semanticModel.LookupNamespacesAndTypes(position, name: named.Name))
             {
-                return true;
+                if (symbol is INamedTypeSymbol candidate
+                    && candidate.Arity == named.Arity
+                    && candidate.ContainingType != null
+                    && candidate.Locations.Any(candidateLocation => candidateLocation.IsInSource)
+                    && candidate.OriginalDefinition.ToDisplayString()
+                        != named.OriginalDefinition.ToDisplayString())
+                {
+                    return true;
+                }
             }
         }
 
@@ -1904,48 +2010,90 @@ public sealed class CSharpTypeMapper
     {
         foreach (string namespaceName in this.GetImportedNamespaceNames(context))
         {
-            INamespaceSymbol candidateNamespace = ResolveNamespace(context.Compilation, namespaceName);
-            if (candidateNamespace is null)
+            // Issue #3805: for a LINKED source this scans every compilation
+            // that compiles the file, not just the one being translated. The
+            // mirror writes ONE .gs per source file, so the spelling chosen
+            // here has to bind in every project that links it — and a rival
+            // same-named type may sit in the reference set of only some of
+            // them (`GSharp.LanguageServer.Protocol.Diagnostic` is visible to
+            // test/Interpreter.Tests, which references the Repl, but not to
+            // test/Compiler.Tests, which does not). Answering per-project made
+            // test/Shared/EmittedOracle.cs translate two different ways and
+            // fail the linked-source cross-check; answering over the union is
+            // order-independent and safe in all of them.
+            foreach (CSharpCompilation compilation in this.LinkedDocumentCompilations(context))
+            {
+                if (this.HasImportedNamespaceHomonym(named, compilation, namespaceName))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3805: the single-compilation half of <see
+    /// cref="HasImportedNamespaceHomonym(INamedTypeSymbol, TranslationContext)"/>
+    /// — whether <paramref name="compilation"/> declares a DIFFERENT type of
+    /// <paramref name="named"/>'s simple name in <paramref
+    /// name="namespaceName"/>.
+    /// </summary>
+    /// <param name="named">The type whose bare name is being considered.</param>
+    /// <param name="compilation">The compilation to resolve the namespace in.</param>
+    /// <param name="namespaceName">An imported namespace name.</param>
+    /// <returns><see langword="true"/> when a rival type of the same name and arity lives there.</returns>
+    private bool HasImportedNamespaceHomonym(
+        INamedTypeSymbol named,
+        CSharpCompilation compilation,
+        string namespaceName)
+    {
+        INamespaceSymbol candidateNamespace = ResolveNamespace(compilation, namespaceName);
+        if (candidateNamespace is null)
+        {
+            return false;
+        }
+
+        // `named` may be a CONSTRUCTED generic (e.g. `Box<Label>`), while
+        // `GetTypeMembers` always yields the unbound generic definition
+        // (`Box<T>`). Comparing them directly makes every reference to a
+        // constructed generic type look like a homonym of itself — compare
+        // original definitions so `Box<Label>` correctly matches `Box<T>`.
+        // Symbol identity only answers WITHIN one compilation; across the
+        // linked-document set the namespace comparison below carries that
+        // weight (the same type reached from two compilations has the same
+        // containing namespace).
+        foreach (INamedTypeSymbol candidate in candidateNamespace.GetTypeMembers(named.Name))
+        {
+            if (SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, named.OriginalDefinition))
             {
                 continue;
             }
 
-            // `named` may be a CONSTRUCTED generic (e.g. `Box<Label>`), while
-            // `GetTypeMembers` always yields the unbound generic definition
-            // (`Box<T>`). Comparing them directly makes every reference to a
-            // constructed generic type look like a homonym of itself — compare
-            // original definitions so `Box<Label>` correctly matches `Box<T>`.
-            foreach (INamedTypeSymbol candidate in candidateNamespace.GetTypeMembers(named.Name))
+            // Issue #3554 follow-up: an arity-differing pair
+            // (System.Collections.IEnumerator vs
+            // System.Collections.Generic.IEnumerator<T>) is not a G#
+            // ambiguity — gsc disambiguates a bare name by its type-argument
+            // count, exactly like the same-namespace
+            // IComparable/IComparable<T> case filtered below.
+            if (candidate.Arity != named.Arity)
             {
-                if (SymbolEqualityComparer.Default.Equals(candidate.OriginalDefinition, named.OriginalDefinition))
-                {
-                    continue;
-                }
-
-                // Issue #3554 follow-up: an arity-differing pair
-                // (System.Collections.IEnumerator vs
-                // System.Collections.Generic.IEnumerator<T>) is not a G#
-                // ambiguity — gsc disambiguates a bare name by its type-argument
-                // count, exactly like the same-namespace
-                // IComparable/IComparable<T> case filtered below.
-                if (candidate.Arity != named.Arity)
-                {
-                    continue;
-                }
-
-                // Types in the same namespace/package are not an import
-                // collision. This also filters facade/implementation symbols
-                // for the same forwarded metadata type, and same-namespace
-                // generic-arity overloads such as IComparable/IComparable<T>
-                // that the type arguments already disambiguate.
-                if (candidate.ContainingNamespace?.ToDisplayString()
-                    == named.ContainingNamespace?.ToDisplayString())
-                {
-                    continue;
-                }
-
-                return true;
+                continue;
             }
+
+            // Types in the same namespace/package are not an import
+            // collision. This also filters facade/implementation symbols
+            // for the same forwarded metadata type, and same-namespace
+            // generic-arity overloads such as IComparable/IComparable<T>
+            // that the type arguments already disambiguate.
+            if (candidate.ContainingNamespace?.ToDisplayString()
+                == named.ContainingNamespace?.ToDisplayString())
+            {
+                continue;
+            }
+
+            return true;
         }
 
         return false;
@@ -1992,8 +2140,33 @@ public sealed class CSharpTypeMapper
             return this.importedNamespaceNames;
         }
 
+        // Issue #3805: a LINKED source is bound once per linking project, and
+        // an inferred type (a lambda parameter, `var`) can name a namespace in
+        // one project's binding that another project never sees. The import
+        // set is therefore the UNION over the linking projects, so the
+        // ambiguity answer — and the emitted spelling — is the same in all of
+        // them.
         var names = new HashSet<string>();
-        if (context.SemanticModel.SyntaxTree.GetRoot() is CompilationUnitSyntax root)
+        foreach (SemanticModel model in this.LinkedDocumentModels(context))
+        {
+            CollectImportedNamespaceNames(model, names);
+        }
+
+        this.importedNamespaceNames = names;
+        return names;
+    }
+
+    /// <summary>
+    /// Issue #2222: adds the namespace names in scope for <paramref
+    /// name="semanticModel"/>'s file to <paramref name="names"/>. Split out of
+    /// <see cref="GetImportedNamespaceNames"/> for issue #3805 so a linked
+    /// source can union the answer over every project that compiles it.
+    /// </summary>
+    /// <param name="semanticModel">One project's semantic model for the file.</param>
+    /// <param name="names">The namespace-name set to add to.</param>
+    private static void CollectImportedNamespaceNames(SemanticModel semanticModel, HashSet<string> names)
+    {
+        if (semanticModel.SyntaxTree.GetRoot() is CompilationUnitSyntax root)
         {
             IEnumerable<UsingDirectiveSyntax> usings = root.Usings
                 .Concat(root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>().SelectMany(n => n.Usings));
@@ -2037,7 +2210,7 @@ public sealed class CSharpTypeMapper
                 {
                     foreach (ParameterSyntax parameter in EnumerateLambdaParameters(lambda))
                     {
-                        if (context.SemanticModel.GetDeclaredSymbol(parameter) is IParameterSymbol { Type: { } parameterType })
+                        if (semanticModel.GetDeclaredSymbol(parameter) is IParameterSymbol { Type: { } parameterType })
                         {
                             AddReferencedNamespaces(parameterType, names);
                         }
@@ -2051,7 +2224,7 @@ public sealed class CSharpTypeMapper
                     continue;
                 }
 
-                if (context.SemanticModel.GetSymbolInfo(node).Symbol is not INamedTypeSymbol candidate)
+                if (semanticModel.GetSymbolInfo(node).Symbol is not INamedTypeSymbol candidate)
                 {
                     continue;
                 }
@@ -2068,10 +2241,132 @@ public sealed class CSharpTypeMapper
                 }
             }
         }
-
-        this.importedNamespaceNames = names;
-        return names;
     }
+
+    /// <summary>
+    /// Issue #3805: one semantic model of the file being translated per
+    /// repository compilation that COMPILES it — normally just the context's
+    /// own, but a LINKED source (<c>test/Shared/*.cs</c>, compiled into
+    /// several projects) yields one per linking project.
+    /// <para>
+    /// The repository mirror writes ONE <c>.gs</c> per source file and
+    /// cross-checks that every project translates a linked file identically,
+    /// so any decision that can differ between those projects has to be
+    /// answered over the WHOLE set, converged and order-independent — the same
+    /// rule the shared-document nullability taint already follows (issue
+    /// #3501). Trees are matched by file path because each compilation parses
+    /// the linked file into its own <see cref="SyntaxTree"/> instance.
+    /// </para>
+    /// </summary>
+    /// <param name="context">The translation context.</param>
+    /// <returns>The semantic models, the context's own first.</returns>
+    private IReadOnlyList<SemanticModel> LinkedDocumentModels(TranslationContext context)
+        => this.LinkedDocumentModels(context, context.SemanticModel.SyntaxTree);
+
+    /// <summary>
+    /// Issue #3805: <see cref="LinkedDocumentModels(TranslationContext)"/> for
+    /// a specific tree — a type reference's location is not always in the
+    /// document the context currently points at.
+    /// </summary>
+    /// <param name="context">The translation context.</param>
+    /// <param name="tree">The tree to find linking projects for.</param>
+    /// <returns>The semantic models, this compilation's own first.</returns>
+    private IReadOnlyList<SemanticModel> LinkedDocumentModels(TranslationContext context, SyntaxTree tree)
+    {
+        this.linkedDocumentModels ??= new Dictionary<SyntaxTree, IReadOnlyList<SemanticModel>>();
+        if (this.linkedDocumentModels.TryGetValue(tree, out IReadOnlyList<SemanticModel> cached))
+        {
+            return cached;
+        }
+
+        var models = new List<SemanticModel>
+        {
+            ReferenceEquals(context.SemanticModel.SyntaxTree, tree)
+                ? context.SemanticModel
+                : context.Compilation.GetSemanticModel(tree),
+        };
+        string path = tree.FilePath;
+        if (!string.IsNullOrEmpty(path)
+            && context.RepositoryCompilations is { Count: > 1 } repository
+            && LinkedDocumentIndex(repository).TryGetValue(path, out List<(CSharpCompilation Compilation, SyntaxTree Tree)> linking))
+        {
+            // The same path is not automatically the same FILE: a project can
+            // feed a generated document, or a differently-preprocessed parse,
+            // through a path another project also uses. Only an identical
+            // parse is the same linked source, and only identical text keeps
+            // the position-based lookups below meaningful across compilations.
+            Microsoft.CodeAnalysis.Text.SourceText text = tree.GetText();
+            foreach ((CSharpCompilation compilation, SyntaxTree linkedTree) in linking)
+            {
+                if (!ReferenceEquals(linkedTree, tree)
+                    && !ReferenceEquals(compilation, context.Compilation)
+                    && linkedTree.GetText().ContentEquals(text))
+                {
+                    models.Add(compilation.GetSemanticModel(linkedTree));
+                }
+            }
+        }
+
+        this.linkedDocumentModels[tree] = models;
+        return models;
+    }
+
+    /// <summary>
+    /// Issue #3805: the repository's linked sources — every file path parsed
+    /// by MORE THAN ONE repository compilation, with the compilations (and
+    /// their own parse of the file) that share it. Ordinary files are absent,
+    /// which is what keeps the union lookup free for them.
+    /// <para>
+    /// Built once per repository compilation set rather than once per
+    /// translated document: the index is a whole-run property, and one mapper
+    /// exists per file.
+    /// </para>
+    /// </summary>
+    /// <param name="repository">The run's repository compilations.</param>
+    /// <returns>The linked-source index, keyed by file path.</returns>
+    private static Dictionary<string, List<(CSharpCompilation Compilation, SyntaxTree Tree)>> LinkedDocumentIndex(
+        IReadOnlyList<CSharpCompilation> repository)
+        => LinkedDocumentIndexes.GetValue(repository, static key => BuildLinkedDocumentIndex((IReadOnlyList<CSharpCompilation>)key));
+
+    private static Dictionary<string, List<(CSharpCompilation Compilation, SyntaxTree Tree)>> BuildLinkedDocumentIndex(
+        IReadOnlyList<CSharpCompilation> repository)
+    {
+        var byPath = new Dictionary<string, List<(CSharpCompilation Compilation, SyntaxTree Tree)>>(
+            System.StringComparer.OrdinalIgnoreCase);
+        foreach (CSharpCompilation compilation in repository)
+        {
+            foreach (SyntaxTree tree in compilation.SyntaxTrees)
+            {
+                if (string.IsNullOrEmpty(tree.FilePath))
+                {
+                    continue;
+                }
+
+                if (!byPath.TryGetValue(tree.FilePath, out List<(CSharpCompilation, SyntaxTree)> linking))
+                {
+                    linking = new List<(CSharpCompilation, SyntaxTree)>();
+                    byPath[tree.FilePath] = linking;
+                }
+
+                linking.Add((compilation, tree));
+            }
+        }
+
+        foreach (string path in byPath.Where(entry => entry.Value.Count < 2).Select(entry => entry.Key).ToList())
+        {
+            byPath.Remove(path);
+        }
+
+        return byPath;
+    }
+
+    /// <summary>
+    /// Issue #3805: the compilations behind <see cref="LinkedDocumentModels(TranslationContext)"/>.
+    /// </summary>
+    /// <param name="context">The translation context.</param>
+    /// <returns>The compilations that compile the file being translated.</returns>
+    private IEnumerable<CSharpCompilation> LinkedDocumentCompilations(TranslationContext context)
+        => this.LinkedDocumentModels(context).Select(model => (CSharpCompilation)model.Compilation);
 
     /// <summary>
     /// Issue #3725: the parameters an anonymous function declares, whatever
@@ -2172,40 +2467,40 @@ public sealed class CSharpTypeMapper
         return current;
     }
 
-    private static Dictionary<string, int> BuildSourceTopLevelSimpleNameCounts(Compilation compilation)
+    /// <summary>
+    /// Issue #1174/#3805: <paramref name="compilation"/>'s source-declared
+    /// type names, simple name to the set of full names declared under it.
+    /// Recording full names rather than a count (the pre-#3805 shape) is what
+    /// lets a linked source ask the same question of several compilations: a
+    /// type is identified by what it IS, not by how many entries a particular
+    /// compilation contributed.
+    /// </summary>
+    /// <param name="compilation">The compilation to census.</param>
+    /// <param name="nested">Census nested declarations instead of top-level ones.</param>
+    /// <returns>Simple name to the full names declared under it.</returns>
+    private static Dictionary<string, HashSet<string>> BuildSourceSimpleNames(
+        Compilation compilation,
+        bool nested)
     {
-        var counts = new Dictionary<string, int>();
-        foreach (var type in EnumerateAllNamedTypes(compilation.GlobalNamespace))
-        {
-            if (type.ContainingType != null
-                || !type.Locations.Any(l => l.IsInSource))
-            {
-                continue;
-            }
-
-            counts.TryGetValue(type.Name, out var existing);
-            counts[type.Name] = existing + 1;
-        }
-
-        return counts;
-    }
-
-    private static Dictionary<string, int> BuildSourceNestedSimpleNameCounts(Compilation compilation)
-    {
-        var counts = new Dictionary<string, int>();
+        var names = new Dictionary<string, HashSet<string>>();
         foreach (INamedTypeSymbol type in EnumerateAllNamedTypes(compilation.GlobalNamespace))
         {
-            if (type.ContainingType == null
+            if ((type.ContainingType != null) != nested
                 || !type.Locations.Any(location => location.IsInSource))
             {
                 continue;
             }
 
-            counts.TryGetValue(type.Name, out int existing);
-            counts[type.Name] = existing + 1;
+            if (!names.TryGetValue(type.Name, out HashSet<string> declarations))
+            {
+                declarations = new HashSet<string>(System.StringComparer.Ordinal);
+                names[type.Name] = declarations;
+            }
+
+            declarations.Add(type.OriginalDefinition.ToDisplayString());
         }
 
-        return counts;
+        return names;
     }
 
     private static HashSet<string> BuildSourceDeclaredTypeNames(


### PR DESCRIPTION
Fixes #3805. The whole-repository translate stage goes **51/52 → 52/52**: `test/Interpreter.Tests` was the last translate-stage failure in the corpus.

## Correcting the issue's premise

#3805 says the file is linked into `Compiler.Tests`, `Extensions.Tests` and `Interpreter.Tests`. It is not. `test/Shared/EmittedOracle.cs` is linked into **`test/Core.Tests`**, **`tools/cs2gs/Cs2Gs.Tests`** and **`test/Interpreter.Tests`** (`grep -rn EmittedOracle.cs --include='*.csproj'`). That matters for reproduction: a subset containing `Compiler.Tests`/`Extensions.Tests` never translates the file twice and always passes.

The spelling diagnosis itself is exactly right: `Diagnostic` short in the first two, `GSharp.Core.CodeAnalysis.Diagnostic` in `Interpreter.Tests`, with the line wrapping a consequence.

## Why the spelling differs per project

Not the imported-namespace scan (#2222/#3554/#3725) — that one answers `false` for this file in all three projects. Instrumenting the decision point on a 22-app run containing exactly the three linking projects:

```
QUALIFY Diagnostic in test/Shared/EmittedOracle.cs [GSharp.Core.Tests]        source=False nested=False imported=False
QUALIFY Diagnostic in test/Shared/EmittedOracle.cs [GSharp.Cs2Gs.Tests]       source=False nested=False imported=False
QUALIFY Diagnostic in test/Shared/EmittedOracle.cs [GSharp.Interpreter.Tests] source=True  nested=False imported=False
```

It is the **#1174 source-homonym census**. The census counts top-level types declared in *source* anywhere in the compilation — and an MSBuild `<ProjectReference>` is a *compilation* reference, whose types carry source locations. So the census follows the project's reference graph: `Interpreter.Tests` references the Repl and through it `GSharp.LanguageServer.Protocol.Diagnostic`; `Core.Tests` and `Cs2Gs.Tests` do not. Same file, same usings, different reference graph, different answer.

## Bug or design question?

Both, and they resolve the same way. Qualifying is *defensible* in `Interpreter.Tests` (the census is deliberately conservative — the rival namespace is not even imported here, so a bare name would in fact have bound correctly), so this is not a case of one project being wrong. The design question is what a linked file should do when the answer legitimately differs, and the repository mirror already fixes the constraint: **one `.gs` per source file, so the chosen spelling must bind in every project that links it.**

The recommendation implemented here is the rule this repo already adopted for the same class of problem in #3501 (shared-document nullability taint): **a decision that can differ between the projects linking a file is answered over the whole set of them, converged and order-independent.** The union of "ambiguous somewhere" is the safe answer because a fully-qualified name binds in every project, while a bare one does not. Rejected alternatives: *always qualify in linked files* (needless churn in the many linked files with no homonym anywhere), and *relax the cross-check to compare semantics* (the mirror can only write one text; comparing semantics does not tell it which one).

## The change

`CSharpTypeMapper` gains a linked-document set: the compilations that compile the file being translated, matched by path **and identical text** (the same path can carry a differently-generated parse in another project — matching on path alone crashed `LookupSymbolsInternal` with an out-of-range position on `src/Core/.../BoundNode.cs`). It is indexed once per repository compilation set, so ordinary files pay one dictionary miss. `HasSourceHomonym`, `HasSourceNestedHomonym`, `HasVisibleSourceNestedHomonym`, `HasImportedNamespaceHomonym` and the imported-namespace name set now answer over that set.

The source census records **full names per simple name** instead of counts: symbols from two compilations are never reference-equal, and the `count > selfCount` arithmetic it replaces was only meaningful within one compilation. Within a single compilation the two formulations agree.

## Evidence

| | apps translated | `test/Interpreter.Tests` |
|---|---|---|
| `origin/main` (whole-repo `build/run-cs2gs-selfmig-migrate.sh`) | **51/52** | `InvalidOperationException: Linked source ... translates differently in multiple projects. First divergence at line 129.` |
| this branch (same script, clean committed tree, Release repack) | **52/52** | translates |

Reproduced on `origin/main` twice, independently, with the identical divergence text.

New failure state for the app — **not fixed here, reported as the new wall**: `cs2gs validate --app test/Interpreter.Tests` is now a *compile*-stage failure, 38 error artifacts, led by GS0157 "Cannot find type GSharp. Are you missing an import?" (×21), GS0154 lambda return-type inference (×11), then GS0113/GS0264/GS0125/GS0252 singletons.

Tests (`tools/cs2gs/Cs2Gs.Tests/Issue3805LinkedSourceHomonymTests.cs`) build two in-memory projects that link the same document under the same path, one of them additionally holding a *compilation* reference declaring a rival `Diagnostic` in a namespace the file never imports — the `ProjectReference` shape that actually caused this:

* `LinkedSource_TranslatesIdenticallyInEveryLinkingProject` — **fails on `origin/main`** (`(d Diagnostic)` vs `(d Corpus.Issue3805.Core.Diagnostic)`, i.e. the exact cross-check comparison), passes here.
* `LinkedSource_QualifiesTheNameThatIsAmbiguousInAnyLinkingProject` — **fails on `origin/main`**, passes here.
* `LinkedSource_WithNoHomonymAnywhere_StaysBare` — **passes on `origin/main` and here**: the anti-vacuity guard rail that the union does not qualify the corpus.

Full `Cs2Gs.Tests`: 2651 passed, 0 failed.

Readability metrics move because the corpus now emits one more app's worth of G#: `lines>300` 599→601, `!!` 21256→21275. `tools/cs2gs/selfmig-baseline.json` is deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
