### PR TITLE
test: emitted fixtures load into a collectible context, not the default one (#3828)

### DIFF
--- a/test/Compiler.Tests/Compiler.Tests.csproj
+++ b/test/Compiler.Tests/Compiler.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="@(GsharpCompiler)" />
     <ProjectReference Include="@(GsharpRepl)" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\src\Sdk\Gsharp.Extensions\Gsharp.Extensions.csproj" />
+    <Compile Include="..\Shared\EmittedFixture.cs" Link="EmittedFixture.cs" />
     <Compile Include="..\Shared\GoldenFile.cs" Link="GoldenFile.cs" />
     <Compile Include="..\Shared\Issue3081CompositeLiteralCases.cs" Link="Issue3081CompositeLiteralCases.cs" />
     <!-- Issue #2215: only this test project needs a real gsgen.dll build output

--- a/test/Compiler.Tests/Emit/AsyncConditionAwaitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncConditionAwaitEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -298,8 +299,7 @@ public class AsyncConditionAwaitEmitTests
 
             IlVerifier.Verify(outPath);
 
-            var bytes = File.ReadAllBytes(outPath);
-            var assembly = Assembly.Load(bytes);
+            var assembly = EmittedFixture.Load(outPath);
 
             var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
             var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncInstanceMethodEmitTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -576,7 +577,6 @@ public class AsyncInstanceMethodEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/AsyncSpilledAwaitInTryEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AsyncSpilledAwaitInTryEmitTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -158,7 +159,6 @@ public class AsyncSpilledAwaitInTryEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/AttributeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/AttributeEmitTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -541,7 +542,6 @@ public class AttributeEmitTests
         IlVerifier.Verify(outPath);
 
         // Read all bytes so the file isn't locked, then load via Assembly.Load.
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/ConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/ConversionEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -252,7 +253,6 @@ public class ConversionEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/DataStructInteropTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructInteropTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -177,7 +178,6 @@ public class DataStructInteropTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs
+++ b/test/Compiler.Tests/Emit/DataStructSynthesizedMembersTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -455,7 +456,6 @@ public class DataStructSynthesizedMembersTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/EnumEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EnumEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -281,7 +282,6 @@ public class EnumEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/EventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/EventEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -1079,7 +1080,6 @@ public class EventEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/FieldAssignmentEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -363,7 +364,6 @@ public class FieldAssignmentEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/GlobalVariableEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -270,7 +271,6 @@ public class GlobalVariableEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/InlineStructEqualsEmitTests.cs
+++ b/test/Compiler.Tests/Emit/InlineStructEqualsEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -115,7 +116,6 @@ public class InlineStructEqualsEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1002UserClassAsyncIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1002UserClassAsyncIteratorEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -67,7 +68,7 @@ public class Issue1002UserClassAsyncIteratorEmitTests
             """;
 
         var outPath = CompileToFile(source, target: "library");
-        var assembly = Assembly.LoadFile(outPath);
+        var assembly = EmittedFixture.Load(outPath);
         var shapeType = assembly.GetType("T.Shape", throwOnError: true)!;
         var elementType = typeof(System.Collections.Generic.KeyValuePair<,>)
             .MakeGenericType(typeof(string), shapeType);
@@ -215,8 +216,7 @@ public class Issue1002UserClassAsyncIteratorEmitTests
     private static Assembly CompileAndRun(string source)
     {
         var outPath = CompileToFile(source, target: "exe");
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -228,8 +228,7 @@ public class Issue1002UserClassAsyncIteratorEmitTests
     private static string CompileRunAndCaptureOutput(string source)
     {
         var outPath = CompileToFile(source, target: "exe");
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue1069NestedTypesEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1069NestedTypesEmitTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -277,6 +278,6 @@ public class Issue1069NestedTypesEmitTests
 
         Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1080NestedTypeNameCollisionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1080NestedTypeNameCollisionEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -106,6 +107,6 @@ public class Issue1080NestedTypeNameCollisionEmitTests
 
         Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1132LetReferenceFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1132LetReferenceFieldWriteEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -141,7 +142,6 @@ public class Issue1132LetReferenceFieldWriteEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1182ValueTypeDefaultOptionalParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1182ValueTypeDefaultOptionalParameterEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -151,8 +152,7 @@ public class Issue1182ValueTypeDefaultOptionalParameterEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue1183NumericLiteralNarrowingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1183NumericLiteralNarrowingEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -229,7 +230,6 @@ public class Issue1183NumericLiteralNarrowingEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1213EventInvokeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1213EventInvokeEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -187,7 +188,6 @@ public class Issue1213EventInvokeEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1221InheritedEventRaiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1221InheritedEventRaiseEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -206,7 +207,6 @@ public class Issue1221InheritedEventRaiseEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1240ParameterShadowsFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1240ParameterShadowsFieldEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -126,8 +127,7 @@ public class Issue1240ParameterShadowsFieldEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue1262DiscardParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1262DiscardParameterEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -139,8 +140,7 @@ public class Issue1262DiscardParameterEmitTests
 
             IlVerifier.Verify(outPath);
 
-            var bytes = File.ReadAllBytes(outPath);
-            var assembly = Assembly.Load(bytes);
+            var assembly = EmittedFixture.Load(outPath);
 
             var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
             var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1278ArrowExpressionMemberEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -273,8 +274,7 @@ public class Issue1278ArrowExpressionMemberEmitTests
     {
         var (exitCode, output, outPath) = CompileToFile(source);
         Assert.True(exitCode == 0, $"gsc failed:\n{output}");
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static (int ExitCode, string Output, string OutPath) CompileToFile(string source)

--- a/test/Compiler.Tests/Emit/Issue1319OptionalDefaultCallSiteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1319OptionalDefaultCallSiteEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -159,8 +160,7 @@ public class Issue1319OptionalDefaultCallSiteEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue1323GenericStaticReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1323GenericStaticReceiverEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -144,7 +145,6 @@ public class Issue1323GenericStaticReceiverEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1431NativeFunctionTypeInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1431NativeFunctionTypeInferenceEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -129,8 +130,7 @@ public class Issue1431NativeFunctionTypeInferenceEmitTests
     {
         var outPath = CompileToFile(source, target: "exe");
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -142,7 +142,7 @@ public class Issue1431NativeFunctionTypeInferenceEmitTests
     private static Assembly CompileLibrary(string source)
     {
         var outPath = CompileToFile(source, target: "library");
-        return Assembly.LoadFile(outPath);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileToFile(string source, string target)

--- a/test/Compiler.Tests/Emit/Issue1481MapFunctionIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1481MapFunctionIteratorEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -302,8 +303,7 @@ public class Issue1481MapFunctionIteratorEmitTests
     {
         var outPath = CompileToFile(source, target: "exe");
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -315,7 +315,7 @@ public class Issue1481MapFunctionIteratorEmitTests
     private static Assembly CompileLibrary(string source)
     {
         var outPath = CompileToFile(source, target: "library");
-        return Assembly.LoadFile(outPath);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileToFile(string source, string target)

--- a/test/Compiler.Tests/Emit/Issue1484AsyncFinallyExitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1484AsyncFinallyExitEmitTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -372,7 +373,6 @@ public class Issue1484AsyncFinallyExitEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1489GenericAsyncIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1489GenericAsyncIteratorEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -478,8 +479,7 @@ public class Issue1489GenericAsyncIteratorEmitTests
     {
         var outPath = CompileToFile(source, target: "exe");
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -491,7 +491,7 @@ public class Issue1489GenericAsyncIteratorEmitTests
     private static Assembly CompileLibrary(string source)
     {
         var outPath = CompileToFile(source, target: "library");
-        return Assembly.LoadFile(outPath);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileToFile(string source, string target)

--- a/test/Compiler.Tests/Emit/Issue1503GenericDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1503GenericDelegateEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -346,7 +347,7 @@ public class Issue1503GenericDelegateEmitTests
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
             IlVerifier.Verify(outPath);
 
-            return Assembly.Load(File.ReadAllBytes(outPath));
+            return EmittedFixture.Load(outPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue1611GenericFieldLikeEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1611GenericFieldLikeEventEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -134,7 +135,6 @@ public class Issue1611GenericFieldLikeEventEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1614FieldAssignmentReceiverOnceEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -263,7 +264,6 @@ public class Issue1614FieldAssignmentReceiverOnceEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue1619SpillCompositeAwaitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1619SpillCompositeAwaitEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -768,8 +769,7 @@ public class Issue1619SpillCompositeAwaitEmitTests
 
             IlVerifier.Verify(outPath);
 
-            var bytes = File.ReadAllBytes(outPath);
-            var assembly = Assembly.Load(bytes);
+            var assembly = EmittedFixture.Load(outPath);
 
             var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
             var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue1714StringZeroValueEmitTests.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -439,7 +440,7 @@ public class Issue1714StringZeroValueEmitTests
             });
             Assert.Equal(0, exitCode);
             IlVerifier.Verify(dllPath);
-            return Assembly.Load(File.ReadAllBytes(dllPath));
+            return EmittedFixture.Load(dllPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2027GotoLabelIsolationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2027GotoLabelIsolationEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -119,8 +120,7 @@ public class Issue2027GotoLabelIsolationEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -358,8 +359,7 @@ public class Issue2280AwaitForPatternAsyncEnumerableEmitTests
 
         IlVerifier.Verify(outPath, extraReferences);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         if (extraReferences != null)
         {
@@ -373,7 +373,7 @@ public class Issue2280AwaitForPatternAsyncEnumerableEmitTests
                 {
                     if (string.Equals(Path.GetFileNameWithoutExtension(reference), name, StringComparison.OrdinalIgnoreCase))
                     {
-                        return Assembly.LoadFrom(reference);
+                        return EmittedFixture.Load(reference);
                     }
                 }
 

--- a/test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2280AwaitForPatternAsyncEnumerableEmitTests.cs
@@ -359,27 +359,15 @@ public class Issue2280AwaitForPatternAsyncEnumerableEmitTests
 
         IlVerifier.Verify(outPath, extraReferences);
 
-        var assembly = EmittedFixture.Load(outPath);
-
-        if (extraReferences != null)
-        {
-            // The helper assembly isn't on the default load path, so resolve
-            // it explicitly when the runtime probes for it while invoking
-            // <Main>$.
-            AppDomain.CurrentDomain.AssemblyResolve += (_, resolveArgs) =>
-            {
-                var name = new AssemblyName(resolveArgs.Name).Name;
-                foreach (var reference in extraReferences)
-                {
-                    if (string.Equals(Path.GetFileNameWithoutExtension(reference), name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return EmittedFixture.Load(reference);
-                    }
-                }
-
-                return null;
-            };
-        }
+        // The helper assemblies aren't on the default load path, so load them
+        // into the same context as the program that references them — the
+        // runtime probes for them while invoking <Main>$. (An
+        // AppDomain.AssemblyResolve hook cannot serve this: it only answers
+        // for the default context, and handing it an assembly from another
+        // context fails with "operation is not supported".)
+        var assembly = extraReferences == null || extraReferences.Length == 0
+            ? EmittedFixture.Load(outPath)
+            : EmittedFixture.LoadTogether(extraReferences.Append(outPath).ToArray())[^1];
 
         // Run the entry point and capture stdout
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue2342PackageScopedExtensionFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2342PackageScopedExtensionFunctionEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -227,7 +228,7 @@ public class Issue2342PackageScopedExtensionFunctionEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 
     private static System.Collections.Generic.List<string> CompileExpectingErrors(params string[] sources)

--- a/test/Compiler.Tests/Emit/Issue2342PackageScopedFunctionAndAliasEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2342PackageScopedFunctionAndAliasEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -206,7 +207,7 @@ public class Issue2342PackageScopedFunctionAndAliasEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 
     private static System.Collections.Generic.List<string> CompileExpectingErrors(params string[] sources)

--- a/test/Compiler.Tests/Emit/Issue2342PackageScopedTypeCollisionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2342PackageScopedTypeCollisionEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -200,7 +201,7 @@ public class Issue2342PackageScopedTypeCollisionEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 
     private static System.Collections.Generic.List<string> CompileExpectingErrors(params string[] sources)

--- a/test/Compiler.Tests/Emit/Issue2361DataToStringOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2361DataToStringOverrideEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -508,7 +509,6 @@ public class Issue2361DataToStringOverrideEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2363EmptyDataTypesEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2363EmptyDataTypesEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -499,7 +500,6 @@ public class Issue2363EmptyDataTypesEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2370ExplicitInterfaceEventIndexerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2370ExplicitInterfaceEventIndexerEmitTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -729,8 +730,7 @@ public class Issue2370ExplicitInterfaceEventIndexerEmitTests
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static int RunAndGetIntResult(string source)
@@ -838,8 +838,7 @@ public class Issue2370ExplicitInterfaceEventIndexerEmitTests
             $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileLibrary(string source)

--- a/test/Compiler.Tests/Emit/Issue2377OperatorMetadataShapeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2377OperatorMetadataShapeEmitTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Loader;
+using GSharp.Tests;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
@@ -73,7 +74,7 @@ public class Issue2377OperatorMetadataShapeEmitTests
             func (a Meters) operator >(b Meters) bool -> a.Value > b.Value
             """);
 
