### PR TITLE
gsc: a runtime reference to an already-loaded assembly reuses the host's identity (#3818)

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -209,9 +209,15 @@ public sealed class ReferenceResolver : IDisposable
 
         public Assembly LoadReference(string path)
         {
-            directories.Add(Path.GetDirectoryName(path) ?? string.Empty);
+            AddProbeDirectory(path);
             return LoadFromAssemblyPath(path);
         }
+
+        // Issue #3818: a reference reused from the host context (rather than
+        // loaded here) still contributes its directory, so a private
+        // dependency sitting beside it stays resolvable from this context.
+        public void AddProbeDirectory(string path)
+            => directories.Add(Path.GetDirectoryName(path) ?? string.Empty);
 
         protected override Assembly? Load(AssemblyName assemblyName)
         {
@@ -509,7 +515,27 @@ public sealed class ReferenceResolver : IDisposable
                 }
 
                 var fullPath = Path.GetFullPath(path);
-                var assembly = runtimeContext.LoadReference(fullPath);
+
+                // Issue #3818: a reference the host has ALREADY loaded from
+                // this exact path must resolve to the host's instance, not to
+                // a second private copy. Loading it again into the driver
+                // context mints a rival identity for every type in it, and any
+                // Type that leaks between two compilations in one process
+                // (through the binder's process-wide symbol/member caches) then
+                // becomes a cross-context type: `MakeGenericMethod` rejects it,
+                // the only candidate is dropped, and the call reports the
+                // opaque "Cannot find function <name>" — order-dependently,
+                // because it needs an earlier compilation to have created the
+                // rival copy. Same file plus same identity means reuse is
+                // always safe; a genuinely different assembly does not match by
+                // path and is still loaded privately.
+                Assembly? reused = TryReuseHostLoadedAssembly(fullPath);
+                if (reused is not null)
+                {
+                    runtimeContext.AddProbeDirectory(fullPath);
+                }
+
+                var assembly = reused ?? runtimeContext.LoadReference(fullPath);
                 RegisterAssemblyOriginalPath(assembly, fullPath);
                 runtimeAssemblies.Add(assembly);
             }
@@ -1578,6 +1604,38 @@ public sealed class ReferenceResolver : IDisposable
         }
 
         AssemblyOriginalPaths.AddOrUpdate(assembly, path);
