### PR TITLE
gsc: members of imported GENERIC types resolve through the substitution (#3814, #3815)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.InterfaceVerification.cs
@@ -201,6 +201,48 @@ internal sealed partial class DeclarationBinder
                             break;
                         }
                     }
+
+                    if (method.ExplicitInterfaceSlot != null)
+                    {
+                        continue;
+                    }
+
+                    // Issue #3814: a clause naming an imported generic interface
+                    // closed over a SYMBOLIC argument (`func (IEquatable[T])
+                    // Equals(other T) bool` inside `class Value[T]`) never
+                    // matches above: `target.ClrType` is the type-ERASED
+                    // `IEquatable<object>`, so the slot reads `Equals(object)`
+                    // while the declaration says `Equals(T)` (GS0494). Match
+                    // against the OPEN definition with the interface's real
+                    // symbolic arguments substituted — the same #949 machinery
+                    // the interface-contract verification already uses — then
+                    // record the erased slot, which is what the MethodImpl row's
+                    // MemberRef is built from (its containing type carries the
+                    // symbolic arguments).
+                    if (!MemberLookup.TryGetSymbolicClrGenericInterface(target, out var openInterface, out var symbolicArgs))
+                    {
+                        continue;
+                    }
+
+                    foreach (var openSlot in openInterface.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+                    {
+                        if (openSlot.IsSpecialName
+                            || openSlot.Name != method.Name
+                            || !MemberLookup.MethodMatchesSymbolicClrInterfaceSignature(method, openSlot, symbolicArgs))
+                        {
+                            continue;
+                        }
+
+                        var erasedSlot = FindErasedSlotForOpenMethod(target.ClrType, openSlot);
+                        if (erasedSlot == null)
+                        {
+                            continue;
+                        }
+
+                        method.ExplicitInterfaceSlot = erasedSlot;
+                        method.ExplicitInterfaceSlotContainingType = target;
+                        break;
+                    }
                 }
 
                 foreach (var property in structSymbol.Properties)
@@ -264,6 +306,28 @@ internal sealed partial class DeclarationBinder
             VerifyPrivateInterfaceHelpersNotOverridden(syntax, structSymbol);
             VerifyExplicitInterfaceClauseResolution(syntax, structSymbol);
         }
+    }
+
+    /// <summary>
+    /// Issue #3814: maps a method of a CLR generic interface's OPEN definition
+    /// onto the corresponding method of the ERASED closed shape the rest of the
+    /// pipeline reflects against, by metadata identity.
+    /// </summary>
+    /// <param name="erasedInterface">The erased closed interface type.</param>
+    /// <param name="openSlot">The method on the open definition.</param>
+    /// <returns>The matching method on <paramref name="erasedInterface"/>, or <see langword="null"/>.</returns>
+    private static MethodInfo? FindErasedSlotForOpenMethod(Type erasedInterface, MethodInfo openSlot)
+    {
+        foreach (var candidate in erasedInterface.GetMethods(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (candidate.MetadataToken == openSlot.MetadataToken
+                && candidate.Module == openSlot.Module)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
     private static bool ExplicitClrPropertyMatches(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -573,7 +573,11 @@ internal sealed partial class ExpressionBinder
                 inhMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, propertyName);
                 if (inhMember != null)
                 {
-                    if (!TryGetWritableClrMember(inhMember, out _, out var inhTargetSymbol, out _, fromDerivedType: true))
+                    // Issue #3815: project the inherited member through the
+                    // derived receiver so an imported GENERIC base's member keeps
+                    // the derived type's own type arguments (ChannelReader[T], not
+                    // the erased ChannelReader[object]).
+                    if (!TryGetWritableClrMember(inhMember, structSymbol, out _, out var inhTargetSymbol, out _, fromDerivedType: true))
                     {
                         Diagnostics.ReportCannotAssign(initSyntax.EqualsToken.Location, propertyName);
                         _ = BindExpression(initSyntax.Value);
@@ -1079,7 +1083,11 @@ internal sealed partial class ExpressionBinder
                 clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
                 if (clrMember != null)
                 {
-                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable, fromDerivedType: true))
+                    // Issue #3815: project the inherited member through the
+                    // derived receiver so an imported GENERIC base's member keeps
+                    // the derived type's own type arguments (ChannelReader[T], not
+                    // the erased ChannelReader[object]).
+                    if (!TryGetWritableClrMember(clrMember, structSymbol, out var inhTargetType, out var inhTargetSymbol, out var inhWritable, fromDerivedType: true))
                     {
                         Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, memberName);
                         return new BoundErrorExpression(null);
@@ -2706,7 +2714,11 @@ internal sealed partial class ExpressionBinder
                 clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, fieldName);
                 if (clrMember != null)
                 {
-                    if (!TryGetWritableClrMember(clrMember, out var inhTargetType, out var inhTargetSymbol, out var inhWritable, fromDerivedType: true))
+                    // Issue #3815: project the inherited member through the
+                    // derived receiver so an imported GENERIC base's member keeps
+                    // the derived type's own type arguments (ChannelReader[T], not
+                    // the erased ChannelReader[object]).
+                    if (!TryGetWritableClrMember(clrMember, structSym, out var inhTargetType, out var inhTargetSymbol, out var inhWritable, fromDerivedType: true))
                     {
                         Diagnostics.ReportCannotAssign(syntax.EqualsToken.Location, fieldName);
                         return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2738,7 +2738,13 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        if (!TryGetWritableClrMember(member, out _, out var targetSymbol, out _, fromDerivedType: true))
+        // Issue #3815: the WRITE must see the same symbolically-projected member
+        // type the READ path already builds through GetInheritedClrMemberType —
+        // inside `class Wrap[T] : Channel[T]`, the inherited `Reader` is
+        // `ChannelReader[T]`, not the erased `ChannelReader[object]`. Passing the
+        // receiver (the derived class) routes the projection through the nearest
+        // imported base; see MemberLookup.GetProjectionReceiverImportedType.
+        if (!TryGetWritableClrMember(member, receiver.Type, out _, out var targetSymbol, out _, fromDerivedType: true))
         {
             Diagnostics.ReportCannotAssign(assignLocation, name);
             _ = BindExpression(valueSyntax);

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -2973,63 +2973,69 @@ internal sealed class MemberLookup
         MethodInfo openMethod,
         ImmutableArray<TypeSymbol> symbolicArgs)
     {
-        var clrParams = openMethod.GetParameters();
         foreach (var candidate in structSymbol.GetMethodsIncludingInherited(openMethod.Name))
         {
-            var callable = GetCallableParameters(candidate);
-            if (callable.Length != clrParams.Length)
-            {
-                continue;
-            }
-
-            if (!ReturnTypeMatchesSubstituted(candidate.Type, openMethod.ReturnType, symbolicArgs))
-            {
-                continue;
-            }
-
-            var allMatch = true;
-            for (var i = 0; i < callable.Length; i++)
-            {
-                var clrParamType = clrParams[i].ParameterType;
-                var gsParam = callable[i];
-
-                if (clrParamType.IsByRef)
-                {
-                    if (gsParam.RefKind == RefKind.None)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-
-                    if (!ParameterTypeMatchesSubstituted(gsParam.Type, clrParamType.GetElementType(), symbolicArgs))
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-                else
-                {
-                    if (gsParam.RefKind != RefKind.None)
-                    {
-                        allMatch = false;
-                        break;
-                    }
-
-                    if (!ParameterTypeMatchesSubstituted(gsParam.Type, clrParamType, symbolicArgs))
-                    {
-                        allMatch = false;
-                        break;
-                    }
-                }
-            }
-
-            if (allMatch)
+            if (MethodMatchesSymbolicClrInterfaceSignature(candidate, openMethod, symbolicArgs))
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Issue #3814: whether one G# method satisfies <paramref name="openMethod"/>
+    /// — a method of a CLR generic interface's OPEN definition — once the
+    /// interface's <paramref name="symbolicArgs"/> are substituted in. The
+    /// per-candidate core of
+    /// <see cref="HasMatchingMethodForSymbolicClrInterface"/>, factored out so
+    /// the explicit-interface-clause resolver can ask the same question about
+    /// one specific method (its name may not even be the slot's, and it must
+    /// pick a slot rather than answer "some method matched").
+    /// </summary>
+    /// <param name="candidate">The candidate G# method.</param>
+    /// <param name="openMethod">The interface method from the open definition.</param>
+    /// <param name="symbolicArgs">The symbolic type arguments closing the interface.</param>
+    /// <returns><see langword="true"/> when the signatures match after substitution.</returns>
+    public static bool MethodMatchesSymbolicClrInterfaceSignature(
+        FunctionSymbol candidate,
+        MethodInfo openMethod,
+        ImmutableArray<TypeSymbol> symbolicArgs)
+    {
+        var clrParams = openMethod.GetParameters();
+        var callable = GetCallableParameters(candidate);
+        if (callable.Length != clrParams.Length)
+        {
+            return false;
+        }
+
+        if (!ReturnTypeMatchesSubstituted(candidate.Type, openMethod.ReturnType, symbolicArgs))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < callable.Length; i++)
+        {
+            var clrParamType = clrParams[i].ParameterType;
+            var gsParam = callable[i];
+
+            if (clrParamType.IsByRef)
+            {
+                if (gsParam.RefKind == RefKind.None
+                    || !ParameterTypeMatchesSubstituted(gsParam.Type, clrParamType.GetElementType(), symbolicArgs))
+                {
+                    return false;
+                }
+            }
+            else if (gsParam.RefKind != RefKind.None
+                || !ParameterTypeMatchesSubstituted(gsParam.Type, clrParamType, symbolicArgs))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -3893,7 +3899,7 @@ internal sealed class MemberLookup
         PropertyInfo closedProperty,
         bool projectOnlyWhenSymbolicallyRequired = false)
     {
-        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+        if (GetProjectionReceiverImportedType(targetType) is ImportedTypeSymbol imported
             && TryGetSymbolicDeclaringContext(
                 imported,
                 closedProperty.DeclaringType,
@@ -3955,7 +3961,7 @@ internal sealed class MemberLookup
     {
         const BindingFlags AllFields = BindingFlags.Public | BindingFlags.NonPublic
             | BindingFlags.Instance | BindingFlags.Static;
-        var imported = GetImportedTypeSymbol(targetType);
+        var imported = GetProjectionReceiverImportedType(targetType);
         var receiverClr = imported?.ClrType;
         if (targetType is NullabilityAnnotatedTypeSymbol annotated
             && receiverClr != null
@@ -4005,7 +4011,7 @@ internal sealed class MemberLookup
     /// <returns>The event handler type after symbolic receiver substitution.</returns>
     internal static TypeSymbol GetClrEventHandlerTypeSymbol(TypeSymbol targetType, EventInfo closedEvent)
     {
-        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+        if (GetProjectionReceiverImportedType(targetType) is ImportedTypeSymbol imported
             && TryGetSymbolicDeclaringContext(
                 imported,
                 closedEvent.DeclaringType,
@@ -4111,7 +4117,7 @@ internal sealed class MemberLookup
         TypeSymbol targetType,
         MethodInfo closedMethod)
     {
-        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+        if (GetProjectionReceiverImportedType(targetType) is ImportedTypeSymbol imported
             && TryGetSymbolicDeclaringContext(
                 imported,
                 closedMethod.DeclaringType,
@@ -4162,7 +4168,7 @@ internal sealed class MemberLookup
         MethodInfo closedMethod,
         int parameterIndex)
     {
-        if (GetImportedTypeSymbol(targetType) is ImportedTypeSymbol imported
+        if (GetProjectionReceiverImportedType(targetType) is ImportedTypeSymbol imported
             && TryGetSymbolicDeclaringContext(
                 imported,
                 closedMethod.DeclaringType,
@@ -4292,6 +4298,32 @@ internal sealed class MemberLookup
             NullabilityAnnotatedTypeSymbol { BaseType: ImportedTypeSymbol imported } => imported,
             _ => null,
         };
+
+    /// <summary>
+    /// Issue #3815: the imported type whose generic arguments a member read
+    /// through <paramref name="type"/> must be projected with.
+    /// <para>
+    /// For an imported receiver that is just <see cref="GetImportedTypeSymbol"/>.
+    /// A USER class deriving from an imported generic base
+    /// (<c>class Wrap[T] : Channel[T]</c>) inherits that base's members, and the
+    /// base's own type arguments are carried SYMBOLICALLY on
+    /// <see cref="StructSymbol.ImportedBaseType"/> — the base's
+    /// reflected <c>ClrType</c> is the erased
+    /// <c>Channel&lt;object&gt;</c>. Reflecting the inherited member off that
+    /// erased type and reading its type straight from metadata therefore bound
+    /// <c>Reader</c> as <c>ChannelReader[object]</c> instead of
+    /// <c>ChannelReader[T]</c>. Walking to the nearest imported base lets the
+    /// existing symbolic-projection machinery substitute the real arguments,
+    /// exactly as it already does when the receiver IS the imported type.
+    /// </para>
+    /// </summary>
+    /// <param name="type">The receiver type a member was reflected through.</param>
+    /// <returns>The imported type carrying the symbolic arguments, or <see langword="null"/>.</returns>
+    internal static ImportedTypeSymbol? GetProjectionReceiverImportedType(TypeSymbol type)
+        => GetImportedTypeSymbol(type)
+            ?? (type is StructSymbol userClass
+                ? TypeMemberModel.GetNearestImportedBase(userClass) as ImportedTypeSymbol
+                : null);
 
     internal static PropertyInfo? FindOpenIndexerDefinition(Type? openDefinition, PropertyInfo closedIndexer)
     {

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1149,7 +1149,8 @@ public sealed class StructSymbol : TypeSymbol
                     var hiddenByDerived = false;
                     foreach (var existing in builder)
                     {
-                        if (BoundScope.FunctionSignaturesEqual(existing, m))
+                        if (BoundScope.FunctionSignaturesEqual(existing, m)
+                            && ExplicitInterfaceClauseTargetsMatch(existing, m))
                         {
                             hiddenByDerived = true;
                             break;
@@ -2196,6 +2197,46 @@ public sealed class StructSymbol : TypeSymbol
             ref substitutedImplementedClrInterfaces,
             new TypeArraySnapshot(source, value));
         return value;
+    }
+
+    /// <summary>
+    /// Issue #3814 / ADR-0149: decides whether two same-signature methods occupy
+    /// the same slot for the purposes of the hiding rule in
+    /// <see cref="GetMethodsIncludingInherited(string)"/>.
+    /// <para>
+    /// Two explicit interface implementations of the SAME member on DIFFERENT
+    /// instantiations of one generic interface (<c>func (IAsyncEnumerable[int32])
+    /// GetAsyncEnumerator(…)</c> and <c>func (IAsyncEnumerable[string])
+    /// GetAsyncEnumerator(…)</c>) have identical callable signatures — the
+    /// interface's type argument only shows up in the RETURN type, which
+    /// <see cref="BoundScope.FunctionSignaturesEqual"/> deliberately ignores.
+    /// Without this guard the second one was dropped from the overload set as if
+    /// it were an override of the first, and the interface-implementation check
+    /// then reported the second interface unimplemented (GS0187). They are two
+    /// distinct CLR slots and must both stay visible.
+    /// </para>
+    /// </summary>
+    /// <param name="a">The first method.</param>
+    /// <param name="b">The second method.</param>
+    /// <returns><see langword="true"/> when both carry the same explicit-interface clause target (including none at all).</returns>
+    private static bool ExplicitInterfaceClauseTargetsMatch(FunctionSymbol a, FunctionSymbol b)
+    {
+        var targetA = a.ExplicitInterfaceClauseTarget;
+        var targetB = b.ExplicitInterfaceClauseTarget;
+        if (ReferenceEquals(targetA, targetB))
+        {
+            return true;
+        }
+
+        if (targetA == null || targetB == null)
+        {
+            return false;
+        }
+
+        return string.Equals(
+            Display.SymbolDisplay.ToTypeDisplayString(targetA),
+            Display.SymbolDisplay.ToTypeDisplayString(targetB),
+            StringComparison.Ordinal);
     }
 
     private TypeSymbol? GetSubstitutedImportedBaseType()

--- a/test/Compiler.Tests/Issue3814ExplicitInterfaceOnImportedGenericTests.cs
+++ b/test/Compiler.Tests/Issue3814ExplicitInterfaceOnImportedGenericTests.cs
@@ -1,0 +1,471 @@
+// <copyright file="Issue3814ExplicitInterfaceOnImportedGenericTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3814 / ADR-0149: a class may explicitly implement the SAME member on
+/// two different instantiations of one imported generic interface.
+/// <para>
+/// <c>StructSymbol.GetMethodsIncludingInherited</c> deduplicated the overload
+/// set with <c>BoundScope.FunctionSignaturesEqual</c>, which — correctly for
+/// ordinary overloads — ignores the return type. Two explicit implementations of
+/// <c>IAsyncEnumerable[T].GetAsyncEnumerator(CancellationToken)</c> differ ONLY
+/// in their return type, so the second was dropped from the overload set as if
+/// it were an override of the first, and the interface-implementation check then
+/// reported that interface unimplemented (GS0187). The dropped method was
+/// whichever was declared second, so the diagnostic followed declaration order.
+/// </para>
+/// <para>
+/// Every case EXECUTES and dispatches THROUGH the interface, because binding
+/// alone cannot see whether the two <c>MethodImpl</c> rows landed on the right
+/// slots — wiring both interface slots to one method is still verifiable IL.
+/// </para>
+/// </summary>
+public class Issue3814ExplicitInterfaceOnImportedGenericTests
+{
+    private const string Preamble = @"
+package P
+import System
+import System.Collections.Generic
+import System.Threading
+import System.Threading.Tasks
+
+class EmptyEnum[T] : IAsyncEnumerator[T] {
+    var cur T
+    prop Current T { get { return cur } }
+    func MoveNextAsync() ValueTask[bool] { return ValueTask[bool](false) }
+    func DisposeAsync() ValueTask { return ValueTask() }
+}
+";
+
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        // The test/Core.Tests shape, reduced: two explicit implementations of
+        // GetAsyncEnumerator, one per instantiation. The program dispatches
+        // through EACH interface and the method itself reports which slot ran,
+        // so a mis-wired MethodImpl row is observable.
+        yield return new object[]
+        {
+            "two-instantiations-of-one-imported-generic-interface",
+            Preamble + @"
+class Fwd : IAsyncEnumerable[int32], IAsyncEnumerable[string] {
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        Console.WriteLine(""int-slot"")
+        return EmptyEnum[int32]()
+    }
+
+    func (IAsyncEnumerable[string]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[string] {
+        Console.WriteLine(""string-slot"")
+        return EmptyEnum[string]()
+    }
+}
+
+let f = Fwd()
+let a IAsyncEnumerable[int32] = f
+let b IAsyncEnumerable[string] = f
+let _ea = a.GetAsyncEnumerator(CancellationToken.None)
+let _eb = b.GetAsyncEnumerator(CancellationToken.None)
+",
+            new[] { "int-slot", "string-slot" },
+        };
+
+        // The declaration order is reversed: on `origin/main` the diagnostic
+        // followed whichever method came SECOND, so both orders must be proved.
+        yield return new object[]
+        {
+            "two-instantiations-reversed-declaration-order",
+            Preamble + @"
+class Fwd : IAsyncEnumerable[int32], IAsyncEnumerable[string] {
+    func (IAsyncEnumerable[string]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[string] {
+        Console.WriteLine(""string-slot"")
+        return EmptyEnum[string]()
+    }
+
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        Console.WriteLine(""int-slot"")
+        return EmptyEnum[int32]()
+    }
+}
+
+let f = Fwd()
+let a IAsyncEnumerable[int32] = f
+let b IAsyncEnumerable[string] = f
+let _ea = a.GetAsyncEnumerator(CancellationToken.None)
+let _eb = b.GetAsyncEnumerator(CancellationToken.None)
+",
+            new[] { "int-slot", "string-slot" },
+        };
+
+        // Three instantiations: the hiding rule dropped every method after the
+        // first, so a two-case fix that only special-cased a pair would fail.
+        yield return new object[]
+        {
+            "three-instantiations-of-one-imported-generic-interface",
+            Preamble + @"
+class Fwd3 : IAsyncEnumerable[int32], IAsyncEnumerable[int64], IAsyncEnumerable[string] {
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        Console.WriteLine(""i32"")
+        return EmptyEnum[int32]()
+    }
+
+    func (IAsyncEnumerable[int64]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int64] {
+        Console.WriteLine(""i64"")
+        return EmptyEnum[int64]()
+    }
+
+    func (IAsyncEnumerable[string]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[string] {
+        Console.WriteLine(""str"")
+        return EmptyEnum[string]()
+    }
+}
+
+let f = Fwd3()
+let a IAsyncEnumerable[int32] = f
+let b IAsyncEnumerable[int64] = f
+let c IAsyncEnumerable[string] = f
+let _ea = a.GetAsyncEnumerator(CancellationToken.None)
+let _eb = b.GetAsyncEnumerator(CancellationToken.None)
+let _ec = c.GetAsyncEnumerator(CancellationToken.None)
+",
+            new[] { "i32", "i64", "str" },
+        };
+
+        // ANTI-VACUITY (passes on `origin/main` too): a SINGLE explicit clause
+        // on an imported generic interface already worked — only the second
+        // same-signature sibling was dropped. It must keep working.
+        yield return new object[]
+        {
+            "single-explicit-clause-on-imported-generic-still-works",
+            Preamble + @"
+class One : IAsyncEnumerable[int32] {
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        Console.WriteLine(""only-slot"")
+        return EmptyEnum[int32]()
+    }
+}
+
+let f = One()
+let a IAsyncEnumerable[int32] = f
+let _ea = a.GetAsyncEnumerator(CancellationToken.None)
+",
+            new[] { "only-slot" },
+        };
+
+        // The clause names an imported generic interface closed over the
+        // declaring class's OWN type parameter. `target.ClrType` is the erased
+        // `IEquatable[object]`, so the slot search saw `Equals(object)` against a
+        // declaration saying `Equals(T)` and reported GS0494; the resolver now
+        // matches through the open definition with the symbolic argument.
+        yield return new object[]
+        {
+            "clause-on-imported-generic-closed-over-own-type-parameter",
+            @"
+package P
+import System
+
+class Value[T] : IEquatable[T] {
+    private func (IEquatable[T]) Equals(other T) bool -> true
+}
+
+let v = Value[int32]()
+let e IEquatable[int32] = v
+Console.WriteLine(e.Equals(1).ToString())
+",
+            new[] { "True" },
+        };
+
+        // The `List[T]` shape from the real corpus: an explicit non-generic
+        // `IEnumerable.GetEnumerator()` alongside two generic instantiations,
+        // reached through an inherited interface (`IReadOnlyCollection[T]`).
+        yield return new object[]
+        {
+            "two-instantiations-reached-through-an-inherited-interface",
+            @"
+package P
+import System
+import System.Collections
+import System.Collections.Generic
+
+class Conflict : IReadOnlyCollection[int32], IReadOnlyCollection[string] {
+    prop Count int32 { get { return 0 } }
+
+    func (IEnumerable[int32]) GetEnumerator() IEnumerator[int32] {
+        return List[int32]().GetEnumerator()
+    }
+
+    func (IEnumerable[string]) GetEnumerator() IEnumerator[string] {
+        return List[string]().GetEnumerator()
+    }
+
+    func (IEnumerable) GetEnumerator() IEnumerator {
+        return List[int32]().GetEnumerator()
+    }
+}
+
+let c = Conflict()
+let a IReadOnlyCollection[int32] = c
+let b IReadOnlyCollection[string] = c
+Console.WriteLine(a.Count.ToString())
+Console.WriteLine(b.Count.ToString())
+",
+            new[] { "0", "0" },
+        };
+
+        // ANTI-VACUITY (passes on `origin/main` too): the hiding rule the fix
+        // narrows is what makes a real OVERRIDE replace its base method rather
+        // than sit beside it as an ambiguous overload. A derived override must
+        // still win, and the base entry must stay hidden.
+        yield return new object[]
+        {
+            "derived-override-still-hides-the-base-method",
+            @"
+package P
+import System
+
+open class Base {
+    open func Speak() string { return ""base"" }
+}
+
+class Derived : Base {
+    override func Speak() string { return ""derived"" }
+}
+
+let d = Derived()
+Console.WriteLine(d.Speak())
+let b Base = d
+Console.WriteLine(b.Speak())
+",
+            new[] { "derived", "derived" },
+        };
+    }
+
+    /// <summary>
+    /// Gets the cases that must still be REJECTED, so the narrowed hiding rule
+    /// did not open up plain duplicate overloads. Each is (name, source).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> RejectedCases()
+    {
+        // ANTI-VACUITY: two same-signature methods with NO explicit-interface
+        // clause are still a duplicate overload (GS0264). The fix keys strictly
+        // on the clause target.
+        yield return new object[]
+        {
+            "plain-duplicate-overloads-still-rejected",
+            @"
+package P
+import System
+
+class Dup {
+    func M(x int32) int32 { return x }
+    func M(x int32) string { return ""no"" }
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+
+        // ANTI-VACUITY: two clauses naming the SAME interface instantiation are
+        // still duplicates — the clause target has to actually differ.
+        yield return new object[]
+        {
+            "two-clauses-on-the-same-instantiation-still-rejected",
+            Preamble + @"
+class SameTwice : IAsyncEnumerable[int32] {
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        return EmptyEnum[int32]()
+    }
+
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        return EmptyEnum[int32]()
+    }
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+
+        // ANTI-VACUITY: a clause naming a member the imported generic interface
+        // does NOT declare is still GS0494 — the symbolic slot search widened
+        // which signatures match, not whether a match is required.
+        yield return new object[]
+        {
+            "clause-naming-a-nonexistent-member-still-rejected",
+            @"
+package P
+import System
+
+class Value[T] : IEquatable[T] {
+    func (IEquatable[T]) Equals(other T) bool -> true
+    func (IEquatable[T]) NotAMember(other T) bool -> true
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+
+        // ANTI-VACUITY: an interface instantiation left with NO implementation
+        // at all is still reported unimplemented — the fix must not have made
+        // GS0187 unreachable for this shape.
+        yield return new object[]
+        {
+            "unimplemented-second-instantiation-still-rejected",
+            Preamble + @"
+class Missing : IAsyncEnumerable[int32], IAsyncEnumerable[string] {
+    func (IAsyncEnumerable[int32]) GetAsyncEnumerator(ct CancellationToken) IAsyncEnumerator[int32] {
+        return EmptyEnum[int32]()
+    }
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void ExplicitInterfaceOnImportedGeneric_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3814_").FullName;
+        try
+        {
+            var outPath = CompileOrThrow(tempDir, name, source);
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(
+                exit == 0,
+                $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Asserts the guard rails: shapes the narrowed hiding rule must NOT admit.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    [Theory]
+    [MemberData(nameof(RejectedCases))]
+    public void InvalidShape_IsStillRejected(string name, string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3814_neg_").FullName;
+        try
+        {
+            var (exit, stdout, stderr) = Compile(tempDir, name, source);
+            Assert.True(
+                exit != 0,
+                $"'{name}' must NOT compile — the #3814 fix is scoped to explicit-interface "
+                    + $"clauses naming DIFFERENT interface instantiations.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+
+    private static string CompileOrThrow(string tempDir, string name, string source)
+    {
+        var (exit, stdout, stderr) = Compile(tempDir, name, source);
+        Assert.True(exit == 0, $"gsc failed for '{name}':\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return Path.Combine(tempDir, name + ".dll");
+    }
+
+    private static (int Exit, string Stdout, string Stderr) Compile(string tempDir, string name, string source)
+    {
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+        var outPath = Path.Combine(tempDir, name + ".dll");
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            return (Program.Main(args.ToArray()), compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}

--- a/test/Compiler.Tests/Issue3815GenericDerivedImportedGenericBaseTests.cs
+++ b/test/Compiler.Tests/Issue3815GenericDerivedImportedGenericBaseTests.cs
@@ -1,0 +1,382 @@
+// <copyright file="Issue3815GenericDerivedImportedGenericBaseTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3815: inside a GENERIC class deriving from an imported generic base
+/// (<c>class Wrap[T] : Channel[T]</c>), the base's inherited members must be
+/// seen at the derived type's own type arguments.
+/// <para>
+/// The base's arguments are carried symbolically on
+/// <c>StructSymbol.ImportedBaseType</c>; its reflected <c>ClrType</c> is the
+/// ERASED <c>Channel&lt;object&gt;</c>. The inherited-member WRITE paths
+/// (issues #319/#1582) reflected the member off that erased type and read its
+/// type straight from metadata, with no receiver to project through, so
+/// <c>Reader</c> bound as <c>ChannelReader[object]</c> and the assignment failed
+/// with GS0155. The read path already projected correctly
+/// (<c>GetInheritedClrMemberType</c>); the two now agree.
+/// </para>
+/// <para>
+/// Every case EXECUTES and round-trips a value through the BASE-typed
+/// reference, so a setter that wrote the wrong slot — or a store that type-
+/// checked only because both sides had been erased to <c>object</c> — is
+/// observable.
+/// </para>
+/// </summary>
+public class Issue3815GenericDerivedImportedGenericBaseTests
+{
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        // The ClrBaseline shape: `GoChan[T] : Channel[T]` installing the
+        // inner channel's reader/writer through the base's protected setters.
+        yield return new object[]
+        {
+            "generic-derived-from-imported-generic-base",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+class Wrap[T] : Channel[T] {
+    init(inner Channel[T]) {
+        Reader = inner.Reader
+        Writer = inner.Writer
+    }
+}
+
+let inner = Channel.CreateUnbounded[int32]()
+let w = Wrap[int32](inner)
+let asBase Channel[int32] = w
+asBase.Writer.TryWrite(41)
+var got = 0
+if asBase.Reader.TryRead(&got) {
+    Console.WriteLine((got + 1).ToString())
+}
+",
+            new[] { "42" },
+        };
+
+        // The `this.`-qualified write is a different binder path than the bare
+        // name; both must project the inherited member through the base.
+        yield return new object[]
+        {
+            "generic-derived-this-qualified-write",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+class Wrap[T] : Channel[T] {
+    init(inner Channel[T]) {
+        this.Reader = inner.Reader
+        this.Writer = inner.Writer
+    }
+}
+
+let inner = Channel.CreateUnbounded[string]()
+let w = Wrap[string](inner)
+let asBase Channel[string] = w
+asBase.Writer.TryWrite(""hi"")
+var got = """"
+if asBase.Reader.TryRead(&got) {
+    Console.WriteLine(got)
+}
+",
+            new[] { "hi" },
+        };
+
+        // The same generic definition instantiated at TWO different arguments in
+        // one program: each construction must see its own T, not a shared
+        // erasure.
+        yield return new object[]
+        {
+            "one-generic-definition-two-instantiations",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+class Wrap[T] : Channel[T] {
+    init(inner Channel[T]) {
+        Reader = inner.Reader
+        Writer = inner.Writer
+    }
+}
+
+let wi Channel[int32] = Wrap[int32](Channel.CreateUnbounded[int32]())
+wi.Writer.TryWrite(7)
+var gotI = 0
+if wi.Reader.TryRead(&gotI) {
+    Console.WriteLine(gotI.ToString())
+}
+
+let ws Channel[string] = Wrap[string](Channel.CreateUnbounded[string]())
+ws.Writer.TryWrite(""seven"")
+var gotS = """"
+if ws.Reader.TryRead(&gotS) {
+    Console.WriteLine(gotS)
+}
+",
+            new[] { "7", "seven" },
+        };
+
+        // Reading the inherited member inside the generic derived type must
+        // give `ChannelReader[T]`, not `ChannelReader[object]` — proved by
+        // handing it to a T-typed local and round-tripping the value.
+        yield return new object[]
+        {
+            "inherited-member-read-inside-the-generic-derived-type",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+class Wrap[T] : Channel[T] {
+    init(inner Channel[T]) {
+        Reader = inner.Reader
+        Writer = inner.Writer
+    }
+
+    func Echo(value T) T {
+        let w ChannelWriter[T] = Writer
+        let r ChannelReader[T] = Reader
+        w.TryWrite(value)
+        var got T
+        if r.TryRead(&got) {
+            return got
+        }
+
+        return value
+    }
+}
+
+let w = Wrap[int32](Channel.CreateUnbounded[int32]())
+Console.WriteLine(w.Echo(99).ToString())
+",
+            new[] { "99" },
+        };
+
+        // ANTI-VACUITY (passes on `origin/main` too, since #3813): the
+        // NON-generic derived class already worked and must keep working.
+        yield return new object[]
+        {
+            "non-generic-derived-from-constructed-imported-base-still-works",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+class Wrap : Channel[int32] {
+    init(inner Channel[int32]) {
+        Reader = inner.Reader
+        Writer = inner.Writer
+    }
+}
+
+let inner = Channel.CreateUnbounded[int32]()
+let w = Wrap(inner)
+let asBase Channel[int32] = w
+asBase.Writer.TryWrite(41)
+var got = 0
+if asBase.Reader.TryRead(&got) {
+    Console.WriteLine((got + 1).ToString())
+}
+",
+            new[] { "42" },
+        };
+    }
+
+    /// <summary>
+    /// Gets the cases that must still be REJECTED, so the projection did not
+    /// silently widen what an inherited member accepts. Each is (name, source).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> RejectedCases()
+    {
+        // The whole point: the inherited member is `ChannelReader[T]`, so a
+        // `ChannelReader[string]` must NOT be assignable to it inside
+        // `Wrap[T]`. Before the fix both sides were `object`-erased, which is
+        // exactly the unsound direction this could have been "fixed" into.
+        yield return new object[]
+        {
+            "wrong-instantiation-still-rejected",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+class Wrap[T] : Channel[T] {
+    init(other Channel[string]) {
+        Reader = other.Reader
+    }
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+
+        // ANTI-VACUITY: `protected` stays out of reach from a NON-derived type
+        // (the #3813 guard rail, re-asserted for the generic shape).
+        yield return new object[]
+        {
+            "protected-setter-not-reachable-from-outside",
+            @"
+package P
+import System
+import System.Threading.Channels
+
+func Break[T](c Channel[T]) {
+    c.Reader = nil
+}
+
+Console.WriteLine(""unreachable"")
+",
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void GenericDerivedFromImportedGenericBase_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3815_").FullName;
+        try
+        {
+            var outPath = CompileOrThrow(tempDir, name, source);
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(
+                exit == 0,
+                $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Asserts the guard rails: shapes the projection must NOT admit.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    [Theory]
+    [MemberData(nameof(RejectedCases))]
+    public void InvalidShape_IsStillRejected(string name, string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3815_neg_").FullName;
+        try
+        {
+            var (exit, stdout, stderr) = Compile(tempDir, name, source);
+            Assert.True(
+                exit != 0,
+                $"'{name}' must NOT compile — the #3815 projection recovers the base's real "
+                    + $"type arguments, it does not erase them.\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static string CompileOrThrow(string tempDir, string name, string source)
+    {
+        var (exit, stdout, stderr) = Compile(tempDir, name, source);
+        Assert.True(exit == 0, $"gsc failed for '{name}':\nstdout:\n{stdout}\nstderr:\n{stderr}");
+        return Path.Combine(tempDir, name + ".dll");
+    }
+
+    private static (int Exit, string Stdout, string Stderr) Compile(string tempDir, string name, string source)
+    {
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+        var outPath = Path.Combine(tempDir, name + ".dll");
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            return (Program.Main(args.ToArray()), compileOut.ToString(), compileErr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -742,8 +742,18 @@ namespace Demo
         AssertGscCompiles(printed);
     }
 
+    /// <summary>
+    /// Issue #3814: an explicit implementation of an IMPORTED GENERIC
+    /// interface's member keeps its ADR-0149 clause and its C#-faithful private
+    /// visibility. This case used to fall back to the #1911 named/forced-public
+    /// path because gsc erased the clause's type arguments while resolving the
+    /// CLR slot (GS0494); it now resolves the slot through the interface's open
+    /// definition with the symbolic arguments substituted, so the fallback — and
+    /// the duplicate-overload collisions it caused for a type implementing TWO
+    /// instantiations — is gone.
+    /// </summary>
     [Fact]
-    public void GenericImportedExplicitInterfaceQualifier_FallsBackAndCompiles()
+    public void GenericImportedExplicitInterfaceQualifier_KeepsClauseAndCompiles()
     {
         string printed = TranslateUnit(@"
 namespace Demo
@@ -756,9 +766,41 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("func Equals(other T) bool -> true", printed);
-        Assert.DoesNotContain("(IEquatable[T])", printed);
-        Assert.DoesNotContain("private func Equals", printed);
+        Assert.Contains("private func (IEquatable[T]) Equals(other T) bool -> true", printed);
+        AssertGscCompiles(printed);
+    }
+
+    /// <summary>
+    /// Issue #3814: the shape that walled <c>test/Core.Tests</c> — one member
+    /// explicitly implemented on TWO instantiations of the same imported generic
+    /// interface. Dropping the clause made the two methods differ only in return
+    /// type, i.e. a duplicate overload (GS0264) plus an unimplemented interface
+    /// (GS0187). Both clauses must now survive.
+    /// </summary>
+    [Fact]
+    public void TwoInstantiationsOfOneImportedGenericInterface_KeepBothClauses()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    public sealed class Conflict : IReadOnlyCollection<int>, IReadOnlyCollection<string>
+    {
+        public int Count => 0;
+
+        IEnumerator<int> IEnumerable<int>.GetEnumerator() => new List<int>().GetEnumerator();
+
+        IEnumerator<string> IEnumerable<string>.GetEnumerator() => new List<string>().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => new List<int>().GetEnumerator();
+    }
+}");
+
+        Assert.Contains("(IEnumerable[int32]) GetEnumerator() IEnumerator[int32]", printed);
+        Assert.Contains("(IEnumerable[string]) GetEnumerator() IEnumerator[string]", printed);
+        Assert.Contains("(IEnumerable) GetEnumerator() IEnumerator", printed);
         AssertGscCompiles(printed);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Members.cs
@@ -1218,19 +1218,26 @@ public sealed partial class CSharpToGSharpTranslator
             // member on a BASE interface (e.g. `void IBar.M(){}` where
             // `interface IBar : IFoo` and IFoo already declares `M`). The
             // clause-based scheme below wires exactly ONE interface slot per
-            // method, so it only applies when there is a SINGLE entry. Imported
-            // generic interfaces also fall back because gsc currently erases
-            // their clause arguments while resolving the CLR slot (GS0494).
+            // method, so it only applies when there is a SINGLE entry.
             // Fallback keeps the pre-#2010 (#1911) named/forced-public path:
             // the method keeps its plain name with no clause, and
             // gsc's ordinary implicit name+signature interface-dispatch matching
             // then satisfies every entry uniformly (no explicit MethodImpl row
             // needed).
+            //
+            // Issue #3814: an IMPORTED GENERIC interface used to fall back here
+            // too, because gsc dropped every explicit implementation after the
+            // first same-signature one from the type's overload set — so a class
+            // explicitly implementing one member on TWO instantiations
+            // (`IAsyncEnumerable<int>` and `IAsyncEnumerable<string>`) reported
+            // the second interface unimplemented (GS0187). The fallback made that
+            // strictly worse: with no clause the two methods differ only in
+            // return type and collide as a duplicate overload (GS0264). gsc now
+            // keeps both slots, so the clause is emitted for imported generic
+            // interfaces as well.
             bool hasSingleExplicitInterfaceImpl = isExplicitInterfaceImpl &&
                 symbol.ExplicitInterfaceImplementations.Length == 1;
-            bool hasClauseCompatibleExplicitInterfaceImpl = hasSingleExplicitInterfaceImpl &&
-                (symbol.ExplicitInterfaceImplementations[0].ContainingType.Locations.Any(l => l.IsInSource) ||
-                 !symbol.ExplicitInterfaceImplementations[0].ContainingType.IsGenericType);
+            bool hasClauseCompatibleExplicitInterfaceImpl = hasSingleExplicitInterfaceImpl;
 
             if (isExplicitInterfaceImpl && symbol.ExplicitInterfaceImplementations.Length > 1 &&
                 symbol.ExplicitInterfaceImplementations.All(e => e.ContainingType.Locations.Any(l => l.IsInSource)))


### PR DESCRIPTION
Issue #3501 Track C. Fixes #3814 and #3815 — the two gsc binder walls PR #3816 filed but did not fix.

## Do they share a root? No — and I proved it, rather than assuming

Both read as "an imported generic type's members do not resolve through a substitution", which is exactly the shape that has collapsed 3–5× on this effort. They are **distinct defects in disjoint code**, and the cross-check is empirical, not architectural: with **only** the #3815 fix in the compiler and the #3814 fix stubbed out, the #3815 repro compiles clean (0 errors) while the #3814 repro still reports its GS0187. Different symbol layer (overload-set construction vs. member-type projection), different files, neither fix touches the other's path.

## Confirmed mechanisms

### #3814 — the overload set, not the clause resolver

The issue's ordering ("make `ResolveExplicitInterfaceClauses` / `VerifyInterfaceImplementations` honour the generic instantiation") is **half right, and the diagnosis points one layer too high**. Verification never consults the clause: it asks the type's overload set whether some method satisfies the CLR slot. The method had already been **deleted from that set**.

`StructSymbol.GetMethodsIncludingInherited` deduplicates with `BoundScope.FunctionSignaturesEqual`, which — correctly for ordinary overloads — ignores the return type. Two explicit implementations of `IAsyncEnumerable[T].GetAsyncEnumerator(CancellationToken)`, one per instantiation, differ **only** in the return type, so the second was dropped as if it were an override of the first.

The tell was order-dependence, which the issue does not mention: whichever method is declared **second** is the one reported unimplemented. Swapping the two declarations moves the diagnostic; a third instantiation loses two.

```
main, methods declared int32-then-string:  GS0187 … IAsyncEnumerable[string].GetAsyncEnumerator
main, methods declared string-then-int32:  GS0187 … IAsyncEnumerable[int32].GetAsyncEnumerator
```

Fix: the hiding rule additionally requires the two methods to carry the **same explicit-interface clause target**. Methods without a clause compare `null == null` and hide exactly as before, so real overrides are untouched.

### #3814b — a second, distinct sub-defect behind the cs2gs carve-out

Removing the translator carve-out uncovered the defect its comment actually names. A clause on an imported generic interface closed over the declaring type's **own type parameter** —

```
class Value[T] : IEquatable[T] {
    private func (IEquatable[T]) Equals(other T) bool -> true
}
```

— never matched a slot: `target.ClrType` is the type-**erased** `IEquatable<object>`, so the slot search compared `Equals(object)` against a declaration saying `Equals(T)` and reported **GS0494**. The resolver now falls back to the interface's OPEN definition with its symbolic arguments substituted (the #949 machinery the contract verification already uses), then records the erased slot the `MethodImpl` MemberRef is built from. This is *not* the same defect as #3814 proper — it survives the overload-set fix and needed its own repro.

### #3815 — the write path, not the read path

The base's arguments are carried symbolically on `StructSymbol.ImportedBaseType`; its reflected `ClrType` is the erased `Channel<object>`. The inherited-member **read** path already projected correctly (`GetInheritedClrMemberType`, #1582); the inherited-member **write** paths (#319/#1582) reflected the member off the erased type and read its type straight from metadata with `receiverType: null`, so `Reader` bound as `ChannelReader[object]`:

```
Program.gs(7,18): error GS0155: Cannot convert 'ChannelReader[T]' to 'ChannelReader[object]'
```

`MemberLookup.GetProjectionReceiverImportedType` walks a user class to its nearest imported base, and the four inherited-write call sites now pass the receiver — routing them through the same symbolic projection the imported-receiver paths already use. The two paths can no longer drift apart.

## Order of work, as #3816 prescribed

1. gsc first (both halves above);
2. **then** cs2gs: the `!ContainingType.IsGenericType` carve-out in `CSharpToGSharpTranslator.Members.cs` is deleted, so an explicit implementation of an imported generic interface keeps its ADR-0149 clause instead of collapsing into two same-signature overloads (GS0264). Doing this first would have made the diagnostics worse, exactly as #3816 warned.

Methods now behave like the event and property paths, which never had this carve-out.

## Test evidence

`test/Compiler.Tests/Issue3814…` + `Issue3815…` — **18 cases, every one compiles + ILVerifies + runs + asserts the program's own stdout.** No binding-only assertions. The #3814 cases dispatch **through each interface** and the method reports which slot ran, because wiring both interface slots to one method is still verifiable IL; the #3815 cases round-trip a value through the **base-typed** reference.

Failing-on-`origin/main` proof (compiler sources reverted, tests kept):

```
Failed!  - Failed: 7, Passed: 8, Total: 15
```

(15 at that point; three cases were added afterwards for the symbolic-clause sub-defect and the inherited-interface shape.) With the fixes:

```
Passed!  - Failed: 0, Passed: 18, Total: 18
```

The cases that pass on **both** sides are the deliberate anti-vacuity guard rails, labelled as such in the source:

- a **single** explicit clause on an imported generic interface already worked and must keep working;
- a real **override** must still hide its base method (that is what the narrowed hiding rule still does);
- plain duplicate overloads with no clause are still **GS0264**;
- two clauses on the **same** instantiation are still duplicates;
- an instantiation left unimplemented is still **GS0187**;
- a clause naming a member the interface does not declare is still **GS0494**;
- the **non-generic** derived class (#3813) still works;
- assigning a `ChannelReader[string]` to the inherited `Reader` inside `Wrap[T]` is still **rejected** — the unsound direction this could have been "fixed" into, given both sides used to be `object`;
- `protected` stays unreachable from a non-derived type.

cs2gs: `Golden` (47), `ExplicitInterface` + `Oahu` (154) all pass. `OahuDecryptTranslationTests.GenericImportedExplicitInterfaceQualifier_FallsBackAndCompiles` **asserted the old fallback** and is rewritten as `…_KeepsClauseAndCompiles`, plus a new case for the two-instantiation shape that walled `test/Core.Tests`.

`build/nullable_hygiene.py`: OK.

## Premise corrections (posted to both issues)

- **#3814's root cause is one layer below where the issue puts it.** It is not that interface verification fails to match a clause against a constructed imported interface — verification never sees the method at all, because the overload set dropped it. The order-dependence (always the *second* declaration) is the evidence, and it is not in the issue.
- **#3814 is two defects, not one.** The GS0494 symbolic-argument case is real, survives the overload-set fix, and needed a separate fix. The issue folds them together.
- **#3815's `[object]` is a WRITE-path defect only.** The issue says "the same `[object]` shows up in the read path's diagnostics"; the read path in fact already projects correctly, and the `[object]` in those diagnostics is the assignment target, not the source.

## Deconfliction

Touches the gsc binder (imported-generic substitution) and **one** cs2gs file — `CSharpToGSharpTranslator.Members.cs`, the carve-out #3814 explicitly ordered second — plus its test. No overlap with the `test/Interpreter.Tests` triage. `tools/cs2gs/selfmig-baseline.json` untouched.

Fixes #3814
Fixes #3815

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