-        var asm = Assembly.LoadFrom(libraryPath);
+        var asm = EmittedFixture.Load(libraryPath);
         var metersType = asm.GetTypes().Single(t => t.Name == "Meters");
         var method = metersType.GetMethod(
             clrName,
@@ -373,7 +374,7 @@ public class Issue2377OperatorMetadataShapeEmitTests
             }
             """);
 
-        var asm = Assembly.LoadFrom(libraryPath);
+        var asm = EmittedFixture.Load(libraryPath);
         var baseType = asm.GetTypes().Single(t => t.Name == "BaseVec");
         var derivedType = asm.GetTypes().Single(t => t.Name == "DerivedVec");
 

--- a/test/Compiler.Tests/Emit/Issue2381AsyncGenericCollectionReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2381AsyncGenericCollectionReturnEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -361,7 +362,7 @@ public class Issue2381AsyncGenericCollectionReturnEmitTests
 
             IlVerifier.Verify(outPath);
 
-            var asm = Assembly.LoadFrom(outPath);
+            var asm = EmittedFixture.Load(outPath);
             var exportType = asm.GetType("issue2381meta.ExportCheckMeta", throwOnError: true)!;
             var runAsync = exportType.GetMethod("RunAsync", BindingFlags.Public | BindingFlags.Instance)!;
 

--- a/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2388NullableCustomEqualityEmitTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
@@ -382,8 +383,12 @@ public class Issue2388NullableCustomEqualityEmitTests
 
         IlVerifier.Verify(consumerPath, additionalReferences: new[] { libraryPath });
 
-        var libraryAsm = Assembly.LoadFrom(libraryPath);
-        var consumerAsm = Assembly.LoadFrom(consumerPath);
+        // One context for both: the consumer's methods are invoked with
+        // instances of the library's types, which requires a single
+        // identity for them.
+        var loaded2388 = EmittedFixture.LoadTogether(libraryPath, consumerPath);
+        var libraryAsm = loaded2388[0];
+        var consumerAsm = loaded2388[1];
         var metersType = libraryAsm.GetTypes().Single(t => t.Name == "Meters");
         var programType = consumerAsm.GetTypes().Single(t => t.Name == "<Program>");
 

--- a/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2443ExternalClrOverrideEmitTests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -63,7 +64,7 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
             Assert.Equal($"derived{Environment.NewLine}2486{Environment.NewLine}True{Environment.NewLine}", Run(result.OutputPath));
             IlVerifier.Verify(result.OutputPath);
 
-            var assembly = Assembly.LoadFrom(result.OutputPath);
+            var assembly = EmittedFixture.Load(result.OutputPath);
             var derived = assembly.GetType("Issue2486.Derived")!;
             AssertOverrideSlot(
                 derived.GetMethod("ToString", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!,
@@ -296,7 +297,7 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
                 """.ReplaceLineEndings(Environment.NewLine) + Environment.NewLine,
                 Run(result.OutputPath));
 
-            var assembly = Assembly.Load(File.ReadAllBytes(result.OutputPath));
+            var assembly = EmittedFixture.Load(result.OutputPath);
             var types = assembly.GetTypes();
             var objectToString = typeof(object).GetMethod(nameof(object.ToString))!;
             var objectEquals = typeof(object).GetMethod(nameof(object.Equals), new[] { typeof(object) })!;
