### PR TITLE
gsc: the imported-type-symbol cache must be load-context sensitive (#3826)

### DIFF
--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -114,9 +114,18 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             throw new ArgumentNullException(nameof(type));
         }
 
+        // Issue #3826: the comparer must be load-context sensitive. Keying on
+        // the assembly-qualified name alone (TypeIdentityComparer) aliases two
+        // copies of one logical type loaded into different contexts, so a
+        // symbol — and the CLR Type it carries — created by one compilation
+        // answers a later compilation's lookup. The outer bucket does not
+        // prevent that: a constructed generic like ImmutableArray[SyntaxNode]
+        // is keyed by ITS OWN assembly (the host's System.Collections.Immutable,
+        // shared by every compilation in the process) while its argument comes
+        // from a private reference context.
         var assemblyCache = Cache.GetValue(
             type.Assembly,
-            static _ => new ConcurrentDictionary<Type, ImportedTypeSymbol>(TypeIdentityComparer.Instance));
+            static _ => new ConcurrentDictionary<Type, ImportedTypeSymbol>(LoadContextSensitiveTypeComparer.Instance));
         return assemblyCache.GetOrAdd(type, static t => new ImportedTypeSymbol(t));
     }
 
@@ -339,9 +348,16 @@ public sealed class ImportedTypeSymbol : TypeSymbol
     }
 
     /// <summary>
-    /// Legacy dispose hook. The cache is weakly keyed by assembly and each
-    /// per-assembly dictionary uses metadata identity for CLR types, so disposed
-    /// metadata contexts are collectable without process-wide clearing.
+    /// Legacy dispose hook, deliberately a NO-OP since #2341: the cache is
+    /// weakly keyed by assembly, so a disposed context's entries are
+    /// collectable without process-wide clearing.
+    /// <para>
+    /// Issue #3826: do NOT reintroduce clearing here as a fix for a
+    /// cross-compilation identity bug. Entries surviving a dispose is by
+    /// design; entries being FOUND by a different compilation's lookup was the
+    /// defect, and that is a property of the key
+    /// (<see cref="LoadContextSensitiveTypeComparer"/>), not of the lifetime.
+    /// </para>
     /// </summary>
     internal static void ClearCache()
     {

--- a/src/Core/CodeAnalysis/Symbols/LoadContextSensitiveTypeComparer.cs
+++ b/src/Core/CodeAnalysis/Symbols/LoadContextSensitiveTypeComparer.cs
@@ -1,0 +1,129 @@
+// <copyright file="LoadContextSensitiveTypeComparer.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using GSharp.Core.CodeAnalysis.Emit;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3826 (the #3705 load-context family): compares <see cref="Type"/>
+/// instances the way <see cref="TypeIdentityComparer"/> does — by structural
+/// identity — but ADDITIONALLY requires that every assembly the type is built
+/// from is the same <see cref="System.Reflection.Assembly"/> INSTANCE.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="TypeIdentityComparer"/> keys on
+/// <see cref="Type.AssemblyQualifiedName"/>. Two copies of the same file loaded
+/// into two different <see cref="System.Runtime.Loader.AssemblyLoadContext"/>s
+/// have the SAME assembly-qualified name, so that comparer treats them as one
+/// type. That is exactly what #420 wanted for the emitter (collapsing duplicate
+/// <c>TypeRef</c> rows for one logical type reached by several paths inside ONE
+/// context), and exactly what a process-wide symbol cache must NOT do: it makes
+/// a <see cref="Type"/> from one compilation answer a later compilation's
+/// lookup.
+/// </para>
+/// <para>
+/// The dangerous case is a constructed generic whose DEFINITION lives in a
+/// shared assembly but whose ARGUMENTS come from a private reference context —
+/// <c>ImmutableArray&lt;SyntaxNode&gt;</c>, say. <c>ImportedTypeSymbol</c>'s
+/// outer cache bucket is keyed by <c>type.Assembly</c>, which for both
+/// constructions is the one host <c>System.Collections.Immutable</c>; only the
+/// inner comparer separates them, and a name-only comparer does not. The
+/// resulting cross-context symbol is silently wrong: closing a generic method
+/// over an operand from each side makes
+/// <see cref="System.Reflection.MethodInfo.MakeGenericMethod"/> throw, overload
+/// resolution drops the candidate per C# §7.5.2, and the call reports "Cannot
+/// find function &lt;name&gt;" about a method that plainly exists (#3818).
+/// </para>
+/// <para>
+/// Equality therefore keeps the structural check and adds a walk over the
+/// type's constituents (element type, generic arguments) requiring
+/// reference-equal assemblies at every position — the same "hash is a bucketing
+/// hint, equality is the real test" shape as <see cref="TypeArgsKey"/>. Two
+/// instances of one logical type reached by different paths inside a single
+/// context still collapse, because a load context returns one
+/// <see cref="System.Reflection.Assembly"/> instance per identity.
+/// </para>
+/// </remarks>
+internal sealed class LoadContextSensitiveTypeComparer : IEqualityComparer<Type>
+{
+    /// <summary>The singleton instance.</summary>
+    public static readonly LoadContextSensitiveTypeComparer Instance = new();
+
+    private LoadContextSensitiveTypeComparer()
+    {
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(Type? x, Type? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return TypeIdentityComparer.Instance.Equals(x, y) && SameAssemblyInstances(x, y);
+    }
+
+    /// <inheritdoc/>
+    public int GetHashCode(Type obj) => TypeIdentityComparer.Instance.GetHashCode(obj);
+
+    /// <summary>
+    /// Walks two structurally identical types in parallel, requiring the same
+    /// <see cref="System.Reflection.Assembly"/> instance at every position.
+    /// </summary>
+    /// <param name="x">The first type.</param>
+    /// <param name="y">The second type, structurally equal to <paramref name="x"/>.</param>
+    /// <returns><see langword="true"/> when both are built from the same assembly instances.</returns>
+    private static bool SameAssemblyInstances(Type x, Type y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (!ReferenceEquals(x.Assembly, y.Assembly))
+        {
+            return false;
+        }
+
+        if (x.HasElementType && y.HasElementType)
+        {
+            Type? xElement = x.GetElementType();
+            Type? yElement = y.GetElementType();
+            if (xElement is not null && yElement is not null && !SameAssemblyInstances(xElement, yElement))
+            {
+                return false;
+            }
+        }
+
+        // Structural equality already guarantees matching arity; the length
+        // guard keeps this total for the pathological reflection shapes
+        // (generic parameters, function pointers) that report otherwise.
+        Type[] xArguments = x.GenericTypeArguments;
+        Type[] yArguments = y.GenericTypeArguments;
+        if (xArguments.Length != yArguments.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < xArguments.Length; i++)
+        {
+            if (!SameAssemblyInstances(xArguments[i], yArguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -251,13 +251,13 @@ public sealed class ReferenceResolver : IDisposable
         metadataContext?.Dispose();
         runtimeContext?.Unload();
 
-        // The static ImportedTypeSymbol cache may hold Type instances that
-        // originated from the now-disposed MetadataLoadContext. Those entries
-        // are unreachable from future compilations and pin the disposed
-        // context's managed object graph. Clearing the cache allows them to
-        // be collected. This is safe because each compilation rebuilds the
-        // cache organically; the only cost is a cold cache on the next
-        // compilation that reuses the same process.
+        // Kept as a call site for symmetry with the caches below, but note
+        // that ImportedTypeSymbol.ClearCache is deliberately a NO-OP: that
+        // cache is weakly keyed by assembly, so a disposed context's entries
+        // become collectable on their own (#2341). Cross-compilation IDENTITY
+        // — a symbol from one compilation answering another's lookup — is not
+        // a lifetime question and is not addressed here; it is handled by the
+        // load-context-sensitive key that cache uses (#3826).
         ImportedTypeSymbol.ClearCache();
 
         // FunctionTypeSymbol eagerly closes a host-runtime Func/Action over

--- a/test/Core.Tests/CodeAnalysis/Symbols/Issue3826CrossCompilationTypeIdentityTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Symbols/Issue3826CrossCompilationTypeIdentityTests.cs
@@ -1,0 +1,154 @@
+// <copyright file="Issue3826CrossCompilationTypeIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Symbols;
+
+/// <summary>
+/// Issue #3826, in the #3705 load-context family: a CLR <see cref="Type"/> from
+/// one compilation must never reach a later compilation's binder.
+/// <para>
+/// The carrier was <c>ImportedTypeSymbol</c>'s process-wide cache. Its outer
+/// bucket is keyed by <c>type.Assembly</c> and its inner dictionary compared
+/// types with <c>TypeIdentityComparer</c>, i.e. by
+/// <see cref="Type.AssemblyQualifiedName"/>. Two copies of one assembly loaded
+/// into two private reference contexts share that name, so the two lookups
+/// collided. The outer bucket did not separate them either, because for a
+/// constructed generic whose definition lives in a SHARED assembly — e.g.
+/// <c>ImmutableArray&lt;SyntaxNode&gt;</c>, keyed by the host's single
+/// <c>System.Collections.Immutable</c> — both compilations land in the same
+/// bucket.
+/// </para>
+/// <para>
+/// The consequence was opaque. The second compilation received the first's
+/// symbol, so a loop variable bound from
+/// <c>ImmutableArray&lt;SyntaxNode&gt;</c> carried the FIRST compilation's
+/// <c>SyntaxNode</c> while an explicit type argument came from the second's;
+/// <see cref="MethodInfo.MakeGenericMethod"/> then throws, overload resolution
+/// drops the sole candidate silently (C# §7.5.2), and the call reports "Cannot
+/// find function" about a method that plainly exists (#3818).
+/// </para>
+/// </summary>
+public class Issue3826CrossCompilationTypeIdentityTests : IDisposable
+{
+    private readonly string workDirectory;
+
+    /// <summary>Initializes a new instance of the <see cref="Issue3826CrossCompilationTypeIdentityTests"/> class.</summary>
+    public Issue3826CrossCompilationTypeIdentityTests()
+    {
+        this.workDirectory = Path.Combine(
+            Path.GetTempPath(), "gs-issue3826-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(this.workDirectory);
+
+        // A copy at a path the host has not loaded is a genuinely private
+        // reference: #3825's path-equality reuse does not apply, so each
+        // resolver really does mint its own copy — the case #3826 says is
+        // still reachable in production (a real /reference: to a user
+        // assembly, cross-targeting).
+        string hostDirectory = Path.GetDirectoryName(typeof(SyntaxNode).Assembly.Location)
+            ?? throw new InvalidOperationException("the host assembly has a directory");
+        foreach (string dll in Directory.GetFiles(hostDirectory, "*.dll"))
+        {
+            File.Copy(dll, Path.Combine(this.workDirectory, Path.GetFileName(dll)), overwrite: true);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(this.workDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A best-effort cleanup; a locked file must not fail the test.
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void TwoPrivateReferenceContextsOverTheSamePath_ProduceDistinctTypes()
+    {
+        (Type first, Type second) = ResolveFromTwoPrivateContexts();
+
+        Assert.NotSame(first, second);
+        Assert.NotSame(first.Assembly, second.Assembly);
+
+        // The two are indistinguishable by name — which is precisely why a
+        // name-keyed cache aliased them.
+        Assert.Equal(first.AssemblyQualifiedName, second.AssemblyQualifiedName);
+    }
+
+    [Fact]
+    public void ConstructedGenericFromASharedAssembly_DoesNotAliasAcrossContexts()
+    {
+        (Type firstNode, Type secondNode) = ResolveFromTwoPrivateContexts();
+
+        // ImmutableArray<T> itself comes from the host's single
+        // System.Collections.Immutable, so both constructions share the cache's
+        // outer per-assembly bucket; only the inner key can separate them.
+        Type firstArray = typeof(ImmutableArray<>).MakeGenericType(firstNode);
+        Type secondArray = typeof(ImmutableArray<>).MakeGenericType(secondNode);
+        Assert.Same(firstArray.Assembly, secondArray.Assembly);
+        Assert.Equal(firstArray.AssemblyQualifiedName, secondArray.AssemblyQualifiedName);
+
+        ImportedTypeSymbol firstSymbol = ImportedTypeSymbol.Get(firstArray);
+        ImportedTypeSymbol secondSymbol = ImportedTypeSymbol.Get(secondArray);
+
+        Assert.NotSame(firstSymbol, secondSymbol);
+        Assert.Same(firstArray, firstSymbol.Type);
+        Assert.Same(secondArray, secondSymbol.Type);
+    }
+
+    [Fact]
+    public void ACachedSymbolNeverHandsBackAnotherContextsTypeArgument()
+    {
+        (Type firstNode, Type secondNode) = ResolveFromTwoPrivateContexts();
+
+        _ = ImportedTypeSymbol.Get(typeof(ImmutableArray<>).MakeGenericType(firstNode));
+        ImportedTypeSymbol second = ImportedTypeSymbol.Get(
+            typeof(ImmutableArray<>).MakeGenericType(secondNode));
+
+        Type element = second.Type.GetGenericArguments().Single();
+        Assert.Same(secondNode, element);
+
+        // The operation #3818 died on: the receiver's type and the explicit
+        // type argument must be closable together.
+        MethodInfo open = element.GetMethods()
+            .Single(m => m.Name == nameof(SyntaxNode.FirstAncestorOrSelf) && m.IsGenericMethodDefinition);
+        Type argument = element.Assembly.GetType(
+            "GSharp.Core.CodeAnalysis.Syntax.FunctionDeclarationSyntax", throwOnError: true)
+            ?? throw new InvalidOperationException("the copy declares FunctionDeclarationSyntax");
+        _ = open.MakeGenericMethod(argument);
+    }
+
+    private (Type First, Type Second) ResolveFromTwoPrivateContexts()
+    {
+        string corePath = Path.Combine(this.workDirectory, "GSharp.Core.dll");
+
+        Type first;
+        using (ReferenceResolver resolver = ReferenceResolver.WithRuntimeReferences(new[] { corePath }))
+        {
+            Assert.True(resolver.TryResolveType("GSharp.Core.CodeAnalysis.Syntax.SyntaxNode", out first));
+        }
+
+        Type second;
+        using (ReferenceResolver resolver = ReferenceResolver.WithRuntimeReferences(new[] { corePath }))
+        {
+            Assert.True(resolver.TryResolveType("GSharp.Core.CodeAnalysis.Syntax.SyntaxNode", out second));
+        }
+
+        return (first, second);
+    }
+}


### PR DESCRIPTION
Fixes #3826.

#3825 removed the *duplicate identities* that made this fatal. The leak itself
was still there, and #3826 asked for the carrier by name. It is:

> **`ImportedTypeSymbol`'s process-wide cache — specifically its key.**

## How it carries a Type across compilations

```csharp
private static readonly ConditionalWeakTable<Assembly, ConcurrentDictionary<Type, ImportedTypeSymbol>> Cache = new();

var assemblyCache = Cache.GetValue(
    type.Assembly,
    static _ => new ConcurrentDictionary<Type, ImportedTypeSymbol>(TypeIdentityComparer.Instance));
return assemblyCache.GetOrAdd(type, static t => new ImportedTypeSymbol(t));
```

`TypeIdentityComparer` compares by `Type.AssemblyQualifiedName` — deliberately,
for #420, so the emitter collapses one logical type reached by several paths
into one `TypeRef` row. Two copies of the *same file* loaded into two different
`AssemblyLoadContext`s have **identical** assembly-qualified names, so that
comparer cannot tell them apart.

The outer `ConditionalWeakTable` bucket looks like it saves us — it is keyed on
the `Assembly` instance, which does differ per context. It does not, because it
is keyed on **the type's own assembly**, not on the assemblies the type is
*built from*. For a constructed generic whose definition lives in a shared
assembly, both compilations land in the same bucket:

| | `ImmutableArray<SyntaxNode>` from compilation A | …from compilation B |
|---|---|---|
| outer key (`type.Assembly`) | host `System.Collections.Immutable` | **same instance** |
| inner key (AQN) | `…ImmutableArray\`1[[…SyntaxNode, GSharp.Core, …]]` | **same string** |

So `ImportedTypeSymbol.Get(ImmutableArray<B.SyntaxNode>)` returns **A's**
symbol, whose `ClrType` and `TypeArguments` are A's. Every type derived from it
downstream — notably a `for` loop variable's element type — is A's too.

That is exactly the #3818 shape: `baseNode` (element of
`ImmutableArray<SyntaxNode>`) carried the *previous* compilation's `SyntaxNode`
while the explicit type argument `FunctionDeclarationSyntax` came from the
current one, `MakeGenericMethod` threw, `ClrOverloadResolution` dropped the only
candidate per C# §7.5.2, and the call reported "Cannot find function
FirstAncestorOrSelf" about a method that plainly exists.

Introduced by #2341, which changed the cache from a reference-keyed
`ConcurrentDictionary<Type, …>` (cleared on dispose) to this shape.

## Instrumented evidence

Tagging every `TypeSymbol` with a monotonic resolver generation and a creation
stack, then dumping at the GS0159 site on a failing run:

```
=== LeakProbe GS0159-imported:FirstAncestorOrSelf gen=21 symbol=ImportedTypeSymbol ===
  name=GSharp.Core.CodeAnalysis.Syntax.SyntaxNode  alc=<unnamed>
  symbolCreatedInGen=1
  creationStack:
   ImportedTypeSymbol.Get  <- TypeSymbol.FromClrType
   <- MemberLookup.MapOpenClrTypeToSymbolic  <- MemberLookup.GetClrPropertyTypeSymbol
   <- ExpressionBinder.BindAccessorStep
   <- Compilation.Emit  <- Adr0169Gsa0005ParityTests.CompileTranslatedGsa0005
  reportStack:
   ExpressionBinder.BindAccessorCall <- … <- StatementBinder.BindForRangeStatement
   <- Compilation.get_BoundProgram
   <- Adr0169AnalyzerTranslationTests.SemanticModelAnalyzer_TranslatesDeclarationAndOverrideIdioms
```

The **symbol object itself**, not merely a `Type`, was created in generation 1
(`Adr0169Gsa0005ParityTests`) and consumed in generation 21
(`Adr0169AnalyzerTranslationTests`). A bounded BFS from every static field in
`GSharp.Core` — taught to see through `ConditionalWeakTable`, which is where the
first attempt went blind — then produced the retaining path in one line:

```
rootScan: nodes=2061 found=True
  <- GSharp.Core.CodeAnalysis.Symbols.ImportedTypeSymbol.Cache [ConditionalWeakTable`2]
  <- {value} [ConcurrentDictionary`2]
  <- {value} [ImportedTypeSymbol]
```

#3826 predicted "every cache reachable on that path is `Type`- or
`Assembly`-keyed", and that is where the previous investigation stopped. It is
true and it is not sufficient: **being keyed on `Type` only helps if the key
compares by identity.** This one compares by name.

Corollary worth recording: `ImportedTypeSymbol.ClearCache()`, which
`ReferenceResolver.Dispose` calls with a comment claiming it clears the cache,
has been an **empty method** since #2341. That is a documentation defect, not
the bug — and clearing is deliberately *not* the fix (see below).

## The fix

`LoadContextSensitiveTypeComparer`: the same structural identity as
`TypeIdentityComparer`, plus a walk over the type's constituents (element type,
generic arguments) requiring the same `Assembly` **instance** at every position.
Hash stays name-based — a bucketing hint — and equality does the real test, the
same shape as the existing `TypeArgsKey`.

Two instances of one logical type reached by different paths inside a *single*
context still collapse, because a load context returns one `Assembly` instance
per identity, so #420's dedup is preserved. `ImportedTypeSymbol.Cache` is the
only process-wide consumer of `TypeIdentityComparer`; `MetadataTokenCache`'s
dictionaries are instance fields scoped to one emit, and the two
`ExpressionBinder` uses compare against a core-library type by name on purpose.

`ClearCache` stays a no-op. Clearing would only paper over the sequential case
and would leave two *live* resolvers aliasing each other; and the caches
`Dispose` really does clear have a churn hazard (symbols obtained before and
after a clear stop being reference-equal) that is not worth re-adding. The
misleading comments on both sides are corrected instead.

## Reproduction and measurement

`Issue3826CrossCompilationTypeIdentityTests` reproduces the leak
**deterministically in ~0.4s**, with no ordering dependence: it copies
`GSharp.Core.dll` to a path the host has not loaded (so #3825's path-equality
reuse does not apply and each resolver really does mint a private copy), takes
`SyntaxNode` from two successive resolvers, and closes `ImmutableArray<>` over
each.

| test | on `main` | here |
|---|---|---|
| `TwoPrivateReferenceContextsOverTheSamePath_ProduceDistinctTypes` | **passes** (anti-vacuity guard rail) | passes |
| `ConstructedGenericFromASharedAssembly_DoesNotAliasAcrossContexts` | fails | passes |
| `ACachedSymbolNeverHandsBackAnotherContextsTypeArgument` | fails | passes |

The first test is honestly labelled: it asserts only that the two contexts *are*
distinct, which is already true on `main`. It exists so a future change that
silently unified the two copies could not make the other two pass vacuously.

For the original flaky repro — `Adr0169Gsa0005ParityTests` +
`Adr0169AnalyzerTranslationTests` in one host — #3825's reuse **masks** the
symptom without fixing the leak, so measuring against it is meaningless. Both
arms below were run with that masking disabled, via this one-line local edit
(not committed):

```diff
-                Assembly? reused = TryReuseHostLoadedAssembly(fullPath);
+                Assembly? reused = Environment.GetEnvironmentVariable("GS_DISABLE_3825") == "1"
+                    ? null
+                    : TryReuseHostLoadedAssembly(fullPath);
```

```
GS_DISABLE_3825=1 dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj --no-build \
  --filter "FullyQualifiedName~Adr0169Gsa0005ParityTests|FullyQualifiedName~Adr0169AnalyzerTranslationTests"
```

| | runs | failures |
|---|---|---|
| without this fix | 10 | **4 (40%)** |
| with this fix | **32** (12 + 20) | **0** |

(#3825 measured the same repro at 18/43 = 42% before its own fix.)

Suites, locally: `Core.Tests` **8598/8598**; `Cs2Gs.Tests` **2664/2665**. The single failure is `Adr0151IfLetExpressionTranslationTests.Issue2819_SameVersionPackedToolAndSdk_CompileTranslatedPatternVariable`, which fails on its first line — `Assert.NotNull(ResolveLocalCs2GsPackage(repoRoot))` — because this worktree has no `out/bin/Release/nupkgs` (it has never run a Release pack). It never reaches the compiler, so it cannot be affected by this change. CI is the authority.

## Relationship to #3830

Same family, different layer, no file overlap — #3830 is the test helper
(emitted fixtures into a collectible context); this is the product cache. They
compose in the right direction: #3830 *increases* the number of distinct
collectible contexts holding same-named types in one process, which is exactly
the input the old name-only key mis-merged and the new key handles. Nothing in
`test/Compiler.Tests/Emit/ConversionEmitTests.cs` was touched here.

## The silent candidate drop — recommendation, not built

`ClrOverloadResolution.EvaluateCandidate` wraps `MakeGenericMethod` in
`catch (ArgumentException) { … return; }` at three sites. That conflates two
unrelated causes:

1. **Generic constraints not satisfied** — a genuine applicability failure.
   C# §7.5.2 says drop it silently. Correct as-is.
2. **Cross-load-context operands** — never a language-level "not applicable".
   It is a violation of the compiler's own type-plumbing invariant, and
   swallowing it converts an internal bug into a user-facing lie about a method
   that exists.

The two are separable *exactly*, without sniffing exception text: before
closing, every element of `typeArgs` must come from the same load context as
`mi.DeclaringType` — the code already reasons about this for the
`MetadataLoadContext` projection a few lines above. Recommendation, as its own
issue rather than in this PR:

- **Recommended:** detect the mismatch explicitly and report a distinct internal
  diagnostic in the `GS9998` ICE family ("cross-load-context operands closing
  `<method>`") instead of dropping. It surfaces the defect at its cause rather
  than as `GS0159` at a distant site. It needs a full-suite run of its own,
  because it turns any remaining silent misbind into a hard error — which is the
  point, but is a behaviour change.
- **Cheap fallback if that is too aggressive:** a `Debug`-only trace at the two
  catch sites recording the method, its declaring type's context, and each type
  argument's context. Zero release cost, and it would have turned this
  investigation from days into one run.
- **Rejected:** making `GS0159` explain why every candidate was dropped — too
  noisy, and it churns a large number of golden diagnostics.

Refs #3818, #3825, #3705, #1622, #2341, #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
