### PR TITLE
G# + cs2gs: scoped diagnostic suppression via @SuppressDiagnostic (ADR-0175, #3820/#3824)

### DIFF
--- a/docs/adr/0175-scoped-diagnostic-suppression.md
+++ b/docs/adr/0175-scoped-diagnostic-suppression.md
@@ -1,0 +1,219 @@
+# ADR-0175: Scoped diagnostic suppression (`@SuppressDiagnostic`)
+
+- **Status**: Accepted
+- **Date**: 2026-09-02
+- **Related**: issue #3820 (the corpus-wide selfmig wall), issue #3824 (cs2gs drops `#pragma warning`), issue #3809 (made the translated analyzers effective), ADR-0169 (G# analyzer framework), ADR-0047 (annotations), ADR-0115 (cs2gs).
+
+## Context
+
+ADR-0169 gave G# analyzers and three ways to turn a diagnostic off:
+`/nowarn:<ids>`, `/gsdiag:<ID>=<severity>`, and `.editorconfig`
+`dotnet_diagnostic.<ID>.severity` (lowered to `/gsdiag:` by `BuildTask`).
+All three are **whole-compilation**. G# had no way to say "this
+diagnostic is wrong *here*, and only here".
+
+C# has had one since 1.0: `#pragma warning disable/restore <ids>`.
+`cs2gs` has never translated it — grep the translator for `PragmaWarning`
+and there are zero hits; `AttachSourceComments` keeps the justifying
+comment beside a suppression and drops the suppression itself. That was
+invisible until #3809 populated `Symbol.ContainingType` on the semantic
+model and the translated ADR-0169 analyzers started reporting. The
+compiler's own deliberate `GSA0005` suppressions then fired in the
+migrated tree, `migrated/src/Core` stopped compiling, and every app that
+project-references it went red — a banked `greenApps` regression, gate
+run `33636317883` at 29/52 against a floor of 43.
+
+### Measured scope
+
+562 `#pragma warning` occurrences across 130 files in the corpus, by
+identifier family:
+
+| family | occurrences | runs on G#? |
+|---|---|---|
+| `SA####` (StyleCop) | 474 | no |
+| `CS####` (C# compiler) | 52 | no |
+| **`GSA####` (G# analyzers)** | **20 (10 disable/restore pairs)** | **yes** |
+| `IDE####` | 6 | no |
+| `VSTHRD###` | 4 | no |
+| `CA####` | 4 | no |
+| `RS####` | 2 | no |
+
+Only the `GSA` rows matter. The other 542 name analyzers that do not run
+on G# at all, so translating them would emit annotations that suppress
+nothing.
+
+The ten `GSA0005` regions:
+
+| file | lines | covers |
+|---|---|---|
+| `src/Core/CodeAnalysis/Lowering/SideEffectSpiller.cs` | 399–437 | `RewriteFieldAssignmentExpression` |
+| `src/Core/CodeAnalysis/Binding/LambdaBinder.cs` | 2561–2582 | `RewriteFieldAssignmentExpression` |
+| `src/Core/CodeAnalysis/Binding/LambdaBinder.cs` | 2588–2606 | `RewriteIndexAssignmentExpression` |
+| `src/Core/CodeAnalysis/Binding/LambdaBinder.cs` | 2664–2698 | `RewriteReturnStatement` |
+| `src/Core/CodeAnalysis/Lowering/Iterators/HoistedFieldRewriter.cs` | 176–191 | `RewriteIndexAssignmentExpression` |
+| `src/Core/CodeAnalysis/Lowering/Iterators/HoistedFieldRewriter.cs` | 197–215 | `RewriteClrIndexAssignmentExpression` |
+| `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs` | 645–672 | `RewriteFieldAssignmentExpression` |
+| `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs` | 678–705 | `RewriteIndexAssignmentExpression` |
+| `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs` | 710–758 | `RewriteClrIndexAssignmentExpression` |
+| `src/Core/CodeAnalysis/Lowering/CaptureBoxingRewriter.cs` | 989–1024 | `RewriteVariableDeclaration` |
+
+**Every one of the ten opens immediately before a method declaration and
+closes immediately after that method's closing brace.** Not one is a
+partial statement range. Declaration-level scope is therefore *exactly*
+equivalent for the whole corpus — there is no fidelity/simplicity
+trade-off to make here, and no `GSA0005` coverage is lost anywhere else
+in those five files.
+
+## Decision
+
+G# grows **`@SuppressDiagnostic("ID", …)`**, an ADR-0047 annotation with
+two positions:
+
+1. **On any declaration an annotation may already precede** — type,
+   function, property, field, event, enum member, parameter, local
+   `var`/`let`/`const`. Scope: that declaration's span.
+
+2. **On a block statement**, `@SuppressDiagnostic("ID") { … }`. Scope:
+   the block's `{`..`}`. This gives a suppression a range narrower than a
+   declaration, the direct analogue of a `#pragma` region inside a method
+   body.
+
+A diagnostic is dropped when its primary location falls inside a scope
+naming its identifier. The check lives in `GSharpAnalyzerDriver.Report`
+— the single funnel every analyzer diagnostic passes through — so `gsc`,
+the language server, and `GSharpAnalyzerVerifier` honour identical
+scoping without three implementations.
+
+### It is compiler-intrinsic, not a CLR attribute
+
+`@SuppressDiagnostic` names no type. It is recognised by source spelling
+(`SuppressDiagnostic` or `SuppressDiagnosticAttribute`), consumed
+straight from the syntax tree, and never written to metadata.
+
+The alternative — a real attribute class — was rejected because G# has
+no always-referenced runtime assembly (unlike Kotlin's `kotlin-stdlib`,
+which is where `@Suppress` lives). A `SuppressDiagnosticAttribute` in
+`GSharp.Core` would be unusable from any project that does not reference
+`GSharp.Core`, which is most of them. Reusing
+`System.Diagnostics.CodeAnalysis.SuppressMessageAttribute` was also
+rejected: it demands a `Category` argument a `#pragma` cannot supply, its
+`CheckId` convention is `"ID:Title"` rather than a bare identifier, and
+it cannot annotate a block.
+
+`DeclarationBinder.BindAttribute` intercepts the name before type
+resolution and returns without producing a `BoundAttribute`;
+`StatementBinder.BindBlockStatement` does the same for the block form.
+
+### Grammar
+
+The parser already reads leading annotations in statement position
+(ADR-0047 §2 / issue #187) and then either attaches them to a
+`var`/`let`/`const` declaration or reports GS0206. The block form adds
+one branch: if the token after the annotations is `{`, parse a block and
+attach.
+
+- **Ambiguity: none.** One token of lookahead suffices. Before this ADR an
+  `@` in statement position admitted only `const`/`let`/`var`, so a
+  following `{` was always an error — the production is new, not
+  reinterpreted.
+- **Against the `{ … } + x` expression-continuation shape (#3355):**
+  annotations *commit* the brace to a statement block. That shape is
+  reachable only from a bare leading `{`, never through an annotation, so
+  the `NestedBraceStartsContinuedExpression` probe is not consulted on
+  the annotated path.
+- **Against object/composite initializers:** those `{ … }` forms are
+  parsed as expressions in expression position; an annotated block is
+  only ever recognised in *statement* position, where a `{` is already a
+  block.
+- The block's annotations are excluded from its children
+  (`[SyntaxChildIgnore]`) so its span stays exactly `{`..`}` — the span
+  *is* the suppression scope, and a diagnostic reported on the annotation
+  itself must not fall inside it.
+
+### Semantics
+
+- **Nesting**: scopes compose by union. An inner block adds its
+  identifiers to whatever the enclosing scopes already suppress.
+- **No re-enabling.** An inner scope cannot un-suppress an identifier an
+  outer one suppressed. C#'s `restore` is a *position*, not a scope, so it
+  can re-enable; a scoped model has no coherent way to express "re-enable
+  within" without a second annotation form, and no corpus case wants one.
+  If a narrower region needs the diagnostic live, move the suppression
+  inward — the block form exists so that is always possible.
+- **Multiple identifiers per annotation** are allowed:
+  `@SuppressDiagnostic("GSA0005", "GSA0007")`, matching `#pragma`'s
+  comma-separated list. Repeating the annotation is equivalent.
+- **Identifier matching is case-insensitive** and keyed on the bare
+  identifier, consistently with `/nowarn` and `/gsdiag:`.
+- **Malformed identifier: diagnosed, not ignored** — new **GS9305**
+  (Error). An argument must be a constant string shaped like a diagnostic
+  identifier (ASCII letters then digits: `GS0157`, `GSA0005`,
+  `PROBE001`). An empty argument list is likewise GS9305. A suppression
+  that silently does nothing is precisely the failure mode this ADR
+  exists to close, so the shape is checked at bind time.
+
+### Deliberately deferred
+
+- **Unknown-identifier reporting.** "`GSA0006` is not a diagnostic anyone
+  declares" cannot be answered honestly per-project: an identifier may
+  belong to an analyzer this project simply does not reference, and
+  warning there would punish correct code. It needs a diagnostic-identifier
+  registry spanning `gsc`'s descriptors and every loaded analyzer's
+  `SupportedDiagnostics`, plus a rule for the unreferenced case.
+- **Unused-suppression reporting.** Dead suppressions do accumulate
+  (Roslyn's IDE0079 exists for this), and the driver already has the
+  information — it knows which scopes matched. Deferred as a separate,
+  opt-in diagnostic rather than bundled into the fix for a red gate.
+- **Compiler (`GS####`) diagnostics.** The scope check runs in the
+  analyzer driver, so today `@SuppressDiagnostic` covers analyzer
+  diagnostics only. Extending it to `gsc`'s own diagnostics is a
+  mechanical follow-up (the same map, consulted in
+  `Program.ApplySuppressPromote`), deliberately not taken here to keep the
+  blast radius of a gate fix small.
+
+### cs2gs
+
+`AttachPragmaSuppressions` runs beside `AttachSourceComments` on each
+translated member. A `#pragma warning disable X … restore X` region
+covering a declaration's *entire* span contributes
+`@SuppressDiagnostic("X")` on the migrated declaration. Identifiers not
+starting with `GSA` are dropped, as is a bare `#pragma warning disable`
+with no identifier list (it names everything and has no faithful scoped
+spelling).
+
+A region that *cuts across* a declaration contributes nothing rather than
+widening to the declaration — a widened suppression would hide violations
+the C# source still reports, which is the one failure this ADR must not
+introduce. No corpus region does this today; if one appears it surfaces
+as a diagnostic rather than as silence. Translating a mid-body statement
+range into the block form is a follow-up, unexercised by the corpus.
+
+## Consequences
+
+- The ten `GSA0005` suppressions in `src/Core` survive migration with the
+  identical scope they had in C#: one method each, nothing wider.
+- `gsc` gains GS9305. Both `docs/diagnostics.md` and
+  `website/docs/ref/diagnostics.md` are updated.
+- `BlockStatementSyntax` gains an `Annotations` list; `Parser.Statements`
+  gains one branch; `GSharpAnalyzerDriver` gains one filter.
+- The remaining ~542 non-`GSA` pragmas keep being dropped — now
+  deliberately and documented, rather than by omission.
+
+## Alternatives considered
+
+- **Project-level `NoWarn` / `dotnet_diagnostic.GSA0005.severity = none`
+  in the migrated tree.** Rejected. It unblocks the gate by deleting the
+  analyzer's coverage across whole projects, so the gate would go green
+  while the property it measures got weaker. `GSA0005` is also reported
+  as an error, which `/nowarn` does not suppress.
+- **A `#pragma`-equivalent directive.** Rejected. G# has no preprocessor
+  and no directive trivia at all; this would be the first, for one
+  feature. It buys exact positional parity with C#'s *restore*
+  re-enabling, which nothing in the corpus uses, at the cost of new lexer
+  and trivia infrastructure. Kotlin and Swift both express this as an
+  annotation, and ADR-0047 already gives G# the grammar for one.
+- **Declaration-level attribute only, no block form.** Sufficient for
+  100% of today's corpus (all ten regions are whole-declaration). Rejected
+  as a language decision: the moment a suppression is needed for three
+  statements in a long method, the only options would be widening it over
+  the whole method or splitting the method, and the widening is silent.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -23,6 +23,33 @@ Every diagnostic emitted by `gsc` carries a stable `GS####` identifier, a severi
 
 IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms are equivalent.
 
+### Source-level, scoped suppression (ADR-0175)
+
+The flags above are whole-compilation. To turn an **analyzer** diagnostic off
+for one declaration or one range of statements, annotate the source with
+`@SuppressDiagnostic`:
+
+```
+@SuppressDiagnostic("GSA0005")
+func RewriteFieldAssignmentExpression(node BoundFieldAssignmentExpression) BoundExpression {
+    // GSA0005 is suppressed here, and nowhere else.
+}
+
+func Elsewhere() {
+    @SuppressDiagnostic("GSA0005", "GSA0007") {
+        // suppressed only inside these braces
+    }
+
+    // still reported here
+}
+```
+
+The annotation is compiler-intrinsic: it names no type, needs no assembly
+reference, and is never written to metadata. Its scope is the span of the
+declaration or block it precedes; nesting adds identifiers and never removes
+them. An argument that is not a constant string shaped like a diagnostic ID is
+reported as [GS9305](#analyzer-host-diagnostics-gs9300gs9319-reserved).
+
 **Example `.gsproj` snippet:**
 ```xml
 <PropertyGroup>
@@ -317,6 +344,7 @@ GS92xx block belongs to the gsgen source-generator host.)
 | GS9302 | Info | An analyzer exceeded its time budget in an interactive host and was disabled for subsequent runs. |
 | GS9303 | Warning | An analyzer was built against a different `GSharp.Core` version than the host; the load is attempted anyway. |
 | GS9304 | Warning | An analyzer reported a diagnostic whose ID is not declared in its `SupportedDiagnostics`; the diagnostic is suppressed. |
+| GS9305 | Error | `@SuppressDiagnostic` (ADR-0175) was given an argument that is not a constant string shaped like a diagnostic ID, or no argument at all. |
 
 ### Internal diagnostics (GS9996–GS9999)
 

--- a/src/Core/CodeAnalysis/Analyzers/DiagnosticSuppressionMap.cs
+++ b/src/Core/CodeAnalysis/Analyzers/DiagnosticSuppressionMap.cs
@@ -1,0 +1,246 @@
+// <copyright file="DiagnosticSuppressionMap.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+
+namespace GSharp.Core.CodeAnalysis.Analyzers;
+
+/// <summary>
+/// ADR-0175 (issues #3820 / #3824): the source-level, scoped analyzer
+/// suppressions declared by <c>@SuppressDiagnostic("ID", …)</c> annotations in
+/// a compilation's syntax trees.
+///
+/// A suppression's scope is the span of the syntactic construct it annotates —
+/// a declaration for the attribute form, the <c>{</c>..<c>}</c> of the block
+/// form. A diagnostic is suppressed when its primary location falls inside a
+/// scope naming its ID; the same diagnostic reported anywhere else in the same
+/// file still surfaces.
+/// </summary>
+public sealed class DiagnosticSuppressionMap
+{
+    /// <summary>An empty map that suppresses nothing.</summary>
+    public static readonly DiagnosticSuppressionMap Empty =
+        new DiagnosticSuppressionMap(ImmutableArray<Scope>.Empty);
+
+    private readonly ImmutableArray<Scope> scopes;
+
+    private DiagnosticSuppressionMap(ImmutableArray<Scope> scopes)
+    {
+        this.scopes = scopes;
+    }
+
+    /// <summary>
+    /// Builds the suppression map for <paramref name="syntaxTrees"/>.
+    /// </summary>
+    /// <param name="syntaxTrees">The trees to scan.</param>
+    /// <returns>The map; <see cref="Empty"/> when no suppression is declared.</returns>
+    public static DiagnosticSuppressionMap Build(IEnumerable<SyntaxTree> syntaxTrees)
+    {
+        if (syntaxTrees is null)
+        {
+            return Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<Scope>();
+        foreach (var tree in syntaxTrees)
+        {
+            Collect(tree.Root, tree.Text, builder);
+        }
+
+        return builder.Count == 0 ? Empty : new DiagnosticSuppressionMap(builder.ToImmutable());
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <paramref name="diagnostic"/> is
+    /// suppressed by a source annotation.
+    /// </summary>
+    /// <param name="diagnostic">The diagnostic to test.</param>
+    /// <returns><see langword="true"/> when a scope covering the diagnostic names its ID.</returns>
+    public bool IsSuppressed(Diagnostic diagnostic)
+    {
+        if (diagnostic is null || this.scopes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        var location = diagnostic.Location;
+        if (location.Text is null)
+        {
+            return false;
+        }
+
+        foreach (var scope in this.scopes)
+        {
+            if (!ReferenceEquals(scope.Text, location.Text))
+            {
+                continue;
+            }
+
+            if (location.Span.Start < scope.Span.Start || location.Span.Start >= scope.Span.End)
+            {
+                continue;
+            }
+
+            foreach (var id in scope.Ids)
+            {
+                if (string.Equals(id, diagnostic.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <paramref name="annotation"/> is the
+    /// compiler-intrinsic <c>@SuppressDiagnostic</c> annotation (ADR-0175).
+    /// Recognition is by source spelling: the annotation has no CLR type, is
+    /// never bound, and is never written to metadata, so a compilation needs no
+    /// extra assembly reference to use it.
+    /// </summary>
+    /// <param name="annotation">The annotation to test.</param>
+    /// <returns><see langword="true"/> when the name is <c>SuppressDiagnostic</c> or <c>SuppressDiagnosticAttribute</c>.</returns>
+    public static bool IsSuppressDiagnostic(AnnotationSyntax annotation)
+    {
+        if (annotation is null || annotation.HasTypeArgumentList)
+        {
+            return false;
+        }
+
+        var name = annotation.GetNameText();
+        return string.Equals(name, "SuppressDiagnostic", StringComparison.Ordinal)
+            || string.Equals(name, "SuppressDiagnosticAttribute", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Extracts the diagnostic IDs named by a <c>@SuppressDiagnostic</c>
+    /// annotation. Every positional argument must be a string literal; an
+    /// argument that is not contributes no ID (the binder reports GS9305).
+    /// </summary>
+    /// <param name="annotation">The annotation to read.</param>
+    /// <returns>The IDs, in source order.</returns>
+    public static ImmutableArray<string> GetSuppressedIds(AnnotationSyntax annotation)
+    {
+        if (annotation is null || annotation.Arguments is null || annotation.Arguments.Count == 0)
+        {
+            return ImmutableArray<string>.Empty;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<string>();
+        foreach (var argument in annotation.Arguments)
+        {
+            if (argument is LiteralExpressionSyntax { Value: string text } && IsWellFormedId(text))
+            {
+                builder.Add(text);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <paramref name="text"/> has the shape of
+    /// a diagnostic ID: at least one ASCII letter followed by at least one
+    /// digit (<c>GS0157</c>, <c>GSA0005</c>, <c>PROBE001</c>).
+    /// </summary>
+    /// <param name="text">The candidate ID.</param>
+    /// <returns><see langword="true"/> when the shape matches.</returns>
+    public static bool IsWellFormedId(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        var i = 0;
+        while (i < text!.Length && char.IsAsciiLetter(text[i]))
+        {
+            i++;
+        }
+
+        if (i == 0 || i == text.Length)
+        {
+            return false;
+        }
+
+        for (var j = i; j < text.Length; j++)
+        {
+            if (!char.IsAsciiDigit(text[j]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Returns the annotations attached to <paramref name="node"/>, or an empty
+    /// array when the node kind carries none. Annotation lists are declared on
+    /// unrelated node types rather than a shared base, so this dispatch is the
+    /// single place that knows all of them.
+    /// </summary>
+    /// <param name="node">The node to inspect.</param>
+    /// <returns>The node's annotations.</returns>
+    internal static ImmutableArray<AnnotationSyntax> GetAnnotations(SyntaxNode node) => node switch
+    {
+        MemberSyntax m => m.Annotations,
+        BlockStatementSyntax b => b.Annotations,
+        VariableDeclarationSyntax v => v.Annotations,
+        FieldDeclarationSyntax f => f.Annotations,
+        PropertyDeclarationSyntax p => p.Annotations,
+        EventDeclarationSyntax e => e.Annotations,
+        EnumMemberSyntax en => en.Annotations,
+        ParameterSyntax pa => pa.Annotations,
+        _ => ImmutableArray<AnnotationSyntax>.Empty,
+    };
+
+    private static void Collect(SyntaxNode node, SourceText text, ImmutableArray<Scope>.Builder builder)
+    {
+        var annotations = GetAnnotations(node);
+        if (!annotations.IsDefaultOrEmpty)
+        {
+            var ids = ImmutableArray.CreateBuilder<string>();
+            foreach (var annotation in annotations)
+            {
+                if (IsSuppressDiagnostic(annotation))
+                {
+                    ids.AddRange(GetSuppressedIds(annotation));
+                }
+            }
+
+            if (ids.Count > 0)
+            {
+                builder.Add(new Scope(text, node.Span, ids.ToImmutable()));
+            }
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            Collect(child, text, builder);
+        }
+    }
+
+    private readonly struct Scope
+    {
+        internal Scope(SourceText text, TextSpan span, ImmutableArray<string> ids)
+        {
+            Text = text;
+            Span = span;
+            Ids = ids;
+        }
+
+        internal SourceText Text { get; }
+
+        internal TextSpan Span { get; }
+
+        internal ImmutableArray<string> Ids { get; }
+    }
+}

--- a/src/Core/CodeAnalysis/Analyzers/DiagnosticSuppressionMap.cs
+++ b/src/Core/CodeAnalysis/Analyzers/DiagnosticSuppressionMap.cs
@@ -41,11 +41,6 @@ public sealed class DiagnosticSuppressionMap
     /// <returns>The map; <see cref="Empty"/> when no suppression is declared.</returns>
     public static DiagnosticSuppressionMap Build(IEnumerable<SyntaxTree> syntaxTrees)
     {
-        if (syntaxTrees is null)
-        {
-            return Empty;
-        }
-
         var builder = ImmutableArray.CreateBuilder<Scope>();
         foreach (var tree in syntaxTrees)
         {
@@ -63,11 +58,13 @@ public sealed class DiagnosticSuppressionMap
     /// <returns><see langword="true"/> when a scope covering the diagnostic names its ID.</returns>
     public bool IsSuppressed(Diagnostic diagnostic)
     {
-        if (diagnostic is null || this.scopes.IsDefaultOrEmpty)
+        if (this.scopes.IsDefaultOrEmpty)
         {
             return false;
         }
 
+        // `TextLocation.Text` is genuinely nullable — the driver reports its own
+        // GS9304 with a `default` location — and a null one matches no scope.
         var location = diagnostic.Location;
         if (location.Text is null)
         {
@@ -109,7 +106,7 @@ public sealed class DiagnosticSuppressionMap
     /// <returns><see langword="true"/> when the name is <c>SuppressDiagnostic</c> or <c>SuppressDiagnosticAttribute</c>.</returns>
     public static bool IsSuppressDiagnostic(AnnotationSyntax annotation)
     {
-        if (annotation is null || annotation.HasTypeArgumentList)
+        if (annotation.HasTypeArgumentList)
         {
             return false;
         }
@@ -128,7 +125,9 @@ public sealed class DiagnosticSuppressionMap
     /// <returns>The IDs, in source order.</returns>
     public static ImmutableArray<string> GetSuppressedIds(AnnotationSyntax annotation)
     {
-        if (annotation is null || annotation.Arguments is null || annotation.Arguments.Count == 0)
+        // `Arguments` is a nullable reference on the syntax node: an annotation
+        // written without a parenthesised list (`@SuppressDiagnostic`) has none.
+        if (annotation.Arguments is null || annotation.Arguments.Count == 0)
         {
             return ImmutableArray<string>.Empty;
         }
@@ -160,7 +159,7 @@ public sealed class DiagnosticSuppressionMap
         }
 
         var i = 0;
-        while (i < text!.Length && char.IsAsciiLetter(text[i]))
+        while (i < text.Length && char.IsAsciiLetter(text[i]))
         {
             i++;
         }

--- a/src/Core/CodeAnalysis/Analyzers/GSharpAnalyzerDriver.cs
+++ b/src/Core/CodeAnalysis/Analyzers/GSharpAnalyzerDriver.cs
@@ -35,6 +35,7 @@ public sealed class GSharpAnalyzerDriver
     private readonly Dictionary<GSharpDiagnosticAnalyzer, Stopwatch> elapsed = new();
     private readonly Dictionary<GSharpDiagnosticAnalyzer, ImmutableHashSet<string>> supportedIds = new();
     private readonly HashSet<(GSharpDiagnosticAnalyzer Owner, string Id)> reportedUnsupported = new();
+    private DiagnosticSuppressionMap? suppressions;
 
     private GSharpAnalyzerDriver(Compilation.Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken)
     {
@@ -293,6 +294,16 @@ public sealed class GSharpAnalyzerDriver
             && fileName.EndsWith(".g.gs", StringComparison.OrdinalIgnoreCase)
             && (!registry.GeneratedCodeFlags.TryGetValue(owner, out var flags)
                 || (flags & GeneratedCodeAnalysisFlags.ReportDiagnostics) == 0))
+        {
+            return;
+        }
+
+        // ADR-0175 (#3820/#3824): a source `@SuppressDiagnostic("ID")` scope
+        // covering this diagnostic's primary location drops it. The check sits
+        // here, in the driver, so gsc, the language server, and
+        // GSharpAnalyzerVerifier all honour the same scoping rule.
+        suppressions ??= DiagnosticSuppressionMap.Build(compilation.SyntaxTrees);
+        if (suppressions.IsSuppressed(diagnostic))
         {
             return;
         }

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -208,6 +208,37 @@ internal sealed partial class DeclarationBinder
         return builder.ToImmutable();
     }
 
+    /// <summary>
+    /// ADR-0175 (#3820/#3824): checks a <c>@SuppressDiagnostic</c> annotation's
+    /// arguments. Every argument must be a constant string with the shape of a
+    /// diagnostic ID; anything else is reported as GS9305 and contributes no
+    /// suppression. A typo'd ID that silently suppresses nothing is exactly the
+    /// failure mode this feature exists to close, so the shape is diagnosed
+    /// even though the ID set itself cannot be validated (an analyzer that
+    /// declares it may simply not be referenced by this project).
+    /// </summary>
+    /// <param name="annotation">The annotation to check.</param>
+    /// <param name="diagnostics">The bag to report into.</param>
+    internal static void ValidateSuppressDiagnostic(AnnotationSyntax annotation, DiagnosticBag diagnostics)
+    {
+        if (annotation.Arguments is null || annotation.Arguments.Count == 0)
+        {
+            diagnostics.ReportSuppressDiagnosticInvalidId(
+                annotation.AtToken.Location,
+                "<none>");
+            return;
+        }
+
+        foreach (var argument in annotation.Arguments)
+        {
+            var text = argument is LiteralExpressionSyntax literal ? literal.Value as string : null;
+            if (!Analyzers.DiagnosticSuppressionMap.IsWellFormedId(text))
+            {
+                diagnostics.ReportSuppressDiagnosticInvalidId(argument.Location, text ?? argument.ToString() ?? "?");
+            }
+        }
+    }
+
     private BoundAttribute? BindAttribute(
         AnnotationSyntax annotation,
         AttributeTargetKind defaultTarget,
@@ -215,6 +246,17 @@ internal sealed partial class DeclarationBinder
         string positionDescription,
         System.AttributeTargets defaultSystemTarget)
     {
+        // 0) ADR-0175 (#3820/#3824): `@SuppressDiagnostic("ID", …)` is
+        // compiler-intrinsic. It has no CLR attribute type — so a compilation
+        // needs no extra assembly reference to write one — and it produces no
+        // metadata; the analyzer driver reads it straight from the syntax tree.
+        // Validate its arguments here and consume it.
+        if (Analyzers.DiagnosticSuppressionMap.IsSuppressDiagnostic(annotation))
+        {
+            ValidateSuppressDiagnostic(annotation, Diagnostics);
+            return null;
+        }
+
         // 1) Resolve target — parser already filtered to canonical kinds; if
         // the user wrote an unrecognised one a GS0197 was already reported,
         // but we still need to map a parsed-but-unknown string back to a

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Attributes.cs
@@ -221,6 +221,9 @@ internal sealed partial class DeclarationBinder
     /// <param name="diagnostics">The bag to report into.</param>
     internal static void ValidateSuppressDiagnostic(AnnotationSyntax annotation, DiagnosticBag diagnostics)
     {
+        // `Arguments` is a nullable reference on the syntax node: an annotation
+        // written without a parenthesised list (`@SuppressDiagnostic`) has none,
+        // which is itself a GS9305 — it names no ID.
         if (annotation.Arguments is null || annotation.Arguments.Count == 0)
         {
             diagnostics.ReportSuppressDiagnosticInvalidId(

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.cs
@@ -275,6 +275,23 @@ internal sealed partial class StatementBinder
         var statements = ImmutableArray.CreateBuilder<BoundStatement>();
         scope = new BoundScope(scope);
 
+        // ADR-0175 (#3820/#3824): the only annotation a block statement accepts
+        // is the compiler-intrinsic `@SuppressDiagnostic`, whose scope is this
+        // block's `{`..`}`. It is consumed straight from the syntax tree by the
+        // analyzer driver and never bound; anything else in annotation position
+        // before a block is the ADR-0047 §2 "not allowed on statement" error.
+        foreach (var annotation in syntax.Annotations)
+        {
+            if (Analyzers.DiagnosticSuppressionMap.IsSuppressDiagnostic(annotation))
+            {
+                DeclarationBinder.ValidateSuppressDiagnostic(annotation, Diagnostics);
+            }
+            else
+            {
+                Diagnostics.ReportAnnotationsNotAllowedOnStatement(annotation.AtToken.Location);
+            }
+        }
+
         // ADR-0122 / issue #1014: an `unsafe { … }` block enters an unsafe
         // context for the duration of its statements. The body of an
         // `unsafe func` (or any method of an `unsafe` type) is likewise an

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Syntax.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Syntax.cs
@@ -239,6 +239,16 @@ public sealed partial class DiagnosticBag
     => Report(location, DiagnosticDescriptors.AnnotationsNotAllowedOnStatement);
 
     /// <summary>
+    /// ADR-0175 (#3820/#3824): reports GS9305 when a
+    /// <c>@SuppressDiagnostic</c> annotation's argument is not a constant
+    /// string shaped like a diagnostic identifier.
+    /// </summary>
+    /// <param name="location">The source location of the offending argument.</param>
+    /// <param name="text">The rejected argument text.</param>
+    public void ReportSuppressDiagnosticInvalidId(TextLocation location, string text)
+    => Report(location, DiagnosticDescriptors.SuppressDiagnosticInvalidId, text);
+
+    /// <summary>
     /// ADR-0055: reports an interpolation hole whose alignment clause
     /// (<c>${expr,alignment}</c>) is not a constant integer.
     /// </summary>

--- a/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
+++ b/src/Core/CodeAnalysis/DiagnosticDescriptors.cs
@@ -442,6 +442,7 @@ internal static class DiagnosticDescriptors
     internal static readonly DiagnosticDescriptor AnalyzerExceededTimeBudget = new("GS9302", DiagnosticSeverity.Info, "Analyzer '{0}' exceeded its time budget ({1} ms) and was disabled for subsequent runs in this host.");
     internal static readonly DiagnosticDescriptor AnalyzerCoreVersionMismatch = new("GS9303", DiagnosticSeverity.Warning, "Analyzer assembly '{0}' was built against GSharp.Core '{1}' but the host is '{2}'; loading anyway.");
     internal static readonly DiagnosticDescriptor AnalyzerUnsupportedDiagnosticId = new("GS9304", DiagnosticSeverity.Warning, "Analyzer '{0}' reported diagnostic '{1}', which is not declared in its SupportedDiagnostics; the diagnostic was suppressed.");
+    internal static readonly DiagnosticDescriptor SuppressDiagnosticInvalidId = new("GS9305", DiagnosticSeverity.Error, "'@SuppressDiagnostic' takes one or more constant string diagnostic identifiers (for example \"GSA0005\"); '{0}' is not one.");
     internal static readonly DiagnosticDescriptor SourceGeneratorExecutionFailure = new("GS9996", DiagnosticSeverity.Error, "Source generator execution failed: {0}");
     internal static readonly DiagnosticDescriptor FatalCompilerIOError = new("GS9997", DiagnosticSeverity.Error, "Fatal compiler I/O error: {0}");
 }

--- a/src/Core/CodeAnalysis/Syntax/BlockStatementSyntax.cs
+++ b/src/Core/CodeAnalysis/Syntax/BlockStatementSyntax.cs
@@ -115,4 +115,24 @@ public sealed class BlockStatementSyntax : StatementSyntax
     /// Gets the close brace token.
     /// </summary>
     public SyntaxToken CloseBraceToken { get; }
+
+    /// <summary>
+    /// Gets the ADR-0175 annotations written immediately before this block's
+    /// <c>{</c> (<c>@SuppressDiagnostic("GSA0005") { … }</c>). Assigned by the
+    /// parser; empty for ordinary blocks.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately excluded from the node's children so the block's span stays
+    /// exactly <c>{</c>..<c>}</c>: that span is the suppression scope, and a
+    /// diagnostic reported on the annotation itself must not be inside it.
+    /// </remarks>
+    [SyntaxChildIgnore]
+    public ImmutableArray<AnnotationSyntax> Annotations { get; private set; } = ImmutableArray<AnnotationSyntax>.Empty;
+
+    /// <summary>Attaches parser-collected annotations to this block.</summary>
+    /// <param name="annotations">The annotations preceding the open brace.</param>
+    internal void WithAnnotations(ImmutableArray<AnnotationSyntax> annotations)
+    {
+        Annotations = annotations.IsDefault ? ImmutableArray<AnnotationSyntax>.Empty : annotations;
+    }
 }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -73,6 +73,22 @@ public partial class Parser
         if (Current.Kind == SyntaxKind.AtToken)
         {
             leadingAnnotations = ParseAnnotations();
+
+            // ADR-0175 / issue #3824: `@Ann { … }` is the annotated-block
+            // statement form, which gives `@SuppressDiagnostic` a scope
+            // narrower than a whole declaration. One token of lookahead is
+            // enough and there is no ambiguity: an `@` in statement position
+            // previously admitted only `const`/`let`/`var`, so a following `{`
+            // was always an error. Annotations also commit the brace to a
+            // block — the `{ … } + x` expression-continuation shape (#3355) is
+            // never reachable through an annotation.
+            if (Current.Kind == SyntaxKind.OpenBraceToken)
+            {
+                var annotatedBlock = ParseBlockStatement();
+                annotatedBlock.WithAnnotations(leadingAnnotations);
+                return annotatedBlock;
+            }
+
             if (Current.Kind != SyntaxKind.ConstKeyword &&
                 Current.Kind != SyntaxKind.LetKeyword &&
                 Current.Kind != SyntaxKind.VarKeyword)

--- a/test/Core.Tests/CodeAnalysis/Adr0175DiagnosticSuppressionTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0175DiagnosticSuppressionTests.cs
@@ -1,0 +1,379 @@
+// <copyright file="Adr0175DiagnosticSuppressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Analyzers;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// ADR-0175 (issues #3820 / #3824): source-level, scoped analyzer suppression
+/// via <c>@SuppressDiagnostic("ID")</c>, in both the declaration-attribute form
+/// and the annotated-block form.
+///
+/// The load-bearing property throughout is *scoping*: every test that asserts a
+/// diagnostic is suppressed also asserts that the same diagnostic still fires
+/// elsewhere in the same file. Without that pair the tests could not tell a
+/// scoped suppression from a blanket disable.
+/// </summary>
+public class Adr0175DiagnosticSuppressionTests
+{
+    private static readonly DiagnosticDescriptor ProbeRule = new(
+        "PROBE001", "Probe", "Probe hit.", "Testing", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor OtherRule = new(
+        "PROBE002", "Other probe", "Other probe hit.", "Testing", DiagnosticSeverity.Warning, isEnabledByDefault: true);
+
+    [Fact]
+    public void NoSuppression_BothCallSitesReport()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+func Suppressed() int32 {
+    return Ping()
+}
+
+func NotSuppressed() int32 {
+    return Ping()
+}
+";
+
+        var produced = Run(source);
+
+        Assert.Equal(2, produced.Count(d => d.Id == "PROBE001"));
+    }
+
+    [Fact]
+    public void DeclarationForm_SuppressesInsideTheAnnotatedFunctionOnly()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+@SuppressDiagnostic(""PROBE001"")
+func Suppressed() int32 {
+    return Ping()
+}
+
+func NotSuppressed() int32 {
+    return Ping()
+}
+";
+
+        var produced = Run(source);
+
+        var hits = produced.Where(d => d.Id == "PROBE001").ToArray();
+
+        // Scoping proof: exactly one survivor, and it is the call in the
+        // *unannotated* function. A blanket disable would leave zero.
+        Assert.Single(hits);
+        Assert.Contains("NotSuppressed", LineOfEnclosingFunction(source, hits[0]));
+    }
+
+    [Fact]
+    public void BlockForm_SuppressesOnlyTheAnnotatedStatementRange()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+func Both() int32 {
+    var first = 0
+    @SuppressDiagnostic(""PROBE001"") {
+        first = Ping()
+    }
+
+    var second = Ping()
+    return first + second
+}
+";
+
+        var produced = Run(source);
+
+        var hits = produced.Where(d => d.Id == "PROBE001").ToArray();
+
+        // Scoping proof, the sharp form: both call sites are in the SAME
+        // function, so only a span-scoped suppression can keep exactly one.
+        Assert.Single(hits);
+        Assert.Equal(12, hits[0].Location.StartLine);
+    }
+
+    [Fact]
+    public void SuppressionIsIdKeyed_OtherIdsStillReport()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+@SuppressDiagnostic(""PROBE001"")
+func Suppressed() int32 {
+    return Ping()
+}
+";
+
+        var produced = Run(source, new DualProbeAnalyzer());
+
+        Assert.Empty(produced.Where(d => d.Id == "PROBE001"));
+        Assert.Single(produced.Where(d => d.Id == "PROBE002"));
+    }
+
+    [Fact]
+    public void MultipleIds_InOneAnnotation_AreAllSuppressed()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+@SuppressDiagnostic(""PROBE001"", ""PROBE002"")
+func Suppressed() int32 {
+    return Ping()
+}
+
+func NotSuppressed() int32 {
+    return Ping()
+}
+";
+
+        var produced = Run(source, new DualProbeAnalyzer());
+
+        // One PROBE001 and one PROBE002 survive — both from NotSuppressed.
+        Assert.Single(produced.Where(d => d.Id == "PROBE001"));
+        Assert.Single(produced.Where(d => d.Id == "PROBE002"));
+    }
+
+    [Fact]
+    public void NestedBlocks_SuppressDifferentIdsIndependently()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+func Nested() int32 {
+    var outer = 0
+    @SuppressDiagnostic(""PROBE001"") {
+        outer = Ping()
+        @SuppressDiagnostic(""PROBE002"") {
+            outer = outer + Ping()
+        }
+    }
+
+    return outer + Ping()
+}
+";
+
+        var produced = Run(source, new DualProbeAnalyzer());
+
+        // PROBE001: suppressed by the outer block for both inner call sites;
+        // the trailing call outside every block survives.
+        Assert.Single(produced.Where(d => d.Id == "PROBE001"));
+
+        // PROBE002: suppressed only inside the inner block; two survive.
+        Assert.Equal(2, produced.Count(d => d.Id == "PROBE002"));
+    }
+
+    [Fact]
+    public void MalformedId_ReportsGS9305_AndSuppressesNothing()
+    {
+        const string source = @"package App
+
+func Ping() int32 {
+    return 1
+}
+
+@SuppressDiagnostic(""not an id"")
+func Suppressed() int32 {
+    return Ping()
+}
+";
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, "app.gs"));
+        var compilation = new Compilation(tree);
+        var bindDiagnostics = compilation.GlobalScope.Diagnostics.Concat(compilation.BoundProgram.Diagnostics);
+
+        Assert.Contains(bindDiagnostics, d => d.Id == "GS9305");
+    }
+
+    [Fact]
+    public void EmptyArgumentList_ReportsGS9305()
+    {
+        const string source = @"package App
+
+@SuppressDiagnostic()
+func Suppressed() int32 {
+    return 1
+}
+";
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, "app.gs"));
+        var compilation = new Compilation(tree);
+
+        Assert.Contains(
+            compilation.GlobalScope.Diagnostics.Concat(compilation.BoundProgram.Diagnostics),
+            d => d.Id == "GS9305");
+    }
+
+    [Fact]
+    public void SuppressDiagnostic_NeedsNoAssemblyReference_AndEmitsNoAttributeError()
+    {
+        // The annotation names no CLR type, so the ordinary
+        // "attribute type not found" path must never run for it.
+        const string source = @"package App
+
+@SuppressDiagnostic(""PROBE001"")
+func Suppressed() int32 {
+    return 1
+}
+";
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, "app.gs"));
+        var compilation = new Compilation(tree);
+
+        Assert.DoesNotContain(
+            compilation.GlobalScope.Diagnostics.Concat(compilation.BoundProgram.Diagnostics),
+            d => d.IsError);
+    }
+
+    [Fact]
+    public void NonSuppressAnnotation_BeforeABlock_IsStillRejected()
+    {
+        const string source = @"package App
+import System
+
+func Foo() {
+    @Obsolete(""x"") {
+        Console.WriteLine(1)
+    }
+}
+";
+
+        var tree = SyntaxTree.Parse(SourceText.From(source, "app.gs"));
+        var compilation = new Compilation(tree);
+
+        Assert.Contains(compilation.BoundProgram.Diagnostics, d => d.Id == "GS0206");
+    }
+
+    [Fact]
+    public void AnnotatedBlock_EmitsAndRuns_WithBlockScopedLocals()
+    {
+        // The block form is new grammar, so it must be proven at runtime, not
+        // only at bind time: the annotated block runs its statements, scopes
+        // its own locals, and produces the same value an unannotated block
+        // would. 0+1+2+3+4 = 10, doubled = 20.
+        const string source = @"
+var total = 0
+@SuppressDiagnostic(""GSA0005"") {
+    var i = 0
+    for i < 5 {
+        total = total + i
+        i = i + 1
+    }
+}
+
+@SuppressDiagnostic(""GSA0005"", ""GSA0001"") {
+    total = total * 2
+}
+
+Console.WriteLine(total)
+";
+
+        var result = EmittedOracle.Evaluate(source);
+
+        Assert.DoesNotContain(result.Diagnostics, d => d.IsError);
+        Assert.Equal("20", result.Output.Trim());
+    }
+
+    [Fact]
+    public void BlockLocal_DoesNotEscapeTheAnnotatedBlock()
+    {
+        const string source = @"
+@SuppressDiagnostic(""GSA0005"") {
+    var inner = 1
+}
+
+Console.WriteLine(inner)
+";
+
+        var result = EmittedOracle.Evaluate(source);
+
+        // An annotated block is a real block: it opens a scope, exactly as the
+        // unannotated form does.
+        Assert.Contains(result.Diagnostics, d => d.IsError);
+    }
+
+    private static string LineOfEnclosingFunction(string source, Diagnostic diagnostic)
+    {
+        var lines = source.Replace("\r\n", "\n").Split('\n');
+        for (var i = diagnostic.Location.StartLine; i >= 0; i--)
+        {
+            if (lines[i].StartsWith("func ", System.StringComparison.Ordinal))
+            {
+                return lines[i];
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private static ImmutableArray<Diagnostic> Run(string source, params GSharpDiagnosticAnalyzer[] analyzers)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source, "app.gs"));
+        var compilation = new Compilation(tree);
+        Assert.Empty(compilation.BoundProgram.Diagnostics.Where(d => d.IsError));
+        var effective = analyzers.Length == 0
+            ? new GSharpDiagnosticAnalyzer[] { new CallProbeAnalyzer() }
+            : analyzers;
+        return GSharpAnalyzerDriver.Run(compilation, effective.ToImmutableArray());
+    }
+
+    /// <summary>Reports PROBE001 on every call expression.</summary>
+    [GSharpDiagnosticAnalyzer]
+    private sealed class CallProbeAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(ProbeRule);
+
+        public override void Initialize(AnalysisContext context)
+            => context.RegisterSyntaxNodeAction(
+                ctx => ctx.ReportDiagnostic(Diagnostic.Create(ProbeRule, ctx.Node.Location)),
+                SyntaxKind.CallExpression);
+    }
+
+    /// <summary>Reports both PROBE001 and PROBE002 on every call expression.</summary>
+    [GSharpDiagnosticAnalyzer]
+    private sealed class DualProbeAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(ProbeRule, OtherRule);
+
+        public override void Initialize(AnalysisContext context)
+            => context.RegisterSyntaxNodeAction(
+                ctx =>
+                {
+                    ctx.ReportDiagnostic(Diagnostic.Create(ProbeRule, ctx.Node.Location));
+                    ctx.ReportDiagnostic(Diagnostic.Create(OtherRule, ctx.Node.Location));
+                },
+                SyntaxKind.CallExpression);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3824PragmaSuppressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3824PragmaSuppressionTranslationTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="Issue3824PragmaSuppressionTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issues #3820 / #3824, ADR-0175: a C# <c>#pragma warning disable GSA####</c>
+/// region covering a declaration translates to an
+/// <c>@SuppressDiagnostic("GSA####")</c> annotation on the migrated
+/// declaration. Identifier families that name analyzers which do not run on G#
+/// (StyleCop <c>SA</c>, the C# compiler <c>CS</c>, the Roslyn ecosystem
+/// <c>CA</c>/<c>IDE</c>/<c>VSTHRD</c>/<c>RS</c>) are dropped, not carried.
+/// </summary>
+public class Issue3824PragmaSuppressionTranslationTests
+{
+    [Fact]
+    public void GsaPragmaRegion_BecomesSuppressDiagnosticOnTheCoveredMethod()
+    {
+        const string source = @"
+public class Rewriter
+{
+    public int Untouched() => 1;
+
+#pragma warning disable GSA0005
+    public int Suppressed() => 2;
+#pragma warning restore GSA0005
+
+    public int AlsoUntouched() => 3;
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.Contains("@SuppressDiagnostic(\"GSA0005\")", printed, StringComparison.Ordinal);
+
+        // Scoping proof at the translator level: exactly ONE annotation is
+        // emitted, on the one method the C# region covered. A file- or
+        // project-level bridge would produce zero here and suppress everything.
+        Assert.Equal(1, CountOccurrences(printed, "@SuppressDiagnostic"));
+
+        int annotation = printed.IndexOf("@SuppressDiagnostic", StringComparison.Ordinal);
+        int suppressed = printed.IndexOf("Suppressed", StringComparison.Ordinal);
+        int alsoUntouched = printed.IndexOf("AlsoUntouched", StringComparison.Ordinal);
+        Assert.True(annotation < suppressed, "annotation must precede the method it covers");
+        Assert.True(suppressed < alsoUntouched, "the following method must be unannotated");
+    }
+
+    [Fact]
+    public void MultipleRegions_EachAnnotateTheirOwnMethod()
+    {
+        const string source = @"
+public class Rewriter
+{
+#pragma warning disable GSA0005
+    public int First() => 1;
+#pragma warning restore GSA0005
+
+    public int Middle() => 2;
+
+#pragma warning disable GSA0005
+    public int Second() => 3;
+#pragma warning restore GSA0005
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.Equal(2, CountOccurrences(printed, "@SuppressDiagnostic(\"GSA0005\")"));
+    }
+
+    [Fact]
+    public void NonGsaPragmas_AreDropped()
+    {
+        const string source = @"
+public class Sample
+{
+#pragma warning disable SA1600, CS1591, CA1822, IDE0060, RS2008
+    public int Documented() => 1;
+#pragma warning restore SA1600, CS1591, CA1822, IDE0060, RS2008
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.DoesNotContain("@SuppressDiagnostic", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MixedRegion_CarriesOnlyTheGsaIdentifier()
+    {
+        const string source = @"
+public class Sample
+{
+#pragma warning disable SA1600, GSA0005, CS1591
+    public int Mixed() => 1;
+#pragma warning restore SA1600, GSA0005, CS1591
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.Contains("@SuppressDiagnostic(\"GSA0005\")", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("SA1600", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("CS1591", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileWideRegion_AnnotatesEveryCoveredMethod()
+    {
+        const string source = @"
+#pragma warning disable GSA0005
+public class Sample
+{
+    public int A() => 1;
+
+    public int B() => 2;
+}
+#pragma warning restore GSA0005
+";
+
+        string printed = Translate(source);
+
+        Assert.Equal(2, CountOccurrences(printed, "@SuppressDiagnostic(\"GSA0005\")"));
+    }
+
+    [Fact]
+    public void TranslatedSuppression_BindsInTheMigratedTree()
+    {
+        const string source = @"
+public class Rewriter
+{
+#pragma warning disable GSA0005
+    public int Suppressed() => 2;
+#pragma warning restore GSA0005
+}
+";
+
+        string printed = Translate(source);
+
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(roundTrip.Success, string.Join(Environment.NewLine, roundTrip.Errors));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Program.cs", source) });
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1388,6 +1388,11 @@ public sealed partial class CSharpToGSharpTranslator
                     {
                         AttachSourceComments(translated, member);
                         this.SanitizeDocParamComments(translated, member);
+
+                        // Issues #3820/#3824, ADR-0175: a `#pragma warning
+                        // disable GSA####` region covering this declaration
+                        // becomes an `@SuppressDiagnostic` annotation on it.
+                        AttachPragmaSuppressions(translated, member);
                         attachedMemberComments = true;
                     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs
@@ -46,6 +46,7 @@ public sealed partial class CSharpToGSharpTranslator
                 FieldDeclaration f => f.Attributes,
                 ConstructorDeclaration c => c.Attributes,
                 EventDeclaration e => e.Attributes,
+                DestructorDeclaration d => d.Attributes,
                 _ => null,
             };
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs
@@ -1,0 +1,164 @@
+// <copyright file="CSharpToGSharpTranslator.PragmaSuppressions.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Cs2Gs.Translator;
+
+/// <summary>
+/// Issues #3820 / #3824, ADR-0175: carries C# <c>#pragma warning
+/// disable/restore</c> regions naming a G# analyzer diagnostic (<c>GSA####</c>)
+/// across into the migrated tree as <c>@SuppressDiagnostic("GSA####")</c>
+/// annotations.
+///
+/// Only <c>GSA</c> identifiers are translated. Every other identifier family in
+/// the corpus names an analyzer that does not run on G# at all — StyleCop
+/// (<c>SA####</c>), the C# compiler (<c>CS####</c>), and the Roslyn ecosystem
+/// (<c>CA####</c>, <c>IDE####</c>, <c>VSTHRD###</c>, <c>RS####</c>) — so
+/// carrying them would emit annotations that suppress nothing.
+/// </summary>
+public sealed partial class CSharpToGSharpTranslator
+{
+    private sealed partial class DeclarationVisitor
+    {
+        /// <summary>
+        /// Appends a <c>@SuppressDiagnostic</c> annotation to
+        /// <paramref name="translated"/> for every <c>GSA</c> identifier whose
+        /// <c>#pragma warning disable</c> region covers the whole of
+        /// <paramref name="source"/>.
+        /// </summary>
+        /// <param name="translated">The translated G# member.</param>
+        /// <param name="source">The C# member declaration it came from.</param>
+        internal static void AttachPragmaSuppressions(GMember translated, MemberDeclarationSyntax source)
+        {
+            IReadOnlyList<AttributeUse> declared = translated switch
+            {
+                MethodDeclaration m => m.Attributes,
+                PropertyDeclaration p => p.Attributes,
+                FieldDeclaration f => f.Attributes,
+                ConstructorDeclaration c => c.Attributes,
+                EventDeclaration e => e.Attributes,
+                _ => null,
+            };
+
+            if (declared is not List<AttributeUse> attributes || source is null)
+            {
+                return;
+            }
+
+            List<string> ids = CoveringGsaSuppressions(source);
+            if (ids.Count == 0)
+            {
+                return;
+            }
+
+            attributes.Add(new AttributeUse(
+                "SuppressDiagnostic",
+                ids.Select(id => new AttributeArgument(LiteralExpression.String(id))).ToList()));
+        }
+
+        /// <summary>
+        /// Returns the <c>GSA</c> identifiers disabled across the entire span of
+        /// <paramref name="source"/>.
+        ///
+        /// A region qualifies only when the whole declaration sits inside it:
+        /// the last directive naming the identifier at or before the
+        /// declaration's start is a <c>disable</c>, and no directive naming it
+        /// appears strictly inside the declaration. A region that cuts a
+        /// declaration in half therefore contributes nothing rather than
+        /// silently widening to the declaration — a widened suppression would
+        /// hide violations the C# source still reports.
+        /// </summary>
+        /// <param name="source">The C# member declaration.</param>
+        /// <returns>The identifiers, in first-mention order.</returns>
+        private static List<string> CoveringGsaSuppressions(MemberDeclarationSyntax source)
+        {
+            var result = new List<string>();
+            SyntaxNode root = source.SyntaxTree?.GetRoot();
+            if (root is null)
+            {
+                return result;
+            }
+
+            List<PragmaWarningDirectiveTriviaSyntax> directives = root
+                .DescendantTrivia(descendIntoTrivia: true)
+                .Where(t => t.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia))
+                .Select(t => (PragmaWarningDirectiveTriviaSyntax)t.GetStructure())
+                .Where(d => d is not null)
+                .OrderBy(d => d.SpanStart)
+                .ToList();
+
+            if (directives.Count == 0)
+            {
+                return result;
+            }
+
+            TextSpan span = source.Span;
+            var state = new Dictionary<string, bool>(StringComparer.Ordinal);
+            var interrupted = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (PragmaWarningDirectiveTriviaSyntax directive in directives)
+            {
+                bool disable = directive.DisableOrRestoreKeyword.IsKind(SyntaxKind.DisableKeyword);
+                foreach (string id in DirectiveIds(directive))
+                {
+                    if (directive.SpanStart <= span.Start)
+                    {
+                        state[id] = disable;
+                    }
+                    else if (directive.SpanStart < span.End)
+                    {
+                        // A directive inside the declaration: the region does
+                        // not cover it uniformly.
+                        interrupted.Add(id);
+                    }
+                }
+            }
+
+            foreach (KeyValuePair<string, bool> entry in state)
+            {
+                if (entry.Value && !interrupted.Contains(entry.Key))
+                {
+                    result.Add(entry.Key);
+                }
+            }
+
+            result.Sort(StringComparer.Ordinal);
+            return result;
+        }
+
+        /// <summary>
+        /// Yields the <c>GSA</c> identifiers a pragma directive names. A bare
+        /// <c>#pragma warning disable</c> (no identifier list) names none — it
+        /// disables everything, which has no faithful scoped G# spelling and is
+        /// deliberately not translated.
+        /// </summary>
+        /// <param name="directive">The directive.</param>
+        /// <returns>The GSA identifiers.</returns>
+        private static IEnumerable<string> DirectiveIds(PragmaWarningDirectiveTriviaSyntax directive)
+        {
+            foreach (ExpressionSyntax code in directive.ErrorCodes)
+            {
+                string text = code switch
+                {
+                    IdentifierNameSyntax name => name.Identifier.ValueText,
+                    LiteralExpressionSyntax literal => literal.Token.ValueText,
+                    _ => null,
+                };
+
+                if (text != null && text.StartsWith("GSA", StringComparison.Ordinal))
+                {
+                    yield return text;
+                }
+            }
+        }
+    }
+}

--- a/website/docs/ref/diagnostics.md
+++ b/website/docs/ref/diagnostics.md
@@ -31,6 +31,33 @@ Every diagnostic emitted by `gsc` carries a stable `GS####` identifier, a severi
 
 IDs may be given as `GS0001`, `0001`, or the bare integer `1`; all three forms are equivalent.
 
+### Source-level, scoped suppression (ADR-0175)
+
+The flags above are whole-compilation. To turn an **analyzer** diagnostic off
+for one declaration or one range of statements, annotate the source with
+`@SuppressDiagnostic`:
+
+```
+@SuppressDiagnostic("GSA0005")
+func RewriteFieldAssignmentExpression(node BoundFieldAssignmentExpression) BoundExpression {
+    // GSA0005 is suppressed here, and nowhere else.
+}
+
+func Elsewhere() {
+    @SuppressDiagnostic("GSA0005", "GSA0007") {
+        // suppressed only inside these braces
+    }
+
+    // still reported here
+}
+```
+
+The annotation is compiler-intrinsic: it names no type, needs no assembly
+reference, and is never written to metadata. Its scope is the span of the
+declaration or block it precedes; nesting adds identifiers and never removes
+them. An argument that is not a constant string shaped like a diagnostic ID is
+reported as [GS9305](#analyzer-host-diagnostics-gs9300gs9319-reserved).
+
 **Example `.gsproj` snippet:**
 ```xml
 <PropertyGroup>
@@ -308,6 +335,7 @@ passed via `/gsanalyzer:`.
 | GS9302 | Info | An analyzer exceeded its time budget in an interactive host and was disabled for subsequent runs. |
 | GS9303 | Warning | An analyzer was built against a different `GSharp.Core` version than the host; the load is attempted anyway. |
 | GS9304 | Warning | An analyzer reported a diagnostic whose ID is not declared in its `SupportedDiagnostics`; the diagnostic is suppressed. |
+| GS9305 | Error | `@SuppressDiagnostic` (ADR-0175) was given an argument that is not a constant string shaped like a diagnostic ID, or no argument at all. |
 
 ### Internal diagnostics (GS9996–GS9999)
 


### PR DESCRIPTION
Fixes #3824. Removes 10 of the 15 `GSA0005` errors walling `src/Core` in #3820; the remaining 5 are #3822 (see "What this does not fix").

## The problem

cs2gs has never handled `#pragma warning disable/restore` — zero `PragmaWarning` hits in the translator. Suppressions were dropped and only the justifying comment survived. #3809 made the translated ADR-0169 analyzers effective, the compiler's own deliberate `GSA0005` suppressions started firing in the migrated tree, and `src/Core` — a **banked** `greenApps` entry — went red, taking every dependent app with it.

G# had no source-level suppression at all: `/nowarn`, `/gsdiag:`, and `.editorconfig` are whole-compilation.

## Measured scope

562 `#pragma warning` occurrences across 130 files. By family: `SA` 474, `CS` 52, **`GSA` 20 (10 disable/restore pairs)**, `IDE` 6, `VSTHRD` 4, `CA` 4, `RS` 2. Only the `GSA` rows name analyzers that run on G#; the other 542 are dropped deliberately.

**All 10 `GSA0005` regions open immediately before a method declaration and close immediately after that method's closing brace.** Not one is a partial statement range, so declaration scope is exactly equivalent and no `GSA0005` coverage is lost anywhere else in those five files.

(The issue text said 6 regions in 2 files; it is 10 regions in 4 files — `SideEffectSpiller` and `HoistedFieldRewriter` were missed, and `CaptureBoxingRewriter` has a fourth at 989–1024.)

## ADR-0175: `@SuppressDiagnostic`

An ADR-0047 annotation in two positions:

```
@SuppressDiagnostic("GSA0005")
func RewriteFieldAssignmentExpression(node BoundFieldAssignmentExpression) BoundExpression { … }

func Elsewhere() {
    @SuppressDiagnostic("GSA0005", "GSA0007") {
        // suppressed only inside these braces
    }
    // still reported here
}
```

- **Compiler-intrinsic**: names no type, needs no assembly reference, emits no metadata. G# has no always-referenced runtime assembly, so an attribute class in `GSharp.Core` would be unusable from most projects; `SuppressMessageAttribute` demands a `Category` a pragma cannot supply and cannot annotate a block.
- **One filter, three hosts**: the check lives in `GSharpAnalyzerDriver.Report`, so `gsc`, the language server, and `GSharpAnalyzerVerifier` share identical scoping.
- **Grammar**: one token of lookahead, no ambiguity — an `@` in statement position previously admitted only `const`/`let`/`var`, so a following `{` was always an error. Annotations commit the brace to a statement block, so the `{ … } + x` continuation shape (#3355) is unreachable. Block annotations are `[SyntaxChildIgnore]` so the block's span stays exactly `{`..`}` — the span *is* the scope.
- **Nesting** composes by union; an inner scope cannot re-enable an id (recommendation recorded in the ADR — move the suppression inward instead).
- **Multiple ids** per annotation, matching `#pragma`'s list.
- **Malformed id is diagnosed**, new **GS9305** (Error). A typo'd id that silently suppresses nothing is the exact failure mode this feature exists to close.
- **Deferred, with reasons in the ADR**: unknown-id reporting (needs a cross-analyzer id registry), unused-suppression reporting, and extension to `GS####` compiler diagnostics.

Rejected: a project-level `NoWarn`/`editorconfig` bridge (goes green by deleting coverage, and `GSA0005` is an error, which `/nowarn` does not suppress); a `#pragma`-equivalent directive (G# has no preprocessor at all — new lexer and trivia infrastructure for one feature, buying `restore` re-enabling that nothing uses).

## cs2gs

`AttachPragmaSuppressions` runs beside `AttachSourceComments`. A region covering a declaration's **entire** span becomes `@SuppressDiagnostic`; `GSA` only; a bare `#pragma warning disable` with no id list is dropped. A region that *cuts across* a declaration contributes nothing rather than widening — a widened suppression would hide violations the C# source still reports. No corpus region does this.

## Measurement

Migration run on `4cd6e8b02`, gsc `0.4.385+4cd6e8b024`, SDK nupkg repacked (`dotnet build GSharp.sln -c Release -graph`).

- **52/52 apps translate.** All 10 `GSA0005` suppressions land on exactly the right 10 methods, justification comment intact.
- **`migrated/src/Core`: 15 distinct `GSA0005` errors → 5.**

| | before (#3820, `89ff8246c`) | after |
|---|---|---|
| distinct `GSA0005` in `migrated/src/Core` | 15 | **5** |
| of which pragma-backed in the C# source | 10 | **0** |
| of which have **no** C# suppression | 5 | 5 |

The 10 removed are precisely the pragma-backed ones. Nothing else changed.

## What this does not fix — and why the gate is still red

The 5 survivors are all sites where **the C# source has no suppression at all**, because the Roslyn analyzer does not report them: it follows reads through a one-level node helper (`BoundNodeForm.DeclaringType(node)`), and the translated analyzer does not. That is **#3822**, the same family as #3795/#3809, #3796, #3797.

```
MoveNextBodyRewriter.gs:289   InnerRewriter.RewriteFieldAssignmentExpression
HoistedFieldRewriter.gs:60    HoistedFieldRewriter.RewriteFieldAccessExpression
HoistedFieldRewriter.gs:78    HoistedFieldRewriter.RewriteFieldAssignmentExpression
SideEffectSpiller.gs:77       SideEffectSpiller.RewriteIndexAssignmentExpression
SideEffectSpiller.gs:110      SideEffectSpiller.RewriteClrIndexAssignmentExpression
```

**#3820 sized this cause at 1; it is 5.** `src/Core` and the five apps behind it stay red until #3822 lands, so the gate cannot reach 43/52 on this PR alone. I deliberately did **not** add pragmas to the C# source to paper over them: a suppression that suppresses nothing in C# is exactly the coverage loss this ADR forbids, and it would bury a real analyzer-translation defect.

## Tests

`test/Core.Tests/CodeAnalysis/Adr0175DiagnosticSuppressionTests.cs` — 12 tests, all failing on `origin/main` where the feature does not exist.

Scoping proofs (the load-bearing ones — without them a test cannot distinguish scoped suppression from a blanket disable):
- `DeclarationForm_SuppressesInsideTheAnnotatedFunctionOnly` — two call sites, one annotated function; exactly one survivor, and it is the one in the *unannotated* function.
- `BlockForm_SuppressesOnlyTheAnnotatedStatementRange` — the sharp form: **both call sites are in the same function**, so only a span-scoped suppression can keep exactly one.
- `NestedBlocks_SuppressDifferentIdsIndependently` — outer suppresses `PROBE001` (1 survivor), inner suppresses `PROBE002` (2 survivors).
- `SuppressionIsIdKeyed_OtherIdsStillReport`.

Executed, not just bound:
- `AnnotatedBlock_EmitsAndRuns_WithBlockScopedLocals` — compiles and runs through `EmittedOracle`, asserts output `20`.
- `BlockLocal_DoesNotEscapeTheAnnotatedBlock` — an annotated block is a real block and opens a scope.

Anti-vacuity guard rails (pass on `main` too): `NoSuppression_BothCallSitesReport`, `NonSuppressAnnotation_BeforeABlock_IsStillRejected` (GS0206 still fires).

`tools/cs2gs/Cs2Gs.Tests/Issue3824PragmaSuppressionTranslationTests.cs` — 6 tests, including `NonGsaPragmas_AreDropped`, `MixedRegion_CarriesOnlyTheGsaIdentifier`, and a translator-level scoping proof (exactly one annotation emitted, on the one covered method).

Suites: **`test/Core.Tests` 8585 passed / 0 failed.** `Cs2Gs.Tests` Issue3824 6/6.

## Docs

`docs/adr/0175-scoped-diagnostic-suppression.md`; GS9305 and a "Source-level, scoped suppression" section added to **both** `docs/diagnostics.md` and `website/docs/ref/diagnostics.md`.

Refs #3820, #3822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs


## Nullable hygiene (ADR-0155)

**Null-forgiving `!`: none.** One slipped into the first push (`DiagnosticSuppressionMap.cs`, `while (i < text!.Length …)`) and the gate was right to reject it. It is **deleted, not justified**: `string.IsNullOrEmpty` is `[NotNullWhen(false)]`, so after the early return the compiler already knows `text` is non-null — which is why the two later uses in the same method never needed one. Removing it leaves the file warning-free, confirming the `!` was pure noise. (An uncommented `!` in the PR that adds suppression support is not lost on me; the fix being a deletion rather than a suppression is the right ending.)

**Guards: 6 → 3.** Four of the six were null checks on **non-nullable reference parameters**, which contradict their own annotations and are exactly what ADR-0155 exists to remove. Deleted, keeping the non-null half of each condition:

| removed | why it was dead |
|---|---|
| `Build`: `syntaxTrees is null` | non-nullable parameter; the one caller passes `compilation.SyntaxTrees` |
| `IsSuppressed`: `diagnostic is null` | **provably** unreachable — `GSharpAnalyzerDriver.Report` dereferences `diagnostic.Id` several lines earlier, so a null would already have thrown. Keeping it implied a null was possible when it demonstrably is not |
| `IsSuppressDiagnostic`: `annotation is null` | non-nullable parameter; callers iterate parser-produced annotation lists |
| `GetSuppressedIds`: `annotation is null` | non-nullable, and only ever called after `IsSuppressDiagnostic` returned true |

None of these changes behaviour: every one was reachable only via a contract violation that already threw.

The **3 that remain** are guards on genuinely nullable-typed expressions, not on annotations:

- `DiagnosticSuppressionMap.cs:69` — `location.Text is null`. `TextLocation.Text` is `SourceText?` and really can be null: the driver reports its own GS9304 with a `default` location. **No control-flow change** — a null `Text` cannot `ReferenceEquals` a non-null scope text, so the loop would have returned `false` anyway; the guard is a fast path, not a reroute.
- `DiagnosticSuppressionMap.cs:130` and `DeclarationBinder.Attributes.cs:227` — `annotation.Arguments is null`. `AnnotationSyntax.Arguments` is a nullable reference; an annotation written without a parenthesised list (`@SuppressDiagnostic`) has none. The pre-existing `BindAttribute` already guards it the same way, so this follows the file's own established convention. Both sites now carry a comment saying so.

**A8 — does any guard change control flow versus the original?** No, and for these the question is vacuous: **all of them are in new code.** `DeclarationBinder.Attributes.cs` is **42 additions / 0 deletions** (`git diff --numstat origin/main`), so line 227 sits inside `ValidateSuppressDiagnostic`, a method this PR introduces — new code in a pre-existing *file*, not an edit to a pre-existing path. No input previously reached any of these lines, because neither the lines nor their enclosing methods existed.

`python3 build/nullable_hygiene.py` → **`nullable hygiene: OK`**. Targeted suites re-run green after the deletions (ADR-0175 + ADR-0169, 48 passed / 0 failed); the full `test/Core.Tests` 8585/0 from the original push is unaffected — the deleted branches were unreachable.
