### PR TITLE
gsc: the semantic model answers for the call node of a qualified call, so a translated analyzer follows a helper hop (ADR-0169, #3822)

### DIFF
--- a/src/Core/CodeAnalysis/SemanticModel.cs
+++ b/src/Core/CodeAnalysis/SemanticModel.cs
@@ -66,7 +66,30 @@ public sealed class SemanticModel
     public BoundNode? GetBoundNode(SyntaxNode node, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return index.Value.BoundBySyntax.TryGetValue(node, out var bound) ? bound : null;
+        if (index.Value.BoundBySyntax.TryGetValue(node, out var bound))
+        {
+            return bound;
+        }
+
+        // A qualified call is split across two syntax nodes in G#: the whole
+        // `Receiver.Callee(args)` is an AccessorExpressionSyntax and the binder
+        // anchors the call there, while `Callee(args)` is a nested
+        // CallExpressionSyntax with no anchor of its own. An unqualified call
+        // has no such split, so without this an analyzer that walks for calls
+        // (the only way to find one -- there is no "invocation" node covering
+        // both shapes) resolves the unqualified ones and silently gets nothing
+        // for the qualified ones. Roslyn has one InvocationExpressionSyntax for
+        // both, so a faithful surface answers for the call node in both shapes.
+        // Miss-only, so a node the binder does anchor keeps its own answer.
+        if (node is CallExpressionSyntax
+            && node.Parent is AccessorExpressionSyntax accessor
+            && ReferenceEquals(accessor.RightPart, node)
+            && index.Value.BoundBySyntax.TryGetValue(accessor, out var qualified))
+        {
+            return qualified;
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -110,10 +133,15 @@ public sealed class SemanticModel
 
             // No directly referenced symbol here — unwrap a same-syntax child
             // (e.g. an implicit BoundConversionExpression wrapper) and retry.
+            // "Same syntax" is measured against the bound node's own syntax,
+            // not the queried node: a qualified call is queried through its
+            // nested CallExpressionSyntax while every bound node in the wrapper
+            // chain carries the enclosing AccessorExpressionSyntax.
             BoundNode? sameSyntaxChild = null;
+            var boundSyntax = bound.Syntax ?? node;
             foreach (var getter in accessors.BoundNodeProperties)
             {
-                if (getter(bound) is BoundNode child && ReferenceEquals(child.Syntax, node))
+                if (getter(bound) is BoundNode child && ReferenceEquals(child.Syntax, boundSyntax))
                 {
                     sameSyntaxChild = child;
                     break;

--- a/test/Core.Tests/CodeAnalysis/Adr0169SemanticModelTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0169SemanticModelTests.cs
@@ -84,6 +84,94 @@ func Main() {
         Assert.Null(model.GetBoundNode(declaration.Identifier));
     }
 
+    /// <summary>
+    /// A qualified call and an unqualified call to the same functions, so one
+    /// model answers both shapes. G# splits <c>Form.Wrap(x)</c> across an
+    /// <see cref="AccessorExpressionSyntax"/> (which the binder anchors) and a
+    /// nested <see cref="CallExpressionSyntax"/> (which it does not); Roslyn
+    /// has a single <c>InvocationExpressionSyntax</c> for both shapes, so an
+    /// analyzer that walks for call nodes must get the same answer either way
+    /// (issue #3822).
+    /// </summary>
+    private const string QualifiedCallSource = @"package App
+
+class Form {
+    shared {
+        func Wrap(value int32) int32 {
+            return value + 1
+        }
+
+        func Twice(value int32) int32 {
+            return value * 2
+        }
+    }
+}
+
+func Bare(value int32) int32 {
+    return value
+}
+
+func Use(value int32) int32 {
+    return Form.Twice(Form.Wrap(Bare(value)))
+}
+";
+
+    [Fact]
+    public void GetSymbolInfo_OnTheCallNodeOfAQualifiedCall_ResolvesTheInvokedFunction()
+    {
+        var (model, tree) = CreateModel(QualifiedCallSource);
+
+        foreach (var name in new[] { "Wrap", "Twice", "Bare" })
+        {
+            var call = NodesOfType<CallExpressionSyntax>(tree).Single(c => c.Identifier.Text == name);
+
+            var symbol = model.GetSymbolInfo(call).Symbol;
+
+            // Each call node resolves to its OWN function: the qualified ones
+            // must not collapse onto an enclosing call's symbol.
+            var function = Assert.IsType<FunctionSymbol>(symbol);
+            Assert.Equal(name, function.Name);
+            Assert.NotEmpty(function.DeclaringSyntaxNodes);
+        }
+    }
+
+    [Fact]
+    public void GetTypeInfo_AndGetBoundNode_AgreeOnBothCallShapes()
+    {
+        var (model, tree) = CreateModel(QualifiedCallSource);
+        var qualified = NodesOfType<CallExpressionSyntax>(tree).Single(c => c.Identifier.Text == "Wrap");
+        var unqualified = NodesOfType<CallExpressionSyntax>(tree).Single(c => c.Identifier.Text == "Bare");
+
+        Assert.NotNull(model.GetBoundNode(qualified));
+        Assert.NotNull(model.GetBoundNode(unqualified));
+        Assert.Equal("int32", model.GetTypeInfo(qualified).Type?.Name);
+        Assert.Equal("int32", model.GetTypeInfo(unqualified).Type?.Name);
+
+        // The qualified call node borrows the answer of the accessor that
+        // encloses it, and only of that accessor: the accessor's LEFT part is
+        // a different node and keeps its own (absent) answer.
+        var accessor = NodesOfType<AccessorExpressionSyntax>(tree)
+            .Single(a => ReferenceEquals(a.RightPart, qualified));
+        Assert.Same(model.GetBoundNode(accessor), model.GetBoundNode(qualified));
+        Assert.Null(model.GetBoundNode(accessor.LeftPart));
+    }
+
+    [Fact]
+    public void GetBoundNode_DoesNotInventAnAnswerForUnanchoredNodes()
+    {
+        // The guard rail for the qualified-call fallback: it is miss-only and
+        // shape-specific, so nodes the binder does not anchor stay unanchored.
+        var (model, tree) = CreateModel(QualifiedCallSource);
+
+        foreach (var node in AllNodes(tree).OfType<TypeClauseSyntax>())
+        {
+            Assert.Null(model.GetBoundNode(node));
+        }
+
+        var declaration = NodesOfType<FunctionDeclarationSyntax>(tree).First(f => f.Identifier.Text == "Use");
+        Assert.Null(model.GetBoundNode(declaration.Identifier));
+    }
+
     [Fact]
     public void GetSemanticModel_CachesPerTree_AndRejectsForeignTrees()
     {

--- a/test/InternalAnalyzers.Tests/RewriterClonePreservationAnalyzerTests.cs
+++ b/test/InternalAnalyzers.Tests/RewriterClonePreservationAnalyzerTests.cs
@@ -156,6 +156,66 @@ class ViaHelper : BoundTreeRewriter
     }
 
     [Fact]
+    public Task AcceptsReadsReachedThroughAQualifiedStaticHelper()
+    {
+        // The shape the compiler actually uses: Lowering/BoundNodeForm.cs is a
+        // separate static class, so the hop is a QUALIFIED call
+        // (`BoundNodeForm.DeclaringType(node)`), not a bare one. Issue #3822 --
+        // G# splits a qualified call across two syntax nodes and the semantic
+        // model answered for only one of them, so the migrated analyzer
+        // reported five methods Roslyn does not.
+        string source = Model + """
+
+static class Form
+{
+    public static string Discriminator(FieldNode node) => node.InterfaceType;
+}
+
+class ViaQualifiedHelper : BoundTreeRewriter
+{
+    protected override Node RewriteFieldNode(FieldNode node)
+    {
+        var owner = Form.Discriminator(node);
+        return owner != null
+            ? new FieldNode(node.Field, owner, node.Value)
+            : new FieldNode(node.Receiver, node.Field, node.Value);
+    }
+}
+""";
+
+        return AnalyzerTestHelper.AssertDiagnosticsAsync(new RewriterClonePreservationAnalyzer(), source);
+    }
+
+    [Fact]
+    public Task AQualifiedStaticHelperThatReadsSomethingElseStillReports()
+    {
+        // The negative's twin, on the same FollowHelper path: the qualified
+        // helper resolves and is followed, but it reads Field rather than the
+        // discriminator, so the drop is still reported. An analyzer that
+        // silenced the qualified-helper shape wholesale -- or that stopped
+        // resolving qualified calls again -- fails here rather than passing
+        // quietly.
+        string source = Model + """
+
+static class OtherForm
+{
+    public static string Label(FieldNode node) => node.Field;
+}
+
+class ViaWrongQualifiedHelper : BoundTreeRewriter
+{
+    protected override Node [|RewriteFieldNode|](FieldNode node)
+    {
+        var label = OtherForm.Label(node);
+        return new FieldNode(node.Receiver, label, node.Value);
+    }
+}
+""";
+
+        return AnalyzerTestHelper.AssertDiagnosticsAsync(new RewriterClonePreservationAnalyzer(), source, "GSA0005");
+    }
+
+    [Fact]
     public Task AcceptsReadsThroughTheRewrittenBaseResult()
     {
         // `var rewritten = (T)base.RewriteX(node);` makes `rewritten` the node's


### PR DESCRIPTION
Fixes #3822. Part of #3501 (ADR-0169 M5, follow-up to #3809).

## The divergence, named precisely

The five `GSA0005` false positives left in `migrated/src/Core` after #3827 all read the member they are accused of dropping through **one qualified static call** — `BoundNodeForm.DeclaringType(node)` / `BoundNodeForm.VariableTarget(rewritten)`. The analyzer's `FollowHelper` resolves that call with `model.GetSymbolInfo(invocation)` and follows it one level. In G#, that call resolves to **nothing**:

```
node=AccessorExpressionSyntax text='Form.VariableTarget(h)' bound=BoundCallExpression symbol=FunctionSymbol:VariableTarget
node=CallExpressionSyntax     text='VariableTarget(h)'      bound=null                symbol=null
```

G# splits a qualified call across **two** syntax nodes: the whole `Receiver.Callee(args)` is an `AccessorExpressionSyntax`, which is where the binder anchors the call, and `Callee(args)` is a nested `CallExpressionSyntax` with no anchor of its own. An **unqualified** call has no such split, so its `CallExpressionSyntax` *is* anchored and resolves. Roslyn has one `InvocationExpressionSyntax` for both shapes.

An analyzer can only find calls by walking for `CallExpressionSyntax` — there is no node type covering both shapes — so the surface silently answered for half of them. Hence: unqualified helper hop followed (the existing `AcceptsReadsReachedThroughAHelper` test passes migrated), qualified helper hop not followed, five methods reported that Roslyn does not report.

## Which layer

**ADR-0169 framework gap**, the same kind as #3809 (`Symbol.ContainingType` null) and #3796 (`FieldSymbol.Location` empty) — *not* a translation defect. The cs2gs translation of this analyzer is faithful and internally consistent: it already knows the split and uses it deliberately elsewhere in the same file, e.g. `Rebuilds` translates `invocation.Expression is MemberAccessExpressionSyntax access` to

```
case CallExpressionSyntax { Parent: AccessorExpressionSyntax access } when access.LeftPart is NameExpressionSyntax owner …
```

so the analyzer's *syntactic* handling of a qualified call is right; only the *semantic* query for that node came back empty. No cs2gs change in this PR.

**All five survivors share this one cause** — every one is a `BoundNodeForm.*(…)` hop, and all five clear together.

## The fix

`SemanticModel.GetBoundNode` answers for the nested `CallExpressionSyntax` of a qualified call by borrowing the enclosing accessor's bound node. It is **miss-only** and shape-specific: a node the binder does anchor keeps its own answer, and the fallback only fires for a `CallExpressionSyntax` that is exactly the `RightPart` of its parent accessor. `GetSymbolInfo`'s wrapper-unwrapping loop now measures "same syntax" against the bound node's own syntax rather than the queried node, so an implicit-conversion wrapper on a qualified call unwraps as it already did for unqualified ones.

## Proof it is a fix and not blindness

The trap on this issue is that "no longer reports" and "reports nothing at all" look identical. Every silencing assertion is paired with a positive on the same code path.

**`test/InternalAnalyzers.Tests` (Roslyn + migrated G#), one shape, two directions:**

| test | asserts | on `origin/main` |
|---|---|---|
| `AcceptsReadsReachedThroughAQualifiedStaticHelper` | the qualified helper reads the discriminator → **no diagnostic** | C#: passes. Migrated G#: **FAILS** — the translated analyzer reports GSA0005. That is the defect, reproduced end-to-end |
| `AQualifiedStaticHelperThatReadsSomethingElseStillReports` | the same qualified-helper shape, helper reads `Field` instead → **GSA0005 reported at the marker** | passes both sides — anti-vacuity guard rail |

Migrated `test/InternalAnalyzers.Tests` parity, same migrated tree, gsc rebuilt and the SDK re-packed on each side:

| | verbatim |
|---|---|
| before | `Failed: 5, Passed: 13, Skipped: 0, Total: 18` — the four known failures (#3794 ×2, #3796, #3797) **plus** `AcceptsReadsReachedThroughAQualifiedStaticHelper` |
| after | `Failed: 4, Passed: 14, Skipped: 0, Total: 18` — the same four known failures, byte-for-byte |

The delta is exactly the one test. `AQualifiedStaticHelperThatReadsSomethingElseStillReports` passes on **both** sides: the analyzer still reports through the very path that was just taught to resolve.

The second is the anti-blindness twin: it resolves and follows the *same* qualified helper. A fix that silenced the shape wholesale, or that stopped resolving qualified calls again, fails it. Both compile and run through the real analyzer (Roslyn in C#, `GSharpAnalyzerVerifier`/gsc in the migrated tree).

**`test/Core.Tests/CodeAnalysis/Adr0169SemanticModelTests.cs` (executes against a real `Compilation`):**

| test | on `origin/main` |
|---|---|
| `GetSymbolInfo_OnTheCallNodeOfAQualifiedCall_ResolvesTheInvokedFunction` | **FAILS** (`Assert.IsType() Failure: Value is null`) |
| `GetTypeInfo_AndGetBoundNode_AgreeOnBothCallShapes` | **FAILS** (`Assert.NotNull() Failure: Value is null`) |
| `GetBoundNode_DoesNotInventAnAnswerForUnanchoredNodes` | passes — guard rail that the fallback stays miss-only |

The first walks three nested calls (`Form.Twice(Form.Wrap(Bare(value)))`) and asserts each call node resolves to **its own** function, so a blunt "borrow the parent's answer" that collapsed nested calls onto one symbol fails it. The second asserts the accessor's `LeftPart` still has no bound node.

Verbatim on `origin/main` (fix reverted, tests kept): `Failed: 2, Passed: 8, Skipped: 0, Total: 10`. With the fix: `Failed: 0, Passed: 10`.

## Measurement — `migrated/src/Core` and the banked apps

Whole-repository `run-cs2gs-selfmig-migrate.sh` (52/52 translate), then `cs2gs validate` on the same migrated tree. **#3827 was merged into the measurement branch** (it is still open); each side is a real commit and the Release solution was rebuilt on each side, so the `git describe`-stamped SDK nupkg is genuinely re-packed rather than silently reusing the old compiler.

| | `src/Core` `GSA0005` | `src/Core` |
|---|---|---|
| before — #3827 only, this fix reverted | **5** | 0/1 green |
| after — #3827 + this fix | **0** | **1/1 green** |

With the fix, all six apps #3822 names come back green in one validate pass, plus `src/Analyzers/InternalAnalyzers` itself:

```
src/Core/Core.csproj                                            succeeded=true
src/Compiler/Compiler.csproj                                    succeeded=true
src/Repl/Repl.csproj                                            succeeded=true
src/LanguageServer/LanguageServer.csproj                        succeeded=true
src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/…csproj     succeeded=true
test/Extensions.Tests/Extensions.Tests.csproj                   succeeded=true
src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj        succeeded=true
```

The five before-side errors are exactly #3822's list: `InnerRewriter.RewriteFieldAssignmentExpression`, `HoistedFieldRewriter.RewriteFieldAccessExpression`, `HoistedFieldRewriter.RewriteFieldAssignmentExpression`, `SideEffectSpiller.RewriteIndexAssignmentExpression`, `SideEffectSpiller.RewriteClrIndexAssignmentExpression`.

No `#pragma warning disable` / `@SuppressDiagnostic` / `NoWarn` / editorconfig entry was added to any of the five methods: they suppress nothing in C#, and burying a false positive under a suppression is the coverage loss ADR-0175 exists to prevent.

**Base**: this branch is on `origin/main`; #3827 is still open, so every gate number above comes from a local merge of `fix/3820-scoped-diagnostic-suppression` into a measurement branch. Until #3827 lands, this PR's own CI selfmig run still sees the 10 pragma-backed `GSA0005` errors #3827 removes — the two changes are jointly, not individually, sufficient to return the gate to its 43/52 floor. Happy to rebase onto #3827 if that is preferred.

## Other suites

`test/Core.Tests` full: `Failed: 0, Passed: 8593`. `test/LanguageServer.Tests`: 4 failures (`Issue3198…`, `LooseExtensionSample_…`) that reproduce identically with this file reverted to `origin/main` — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
