### PR TITLE
gsc: a fully-qualified constructor call with no applicable overload reports the overload error, not GS0157 (#3821)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -272,6 +272,45 @@ internal sealed partial class ExpressionBinder
                 boundArguments,
                 ref result,
                 TypeSymbol.FromClrType(clrType));
+
+        // Issue #3821: the shared failure helper only commits to the
+        // no-applicable-overload diagnostic when the call carries an explicit
+        // type-argument list (issue #2633 fixed this cascade for the GENERIC
+        // spelling only). Without that, a non-generic qualified construction
+        // whose arguments match no constructor answered "not handled", the
+        // whole accessor chain re-bound as a namespace walk, and the walk
+        // failed at its HEAD — reporting GS0157 "Cannot find type System"
+        // about a segment that resolves perfectly. cs2gs writes fully-qualified
+        // type names whenever a simple name is ambiguous (issues #2258/#3805),
+        // so on the self-migration corpus every argument error at such a call
+        // site collapsed into that one misleading line.
+        //
+        // Committing is gated twice, because two later arms of
+        // `BindAccessorExpression` can still bind a chain this one gave up on:
+        //
+        //   * the prefix must be a NAMESPACE, not a type. When the last prefix
+        //     segment is itself a type (`Outer.Nested(...)`,
+        //     `DebuggableAttribute.DebuggingModes(2)`), the fully-qualified
+        //     static-access arm can still find a member of it.
+        //   * the terminal simple name must not also name a SOURCE type. A
+        //     package-qualified source construction (`Oahu.Tui.Nested.Refresh(1)`,
+        //     issue #2585) reaches the CLR arm first and can resolve a
+        //     same-named REFERENCE type whose constructors do not match — the
+        //     source arm below is the one that binds it.
+        //
+        // A namespace prefix with no source homonym has neither second chance,
+        // so there the fallthrough can only ever produce GS0157.
+        if (!handled
+            && noApplicableOverload
+            && namespacePrefix.Length > 0
+            && !scope.References.TryResolveType(namespacePrefix, out _)
+            && !TryLookupSourceTypeWithImportPrecedence(typeSimpleName, preferredArity: -1, declaration: null, out _))
+        {
+            Diagnostics.ReportNoApplicableOverload(terminalCall.Identifier.Location, typeSimpleName);
+            result = new BoundErrorExpression(terminalCall);
+            handled = true;
+        }
+
         if (handled && terminalObjectCreation != null)
         {
             result = BindObjectInitializerSuffix(

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3821QualifiedConstructorOverloadDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3821QualifiedConstructorOverloadDiagnosticTests.cs
@@ -1,0 +1,129 @@
+// <copyright file="Issue3821QualifiedConstructorOverloadDiagnosticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3821: a FULLY-QUALIFIED constructor call whose arguments match no
+/// constructor reported <c>GS0157 "Cannot find type &lt;first segment&gt;"</c>
+/// — a diagnostic about the leading namespace segment, which is perfectly
+/// resolvable — instead of the overload error the same call reports when the
+/// type name is written unqualified.
+/// <para>
+/// Cause: <c>TryBindQualifiedClrConstructorCall</c> resolves the dotted name to
+/// a CLR type and then asks the shared constructor core to bind. On
+/// no-applicable-overload the shared failure helper only commits to
+/// <c>GS0267</c> when the call carries an explicit type-argument list (issue
+/// #2633 fixed exactly this cascade, but only for the generic spelling), so the
+/// non-generic call returned "not handled" and the whole accessor chain
+/// re-bound as a namespace walk — which fails at its head and reports GS0157.
+/// </para>
+/// <para>
+/// cs2gs emits fully-qualified type names whenever a simple name is ambiguous
+/// (issues #2258 / #3805), so on the self-migration corpus this turns every
+/// genuine argument error at such a call site into the same misleading
+/// "Cannot find type GSharp" line.
+/// </para>
+/// </summary>
+public sealed class Issue3821QualifiedConstructorOverloadDiagnosticTests
+{
+    [Fact]
+    public void QualifiedConstructorCall_NoApplicableOverload_ReportsOverloadErrorNotMissingType()
+    {
+        // FAILS on origin/main: reports GS0157 "Cannot find type System".
+        const string source = """
+            package Demo
+
+            func Build() {
+                let sb = System.Text.StringBuilder("a", "b", "c", "d", "e")
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0157");
+    }
+
+    [Fact]
+    public void QualifiedConstructorCall_WrongArgumentType_ReportsOverloadErrorNotMissingType()
+    {
+        // FAILS on origin/main: reports GS0157 "Cannot find type System".
+        // Four arguments matches `StringBuilder(string, int, int, int)` in
+        // arity only — the second argument is a string, so no overload applies.
+        const string source = """
+            package Demo
+
+            func Build() {
+                let sb = System.Text.StringBuilder("a", "b", "c", "d")
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0267");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0157");
+    }
+
+    [Fact]
+    public void QualifiedConstructorCall_ThatBinds_StillBinds()
+    {
+        // Anti-vacuity guard rail: PASSES on origin/main and here. The change
+        // must only affect the failure path.
+        const string source = """
+            package Demo
+
+            func Build() string {
+                let sb = System.Text.StringBuilder("hi")
+                return sb.ToString()
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void QualifiedStaticCall_OnTypeReceiver_StillBinds()
+    {
+        // Anti-vacuity guard rail: PASSES on origin/main and here. A dotted
+        // chain whose last prefix segment is a TYPE (not a namespace) must keep
+        // falling through to member binding — the fix is gated on the prefix
+        // being a namespace precisely so this shape is untouched.
+        const string source = """
+            package Demo
+
+            func Combine() string {
+                return System.IO.Path.Combine("a", "b")
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void UnqualifiedConstructorCall_NoApplicableOverload_AlreadyReportsOverloadError()
+    {
+        // Anti-vacuity guard rail: PASSES on origin/main and here. It pins the
+        // asymmetry the fix removes — the unqualified spelling of the very same
+        // call already reports the overload error.
+        const string source = """
+            package Demo
+            import System.Text
+
+            func Build() {
+                let sb = StringBuilder("a", "b", "c", "d", "e")
+            }
+            """;
+
+        Assert.DoesNotContain(Bind(source), diagnostic => diagnostic.Id == "GS0157");
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        return EmittedOracle.Evaluate(source).Diagnostics;
+    }
+}


### PR DESCRIPTION
Fixes #3821.

A **fully-qualified constructor call** whose arguments match no constructor reported

```
error GS0157: Cannot find type System. Are you missing an import?
```

— about the *leading namespace segment*, which resolves perfectly — while the unqualified spelling of the same call reported the overload error correctly.

## Cause

`ExpressionBinder.TryBindQualifiedClrConstructorCall` resolves the dotted name to a CLR type and hands off to the shared constructor core. On no-applicable-overload, `FinishClrConstructorBindingFailure` only commits to `GS0267`:

```csharp
if (syntax.TypeArgumentList == null)
{
    result = null;
    return false;      // non-generic call: give up silently
}
```

That guard came from #2633 (fixes #2621), which cured exactly this misleading cascade — **but only for the generic spelling** (`List[T](bad)`). The non-generic qualified call answered "not handled", `BindAccessorExpression` fell through, the chain re-bound as a namespace walk, and the walk failed at its head, which is where GS0157 is reported.

## The change

Commit to the overload diagnostic in `TryBindQualifiedClrConstructorCall` itself, gated twice so the two later arms of `BindAccessorExpression` that can still bind such a chain keep their second chance:

* the prefix must be a **namespace**, not a type — otherwise the fully-qualified static-access arm may still find a member of it (`DebuggableAttribute.DebuggingModes(2)`, #3749);
* the terminal simple name must not also name a **source** type — a package-qualified source construction (`Oahu.Tui.Nested.Refresh(1)`, #2585) reaches the CLR arm first, can resolve a same-named *reference* type whose constructors do not match, and is bound by the source arm below.

The second gate is not speculative: without it, `Issue2585SemanticQualificationTests.SourceQualifiedTypeAndValueReceiver_RemainDistinct` fails.

## Why it matters

cs2gs writes fully-qualified type names whenever a simple name is ambiguous (#2258, and #3805/#3817 for linked sources), so on the self-migration corpus every genuine argument error at such a call site collapsed into the same one misleading line pointing at a namespace root. #3817's triage of `test/Interpreter.Tests` recorded *"GS0157 Cannot find type GSharp ×21"* as the leading family — 21 errors whose real causes the diagnostic hid.

This does **not** clear that app's wall. Re-measuring it on `origin/main` @ `89ff8246c` shows the wall is now 15 `GSA0005` errors in migrated `src/Core` (filed as #3820, with #3822 split out); the GS0157 layer sits behind them.

## Tests

`test/Core.Tests/CodeAnalysis/Binding/Issue3821QualifiedConstructorOverloadDiagnosticTests.cs`, executing through `EmittedOracle.Evaluate` (compile + run), honestly labelled:

| test | on `origin/main` | here |
|---|---|---|
| `QualifiedConstructorCall_NoApplicableOverload_ReportsOverloadErrorNotMissingType` | **fails** (`Collection: [Cannot find type System. …]`) | passes |
| `QualifiedConstructorCall_WrongArgumentType_ReportsOverloadErrorNotMissingType` | **fails** (same) | passes |
| `QualifiedConstructorCall_ThatBinds_StillBinds` | passes | passes (anti-vacuity) |
| `QualifiedStaticCall_OnTypeReceiver_StillBinds` | passes | passes (anti-vacuity — pins the type-prefix gate) |
| `UnqualifiedConstructorCall_NoApplicableOverload_AlreadyReportsOverloadError` | passes | passes (anti-vacuity — pins the asymmetry being removed) |

Measured, not asserted: 2 failed / 3 passed on `origin/main`; 5 passed here.

Full `test/Core.Tests`: **8578 passed, 0 failed** (the intermediate version of the gate, without the source-type condition, failed 1 — `Issue2585SemanticQualificationTests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