@@ -398,7 +399,7 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
         {
             IlVerifier.Verify(result.OutputPath);
 
-            var assembly = Assembly.LoadFrom(result.OutputPath);
+            var assembly = EmittedFixture.Load(result.OutputPath);
             var type = assembly.GetType("Issue2486.Shadow")!;
             var instance = Activator.CreateInstance(type);
             var shadow = type.GetMethod("ToString", BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
@@ -469,7 +470,7 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
             Assert.Equal($"derived{Environment.NewLine}", Run(result.OutputPath));
             IlVerifier.Verify(result.OutputPath);
 
-            var assembly = Assembly.LoadFrom(result.OutputPath);
+            var assembly = EmittedFixture.Load(result.OutputPath);
             var method = assembly.GetType("Issue2443.Derived")!.GetMethod(
                 "ToString",
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)!;
@@ -522,8 +523,13 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
         {
             IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { ExternalBaseAssembly.Value });
 
-            var baseAssembly = Assembly.LoadFrom(ExternalBaseAssembly.Value);
-            var derivedAssembly = Assembly.LoadFrom(result.OutputPath);
+            // One context for both: the assertions below compare the
+            // derived type's base methods and return types against the
+            // external base's, which only holds when a single context
+            // supplies one identity for Issue2443Base.
+            var loaded = EmittedFixture.LoadTogether(ExternalBaseAssembly.Value, result.OutputPath);
+            var baseAssembly = loaded[0];
+            var derivedAssembly = loaded[1];
             var derived = derivedAssembly.GetType("Issue2443.Derived")!;
             var closedBase = baseAssembly.GetType("Issue2443Base.ExternalBase`1")!.MakeGenericType(typeof(int));
 
@@ -582,8 +588,13 @@ public sealed class Issue2443ExternalClrOverrideEmitTests
         var result = Compile(Source, target: "library", ExternalBaseAssembly.Value);
         try
         {
-            var baseAssembly = Assembly.LoadFrom(ExternalBaseAssembly.Value);
-            var derivedAssembly = Assembly.LoadFrom(result.OutputPath);
+            // One context for both: the assertions below compare the
+            // derived type's base methods and return types against the
+            // external base's, which only holds when a single context
+            // supplies one identity for Issue2443Base.
+            var loaded = EmittedFixture.LoadTogether(ExternalBaseAssembly.Value, result.OutputPath);
+            var baseAssembly = loaded[0];
+            var derivedAssembly = loaded[1];
             var derivedType = derivedAssembly.GetType("Issue2443.ShadowingDerived")!;
             var instance = Activator.CreateInstance(derivedType);
             var closedBase = baseAssembly.GetType("Issue2443Base.ExternalBase`1")!.MakeGenericType(typeof(int));

--- a/test/Compiler.Tests/Emit/Issue2471DictionaryIndexerSameCompilationTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2471DictionaryIndexerSameCompilationTypeTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -574,7 +575,7 @@ public class Issue2471DictionaryIndexerSameCompilationTypeTests
                 csharpSource: null);
             Assert.True(exitCode == 0, diagnostics);
             IlVerifier.Verify(outPath, additionalReferences: references);
-            return Assembly.Load(File.ReadAllBytes(outPath));
+            return EmittedFixture.Load(outPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2488NarrowedInheritedAssignmentTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2488NarrowedInheritedAssignmentTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -280,7 +281,7 @@ public class Issue2488NarrowedInheritedAssignmentTests
             var (exitCode, diagnostics, outPath, references) = Compile(workDir, source, "exe", csharpSource: null);
             Assert.True(exitCode == 0, diagnostics);
             IlVerifier.Verify(outPath, additionalReferences: references);
-            return Assembly.Load(File.ReadAllBytes(outPath));
+            return EmittedFixture.Load(outPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2492NullableBoxedConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2492NullableBoxedConversionEmitTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -206,7 +207,7 @@ public sealed class Issue2492NullableBoxedConversionEmitTests
             var (exitCode, stdout, stderr) = Compile(sourcePath, outputPath, "library");
             Assert.True(exitCode == 0, $"gsc failed:\nstdout:\n{stdout}\nstderr:\n{stderr}");
             IlVerifier.Verify(outputPath);
-            return Assembly.Load(File.ReadAllBytes(outputPath));
+            return EmittedFixture.Load(outputPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2494EnumLinqExtremaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2494EnumLinqExtremaEmitTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -409,7 +410,7 @@ public sealed class Issue2494EnumLinqExtremaEmitTests
                 csharpSource: null);
             Assert.True(exitCode == 0, diagnostics);
             IlVerifier.Verify(outPath, additionalReferences: references);
-            return Assembly.Load(File.ReadAllBytes(outPath));
+            return EmittedFixture.Load(outPath);
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2498NullableLambdaGenericInferenceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2498NullableLambdaGenericInferenceEmitTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -139,7 +140,7 @@ public sealed class Issue2498NullableLambdaGenericInferenceEmitTests
 
         WithCompiledLibrary(source, (dllPath, references) =>
         {
-            var assembly = Assembly.Load(File.ReadAllBytes(dllPath));
+            var assembly = EmittedFixture.Load(dllPath);
             var api = assembly.GetType("Issue2498.Metadata.Api2498", throwOnError: true)!;
             var nullability = new NullabilityInfoContext();
 

--- a/test/Compiler.Tests/Emit/Issue2502InheritedStaticMembersEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2502InheritedStaticMembersEmitTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -65,7 +66,7 @@ public sealed class Issue2502InheritedStaticMembersEmitTests
             var library = CompileGSharp(directory, "Issue2502Source", Source, "library");
             IlVerifier.Verify(library);
 
-            var assembly = Assembly.LoadFrom(library);
+            var assembly = EmittedFixture.Load(library);
             var derived = assembly.GetType("Issue2502Source.Derived2502")!;
             var closedBase = assembly.GetType("Issue2502Source.Base2502`1")!.MakeGenericType(typeof(string));
             Assert.Equal(closedBase, derived.BaseType!.BaseType);

--- a/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2514ImportedInterfaceConstraintMemberTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -202,7 +203,7 @@ public sealed class Issue2514ImportedInterfaceConstraintMemberTests
             Run(result.OutputPath));
         IlVerifier.Verify(result.OutputPath, additionalReferences: new[] { result.ContractsPath });
 
-        var assembly = Assembly.LoadFrom(result.OutputPath);
+        var assembly = EmittedFixture.Load(result.OutputPath);
         var api = assembly.GetType("Issue2514.Api")!;
         var readNameParameter = api.GetMethod("ReadName")!.GetGenericArguments().Single();
         Assert.Contains(

--- a/test/Compiler.Tests/Emit/Issue2523NullableImportedGenericBaseConversionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2523NullableImportedGenericBaseConversionEmitTests.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -77,8 +78,12 @@ public sealed class Issue2523NullableImportedGenericBaseConversionEmitTests
             IlVerifier.Verify(outputPath, additionalReferences: references);
             Assert.Equal($"3{Environment.NewLine}2{Environment.NewLine}", Run(outputPath));
 
-            var fixture = Assembly.LoadFrom(fixturePath);
-            var emitted = Assembly.LoadFrom(outputPath);
+            // One context for the reference fixture and the emitted
+            // assembly that imports it, so the nullability assertions
+            // below see one identity for the fixture's types.
+            var loaded2523 = EmittedFixture.LoadTogether(fixturePath, outputPath);
+            var fixture = loaded2523[0];
+            var emitted = loaded2523[1];
             var api = emitted.GetType("Issue2523.Emit.Api2523", throwOnError: true)!;
             var buildChain = api.GetMethod(
                 "BuildChain",

--- a/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
@@ -686,14 +686,18 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
             """.ReplaceLineEndings(Environment.NewLine) + Environment.NewLine,
             Run(result.OutputPath));
 
-        var contracts = EmittedFixture.Load(result.ContractsPath);
+        // One context for both: the emitted API is invoked below with
+        // instances of the contracts assembly's types, which requires a
+        // single identity for them.
+        var loaded2525 = EmittedFixture.LoadTogether(result.ContractsPath, result.OutputPath);
+        var contracts = loaded2525[0];
         var derivedType = contracts.GetType("Issue2525.Contracts.IDerived", throwOnError: true)!;
         var baseType = contracts.GetType("Issue2525.Contracts.IBase", throwOnError: true)!;
         var derivedProperty = derivedType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Single();
         var baseProperty = baseType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Single();
         Assert.NotEqual(baseProperty.MetadataToken, derivedProperty.MetadataToken);
 
-        var emitted = EmittedFixture.Load(result.OutputPath);
+        var emitted = loaded2525[1];
         var api = emitted.GetType("Issue2525.Api", throwOnError: true)!;
         Assert.Equal("Issue2525.Contracts.IDerived", api.GetMethod("Read")!.GetParameters()[0].ParameterType.FullName);
         Assert.Equal("Issue2525.Contracts.IBase", api.GetMethod("ReadBase")!.GetParameters()[0].ParameterType.FullName);

--- a/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -685,14 +686,14 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
             """.ReplaceLineEndings(Environment.NewLine) + Environment.NewLine,
             Run(result.OutputPath));
 
-        var contracts = Assembly.LoadFrom(result.ContractsPath);
+        var contracts = EmittedFixture.Load(result.ContractsPath);
         var derivedType = contracts.GetType("Issue2525.Contracts.IDerived", throwOnError: true)!;
         var baseType = contracts.GetType("Issue2525.Contracts.IBase", throwOnError: true)!;
         var derivedProperty = derivedType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Single();
         var baseProperty = baseType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Single();
         Assert.NotEqual(baseProperty.MetadataToken, derivedProperty.MetadataToken);
 
-        var emitted = Assembly.LoadFrom(result.OutputPath);
+        var emitted = EmittedFixture.Load(result.OutputPath);
         var api = emitted.GetType("Issue2525.Api", throwOnError: true)!;
         Assert.Equal("Issue2525.Contracts.IDerived", api.GetMethod("Read")!.GetParameters()[0].ParameterType.FullName);
         Assert.Equal("Issue2525.Contracts.IBase", api.GetMethod("ReadBase")!.GetParameters()[0].ParameterType.FullName);

--- a/test/Compiler.Tests/Emit/Issue2615ImportedEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2615ImportedEventEmitTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -68,8 +69,9 @@ public sealed class Issue2615ImportedEventEmitTests
     public void ImportedInheritedPropertyChanged_AddRemove_Runs()
     {
         using var artifacts = Compile(OahuSource);
-        _ = Assembly.LoadFrom(artifacts.FixturePath);
-        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        // One context for the reference fixture and the emitted assembly
+        // that imports it.
+        var assembly = EmittedFixture.LoadTogether(artifacts.FixturePath, artifacts.OutputPath)[1];
         var probeType = assembly.GetType("Oahu.Core.UI.Avalonia.ViewModels.Probe");
         var probe = Activator.CreateInstance(probeType!);
 

--- a/test/Compiler.Tests/Emit/Issue2619IteratorGetterReturnFlowTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2619IteratorGetterReturnFlowTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -133,7 +134,7 @@ public class Issue2619IteratorGetterReturnFlowTests
             result.Success,
             string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
 
-        var assembly = Assembly.Load(peStream.ToArray());
+        var assembly = EmittedFixture.Load(peStream.ToArray());
         var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });

--- a/test/Compiler.Tests/Emit/Issue2667AsyncVoidImportedBaseReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2667AsyncVoidImportedBaseReceiverEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -60,7 +61,7 @@ public sealed class Issue2667AsyncVoidImportedBaseReceiverEmitTests
 
         Assert.Equal($"base-opened{Environment.NewLine}async-opened{Environment.NewLine}", fixture.Run(result.OutputPath));
 
-        var assembly = Assembly.LoadFrom(result.OutputPath);
+        var assembly = EmittedFixture.Load(result.OutputPath);
         var mainWindow = assembly.GetType("Oahu.App.Avalonia.MainWindow")!;
         Assert.Contains(
             mainWindow.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly),
@@ -124,7 +125,7 @@ public sealed class Issue2667AsyncVoidImportedBaseReceiverEmitTests
 
     private static void AssertNoForwarder(string assemblyPath, string typeName)
     {
-        var type = Assembly.LoadFrom(assemblyPath).GetType(typeName)!;
+        var type = EmittedFixture.Load(assemblyPath).GetType(typeName)!;
         Assert.DoesNotContain(
             type.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly),
             method => method.Name.StartsWith("<>n__", StringComparison.Ordinal));

--- a/test/Compiler.Tests/Emit/Issue2668AsyncLambdaPrivateStaticAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2668AsyncLambdaPrivateStaticAccessEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -80,7 +81,7 @@ public class Issue2668AsyncLambdaPrivateStaticAccessEmitTests
             Assert.Equal(0, Compile(sourcePath, outputPath));
             IlVerifier.Verify(outputPath);
 
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             var httpEndpoints = assembly.GetType("Oahu.Cli.Server.HttpEndpoints", throwOnError: true)!;
             var nestedNames = httpEndpoints.GetNestedTypes(BindingFlags.NonPublic)
                 .Select(type => type.Name)

--- a/test/Compiler.Tests/Emit/Issue2717ImportedNullableInitializerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2717ImportedNullableInitializerEmitTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -87,8 +88,10 @@ public sealed class Issue2717ImportedNullableInitializerEmitTests
             Assert.True(result.ExitCode == 0, result.Diagnostics);
             IlVerifier.Verify(result.OutputPath, new[] { fixturePath });
 
-            _ = Assembly.LoadFrom(fixturePath);
-            var emitted = Assembly.LoadFrom(result.OutputPath);
+            // One context for the reference fixture and the emitted
+            // assembly that imports it, so the emitted code binds the
+            // same fixture types the test reflects over.
+            var emitted = EmittedFixture.LoadTogether(fixturePath, result.OutputPath)[1];
             var build = emitted.GetTypes()
                 .Single(type => type.Name == "<Program>")
                 .GetMethod("Build", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2726NominalEventDelegateEmitTests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -58,7 +59,7 @@ public sealed class Issue2726NominalEventDelegateEmitTests
         using var artifacts = CompileGSharp(source, "NominalEvents.dll");
         IlVerifier.Verify(artifacts.OutputPath);
 
-        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var assembly = EmittedFixture.Load(artifacts.OutputPath);
         var interfaceEvent = assembly.GetType("Issue2726.IChanges")!.GetEvent("InterfaceChanged")!;
         var raiser = assembly.GetType("Issue2726.Raiser")!;
 
@@ -97,7 +98,7 @@ public sealed class Issue2726NominalEventDelegateEmitTests
         using var artifacts = CompileGSharp(source, "NegativeEvents.dll");
         IlVerifier.Verify(artifacts.OutputPath);
 
-        var raiser = Assembly.LoadFrom(artifacts.OutputPath).GetType("Issue2726.Negative.Raiser")!;
+        var raiser = EmittedFixture.Load(artifacts.OutputPath).GetType("Issue2726.Negative.Raiser")!;
         AssertEventAbi(raiser.GetEvent("NonNullableSender")!, typeof(Action<object, EventArgs>));
         AssertEventAbi(raiser.GetEvent("OtherPayload")!, typeof(Action<object, string>));
         AssertEventAbi(raiser.GetEvent("NamedAction")!, typeof(Action<object, EventArgs>));
@@ -132,7 +133,7 @@ public sealed class Issue2726NominalEventDelegateEmitTests
         using var artifacts = CompileGSharp(source, "GenericEvents.dll");
         IlVerifier.Verify(artifacts.OutputPath);
 
-        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var assembly = EmittedFixture.Load(artifacts.OutputPath);
         var openRaiser = assembly.GetType("Issue2726.Generic.GenericRaiser`1")!;
         var typeParameter = openRaiser.GetGenericArguments().Single();
         var expectedHandler = typeof(EventHandler<>).MakeGenericType(typeParameter);
@@ -236,7 +237,7 @@ public sealed class Issue2726NominalEventDelegateEmitTests
 
         // Tie the shared metadata back to concrete CLR parameter types on the
         // loadable implementation assembly for the closed shapes.
-        var assembly = Assembly.LoadFrom(artifacts.OutputPath);
+        var assembly = EmittedFixture.Load(artifacts.OutputPath);
         var raiser = assembly.GetType("Issue2726.Refout.Raiser")!;
         var localArgs = assembly.GetType("Issue2726.Refout.LocalArgs")!;
         Assert.Equal(

--- a/test/Compiler.Tests/Emit/Issue2742InheritedInterfaceEventEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2742InheritedInterfaceEventEmitTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -43,7 +44,7 @@ public sealed class Issue2742InheritedInterfaceEventEmitTests
         using var artifacts = Compile(source);
         IlVerifier.Verify(artifacts.OutputPath);
 
-        var assembly = Assembly.Load(File.ReadAllBytes(artifacts.OutputPath));
+        var assembly = EmittedFixture.Load(artifacts.OutputPath);
         var type = assembly.GetType("Oahu.Core.DownloadSettings", throwOnError: true)!;
         var instance = Activator.CreateInstance(type)!;
         var contract = assembly.GetType("Oahu.Core.IDownloadSettings", throwOnError: true)!;
@@ -103,7 +104,7 @@ public sealed class Issue2742InheritedInterfaceEventEmitTests
         using var artifacts = Compile(source);
         IlVerifier.Verify(artifacts.OutputPath);
 
-        var assembly = Assembly.Load(File.ReadAllBytes(artifacts.OutputPath));
+        var assembly = EmittedFixture.Load(artifacts.OutputPath);
         var type = assembly.GetType("Issue2742.Custom.Derived", throwOnError: true)!;
         var contract = assembly.GetType("Issue2742.Custom.IChanges", throwOnError: true)!;
         var instance = Activator.CreateInstance(type)!;
@@ -137,7 +138,7 @@ public sealed class Issue2742InheritedInterfaceEventEmitTests
         using var artifacts = Compile(source);
         IlVerifier.Verify(artifacts.OutputPath);
 
-        var assembly = Assembly.Load(File.ReadAllBytes(artifacts.OutputPath));
+        var assembly = EmittedFixture.Load(artifacts.OutputPath);
         var type = assembly.GetType("Issue2742.Imported.Derived", throwOnError: true)!;
         var instance = Activator.CreateInstance(type)!;
         var map = type.GetInterfaceMap(typeof(INotifyPropertyChanged));

--- a/test/Compiler.Tests/Emit/Issue2796NullConditionalEventRaiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2796NullConditionalEventRaiseEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -228,7 +229,6 @@ public class Issue2796NullConditionalEventRaiseEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2798NullConditionalValueEventRaiseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2798NullConditionalValueEventRaiseEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -347,7 +348,6 @@ public class Issue2798NullConditionalValueEventRaiseEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2799NullConditionalStructuralDelegateReceiverEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2799NullConditionalStructuralDelegateReceiverEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -464,8 +465,7 @@ public class Issue2799NullConditionalStructuralDelegateReceiverEmitTests
         CompileFile(srcPath, outPath, target);
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static void CompileFile(string srcPath, string outPath, string target)

--- a/test/Compiler.Tests/Emit/Issue2831NegativeAttributeArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2831NegativeAttributeArgumentEmitTests.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -158,7 +159,6 @@ public class Issue2831NegativeAttributeArgumentEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue2843FixedDefiniteReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2843FixedDefiniteReturnEmitTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -235,7 +236,7 @@ public class Issue2843FixedDefiniteReturnEmitTests
             }
         }
 
-        var assembly = Assembly.Load(peStream.ToArray());
+        var assembly = EmittedFixture.Load(peStream.ToArray());
         var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });

--- a/test/Compiler.Tests/Emit/Issue2875DataClassSettableInterfaceTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2875DataClassSettableInterfaceTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -386,7 +387,7 @@ public class Issue2875DataClassSettableInterfaceTests
 
             Assert.True(exitCode == 0, "gsc failed:\n" + output);
             IlVerifier.Verify(outputPath);
-            _ = System.Reflection.Assembly.Load(File.ReadAllBytes(outputPath)).GetTypes();
+            _ = EmittedFixture.Load(outputPath).GetTypes();
 
             var startInfo = new ProcessStartInfo("dotnet")
             {
@@ -429,7 +430,7 @@ public class Issue2875DataClassSettableInterfaceTests
 
             Assert.True(exitCode == 0, "gsc failed:\n" + output);
             IlVerifier.Verify(outputPath);
-            _ = System.Reflection.Assembly.Load(File.ReadAllBytes(outputPath)).GetTypes();
+            _ = EmittedFixture.Load(outputPath).GetTypes();
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2883FixedEscapingBranchEmitTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -195,7 +196,7 @@ public class Issue2883FixedEscapingBranchEmitTests
             File.Delete(assemblyPath);
         }
 
-        var assembly = Assembly.Load(peStream.ToArray());
+        var assembly = EmittedFixture.Load(peStream.ToArray());
         var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });

--- a/test/Compiler.Tests/Emit/Issue2885NullableDelegateReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2885NullableDelegateReceiverTests.cs
@@ -12,6 +12,7 @@ using GSharp.Compiler;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -966,12 +967,11 @@ public class Issue2885NullableDelegateReceiverTests
                 assemblyPath,
                 additionalReferences: fixturePath == null ? null : new[] { fixturePath });
 
-            if (fixturePath != null)
-            {
-                Assembly.Load(File.ReadAllBytes(fixturePath));
-            }
-
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            // One context for the reference fixture and the emitted
+            // assembly that imports it.
+            var assembly = fixturePath == null
+                ? EmittedFixture.Load(assemblyPath)
+                : EmittedFixture.LoadTogether(fixturePath, assemblyPath)[1];
             _ = assembly.GetTypes();
 
             using var process = Process.Start(new ProcessStartInfo("dotnet")

--- a/test/Compiler.Tests/Emit/Issue2888InterfacePropertyTypeMismatchTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2888InterfacePropertyTypeMismatchTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -756,7 +757,7 @@ public class Issue2888InterfacePropertyTypeMismatchTests
                 _ = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.GetFullPath(referencePath));
             }
 
-            _ = Assembly.Load(File.ReadAllBytes(outputPath)).GetTypes();
+            _ = EmittedFixture.Load(outputPath).GetTypes();
         }
         finally
         {

--- a/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2890SwitchSelectEscapingBranchEmitTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -270,7 +271,7 @@ public class Issue2890SwitchSelectEscapingBranchEmitTests
             File.Delete(assemblyPath);
         }
 
-        var assembly = Assembly.Load(peStream.ToArray());
+        var assembly = EmittedFixture.Load(peStream.ToArray());
         var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });

--- a/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
@@ -188,10 +188,19 @@ public class Issue2891TryRegionFlowEmitTests
             }
             public var result = F(false) + F(true)
             """);
+        // `Origin` carries a loop purely so the JIT will not inline it:
+        // the assertion below reads its frame out of the rethrown stack
+        // trace, and an inlined frame simply is not there. Code loaded into
+        // a collectible context is jitted with full optimizations from the
+        // start, so a one-line thrower would vanish (issue #3828).
         yield return Case("RethrowPreservesOriginStack", 7, """
             import System
             func Origin() {
-                throw Exception("origin")
+                var pad = 0
+                for var i = 0; i < 3; i++ {
+                    pad += i
+                }
+                throw Exception("origin" + pad.ToString())
             }
             func F(replace bool) int32 {
                 try {

--- a/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -628,7 +629,7 @@ public class Issue2891TryRegionFlowEmitTests
             File.Delete(assemblyPath);
         }
 
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(bytes);
         var types = assembly.GetTypes();
         Assert.NotEmpty(types);
         var program = types.Single(type => type.Name == "<Program>");
@@ -660,7 +661,7 @@ public class Issue2891TryRegionFlowEmitTests
             });
             Assert.Equal(0, exitCode);
             IlVerifier.Verify(assemblyPath);
-            Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+            Assert.NotEmpty(EmittedFixture.Load(assemblyPath).GetTypes());
 
             var start = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue2893ConstructorAccessibilityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2893ConstructorAccessibilityEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -138,7 +139,7 @@ public sealed class Issue2893ConstructorAccessibilityEmitTests
             var assemblyPath = Compile(Source, directory);
             IlVerifier.Verify(assemblyPath);
 
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             var types = assembly.GetTypes();
             Assert.Equal(16, types.Length);
             assertions(types);

--- a/test/Compiler.Tests/Emit/Issue2894LambdaBodyGenericClosureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2894LambdaBodyGenericClosureTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -264,7 +265,7 @@ public class Issue2894LambdaBodyGenericClosureTests
 
             Assert.Equal(expectedOutput + Environment.NewLine, Run(assemblyPath, directory));
 
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             var closureTypes = assembly.GetTypes()
                 .Where(type => type.Name.StartsWith("<closure_", StringComparison.Ordinal))
                 .ToArray();

--- a/test/Compiler.Tests/Emit/Issue2895InheritedFieldDeclaringTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2895InheritedFieldDeclaringTypeTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -294,7 +295,7 @@ public class Issue2895InheritedFieldDeclaringTypeTests
         });
         Assert.Equal(0, exitCode);
 
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         _ = assembly.GetTypes();
         return new Artifact(directory, assemblyPath, assembly);
     }

--- a/test/Compiler.Tests/Emit/Issue2898NestedEnumConstructedOuterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2898NestedEnumConstructedOuterEmitTests.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -239,14 +240,17 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
             Assert.DoesNotContain("1300", intSignature);
             Assert.DoesNotContain("1300", stringSignature);
 
-            var library = Assembly.Load(File.ReadAllBytes(libraryPath));
+            // One context for both: the assertions compare the consumer's
+            // constructed enum types against the library's definitions,
+            // and loading them together is also what resolves the
+            // consumer's reference to the library (the AppDomain-wide
+            // AssemblyResolve hook this replaced only ever fired for the
+            // default load context).
+            var loaded2898 = EmittedFixture.LoadTogether(libraryPath, consumerPath);
+            var library = loaded2898[0];
             var libraryTypes = library.GetTypes();
-            ResolveEventHandler resolveLibrary = (_, args) =>
-                new AssemblyName(args.Name).Name == library.GetName().Name ? library : null;
-            AppDomain.CurrentDomain.AssemblyResolve += resolveLibrary;
-            try
             {
-                var consumer = Assembly.Load(File.ReadAllBytes(consumerPath));
+                var consumer = loaded2898[1];
                 var consumerTypes = consumer.GetTypes();
                 var program = consumerTypes.Single(t => t.Name == "<Program>");
                 var intEnum = program.GetField("c", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static).FieldType;
@@ -266,10 +270,6 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
                 Assert.Equal(6, GetMethod(program, "S").Invoke(null, null));
                 Assert.Equal(intEnum, GetMethod(program, "BI").Invoke(null, null).GetType());
                 Assert.Equal(stringEnum, GetMethod(program, "BS").Invoke(null, null).GetType());
-            }
-            finally
-            {
-                AppDomain.CurrentDomain.AssemblyResolve -= resolveLibrary;
             }
         }
         finally
@@ -458,8 +458,7 @@ public class Issue2898NestedEnumConstructedOuterEmitTests
             var outputPath = Compile(tempDir, "test", source);
             IlVerifier.Verify(outputPath, ignoredErrorCodes: ignoredErrorCodes);
 
-            var bytes = File.ReadAllBytes(outputPath);
-            var assembly = Assembly.Load(bytes);
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             return assembly;
         }

--- a/test/Compiler.Tests/Emit/Issue2899ThrowDeadCodeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2899ThrowDeadCodeEmitTests.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -94,7 +95,7 @@ public class Issue2899ThrowDeadCodeEmitTests
             File.Delete(assemblyPath);
         }
 
-        var assembly = Assembly.Load(peStream.ToArray());
+        var assembly = EmittedFixture.Load(peStream.ToArray());
         var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
         entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() });

--- a/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2906ExhaustiveSwitchReturnEmitTests.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -356,7 +357,7 @@ public class Issue2906ExhaustiveSwitchReturnEmitTests
             File.Delete(assemblyPath);
         }
 
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(bytes);
         var types = assembly.GetTypes();
         Assert.NotEmpty(types);
         var program = types.Single(type => type.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue2907IteratorLoopCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2907IteratorLoopCaptureTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -528,7 +529,7 @@ public class Issue2907IteratorLoopCaptureTests
         var assemblyPath = Compile(source, name);
         IlVerifier.Verify(assemblyPath);
 
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
 
         var output = RunBounded(assemblyPath, name);
@@ -595,7 +596,7 @@ public class Issue2907IteratorLoopCaptureTests
 
         var assemblyPath = Compile(Source, nameof(LibraryIteratorLoopCaptureLoadsAndInvokes), target: "library");
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var method = program.GetMethod("values", BindingFlags.Public | BindingFlags.Static);
         Assert.NotNull(method);
@@ -630,7 +631,7 @@ public class Issue2907IteratorLoopCaptureTests
 
         var assemblyPath = Compile(Source, nameof(NonIteratorLoopCaptureGuard));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"0,1,{Environment.NewLine}", RunBounded(assemblyPath, nameof(NonIteratorLoopCaptureGuard)));
     }
@@ -666,7 +667,7 @@ public class Issue2907IteratorLoopCaptureTests
     {
         var assemblyPath = Compile(source, name);
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"{expected}{Environment.NewLine}{expected}{Environment.NewLine}", RunBounded(assemblyPath, name));
     }

--- a/test/Compiler.Tests/Emit/Issue2914ConstantPatternSwitchLoweringTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2914ConstantPatternSwitchLoweringTests.cs
@@ -10,6 +10,7 @@ using System.Reflection.Emit;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -385,7 +386,7 @@ public class Issue2914ConstantPatternSwitchLoweringTests
             File.Delete(assemblyPath);
         }
 
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(bytes);
         _ = assembly.GetTypes();
         var program = GetProgram(assembly);
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;

--- a/test/Compiler.Tests/Emit/Issue2915ImplicitInterfaceIndexerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2915ImplicitInterfaceIndexerEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 using Xunit.Sdk;
 
@@ -431,7 +432,7 @@ public class Issue2915ImplicitInterfaceIndexerEmitTests
             }
 
             IlVerifier.Verify(assemblyPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             _ = assembly.GetTypes();
             inspectAssembly?.Invoke(assembly);
 

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -13,6 +13,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -1038,8 +1039,8 @@ public class Issue2918InlineLambdaErasedReceiverTests
         string expectedSourceTypeName,
         bool allowDirectObjectParameter = false)
     {
-        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(contractsPath)).GetTypes());
-        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        Assert.NotEmpty(EmittedFixture.Load(contractsPath).GetTypes());
+        Assert.NotEmpty(EmittedFixture.Load(assemblyPath).GetTypes());
 
         var loadContext = new AssemblyLoadContext(
             "Issue2918_" + Guid.NewGuid().ToString("N"),
@@ -1198,8 +1199,8 @@ public class Issue2918InlineLambdaErasedReceiverTests
             if (exitCode == 0)
             {
                 IlVerifier.Verify(assemblyPath, additionalReferences: new[] { contractsPath });
-                Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(contractsPath)).GetTypes());
-                Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+                Assert.NotEmpty(EmittedFixture.Load(contractsPath).GetTypes());
+                Assert.NotEmpty(EmittedFixture.Load(assemblyPath).GetTypes());
                 var runtimeOutput = Run(assemblyPath, directory);
                 throw new XunitException(
                     "Expected ambiguous delegate overloads to be rejected, "

--- a/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2921LambdaBodyDefiniteReturnTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -171,7 +172,7 @@ public class Issue2921LambdaBodyDefiniteReturnTests
         var result = InvokeCompiler(source, name);
 
         Assert.Equal(0, result.ExitCode);
-        var assembly = Assembly.Load(File.ReadAllBytes(result.AssemblyPath));
+        var assembly = EmittedFixture.Load(result.AssemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal(expectedOutput, RunBounded(result.AssemblyPath, name));
     }

--- a/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2922FixedSwitchIlTests.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -447,7 +448,7 @@ public class Issue2922FixedSwitchIlTests
 
         public string AssemblyPath { get; }
 
-        public Assembly Load() => Assembly.Load(File.ReadAllBytes(AssemblyPath));
+        public Assembly Load() => EmittedFixture.Load(AssemblyPath);
 
         public void AssertLoadable() => Assert.NotEmpty(Load().GetTypes());
 

--- a/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2924TupleElementDelegateCallTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -310,7 +311,7 @@ public class Issue2924TupleElementDelegateCallTests
             exitCode == 0,
             $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
         IlVerifier.Verify(outputPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+        var assembly = EmittedFixture.Load(outputPath);
         _ = assembly.GetTypes();
         return assembly;
     }

--- a/test/Compiler.Tests/Emit/Issue2925InterfaceDelegatePropertyInvocationTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2925InterfaceDelegatePropertyInvocationTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -109,7 +110,7 @@ public class Issue2925InterfaceDelegatePropertyInvocationTests
                 exitCode == 0,
                 $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
             IlVerifier.Verify(outputPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");

--- a/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2927NullableSequenceElementTypeTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -153,7 +154,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(NullableSequenceParameterAcceptsList));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"1,nil,3,{Environment.NewLine}", RunBounded(assemblyPath, nameof(NullableSequenceParameterAcceptsList)));
     }
@@ -177,7 +178,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(ReferenceConstrainedGenericNullableSequenceLoadsVerifiesAndRuns));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"x{Environment.NewLine}nil{Environment.NewLine}", RunBounded(assemblyPath, nameof(ReferenceConstrainedGenericNullableSequenceLoadsVerifiesAndRuns)));
     }
@@ -208,7 +209,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(BaseClassConstrainedGenericNullableSequenceLoadsVerifiesAndRuns));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"woof{Environment.NewLine}nil{Environment.NewLine}", RunBounded(assemblyPath, nameof(BaseClassConstrainedGenericNullableSequenceLoadsVerifiesAndRuns)));
     }
@@ -232,7 +233,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(StructConstrainedGenericNullableSequenceLoadsVerifiesAndRuns));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"5{Environment.NewLine}nil{Environment.NewLine}", RunBounded(assemblyPath, nameof(StructConstrainedGenericNullableSequenceLoadsVerifiesAndRuns)));
     }
@@ -259,7 +260,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(NullableReferenceSequenceGuardLoadsVerifiesAndRuns));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"x{Environment.NewLine}nil{Environment.NewLine}", RunBounded(assemblyPath, nameof(NullableReferenceSequenceGuardLoadsVerifiesAndRuns)));
     }
@@ -288,7 +289,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(NullableUserEnumSequenceGuardLoadsVerifiesAndRuns));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"A{Environment.NewLine}nil{Environment.NewLine}", RunBounded(assemblyPath, nameof(NullableUserEnumSequenceGuardLoadsVerifiesAndRuns)));
     }
@@ -479,7 +480,7 @@ public class Issue2927NullableSequenceElementTypeTests
 
         var assemblyPath = Compile(Source, nameof(GenericNullableSequenceMetadataUsesMatchingSpecializedSignaturesAndInterfaces));
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         var types = assembly.GetTypes();
         Assert.NotEmpty(types);
 
@@ -719,7 +720,7 @@ public class Issue2927NullableSequenceElementTypeTests
     {
         var assemblyPath = Compile(source, name);
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal(expected, RunBounded(assemblyPath, name));
     }
@@ -767,7 +768,7 @@ public class Issue2927NullableSequenceElementTypeTests
     {
         var assemblyPath = Compile(source, name);
         IlVerifier.Verify(assemblyPath);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal($"{expected}{Environment.NewLine}{expected}{Environment.NewLine}", RunBounded(assemblyPath, name));
     }

--- a/test/Compiler.Tests/Emit/Issue2928TupleFunctionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2928TupleFunctionEmitTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -55,7 +56,7 @@ public class Issue2928TupleFunctionEmitTests
             result.Success,
             string.Join(Environment.NewLine, result.Diagnostics.Select(diagnostic => diagnostic.ToString())));
 
-        var assembly = Assembly.Load(peStream.ToArray());
+        var assembly = EmittedFixture.Load(peStream.ToArray());
         var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
 

--- a/test/Compiler.Tests/Emit/Issue2930ImportedConstructorCacheRemapTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2930ImportedConstructorCacheRemapTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -76,7 +77,7 @@ public class Issue2930ImportedConstructorCacheRemapTests
     private static void AssertRunsWithExactOutput(string source, string name, string expected)
     {
         var assemblyPath = Compile(source, name);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal(expected, Run(assemblyPath, name));
         IlVerifier.Verify(assemblyPath);

--- a/test/Compiler.Tests/Emit/Issue2931StructReceiverStateMachineTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2931StructReceiverStateMachineTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -291,7 +292,7 @@ public class Issue2931StructReceiverStateMachineTests
     private static void AssertRunsWithExactOutput(string source, string name, string expected)
     {
         var assemblyPath = Compile(source, name);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
 
         for (var i = 0; i < 6; i++)

--- a/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2933AsyncSelectArmBindingTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -478,7 +479,7 @@ public class Issue2933AsyncSelectArmBindingTests
         }
 
         Assert.True(exitCode == 0, $"{name}: gsc failed:\n{stdout}\n{stderr}");
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         return RunBounded(assemblyPath, name);
     }