+    }
+
+    /// <summary>
+    /// Issue #3818: finds an assembly the default load context already holds
+    /// for <paramref name="fullPath"/>, so a runtime reference to it reuses the
+    /// host's identity instead of minting a second copy.
+    /// </summary>
+    /// <param name="fullPath">The absolute reference path.</param>
+    /// <returns>The already-loaded assembly, or <see langword="null"/>.</returns>
+    private static Assembly? TryReuseHostLoadedAssembly(string fullPath)
+    {
+        foreach (var loaded in AssemblyLoadContext.Default.Assemblies)
+        {
+            string location;
+            try
+            {
+                location = loaded.Location;
+            }
+            catch (NotSupportedException)
+            {
+                // Dynamic / in-memory assemblies have no location to match.
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(location)
+                && string.Equals(location, fullPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return loaded;
+            }
+        }
+
+        return null;
     }
 
     private static ImmutableArray<Assembly> BuildHostAssemblies()

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue3818RuntimeReferenceIdentityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue3818RuntimeReferenceIdentityTests.cs
@@ -1,0 +1,70 @@
+// <copyright file="Issue3818RuntimeReferenceIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3818, in the #3705 load-context family: a runtime reference to an
+/// assembly the host has ALREADY loaded from that exact path must resolve to
+/// the host's instance rather than to a second private copy.
+/// <para>
+/// <see cref="ReferenceResolver.WithRuntimeReferences"/> used to load every
+/// path into a fresh collectible context unconditionally, so each compilation
+/// in a process minted a rival identity for every type in that assembly. Any
+/// <see cref="Type"/> that then crossed from one compilation into the next —
+/// the binder's process-wide symbol and member caches are keyed on
+/// <see cref="Type"/> and outlive a single compilation — became a
+/// cross-context operand. The visible failure was order-dependent and
+/// entirely opaque: closing a generic method over a type argument from one
+/// copy while the receiver came from the other makes
+/// <see cref="MethodInfo.MakeGenericMethod"/> throw, overload resolution drops
+/// the candidate silently (C# §7.5.2), and the call reports "Cannot find
+/// function &lt;name&gt;" about a method that plainly exists.
+/// </para>
+/// </summary>
+public class Issue3818RuntimeReferenceIdentityTests
+{
+    private static string CorePath => typeof(SyntaxNode).Assembly.Location;
+
+    [Fact]
+    public void RuntimeReferenceToAnAlreadyLoadedAssembly_ResolvesToTheHostInstance()
+    {
+        using ReferenceResolver resolver = ReferenceResolver.WithRuntimeReferences(new[] { CorePath });
+
+        Assert.True(resolver.TryResolveType("GSharp.Core.CodeAnalysis.Syntax.SyntaxNode", out Type resolved));
+        Assert.Same(typeof(SyntaxNode), resolved);
+    }
+
+    [Fact]
+    public void TwoRuntimeReferenceResolversOverTheSamePath_ShareTypeIdentity()
+    {
+        Type receiverType;
+        using (ReferenceResolver first = ReferenceResolver.WithRuntimeReferences(new[] { CorePath }))
+        {
+            Assert.True(first.TryResolveType("GSharp.Core.CodeAnalysis.Syntax.SyntaxNode", out receiverType));
+        }
+
+        Type typeArgument;
+        using (ReferenceResolver second = ReferenceResolver.WithRuntimeReferences(new[] { CorePath }))
+        {
+            Assert.True(second.TryResolveType("GSharp.Core.CodeAnalysis.Syntax.FunctionDeclarationSyntax", out typeArgument));
+        }
+
+        Assert.Same(receiverType.Assembly, typeArgument.Assembly);
+
+        // The exact operation that failed in #3818: the two operands reach the
+        // binder from different compilations, and MakeGenericMethod is what
+        // rejects them when they are not the same identity.
+        MethodInfo open = receiverType.GetMethods()
+            .Single(m => m.Name == nameof(SyntaxNode.FirstAncestorOrSelf) && m.IsGenericMethodDefinition);
+        _ = open.MakeGenericMethod(typeArgument);
+    }
+}


### PR DESCRIPTION
Fixes #3818.

`tests (cs2gs-remainder)` has been failing about half the time on
`Adr0169AnalyzerTranslationTests`, always with one opaque error —
`Cannot find function FirstAncestorOrSelf` — while every other member of the
same translated analyzer bound cleanly.

## Not test isolation — a product defect

`ReferenceResolver.WithRuntimeReferences` loaded every reference path into a
fresh collectible `DriverReferenceLoadContext`, unconditionally. When the path
names an assembly the host has **already** loaded — exactly what the ADR-0169
helpers pass, `typeof(Diagnostic).Assembly.Location` — that mints a second,
rival identity for every type in `GSharp.Core`, once per compilation.

The binder's symbol and member caches are process-wide and keyed on `Type`, so a
`Type` can outlive the compilation that created it. Instrumenting the GS0159
site on a local reproduction showed exactly that: the receiver's `SyntaxNode`
came from a *previous* compilation's driver context (`recvInResolverList=False`,
`recvIsCurrent=False`) while the explicit type argument
`FunctionDeclarationSyntax` came from the current one. Closing
`FirstAncestorOrSelf<T>` over operands from two contexts makes
`MakeGenericMethod` throw; `ClrOverloadResolution` drops the candidate silently
(C# §7.5.2), and the call reports "Cannot find function" about a method that
plainly exists.

This is the #3705 load-context family: two operands for one logical CLR type,
and an answer that depends on which one arrives.

## The fix

A reference whose path the default load context already holds resolves to the
host's instance instead of a private copy. Same file plus same identity means
reuse is always safe; a genuinely different assembly does not match by path and
is still loaded privately, so driver `/reference:` behaviour for user assemblies
is unchanged. The reused reference still contributes its directory to the driver
context's probe set.

## Evidence

Reproduction: `Adr0169Gsa0005ParityTests` + `Adr0169AnalyzerTranslationTests` in
one test host (~40s per run).

| | runs | failures |
|---|---|---|
| before | 43 | 18 (42%) |
| after | 8 | 0 |

The two new `Issue3818RuntimeReferenceIdentityTests` fail on `main` and pass
here.

Refs #3705, #3780, #3777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs