### PR TITLE
cs2gs: #3827's own new file must survive its own migration (#3831)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3824PragmaSuppressionTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3824PragmaSuppressionTranslationTests.cs
@@ -134,6 +134,99 @@ public class Sample
     }
 
     [Fact]
+    public void SeveralGsaIdentifiers_LandInOneAnnotation()
+    {
+        const string source = @"
+public class Sample
+{
+#pragma warning disable GSA0007, GSA0005
+    public int Both() => 1;
+#pragma warning restore GSA0007, GSA0005
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.Contains("@SuppressDiagnostic(\"GSA0005\", \"GSA0007\")", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "@SuppressDiagnostic"));
+    }
+
+    /// <summary>
+    /// Issue #3831: the region opens INSIDE the method and closes after it, so
+    /// it covers no declaration whole. Widening it to the method would suppress
+    /// diagnostics on the statements before the <c>disable</c>, which the C#
+    /// source still reports.
+    /// </summary>
+    [Fact]
+    public void ARegionThatCutsAcrossADeclaration_IsNotWidenedToIt()
+    {
+        const string source = @"
+public class Sample
+{
+    public int Cut()
+    {
+        int a = 1;
+#pragma warning disable GSA0005
+        return a;
+    }
+#pragma warning restore GSA0005
+
+    public int After() => 2;
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.DoesNotContain("@SuppressDiagnostic", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Issue #3831: a numeric error code is a literal, not an identifier — the
+    /// other arm of the code-text switch. It names no <c>GSA</c> analyzer, so it
+    /// is dropped while the identifier beside it is carried.
+    /// </summary>
+    [Fact]
+    public void ANumericErrorCodeIsDropped_AndTheGsaIdentifierBesideItSurvives()
+    {
+        const string source = @"
+public class Sample
+{
+#pragma warning disable 1591, GSA0005
+    public int Mixed() => 1;
+#pragma warning restore 1591, GSA0005
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.Contains("@SuppressDiagnostic(\"GSA0005\")", printed, StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(printed, "@SuppressDiagnostic"));
+        Assert.DoesNotContain("1591", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Issue #3831: a bare <c>#pragma warning disable</c> names no identifier at
+    /// all. It must translate to nothing — never to an annotation with an empty
+    /// or absent identifier.
+    /// </summary>
+    [Fact]
+    public void ABareDisableNamesNothing_AndProducesNoAnnotation()
+    {
+        const string source = @"
+public class Sample
+{
+#pragma warning disable
+    public int Everything() => 1;
+#pragma warning restore
+}
+";
+
+        string printed = Translate(source);
+
+        Assert.DoesNotContain("@SuppressDiagnostic", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TranslatedSuppression_BindsInTheMigratedTree()
     {
         const string source = @"

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs
@@ -50,7 +50,7 @@ public sealed partial class CSharpToGSharpTranslator
                 _ => null,
             };
 
-            if (declared is not List<AttributeUse> attributes || source is null)
+            if (declared is not List<AttributeUse> attributes)
             {
                 return;
             }
@@ -89,11 +89,24 @@ public sealed partial class CSharpToGSharpTranslator
                 return result;
             }
 
-            List<PragmaWarningDirectiveTriviaSyntax> directives = root
-                .DescendantTrivia(descendIntoTrivia: true)
-                .Where(t => t.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia))
-                .Select(t => (PragmaWarningDirectiveTriviaSyntax)t.GetStructure())
-                .Where(d => d is not null)
+            // Issue #3831: collected with a type PATTERN rather than
+            // `Select(cast).Where(d => d is not null)`. This file is itself in
+            // the self-migration corpus, and a sequence-level null filter does
+            // not narrow the ELEMENT type: the migrated G# kept
+            // `PragmaWarningDirectiveTriviaSyntax?` all the way down, so every
+            // member access on a directive below failed to resolve. The
+            // pattern narrows, and the loop is the same work.
+            var collected = new List<PragmaWarningDirectiveTriviaSyntax>();
+            foreach (SyntaxTrivia trivia in root.DescendantTrivia(descendIntoTrivia: true))
+            {
+                if (trivia.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia)
+                    && trivia.GetStructure() is PragmaWarningDirectiveTriviaSyntax pragma)
+                {
+                    collected.Add(pragma);
+                }
+            }
+
+            List<PragmaWarningDirectiveTriviaSyntax> directives = collected
                 .OrderBy(d => d.SpanStart)
                 .ToList();
 
@@ -148,14 +161,19 @@ public sealed partial class CSharpToGSharpTranslator
         {
             foreach (ExpressionSyntax code in directive.ErrorCodes)
             {
+                // Issue #3831: the "names nothing" arm is the empty string, not
+                // `null`. A `null` arm makes the whole switch — and with it this
+                // iterator's element type — nullable in the migrated G#, where
+                // the `text != null` test does not narrow across the `yield`;
+                // no identifier starts with "GSA" for the empty string either.
                 string text = code switch
                 {
                     IdentifierNameSyntax name => name.Identifier.ValueText,
                     LiteralExpressionSyntax literal => literal.Token.ValueText,
-                    _ => null,
+                    _ => string.Empty,
                 };
 
-                if (text != null && text.StartsWith("GSA", StringComparison.Ordinal))
+                if (text.StartsWith("GSA", StringComparison.Ordinal))
                 {
                     yield return text;
                 }


### PR DESCRIPTION
Fixes #3831. Follow-up to #3827 (which introduced the file) and #3829. Part of #3501.

## The failure

`tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.PragmaSuppressions.cs`, new in #3827, does
not survive its own migration. cs2gs is inside its own corpus, so every project referencing
`Cs2Gs.Translator` inherits the failure — in the local before-run, **nine** apps fail on this one
file and nothing else.

## The cause — one root, not five, and NOT a missing import surface

The issue reads the five diagnostics as two families ("imported Roslyn members the G# import
surface does not expose" + "nullability"). That premise is wrong, and worth correcting: **four of
the five errors are one root cause, and `SpanStart` / `DisableOrRestoreKeyword` resolve fine.**

The migrated `.gs` (verbatim, before):

```
let directives = root
    .DescendantTrivia(descendIntoTrivia: true)
    .Where((t SyntaxTrivia) -> t.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia))
    .Select((t SyntaxTrivia) -> (t.GetStructure() as PragmaWarningDirectiveTriviaSyntax))
    .Where((d PragmaWarningDirectiveTriviaSyntax?) -> d != nil)
    .OrderBy((d PragmaWarningDirectiveTriviaSyntax) -> d.SpanStart)
    .ToList()
```

The C# explicit cast becomes an `as`, so the element type is `PragmaWarningDirectiveTriviaSyntax?`,
and `Where(d => d is not null)` filters the *sequence* without narrowing the *element type*. Every
downstream use is then a member access on a nullable receiver:

| migrated line | diagnostic | actual cause |
|---|---|---|
| `directive.DisableOrRestoreKeyword` | GS0158 Cannot find member | nullable receiver |
| `DirectiveIds(directive)` | GS0154 wants `T`, given `T?` | nullable element |
| `directive.SpanStart` ×2 | GS0158 Cannot find member | nullable receiver |
| `state[id] = disable` | GS0155 `string?` → `string` | `DirectiveIds` became `sequence[string?]` |

`SpanStart` is used in ~15 other `Cs2Gs.Translator` files and this PR still calls both
`SpanStart` and `DisableOrRestoreKeyword` — the app compiles clean afterwards, which is the
direct disproof of the "member is not exposed" reading. **No G# API surface was added.**

The fifth error has its own root: `DirectiveIds`'s `_ => null` switch arm made the local
`string?`, and the `text != null` test does not narrow across the `yield`, so the iterator's
element type became `sequence[string?]`.

## The rewrite

Three portable-shape changes, no feature lost:

1. Collect the directives with a **type pattern** (`trivia.GetStructure() is
   PragmaWarningDirectiveTriviaSyntax pragma`) in an explicit loop instead of
   `Select(cast).Where(x => x is not null)`. The pattern narrows; the sequence filter cannot.
2. The "names nothing" arm of the error-code switch is `string.Empty`, not `null` — no identifier
   starts with `GSA` either way, and the iterator stays `IEnumerable<string>`.
3. Dropped the dead `source is null` guard. The one caller passes a non-null
   `MemberDeclarationSyntax`; the guard's only effect was to make cs2gs infer the parameter
   nullable, which spent two `!!` null-assertions in the migrated output.

## Tests (executing, not binding-only)

`tools/cs2gs/Cs2Gs.Tests/Issue3824PragmaSuppressionTranslationTests.cs` runs the real translator
and prints the G#. Four new cases pin the behaviour the rewrite touched:

- `SeveralGsaIdentifiers_LandInOneAnnotation` — the multi-id list, the sorted spelling.
- `ARegionThatCutsAcrossADeclaration_IsNotWidenedToIt` — the `interrupted` path, i.e. the
  no-widening promise #3827 made.
- `ANumericErrorCodeIsDropped_AndTheGsaIdentifierBesideItSurvives` — the literal arm of the switch.
- `ABareDisableNamesNothing_AndProducesNoAnnotation` — a bare `#pragma warning disable`.

Plus the six #3827 tests, unchanged and still green.

## Measurement — full 52-app gate, both sides local, same machine

Both sides are full local `build/run-cs2gs-selfmig.sh` runs on the same machine with the SDK nupkg
repacked (`dotnet build GSharp.sln -c Release -graph`), so each migrated tree is stamped with its
own side's gsc. The BEFORE side is the run #3831 was filed from; I re-derived every number below
from its `run.json` and per-app `sdk.build.log` directly rather than quoting the issue.

| | before (`d7d0c0f97`, = `main` with #3827+#3829, gsc `0.4.388`) | after (`a7f344324`, this branch) |
|---|---|---|
| summary | `35/52 green (floor 43); labels=0; __local_=29; lines>300=602; bangs=17116` | `43/52 green (floor 43); labels=0; __local_=29; lines>300=602; **bangs=10681**` |
| `Cs2Gs.Translator` compile | 5 × `error GS` | **0** |
| apps failing on `PragmaSuppressions.gs` | **9** | **0** |

Newly green, exactly the cascade set plus `ClrBaseline` (which #3819 fixed and which the
nightly 33663855851 also reports newly green):

```
+ tools/cs2gs/Cs2Gs.Cli          + tools/cs2gs/Cs2Gs.Report      + tools/gsgen/Gsgen.Cli
+ tools/cs2gs/Cs2Gs.Pipeline     + tools/cs2gs/Cs2Gs.Translator  + tools/gsgen/GSharp.GeneratorHost
+ tools/cs2gs/Cs2Gs.ProjectLoading                               + bench/concurrency/clr/ClrBaseline
```

All seven banked casualties named in #3831 are green again, and the corpus is back **at** its 43 floor.

**The `bangs` ceiling breach was a consequence, confirmed rather than assumed**: 17116 → **10681**
(ceiling 11500). The polish pass never ran over the failing apps; nothing in this PR targets `!!`
beyond the two the dead null guard was spending.

**The feature is intact.** `migrated/src/Core` compiles with **0** `GSA0005` and 0 errors, and all
ten `@SuppressDiagnostic("GSA0005")` annotations still land on the same ten methods
(`CaptureBoxingRewriter` ×4, `LambdaBinder` ×3, `HoistedFieldRewriter` ×2, `SideEffectSpiller` ×1).

The one remaining banked red is `test/Extensions.Tests`, failing 2 of 173 tests with
`Gsharp.Extensions.dll must be built before running this test` — the artifact-precondition
ordering effect of the local single-job path that #3831 itself flagged (`src/Sdk/Gsharp.Extensions`
is on the gate's `--exclude` list). It is green in the sharded path, and the nightly does not list
it among the red banked apps.

## Correcting #3831's premise

#3831 reads `GS0158 Cannot find member DisableOrRestoreKeyword` / `SpanStart` as "imported Roslyn
members that the G# import surface does not expose … same family as #3814/#3815". They are not:
this PR still calls both members, adds no G# surface, and the app compiles clean. They were member
lookups on a nullable receiver.

## Siblings, and catching this at PR time

**In the BEFORE run, all nine failing apps failed on this one file and nothing else** — every
`Cs2Gs.*`/`gsgen` app's `sdk.build.log` contains exactly the same five diagnostics — so there was
no second latent instance among the production cs2gs sources added since 2026-08-20
(`ConditionalNotNullPostcondition.cs`, `CSharpToGSharpTranslator.AnalyzerSnippets.cs`,
`Analyzers/SnippetTranslationResult.cs`, `CanonicalRootPath.cs`, `TranslationCrashException.cs` —
all green here). Two recently-added **test** sources do not migrate, in the non-banked
`tools/cs2gs/Cs2Gs.Tests`; filed separately rather than widened into this PR.

**Recommendation — a path-filtered PR job.** CI compiles the C# sources; only the nightly gate
translates *then* compiles them, so a translator change can be fully CI-green and break the gate
purely by existing. The cheap catch is a job triggered on `paths: tools/cs2gs/**` that migrates
only `Cs2Gs.Translator`'s reference closure and compiles it:

```
cs2gs migrate --corpus . --out <tmp> --artifacts <tmp>/runs --config Release \
  --exclude <everything except src/Core, tools/cs2gs/Cs2Gs.CodeModel, tools/cs2gs/Cs2Gs.Translator>
```

Three apps, compile stage only — no ilverify, no test parity, no 52-app translate. The closure
must be kept whole (`Cs2Gs.Translator → Cs2Gs.CodeModel → src/Core`): excluding a project that a
kept app project-references manufactures phantom cascades, which is why `--exclude` is not a
sharding mechanism in the nightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