--- a/test/Compiler.Tests/Emit/Issue2936SourceGenericReceiverCallTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2936SourceGenericReceiverCallTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -41,7 +42,7 @@ public class Issue2936SourceGenericReceiverCallTests
         {
             var assemblyPath = Compile(Source, directory);
             IlVerifier.Verify(assemblyPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             Assert.NotEmpty(assembly.GetTypes());
             Assert.Equal($"5{Environment.NewLine}", RunBounded(assemblyPath));
         }

--- a/test/Compiler.Tests/Emit/Issue2941FlagsEnumExhaustivenessTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2941FlagsEnumExhaustivenessTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -104,7 +105,7 @@ public class Issue2941FlagsEnumExhaustivenessTests
     public void NameCompleteEnumSwitches_LoadAndRunWithExactOutput()
     {
         var assemblyPath = Compile(Source);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
 
         for (var i = 0; i < 3; i++)
@@ -121,7 +122,7 @@ public class Issue2941FlagsEnumExhaustivenessTests
     public void UnmatchedFlagsValue_FailsLoudly()
     {
         var assemblyPath = Compile(UnmatchedSource);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
 
         var result = RunBounded(assemblyPath);

--- a/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2942ConditionalGotoFinallyFunnelTests.cs
@@ -15,6 +15,7 @@ using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -351,7 +352,7 @@ public class Issue2942ConditionalGotoFinallyFunnelTests
                   """);
 
             IlVerifier.Verify(assemblyPath);
-            Assert.NotEmpty(Assembly.Load(bytes).GetTypes());
+            Assert.NotEmpty(EmittedFixture.Load(bytes).GetTypes());
 
             var start = new ProcessStartInfo("dotnet")
             {

--- a/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2943LoopBackEdgeNarrowingTests.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using GSharp.Compiler;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 using GsCompilation = GSharp.Core.CodeAnalysis.Compilation.Compilation;
 using GsSyntaxTree = GSharp.Core.CodeAnalysis.Syntax.SyntaxTree;
@@ -982,7 +983,7 @@ public class Issue2943LoopBackEdgeNarrowingTests
                 Console.SetError(previousErr);
             }
 
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             _ = assembly.GetTypes();
 
             var startInfo = new ProcessStartInfo("dotnet")

--- a/test/Compiler.Tests/Emit/Issue2945StaticVirtualNullableErasureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2945StaticVirtualNullableErasureTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -201,7 +202,7 @@ public class Issue2945StaticVirtualNullableErasureTests
         try
         {
             var libraryPath = CompileGSharp(source, directory, "Issue2945Matrix.dll", target: "library");
-            _ = Assembly.Load(File.ReadAllBytes(libraryPath)).GetTypes();
+            _ = EmittedFixture.Load(libraryPath).GetTypes();
             var consumerPath = CompileCSharpConsumer(consumer, libraryPath, directory);
             Assert.Equal(expected + Environment.NewLine, RunChild(consumerPath, directory));
             IlVerifier.Verify(libraryPath);
@@ -241,7 +242,7 @@ public class Issue2945StaticVirtualNullableErasureTests
         try
         {
             var outputPath = CompileGSharp(source, directory, "Issue2945GSharp.dll", target: "exe");
-            _ = Assembly.Load(File.ReadAllBytes(outputPath)).GetTypes();
+            _ = EmittedFixture.Load(outputPath).GetTypes();
             Assert.Equal($"ok{Environment.NewLine}", RunChild(outputPath, directory));
             IlVerifier.Verify(
                 outputPath,

--- a/test/Compiler.Tests/Emit/Issue2951NestedGenericStructIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2951NestedGenericStructIteratorTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -508,7 +509,7 @@ public class Issue2951NestedGenericStructIteratorTests
     private static void AssertLoadsAndRuns(string source, string name, string expected)
     {
         var assemblyPath = Compile(source, name);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         Assert.Equal(expected, RunBounded(assemblyPath, name));
     }

--- a/test/Compiler.Tests/Emit/Issue2953FixedReturnFallthroughGuardTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2953FixedReturnFallthroughGuardTests.cs
@@ -12,6 +12,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -323,7 +324,7 @@ public class Issue2953FixedReturnFallthroughGuardTests
             string.Join(Environment.NewLine, emit.Diagnostics.Select(diagnostic => diagnostic.ToString())));
 
         var bytes = peStream.ToArray();
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(bytes);
         Assert.NotEmpty(assembly.GetTypes());
 
         var stem = $"Issue2953_{name}_{Guid.NewGuid():N}";

--- a/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2957FunctionLiteralIteratorTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -194,7 +195,7 @@ public sealed class Issue2957FunctionLiteralIteratorTests
     {
         var assemblyPath = Compile(name, source);
         IlVerifier.Verify(assemblyPath);
-        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        Assert.NotEmpty(EmittedFixture.Load(assemblyPath).GetTypes());
         Assert.Equal(expectedOutput, RunBounded(name, assemblyPath));
     }
 
@@ -252,7 +253,7 @@ public sealed class Issue2957FunctionLiteralIteratorTests
         }
 
         IlVerifier.Verify(assemblyPath);
-        Assert.NotEmpty(Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes());
+        Assert.NotEmpty(EmittedFixture.Load(assemblyPath).GetTypes());
         Assert.Equal($"ok{Environment.NewLine}", RunBounded(name, assemblyPath));
     }
 

--- a/test/Compiler.Tests/Emit/Issue2962ConstrainedStaticPropertyChainTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2962ConstrainedStaticPropertyChainTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 using Xunit.Sdk;
 
@@ -115,7 +116,7 @@ public class Issue2962ConstrainedStaticPropertyChainTests
         try
         {
             var assemblyPath = CompileSource(Source, directory, "Issue2962Chains.dll", target: "exe");
-            _ = Assembly.Load(File.ReadAllBytes(assemblyPath)).GetTypes();
+            _ = EmittedFixture.Load(assemblyPath).GetTypes();
             Assert.Equal(Expected, RunChild(assemblyPath, directory));
         }
         finally

--- a/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2965ChannelElementSlotTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -202,7 +203,7 @@ public class Issue2965ChannelElementSlotTests
     private static void AssertRuns(string source, string name, string expected)
     {
         var assemblyPath = Compile(source, name);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
 
         for (var i = 0; i < 3; i++)

--- a/test/Compiler.Tests/Emit/Issue3001StructComputedAccessorVirtualTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3001StructComputedAccessorVirtualTests.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -183,7 +184,7 @@ public class Issue3001StructComputedAccessorVirtualTests
     private static void AssertRuns(string source, string name, string expected)
     {
         var assemblyPath = Compile(source, name, target: "exe");
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
         IlVerifier.Verify(assemblyPath);
         Assert.Equal(expected, RunBounded(assemblyPath, name));

--- a/test/Compiler.Tests/Emit/Issue3067IteratorConstraintRemapTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3067IteratorConstraintRemapTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -209,7 +210,7 @@ public class Issue3067IteratorConstraintRemapTests
         try
         {
             var assemblyPath = Compile(source, directory);
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             var types = assembly.GetTypes();
             var stateMachine = Assert.Single(
                 types,

--- a/test/Compiler.Tests/Emit/Issue3081CompositeLiteralInheritedFieldTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3081CompositeLiteralInheritedFieldTests.cs
@@ -104,7 +104,7 @@ public class Issue3081CompositeLiteralInheritedFieldTests
 
             Assert.True(compile.ExitCode == 0, $"{name} emit failed:\n{compile.Stdout}\n{compile.Stderr}");
             Assert.Equal(string.Empty, compile.Stderr);
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             Assert.NotEmpty(assembly.GetTypes());
 
             using var process = Process.Start(new ProcessStartInfo("dotnet")

--- a/test/Compiler.Tests/Emit/Issue3090AwaitInvocationArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3090AwaitInvocationArgumentEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -230,6 +231,6 @@ public sealed class Issue3090AwaitInvocationArgumentEmitTests
             $"gsc failed:{Environment.NewLine}stdout:{Environment.NewLine}{stdout}" +
             $"{Environment.NewLine}stderr:{Environment.NewLine}{stderr}");
         IlVerifier.Verify(outputPath);
-        return Assembly.Load(File.ReadAllBytes(outputPath));
+        return EmittedFixture.Load(outputPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue3093SequenceInterfaceContractTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3093SequenceInterfaceContractTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -58,7 +59,7 @@ public sealed class Issue3093SequenceInterfaceContractTests
             var assemblyPath = Compile(Source, directory);
             Assert.Equal($"3{Environment.NewLine}3{Environment.NewLine}", Run(assemblyPath));
 
-            var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+            var assembly = EmittedFixture.Load(assemblyPath);
             var detector = assembly.GetType("Issue3093.User.Detector");
             Assert.NotNull(detector);
             Assert.All(

--- a/test/Compiler.Tests/Emit/Issue3304GoVoidOperandEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3304GoVoidOperandEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using GSharp.Compiler;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -58,7 +59,7 @@ public class Issue3304GoVoidOperandEmitTests
     private static void AssertRuns(string source, string name, string expected)
     {
         var assemblyPath = Compile(source, name);
-        var assembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+        var assembly = EmittedFixture.Load(assemblyPath);
         Assert.NotEmpty(assembly.GetTypes());
 
         for (var i = 0; i < 3; i++)

--- a/test/Compiler.Tests/Emit/Issue3352WhileLetEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3352WhileLetEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -241,7 +242,7 @@ public sealed class Issue3352WhileLetEmitTests
             Assert.Equal(0, exitCode);
             IlVerifier.Verify(outputPath);
 
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             var program = assembly.GetTypes().Single(type => type.Name == "<Program>");
             var entry = program.GetMethod(
                 "<Main>$",

--- a/test/Compiler.Tests/Emit/Issue3501LambdaWhilePatternCaptureTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501LambdaWhilePatternCaptureTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -123,7 +124,7 @@ public class Issue3501LambdaWhilePatternCaptureTests
                 exitCode == 0,
                 $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
             IlVerifier.Verify(outputPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");

--- a/test/Compiler.Tests/Emit/Issue3501NullableOutParameterStoreTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501NullableOutParameterStoreTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -88,7 +89,7 @@ public class Issue3501NullableOutParameterStoreTests
                 exitCode == 0,
                 $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
             IlVerifier.Verify(outputPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");

--- a/test/Compiler.Tests/Emit/Issue3501SpanForeachTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3501SpanForeachTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -112,7 +113,7 @@ public class Issue3501SpanForeachTests
                 exitCode == 0,
                 $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
             IlVerifier.Verify(outputPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");

--- a/test/Compiler.Tests/Emit/Issue3519PackageConstEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3519PackageConstEmitTests.cs
@@ -14,6 +14,7 @@ using System.Runtime.Loader;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 using CSharpCompilation = Microsoft.CodeAnalysis.CSharp.CSharpCompilation;
 using CSharpCompilationOptions = Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions;
@@ -626,7 +627,7 @@ public sealed class Issue3519PackageConstEmitTests
 
         public string OutputPath { get; }
 
-        public Assembly Load() => Assembly.Load(File.ReadAllBytes(OutputPath));
+        public Assembly Load() => EmittedFixture.Load(OutputPath);
 
         public void Dispose()
         {

--- a/test/Compiler.Tests/Emit/Issue3566SequenceToNonGenericEnumerableTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3566SequenceToNonGenericEnumerableTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -102,7 +103,7 @@ public class Issue3566SequenceToNonGenericEnumerableTests
                 exitCode == 0,
                 $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
             IlVerifier.Verify(outputPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");

--- a/test/Compiler.Tests/Emit/Issue3592SpillTempNameCollisionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3592SpillTempNameCollisionTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -111,7 +112,7 @@ public class Issue3592SpillTempNameCollisionTests
                 exitCode == 0,
                 $"gsc failed:\nstdout:\n{standardOut}\nstderr:\n{standardError}");
             IlVerifier.Verify(outputPath);
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             _ = assembly.GetTypes();
             var entryPoint = assembly.EntryPoint
                 ?? throw new InvalidOperationException("Emitted assembly has no entry point.");

--- a/test/Compiler.Tests/Emit/Issue3627VariadicCarrierEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3627VariadicCarrierEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -122,7 +123,7 @@ public class Issue3627VariadicCarrierEmitTests
         File.WriteAllText(srcPath, source);
         RunGsc(new[] { "/out:" + outPath, "/target:library", "/targetframework:net10.0", srcPath });
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileAndRun(string source)

--- a/test/Compiler.Tests/Emit/Issue3828EmittedFixtureIsolationTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3828EmittedFixtureIsolationTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="Issue3828EmittedFixtureIsolationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3828: an emitted test fixture must not become a reference for the
+/// next in-process compilation.
+/// </summary>
+/// <remarks>
+/// Emit tests run gsc in-process with no <c>/reference:</c> and then load the
+/// produced PE. Loading it into the default context left it visible to
+/// <c>ReferenceResolver.BuildHostAssemblies</c>, so a later fixture declaring
+/// the same package bound the earlier fixture's types and the compile failed
+/// inside gsc — <c>GS0156: Cannot convert type 'P.Color' to 'Color'</c> in
+/// <c>compiler-emit-remainder</c>, whenever class order put the colliding
+/// fixture first.
+/// </remarks>
+public class Issue3828EmittedFixtureIsolationTests
+{
+    private const string FirstFixture = """
+        package P
+        import System
+
+        enum Color { Red, Green, Blue }
+
+        func ToInt(c Color) int32 {
+            return int32(c)
+        }
+        """;
+
+    private const string SecondFixture = """
+        package P
+        import System
+
+        enum Color { Red, Green, Blue }
+
+        func FromInt(i int32) Color {
+            return Color(i)
+        }
+        """;
+
+    /// <summary>
+    /// Forces the order that made the shard fail: compile and load a fixture
+    /// declaring <c>P.Color</c>, then compile a second one declaring its own
+    /// <c>P.Color</c>. Before the fix the second compile fails with GS0156,
+    /// because it binds the first fixture's enum; both fixtures here also run,
+    /// so the isolation is proved at execution and not only at bind time.
+    /// </summary>
+    [Fact]
+    public void LoadedFixture_DoesNotShadow_TheNextCompilationOfTheSamePackage()
+    {
+        var first = CompileAndLoad(FirstFixture, "first");
+        var firstColor = first.GetTypes().Single(t => t.Name == "Color");
+        var toInt = first.GetTypes().Single(t => t.Name == "<Program>").GetMethod(
+            "ToInt",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(toInt);
+        Assert.Equal(2, toInt.Invoke(null, new[] { Enum.ToObject(firstColor, 2) }));
+
+        // The compile that GS0156 used to fail.
+        var second = CompileAndLoad(SecondFixture, "second");
+        var secondColor = second.GetTypes().Single(t => t.Name == "Color");
+        var fromInt = second.GetTypes().Single(t => t.Name == "<Program>").GetMethod(
+            "FromInt",
+            BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(fromInt);
+
+        var value = fromInt.Invoke(null, new object[] { 1 });
+        Assert.NotNull(value);
+        Assert.Equal(secondColor, value.GetType());
+        Assert.Equal("Green", value.ToString());
+
+        // Each fixture keeps its own enum identity; neither borrowed the other's.
+        Assert.NotSame(firstColor, secondColor);
+    }
+
+    /// <summary>
+    /// Pins the property <c>BuildHostAssemblies</c> keys on: a fixture loaded
+    /// through the shared helper lives in a collectible context, which that
+    /// scan skips. Unique assembly names would not give this — the leak, not
+    /// the name, is what made a fixture ambient.
+    /// </summary>
+    [Fact]
+    public void LoadedFixture_LivesInACollectibleContext_SoTheHostScanSkipsIt()
+    {
+        var assembly = CompileAndLoad(FirstFixture, "context");
+
+        var context = AssemblyLoadContext.GetLoadContext(assembly);
+        Assert.NotNull(context);
+        Assert.True(context.IsCollectible, "Emitted fixtures must load into a collectible context.");
+        Assert.NotSame(AssemblyLoadContext.Default, context);
+
+        Assert.DoesNotContain(
+            AppDomain.CurrentDomain.GetAssemblies(),
+            loaded => ReferenceEquals(loaded, assembly)
+                && !(AssemblyLoadContext.GetLoadContext(loaded)?.IsCollectible ?? false));
+    }
+
+    private static Assembly CompileAndLoad(string source, string assemblyName)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3828_").FullName;
+        var sourcePath = Path.Combine(directory, "test.gs");
+        var outputPath = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllText(sourcePath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int exitCode;
+        try
+        {
+            exitCode = Program.Main(new[]
+            {
+                "/out:" + outputPath,
+                "/target:library",
+                "/targetframework:net10.0",
+                sourcePath,
+            });
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(
+            exitCode == 0,
+            $"gsc failed for {assemblyName}:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        return EmittedFixture.Load(outputPath);
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue454ReceiverPredicateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue454ReceiverPredicateEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -217,7 +218,6 @@ public class Issue454ReceiverPredicateEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue502AsyncUserClassReturnTypeTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -300,8 +301,7 @@ public class Issue502AsyncUserClassReturnTypeTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static (int ExitCode, string Stdout, string Stderr) CompileRaw(string source)

--- a/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
+++ b/test/Compiler.Tests/Emit/Issue503ClosureCaptureRegressionTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -16,7 +17,7 @@ namespace GSharp.Compiler.Tests.Emit;
 //
 // Each test compiles a small G# source to a real DLL, IL-verifies it, loads
 // it into the current AppDomain, and exercises the closure via reflection.
-// `Assembly.Load(byte[])` is used deliberately — multiple fixtures share the
+// `EmittedFixture.Load(byte[])` is used deliberately — multiple fixtures share the
 // "MyLib" assembly name, and `Assembly.LoadFrom` would collide.
 public class Issue503ClosureCaptureRegressionTests
 {
@@ -847,8 +848,7 @@ public class Issue503ClosureCaptureRegressionTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileAndRunWithSiblingCs(string csSource, string gSource, string siblingName)

--- a/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue507MemberIndexAssignmentEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -522,7 +523,6 @@ public class Issue507MemberIndexAssignmentEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue641AsyncIteratorClassMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue641AsyncIteratorClassMemberEmitTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -546,8 +547,7 @@ public class Issue641AsyncIteratorClassMemberEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         // Run the entry point
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue648ChainedMemberAssignmentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue648ChainedMemberAssignmentEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -331,7 +332,6 @@ public class Issue648ChainedMemberAssignmentEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue652AwaitForAsyncEnumerableEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue652AwaitForAsyncEnumerableEmitTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -220,8 +221,7 @@ public class Issue652AwaitForAsyncEnumerableEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         // Run the entry point and capture stdout
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue654IfInLambdaEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue654IfInLambdaEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -166,8 +167,7 @@ public class Issue654IfInLambdaEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue655AsyncIteratorFieldAccessEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue655AsyncIteratorFieldAccessEmitTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -410,8 +411,7 @@ public class Issue655AsyncIteratorFieldAccessEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         // Run the entry point
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue660InlineDataNilEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue660InlineDataNilEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -138,8 +139,7 @@ public class Issue660InlineDataNilEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static (int ExitCode, string Stdout, string Stderr) CompileRaw(string source)

--- a/test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue689AsyncIteratorNestedFieldWriteEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -528,8 +529,7 @@ public class Issue689AsyncIteratorNestedFieldWriteEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         // Run the entry point.
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");

--- a/test/Compiler.Tests/Emit/Issue698DeinitEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue698DeinitEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -43,7 +44,7 @@ public class Issue698DeinitEmitTests
         {
             // Load the produced assembly in a fresh AppDomain-ish reflection
             // context so we can inspect the emitted Finalize method.
-            var asm = Assembly.LoadFile(asmPath);
+            var asm = EmittedFixture.Load(asmPath);
             var resource = asm.GetTypes().Single(t => t.Name == "Resource");
             var finalize = resource.GetMethod(
                 "Finalize",

--- a/test/Compiler.Tests/Emit/Issue798SharedStaticIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue798SharedStaticIteratorEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -256,8 +257,7 @@ public class Issue798SharedStaticIteratorEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue810OpenGenericIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue810OpenGenericIteratorEmitTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -303,8 +304,7 @@ public class Issue810OpenGenericIteratorEmitTests
     {
         var outPath = CompileToFile(source, target: "exe");
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -316,7 +316,7 @@ public class Issue810OpenGenericIteratorEmitTests
     private static Assembly CompileLibrary(string source)
     {
         var outPath = CompileToFile(source, target: "library");
-        return Assembly.LoadFile(outPath);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileToFile(string source, string target)

--- a/test/Compiler.Tests/Emit/Issue813TupleSequenceReturnEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue813TupleSequenceReturnEmitTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -382,8 +383,7 @@ public class Issue813TupleSequenceReturnEmitTests
     {
         var outPath = CompileToFile(source, target: "exe");
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -395,7 +395,7 @@ public class Issue813TupleSequenceReturnEmitTests
     private static Assembly CompileLibrary(string source)
     {
         var outPath = CompileToFile(source, target: "library");
-        return Assembly.LoadFile(outPath);
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileToFile(string source, string target)

--- a/test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue814OrNilOverloadEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -246,8 +247,7 @@ public class Issue814OrNilOverloadEmitTests
     private static Assembly CompileAndRun(string source)
     {
         var outPath = CompileToFile(source, target: "exe");
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue819PrimaryCtorVariadicEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue819PrimaryCtorVariadicEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -165,7 +166,7 @@ public class Issue819PrimaryCtorVariadicEmitTests
             CompileLibrary(gsSrc, gsDll);
             IlVerifier.Verify(gsDll);
 
-            var asm = System.Reflection.Assembly.LoadFrom(gsDll);
+            var asm = EmittedFixture.Load(gsDll);
             var flags = System.Reflection.BindingFlags.Public
                 | System.Reflection.BindingFlags.NonPublic
                 | System.Reflection.BindingFlags.Instance;

--- a/test/Compiler.Tests/Emit/Issue821SliceToInterfaceAtArgumentSlotEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue821SliceToInterfaceAtArgumentSlotEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -218,8 +219,7 @@ public class Issue821SliceToInterfaceAtArgumentSlotEmitTests
     {
         var outPath = CompileToFile(source);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue836IteratorTryFinallyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue836IteratorTryFinallyEmitTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -154,8 +155,7 @@ public class Issue836IteratorTryFinallyEmitTests
     {
         var outPath = CompileToFile(source, target: "exe");
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue910NestedTypeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue910NestedTypeEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -429,6 +430,6 @@ public class Issue910NestedTypeEmitTests
 
         Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
-        return System.Reflection.Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue936StaticOptionalParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue936StaticOptionalParameterEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -149,8 +150,7 @@ public class Issue936StaticOptionalParameterEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue937AwaitForBreakContinueEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue937AwaitForBreakContinueEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -284,8 +285,7 @@ public class Issue937AwaitForBreakContinueEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue938InBodyStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue938InBodyStructMethodEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -238,6 +239,6 @@ public class Issue938InBodyStructMethodEmitTests
         IlVerifier.Verify(outPath);
 
         var bytes = File.ReadAllBytes(outPath);
-        return (Assembly.Load(bytes), diagnostics);
+        return (EmittedFixture.Load(bytes), diagnostics);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue940StaticOverloadArityEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue940StaticOverloadArityEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -149,8 +150,7 @@ public class Issue940StaticOverloadArityEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue942IndexerIdentifierParseEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue942IndexerIdentifierParseEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -275,7 +276,6 @@ public class Issue942IndexerIdentifierParseEmitTests
             compileExit == 0,
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/Issue944IndexerDeclarationEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue944IndexerDeclarationEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -249,8 +250,7 @@ public class Issue944IndexerDeclarationEmitTests
     {
         var (exitCode, output, outPath) = CompileToFile(source);
         Assert.True(exitCode == 0, $"gsc failed:\n{output}");
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 
     private static (int ExitCode, string Output) TryCompile(string source)

--- a/test/Compiler.Tests/Emit/Issue973ClassValueTypeFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue973ClassValueTypeFieldEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -188,8 +189,7 @@ public class Issue973ClassValueTypeFieldEmitTests
 
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/Issue988TypeParameterConstructionEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue988TypeParameterConstructionEmitTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -140,7 +141,7 @@ public class Issue988TypeParameterConstructionEmitTests
         try
         {
             var outPath = CompileLibrary(source, tempDir);
-            var asm = Assembly.LoadFile(outPath);
+            var asm = EmittedFixture.Load(outPath);
             var factory = asm.GetTypes().First(t => t.Name.StartsWith("Factory", StringComparison.Ordinal));
             var tp = factory.GetGenericArguments().Single();
             Assert.True(

--- a/test/Compiler.Tests/Emit/Issue990UserClassIteratorEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue990UserClassIteratorEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -168,8 +169,7 @@ public class Issue990UserClassIteratorEmitTests
     private static Assembly CompileAndRun(string source)
     {
         var outPath = CompileToFile(source, target: "exe");
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
@@ -181,8 +181,7 @@ public class Issue990UserClassIteratorEmitTests
     private static string CompileRunAndCaptureOutput(string source)
     {
         var outPath = CompileToFile(source, target: "exe");
-        var bytes = File.ReadAllBytes(outPath);
-        var assembly = Assembly.Load(bytes);
+        var assembly = EmittedFixture.Load(outPath);
 
         var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
         var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);

--- a/test/Compiler.Tests/Emit/LetFieldEmitTests.cs
+++ b/test/Compiler.Tests/Emit/LetFieldEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -95,7 +96,6 @@ public class LetFieldEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/NamedArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedArgumentEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -370,7 +371,6 @@ public class NamedArgumentEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/NamedDelegateEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedDelegateEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -145,7 +146,6 @@ public class NamedDelegateEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/NamedTupleMetadataEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedTupleMetadataEmitTests.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -253,7 +254,7 @@ public class NamedTupleMetadataEmitTests
         File.WriteAllText(srcPath, source);
         RunGsc(new[] { "/out:" + outPath, "/target:library", "/targetframework:net10.0", srcPath });
         IlVerifier.Verify(outPath);
-        return Assembly.Load(File.ReadAllBytes(outPath));
+        return EmittedFixture.Load(outPath);
     }
 
     private static string CompileAndRunWithLibrary(string libSource, string appSource, string libraryName = "namedlib")

--- a/test/Compiler.Tests/Emit/PropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/PropertyEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -436,7 +437,6 @@ public class PropertyEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructMethodEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -436,7 +437,6 @@ public class UserStructMethodEmitTests
             ignoredErrorCodes: ignoredErrorScope is null ? null : IlVerifier.KnownIssues.RefStruct,
             ignoredErrorScope: ignoredErrorScope);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
+++ b/test/Compiler.Tests/Emit/UserStructPropertyEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -265,7 +266,6 @@ public class UserStructPropertyEmitTests
             $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
         IlVerifier.Verify(outPath);
 
-        var bytes = File.ReadAllBytes(outPath);
-        return Assembly.Load(bytes);
+        return EmittedFixture.Load(outPath);
     }
 }

--- a/test/Compiler.Tests/Emit/VariadicEmitTests.cs
+++ b/test/Compiler.Tests/Emit/VariadicEmitTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests.Emit;
@@ -287,7 +288,7 @@ public class VariadicEmitTests
                 $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
             IlVerifier.Verify(gsDll);
 
-            var asm = System.Reflection.Assembly.LoadFrom(gsDll);
+            var asm = EmittedFixture.Load(gsDll);
             var programType = asm.GetTypes().Single(t => t.Namespace == "GsVariadicLib" && t.Name == "<Program>");
 
             var sumMethod = programType.GetMethod("Sum", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
@@ -556,7 +557,7 @@ public class VariadicEmitTests
             CompileLibrary(gsSrc, gsDll);
             IlVerifier.Verify(gsDll);
 
-            var asm = System.Reflection.Assembly.LoadFrom(gsDll);
+            var asm = EmittedFixture.Load(gsDll);
             var flags = System.Reflection.BindingFlags.Public
                 | System.Reflection.BindingFlags.NonPublic
                 | System.Reflection.BindingFlags.Static
@@ -624,7 +625,7 @@ public class VariadicEmitTests
             CompileLibrary(gsSrc, gsDll);
             IlVerifier.Verify(gsDll);
 
-            var asm = System.Reflection.Assembly.LoadFrom(gsDll);
+            var asm = EmittedFixture.Load(gsDll);
             var stringJoinerType = asm.GetTypes().Single(t => t.Name == "StringJoiner");
             var invokeMethod = stringJoinerType.GetMethod("Invoke");
             Assert.NotNull(invokeMethod);

--- a/test/Compiler.Tests/Issue2215AnalyzerFlagTests.cs
+++ b/test/Compiler.Tests/Issue2215AnalyzerFlagTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using GSharp.Gsgen.Cli;
+using GSharp.Tests;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -129,7 +130,7 @@ public class Issue2215AnalyzerFlagTests
         Assert.True(exit == 0, $"gsc failed:\nstdout:\n{outWriter}\nstderr:\n{errWriter}");
         Assert.True(File.Exists(outPath));
 
-        var assembly = Assembly.Load(File.ReadAllBytes(outPath));
+        var assembly = EmittedFixture.Load(outPath);
         var foo = assembly.GetTypes().Single(t => t.Name == "Foo");
 
         // "Greeting" only exists on Foo if gsc actually ran the generator (via
@@ -190,7 +191,7 @@ public class Issue2215AnalyzerFlagTests
         Assert.True(exit == 0, $"gsc failed:\nstdout:\n{outWriter}\nstderr:\n{errWriter}");
         Assert.True(File.Exists(outPath));
 
-        var assembly = Assembly.Load(File.ReadAllBytes(outPath));
+        var assembly = EmittedFixture.Load(outPath);
         var foo = assembly.GetTypes().Single(t => t.Name == "Foo");
 
         // Only present if gsgen actually ran (paths tokenized correctly) and

--- a/test/Compiler.Tests/Issue2920ReleaseJitOptimizerTests.cs
+++ b/test/Compiler.Tests/Issue2920ReleaseJitOptimizerTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests;
@@ -71,7 +72,7 @@ public class Issue2920ReleaseJitOptimizerTests
             Assert.Equal(expectPdb, File.Exists(pdbPath));
             IlVerifier.Verify(outputPath);
 
-            var assembly = Assembly.Load(File.ReadAllBytes(outputPath));
+            var assembly = EmittedFixture.Load(outputPath);
             Assert.NotEmpty(assembly.GetTypes());
             var debuggable = assembly.GetCustomAttribute<DebuggableAttribute>();
             Assert.NotNull(debuggable);

--- a/test/Compiler.Tests/LanguageConformance/DriverConformanceHarness.cs
+++ b/test/Compiler.Tests/LanguageConformance/DriverConformanceHarness.cs
@@ -387,7 +387,7 @@ internal static class DriverConformanceHarness
                 additionalReferences: usesExtensions ? new[] { extensionsAssemblyPath } : null,
                 ignoredErrorCodes: knownIlIssues.ErrorCodes,
                 ignoredErrorScope: knownIlIssues.Scope);
-            Assembly.Load(File.ReadAllBytes(outputPath)).GetTypes();
+            EmittedFixture.Load(outputPath).GetTypes();
             string ilDump = captureIl ? NormalizedIlDump.Create(outputPath) : null;
             IReadOnlyList<string> assemblyReferences = captureIl
                 ? NormalizedIlDump.AssemblyReferenceNames(outputPath)

--- a/test/Compiler.Tests/ProgramTests.cs
+++ b/test/Compiler.Tests/ProgramTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Compiler.Tests;
@@ -139,7 +140,7 @@ public class ProgramTests
             var runtimeConfig = Path.ChangeExtension(outPath, ".runtimeconfig.json");
             Assert.True(File.Exists(runtimeConfig), "expected runtimeconfig.json beside output");
             Assert.Contains("Microsoft.NETCore.App", File.ReadAllText(runtimeConfig));
-            var assembly = Assembly.Load(File.ReadAllBytes(outPath));
+            var assembly = EmittedFixture.Load(outPath);
             var targetFramework = assembly.GetCustomAttribute<System.Runtime.Versioning.TargetFrameworkAttribute>();
             Assert.Equal(".NETCoreApp,Version=v10.0", targetFramework?.FrameworkName);
         }
@@ -195,7 +196,7 @@ public class ProgramTests
             });
 
             Assert.Equal(0, exit);
-            var assembly = Assembly.Load(File.ReadAllBytes(outPath));
+            var assembly = EmittedFixture.Load(outPath);
             using var stream = assembly.GetManifestResourceStream("Demo.Payload");
             Assert.NotNull(stream);
             using var reader = new StreamReader(stream!);

--- a/test/Core.Tests/CodeAnalysis/Binding/GenericMethodUserTypeArgUnderReferencesTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/GenericMethodUserTypeArgUnderReferencesTests.cs
@@ -13,6 +13,7 @@ using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 using Binder = GSharp.Core.CodeAnalysis.Binding.Binder;
 
@@ -93,7 +94,7 @@ public class GenericMethodUserTypeArgUnderReferencesTests
         var result = compilation.Emit(stream);
         Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
 
-        var assembly = Assembly.Load(stream.ToArray());
+        var assembly = EmittedFixture.Load(stream.ToArray());
         var main = assembly.GetTypes()
             .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
             .SingleOrDefault(method => method.Name == "main" && method.GetParameters().Length == 0);

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1019StaticInterfacePropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1019StaticInterfacePropertyTests.cs
@@ -248,6 +248,6 @@ sealed interface IData {
             result.Success,
             "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
 
-        _ = System.Reflection.Assembly.Load(peStream.ToArray()).GetTypes();
+        _ = EmittedFixture.Load(peStream.ToArray()).GetTypes();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2150DataClassInterfacePropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2150DataClassInterfacePropertyTests.cs
@@ -11,6 +11,7 @@ using GSharp.Core.CodeAnalysis;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Binding;
@@ -511,6 +512,6 @@ public class Issue2150DataClassInterfacePropertyTests
             result.Success,
             "compilation should succeed: " + string.Join("; ", result.Diagnostics.Select(d => d.Message)));
 
-        _ = System.Reflection.Assembly.Load(peStream.ToArray()).GetTypes();
+        _ = EmittedFixture.Load(peStream.ToArray()).GetTypes();
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3065MethodSpecRemapKeyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3065MethodSpecRemapKeyTests.cs
@@ -16,6 +16,7 @@ using GSharp.Core.CodeAnalysis.Emit;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
 using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
 using Xunit;
 
 namespace GSharp.Core.Tests.CodeAnalysis.Emit;
@@ -92,7 +93,7 @@ public class Issue3065MethodSpecRemapKeyTests
     [Fact]
     public void GenericLambdaMethodSpecs_WithDistinctRemaps_EmitRunnableAssembly()
     {
-        var assembly = Assembly.Load(Emit());
+        var assembly = EmittedFixture.Load(Emit());
         Assert.NotEmpty(assembly.GetTypes());
         var entryPoint = Assert.IsAssignableFrom<MethodInfo>(assembly.EntryPoint);
 

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\EmittedFixture.cs" Link="EmittedFixture.cs" />
     <Compile Include="..\Shared\EmittedOracle.cs" Link="EmittedOracle.cs" />
     <Compile Include="..\Shared\EmittedOracleOptions.cs" Link="EmittedOracleOptions.cs" />
     <Compile Include="..\Shared\EmittedOracleResult.cs" Link="EmittedOracleResult.cs" />

--- a/test/Shared/EmittedFixture.cs
+++ b/test/Shared/EmittedFixture.cs
@@ -1,0 +1,185 @@
+// <copyright file="EmittedFixture.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace GSharp.Tests;
+
+/// <summary>
+/// Loads a compiler-emitted test fixture assembly for reflection and
+/// in-process invocation without making it ambient to later compilations
+/// (issue #3828).
+/// </summary>
+/// <remarks>
+/// <para><b>Why this exists.</b> Emit tests run gsc in-process
+/// (<c>Program.Main</c>) and then load the produced PE so they can invoke it.
+/// The historical pattern — <c>Assembly.Load(bytes)</c> or
+/// <c>Assembly.LoadFrom(path)</c> — puts every fixture into the default,
+/// non-collectible load context, permanently.
+/// <c>ReferenceResolver.BuildHostAssemblies</c> enumerates
+/// <c>AppDomain.CurrentDomain.GetAssemblies()</c> and excludes only dynamic
+/// and <em>collectible</em> contexts (issue #3235), so every fixture already
+/// loaded that way is offered to every later in-process compile as a
+/// reference. A later fixture declaring the same package as an earlier one
+/// then binds the earlier fixture's types and the compile fails inside gsc —
+/// the observed <c>GS0156: Cannot convert type 'P.Color' to 'Color'</c>. The
+/// symptom is order-dependent because it needs the colliding fixture to have
+/// been loaded first, and xUnit's class order varies per process.</para>
+/// <para><b>What this does.</b> Each fixture is loaded into its own
+/// collectible <see cref="AssemblyLoadContext"/>, which
+/// <c>BuildHostAssemblies</c> already excludes, so the fixture simply stops
+/// being ambient. Unique per-test package or assembly names would only make
+/// the collision rarer; they would not close the gap, because the leak — not
+/// the name — is the defect.</para>
+/// <para><b>Dependency resolution.</b> The fixture's context prefers the
+/// host's identity for anything the default context can supply (the
+/// framework, <c>Gsharp.Extensions</c>, the test assembly, and any reference
+/// assembly the test itself loaded), so types shared with the test still
+/// compare equal. Only what the default context cannot supply is probed for
+/// beside the fixture and loaded privately.</para>
+/// <para><b>Lifetime.</b> The context is collectible but is deliberately not
+/// unloaded: emit tests hold types, delegates, and running state from the
+/// fixture for the rest of the test, and some invoke asynchronous code whose
+/// completion outlives the call. Nothing is reclaimed earlier than it was
+/// before this helper existed; the change is which context the fixture lives
+/// in, not how long it lives.</para>
+/// </remarks>
+public static class EmittedFixture
+{
+    /// <summary>
+    /// Loads the emitted assembly at <paramref name="assemblyPath"/> into a
+    /// fresh collectible context that probes the assembly's own directory for
+    /// dependencies the host cannot supply.
+    /// </summary>
+    /// <param name="assemblyPath">Path to the emitted assembly.</param>
+    /// <returns>The loaded assembly.</returns>
+    public static Assembly Load(string assemblyPath)
+    {
+        if (assemblyPath is null)
+        {
+            throw new ArgumentNullException(nameof(assemblyPath));
+        }
+
+        var fullPath = Path.GetFullPath(assemblyPath);
+        var context = CreateContext(Path.GetDirectoryName(fullPath));
+
+        // Load from bytes so the file stays deletable — emit tests routinely
+        // clean up their temp directory while still asserting on the assembly.
+        return context.LoadFromStream(new MemoryStream(File.ReadAllBytes(fullPath)));
+    }
+
+    /// <summary>
+    /// Loads an emitted assembly image into a fresh collectible context.
+    /// </summary>
+    /// <param name="rawAssembly">The emitted PE image.</param>
+    /// <param name="probeDirectory">Directory to probe for dependencies the host cannot supply; may be <see langword="null"/>.</param>
+    /// <returns>The loaded assembly.</returns>
+    public static Assembly Load(byte[] rawAssembly, string probeDirectory = null)
+    {
+        if (rawAssembly is null)
+        {
+            throw new ArgumentNullException(nameof(rawAssembly));
+        }
+
+        var context = CreateContext(probeDirectory);
+        return context.LoadFromStream(new MemoryStream(rawAssembly));
+    }
+
+    /// <summary>
+    /// Loads several emitted assemblies into <em>one</em> collectible context,
+    /// for tests that assert across them — a type from one fixture only
+    /// compares equal to the same type seen through another fixture when both
+    /// were loaded into the same context.
+    /// </summary>
+    /// <param name="assemblyPaths">Paths to the emitted assemblies, in load order.</param>
+    /// <returns>The loaded assemblies, in the same order.</returns>
+    public static Assembly[] LoadTogether(params string[] assemblyPaths)
+    {
+        if (assemblyPaths is null)
+        {
+            throw new ArgumentNullException(nameof(assemblyPaths));
+        }
+
+        var probeDirectories = new List<string>();
+        var fullPaths = new string[assemblyPaths.Length];
+        for (var i = 0; i < assemblyPaths.Length; i++)
+        {
+            fullPaths[i] = Path.GetFullPath(assemblyPaths[i]);
+            var directory = Path.GetDirectoryName(fullPaths[i]);
+            if (directory is not null && !probeDirectories.Contains(directory))
+            {
+                probeDirectories.Add(directory);
+            }
+        }
+
+        var context = CreateContext(probeDirectories);
+        var loaded = new Assembly[fullPaths.Length];
+        for (var i = 0; i < fullPaths.Length; i++)
+        {
+            loaded[i] = context.LoadFromStream(new MemoryStream(File.ReadAllBytes(fullPaths[i])));
+        }
+
+        return loaded;
+    }
+
+    private static AssemblyLoadContext CreateContext(string probeDirectory)
+        => CreateContext(probeDirectory is null ? new List<string>() : new List<string> { probeDirectory });
+
+    private static AssemblyLoadContext CreateContext(IReadOnlyList<string> probeDirectories)
+    {
+        var context = new AssemblyLoadContext(
+            "gsharp-emitted-fixture-" + Guid.NewGuid().ToString("N"),
+            isCollectible: true);
+        context.Resolving += (resolving, name) => Resolve(resolving, name, probeDirectories);
+        return context;
+    }
+
+    private static Assembly Resolve(
+        AssemblyLoadContext context,
+        AssemblyName assemblyName,
+        IReadOnlyList<string> probeDirectories)
+    {
+        // The host's identity wins: the framework, Gsharp.Extensions, the
+        // test assembly, and any reference assembly the test loaded itself
+        // must stay one type identity across the fixture boundary, or
+        // assertions comparing them silently fail.
+        try
+        {
+            var fromHost = AssemblyLoadContext.Default.LoadFromAssemblyName(assemblyName);
+            if (fromHost is not null)
+            {
+                return fromHost;
+            }
+        }
+        catch (FileNotFoundException)
+        {
+        }
+        catch (FileLoadException)
+        {
+        }
+        catch (BadImageFormatException)
+        {
+        }
+
+        if (assemblyName.Name is null)
+        {
+            return null;
+        }
+
+        foreach (var directory in probeDirectories)
+        {
+            var candidate = Path.Combine(directory, assemblyName.Name + ".dll");
+            if (File.Exists(candidate))
+            {
+                return context.LoadFromStream(new MemoryStream(File.ReadAllBytes(candidate)));
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #3828.

Emit tests run gsc in-process with no `/reference:` and then load the produced
PE so they can invoke it. `Assembly.Load(bytes)` / `Assembly.LoadFrom(path)` put
every fixture into the **default, non-collectible** load context, permanently.
`ReferenceResolver.BuildHostAssemblies()` enumerates
`AppDomain.CurrentDomain.GetAssemblies()` and excludes only dynamic and
*collectible* contexts (#3235), so every fixture loaded that way is offered to
every later in-process compile as a reference.

`EnumEmitTests` emits `package P` with an `enum Color`. When its fixture is
loaded before `ConversionEmitTests.Int32_To_Enum_Cast_Produces_Corresponding_Enum_Value`
compiles its own `package P` / `enum Color`, gsc binds the leaked one and the
compile fails inside the compiler:

```
test.gs(7,12,7,20): error GS0156: Cannot convert type 'P.Color' to 'Color'.
```

xUnit's class order varies per process and intra-class order does not, which is
the whole of the intermittency — and why the class alone is green in isolation.

## The fix

`test/Shared/EmittedFixture.cs` loads each fixture into its own collectible
`AssemblyLoadContext`, which `BuildHostAssemblies` already skips, so the fixture
simply stops being ambient. Unique per-test package or assembly names were
considered and rejected: they make the collision rarer without closing it,
because the leak — not the name — is the defect.

The fixture's context prefers the host's identity for anything the default
context can supply (framework, `Gsharp.Extensions`, the test assembly, any
reference the test loaded itself) so shared types still compare equal; only what
the host cannot supply is probed for beside the fixture. `LoadTogether` puts
several fixtures in one context for the handful of tests that assert across a
library and its consumer. The context is deliberately not unloaded — emit tests
hold types and running state for the rest of the test, and nothing is reclaimed
later than it was before.

The pattern was copied across ~215 call sites in ~165 files, so this converts
them all rather than the one call site the issue was filed about.

Three sites keep the default context on purpose, because they deliberately use
the ambient channel this closes: `Issue750ConstraintOverloadEmittedOracleTests`
and `SyncMapImportEmittedOracleTests` seed `Gsharp.Extensions` into the host so
the binder can see it, and `Issue2947Imported*` loads a library specifically to
assert that an ambient host assembly is bound.

## Evidence

Reproduction: `EnumEmitTests` + `ConversionEmitTests` in one test host, which
fails with the exact CI signature and runs in well under a minute.

| | runs | failing runs |
|---|---|---|
| before (`main` @ 7a6fa9f35) | 30 | 15 (50%) |
| after | 30 | 0 |

Every one of the 15 failures was
`Int32_To_Enum_Cast_Produces_Corresponding_Enum_Value` with the GS0156 message
above.

`Issue3828EmittedFixtureIsolationTests` pins both halves and executes rather
than only binding: it forces the failing order and invokes both fixtures'
functions, and it asserts the loaded fixture lives in a collectible context —
the property `BuildHostAssemblies` keys on. Both fail on `main` when the helper
call is replaced with the historical `Assembly.Load(File.ReadAllBytes(...))`.

Refs #3818, #3825, #3235. The process-wide `Type` cache that let a `Type` cross
compilations is #3826 and is untouched here; no `src/` file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
