### PR TITLE
Fix source locations for field symbols

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Interfaces.cs
@@ -850,7 +850,7 @@ internal sealed partial class DeclarationBinder
                             continue;
                         }
 
-                        var constField = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true);
+                        var constField = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true, declaration: fieldSyntax);
                         Binder.AttachDocumentation(constField, fieldSyntax);
 
                         if (fieldSyntax.Initializer == null)
@@ -886,7 +886,7 @@ internal sealed partial class DeclarationBinder
                         continue;
                     }
 
-                    var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: fieldSyntax.IsReadOnly, isStatic: true);
+                    var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: fieldSyntax.IsReadOnly, isStatic: true, declaration: fieldSyntax);
                     Binder.AttachDocumentation(fieldSymbol, fieldSyntax);
 
                     if (fieldSyntax.Initializer != null)

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Structs.cs
@@ -363,7 +363,7 @@ internal sealed partial class DeclarationBinder
                 // C# records); their backing fields are synthesized below.
                 if (!syntax.IsData)
                 {
-                    fields.Add(new FieldSymbol(paramName, paramType, Accessibility.Public, isReadOnly: syntax.IsInline));
+                    fields.Add(new FieldSymbol(paramName, paramType, Accessibility.Public, isReadOnly: syntax.IsInline, declaration: paramSyntax));
                 }
             }
 
@@ -474,7 +474,7 @@ internal sealed partial class DeclarationBinder
                 }
 
                 var fbBacking = SynthesizeFixedBufferBackingStruct(structSymbol, fieldName, fbElement, fbLength, fbElemSize, package);
-                var fbFieldSymbol = new FieldSymbol(fieldName, fbBacking, fieldAccessibility, isReadOnly: false);
+                var fbFieldSymbol = new FieldSymbol(fieldName, fbBacking, fieldAccessibility, isReadOnly: false, declaration: fieldSyntax);
                 fbFieldSymbol.SetFixedBuffer(fbElement, fbLength);
                 Binder.AttachDocumentation(fbFieldSymbol, fieldSyntax);
                 fields.Add(fbFieldSymbol);
@@ -494,7 +494,7 @@ internal sealed partial class DeclarationBinder
                     continue;
                 }
 
-                var constFieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true);
+                var constFieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true, declaration: fieldSyntax);
                 Binder.AttachDocumentation(constFieldSymbol, fieldSyntax);
 
                 if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
@@ -520,7 +520,7 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
-            var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: syntax.IsInline || fieldSyntax.IsReadOnly);
+            var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: syntax.IsInline || fieldSyntax.IsReadOnly, declaration: fieldSyntax);
             Binder.AttachDocumentation(fieldSymbol, fieldSyntax);
 
             // Issue #186 / ADR-0047 §3: bind any `@Foo` annotations attached
@@ -2242,7 +2242,7 @@ internal sealed partial class DeclarationBinder
                         continue;
                     }
 
-                    var sharedConstField = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true);
+                    var sharedConstField = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: true, isStatic: true, isConst: true, declaration: fieldSyntax);
                     Binder.AttachDocumentation(sharedConstField, fieldSyntax);
 
                     if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
@@ -2271,7 +2271,7 @@ internal sealed partial class DeclarationBinder
                     continue;
                 }
 
-                var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: fieldSyntax.IsReadOnly, isStatic: true);
+                var fieldSymbol = new FieldSymbol(fieldName, fieldType, fieldAccessibility, isReadOnly: fieldSyntax.IsReadOnly, isStatic: true, declaration: fieldSyntax);
 
                 if (!fieldSyntax.Annotations.IsDefaultOrEmpty)
                 {

--- a/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
+++ b/src/Core/CodeAnalysis/Binding/IncrementalGlobalScopeReuse.cs
@@ -43,7 +43,8 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// accessor bodies (<see cref="EventSymbol.RepointDeclaration"/>). The owning
 /// struct and interface type symbols are re-pointed too
 /// (<see cref="StructSymbol.RepointDeclaration"/>,
-/// <see cref="InterfaceSymbol.RepointDeclaration"/>). Re-binding of every
+/// <see cref="InterfaceSymbol.RepointDeclaration"/>), as are source field
+/// declarations (<see cref="FieldSymbol.RepointDeclaration"/>). Re-binding of every
 /// re-pointed body is forced by passing the edited tree as a <c>dirtyTree</c> to
 /// <see cref="Binder.BindProgram(BoundGlobalScope, ReferenceResolver, BoundBodyCache, System.Collections.Immutable.ImmutableHashSet{SyntaxTree})"/>;
 /// because each body's backing syntax now belongs to the dirty tree, the
@@ -150,6 +151,7 @@ public static class IncrementalGlobalScopeReuse
             || !TryBuildPositionalMap<InterfaceDeclarationSyntax>(previousTree, updatedTree, out var interfaceMap)
             || !TryBuildPositionalMap<ConstructorDeclarationSyntax>(previousTree, updatedTree, out var constructorMap)
             || !TryBuildPositionalMap<DeinitDeclarationSyntax>(previousTree, updatedTree, out var deinitMap)
+            || !TryBuildPositionalMap<FieldDeclarationSyntax>(previousTree, updatedTree, out var fieldMap)
             || !TryBuildPositionalMap<PropertyDeclarationSyntax>(previousTree, updatedTree, out var propertyMap)
             || !TryBuildPositionalMap<EventDeclarationSyntax>(previousTree, updatedTree, out var eventMap))
         {
@@ -229,11 +231,37 @@ public static class IncrementalGlobalScopeReuse
 
         var constructorsToRepoint = new List<(ConstructorSymbol Symbol, ConstructorDeclarationSyntax Updated)>();
         var deinitsToRepoint = new List<(DeinitSymbol Symbol, DeinitDeclarationSyntax Updated)>();
+        var fieldsToRepoint = new List<(FieldSymbol Symbol, SyntaxNode Updated)>();
         var propertiesToRepoint = new List<(PropertySymbol Symbol, PropertyDeclarationSyntax Updated, BlockStatementSyntax? Getter, BlockStatementSyntax? Setter)>();
         var eventsToRepoint = new List<(EventSymbol Symbol, EventDeclarationSyntax Updated, BlockStatementSyntax? Add, BlockStatementSyntax? Remove, BlockStatementSyntax? Raise)>();
 
         foreach (var structSymbol in scope.Structs)
         {
+            foreach (var field in structSymbol.Fields.Concat(structSymbol.StaticFields).Concat(structSymbol.ConstFields))
+            {
+                var declaration = field.Declaration;
+                if (declaration == null || declaration.SyntaxTree != previousTree)
+                {
+                    continue;
+                }
+
+                SyntaxNode? updated = declaration switch
+                {
+                    FieldDeclarationSyntax fieldDeclaration when fieldMap.TryGetValue(fieldDeclaration, out var updatedField) => updatedField,
+                    ParameterSyntax when structSymbol.Declaration is { } structDeclaration
+                        && structMap.TryGetValue(structDeclaration, out var updatedStruct)
+                        => updatedStruct.PrimaryConstructorParameters?.FirstOrDefault(
+                            parameter => parameter.Identifier.ValueText == field.Name),
+                    _ => null,
+                };
+                if (updated == null)
+                {
+                    return false;
+                }
+
+                fieldsToRepoint.Add((field, updated));
+            }
+
             // Constructors (ADR-0063 §9). Synthesized primary constructors carry
             // no declaration node and have no rebindable body — skip them.
             if (!structSymbol.ExplicitConstructors.IsDefaultOrEmpty)
@@ -324,6 +352,26 @@ public static class IncrementalGlobalScopeReuse
             }
         }
 
+        foreach (var interfaceSymbol in scope.Interfaces)
+        {
+            foreach (var field in interfaceSymbol.StaticFields.Concat(interfaceSymbol.ConstFields))
+            {
+                var declaration = field.Declaration;
+                if (declaration == null || declaration.SyntaxTree != previousTree)
+                {
+                    continue;
+                }
+
+                if (declaration is not FieldDeclarationSyntax fieldDeclaration
+                    || !fieldMap.TryGetValue(fieldDeclaration, out var updated))
+                {
+                    return false;
+                }
+
+                fieldsToRepoint.Add((field, updated));
+            }
+        }
+
         // ---- Phase 2: all validation passed — apply the re-point. This is the
         // only mutation, and it only swaps backing syntax (signatures and
         // accessor shapes are byte-identical).
@@ -348,6 +396,11 @@ public static class IncrementalGlobalScopeReuse
         }
 
         foreach (var (symbol, updated) in deinitsToRepoint)
+        {
+            symbol.RepointDeclaration(updated);
+        }
+
+        foreach (var (symbol, updated) in fieldsToRepoint)
         {
             symbol.RepointDeclaration(updated);
         }

--- a/src/Core/CodeAnalysis/Symbols/FieldSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FieldSymbol.cs
@@ -2,6 +2,9 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Syntax;
+
 namespace GSharp.Core.CodeAnalysis.Symbols;
 
 /// <summary>
@@ -19,7 +22,16 @@ public sealed class FieldSymbol : Symbol
     /// <param name="isStatic">True when the field is declared inside a <c>shared</c> block (ADR-0053).</param>
     /// <param name="isConst">True when the field is a compile-time constant declared with <c>const</c> (Issue #948). Const fields are implicitly static and read-only and emitted as literal fields.</param>
     /// <param name="isEventBackingField">True when this field is the compiler-synthesized backing field of a field-like <c>event</c> declaration (issue #2083). Unlike an ordinary non-nullable field/local/parameter, an event backing field's declared (non-nullable) delegate type does not guarantee a non-null runtime value: an unsubscribed event's backing field genuinely holds <c>null</c>. The emitter uses this flag to keep the null-guarded delegate-to-delegate adaptation (issue #2066) for event snapshots while restoring the fail-fast (throwing) adaptation for every other statically non-nullable source.</param>
-    public FieldSymbol(string name, TypeSymbol type, Accessibility accessibility, bool isReadOnly = false, bool isStatic = false, bool isConst = false, bool isEventBackingField = false)
+    /// <param name="declaration">The declaring field or primary-constructor parameter syntax, or <see langword="null"/> for imported and synthesized fields.</param>
+    public FieldSymbol(
+        string name,
+        TypeSymbol type,
+        Accessibility accessibility,
+        bool isReadOnly = false,
+        bool isStatic = false,
+        bool isConst = false,
+        bool isEventBackingField = false,
+        SyntaxNode? declaration = null)
         : base(name)
     {
         Type = type;
@@ -28,10 +40,22 @@ public sealed class FieldSymbol : Symbol
         IsStatic = isStatic;
         IsConst = isConst;
         IsEventBackingField = isEventBackingField;
+        Declaration = declaration;
     }
 
     /// <inheritdoc/>
     public override SymbolKind Kind => SymbolKind.Field;
+
+    /// <summary>Gets the declaring field or primary-constructor parameter syntax, or <see langword="null"/> for imported and synthesized fields.</summary>
+    public SyntaxNode? Declaration { get; private set; }
+
+    /// <inheritdoc/>
+    public override ImmutableArray<SyntaxNode> DeclaringSyntaxNodes => Declaration switch
+    {
+        FieldDeclarationSyntax fieldDeclaration => ImmutableArray.Create<SyntaxNode>(fieldDeclaration.Identifier),
+        ParameterSyntax parameter => ImmutableArray.Create<SyntaxNode>(parameter.Identifier),
+        _ => ImmutableArray<SyntaxNode>.Empty,
+    };
 
     /// <summary>Gets the field type.</summary>
     public TypeSymbol Type { get; }
@@ -128,6 +152,13 @@ public sealed class FieldSymbol : Symbol
         IsFixedBuffer = true;
         FixedBufferElementType = elementType;
         FixedBufferLength = length;
+    }
+
+    /// <summary>Re-points this reused field symbol at the corresponding declaration in a freshly parsed syntax tree.</summary>
+    /// <param name="declaration">The corresponding declaration in the re-parsed tree.</param>
+    internal void RepointDeclaration(SyntaxNode declaration)
+    {
+        Declaration = declaration;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -1888,7 +1888,11 @@ public sealed class StructSymbol : TypeSymbol
         var substitutedFields = ImmutableArray.CreateBuilder<FieldSymbol>(definition.Fields.Length);
         foreach (var f in definition.Fields)
         {
-            substitutedFields.Add(new FieldSymbol(f.Name, SubstituteTypeForConstruction(f.Type, subst, mapClrType), f.Accessibility));
+            substitutedFields.Add(new FieldSymbol(
+                f.Name,
+                SubstituteTypeForConstruction(f.Type, subst, mapClrType),
+                f.Accessibility,
+                declaration: f.Declaration));
         }
 
         var substitutedPrimary = ImmutableArray<ParameterSymbol>.Empty;
@@ -2301,7 +2305,8 @@ public sealed class StructSymbol : TypeSymbol
                     f.IsReadOnly,
                     f.IsStatic,
                     f.IsConst,
-                    f.IsEventBackingField);
+                    f.IsEventBackingField,
+                    f.Declaration);
                 if (f.IsConst)
                 {
                     substituted.SetConstantValue(f.ConstantValue);

--- a/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
@@ -238,6 +238,37 @@ func Leak() int32 {
     }
 
     /// <summary>
+    /// Issue #3796: a source-declared field exposes its identifier location so
+    /// a migrated symbol-action analyzer can report against the field marker.
+    /// </summary>
+    [Fact]
+    public void FieldSymbolAction_ReportsAtDeclaringIdentifier()
+    {
+        GSharpAnalyzerVerifier<FieldLocationAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+class Cache {
+    shared {
+        var [|entries|] int32
+    }
+}
+",
+            "TESTGSA0003");
+    }
+
+    [Fact]
+    public void PrimaryConstructorFieldSymbolAction_ReportsAtDeclaringIdentifier()
+    {
+        GSharpAnalyzerVerifier<FieldLocationAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+class Cache([|entries|] int32) {
+}
+",
+            "TESTGSA0003");
+    }
+
+    /// <summary>
     /// The G# analogue of GSA0001: direct index reads of a member named
     /// <c>structFieldDefs</c> outside <c>ResolveFieldToken</c> /
     /// <c>ResolveInterfaceFieldToken</c> are flagged. Uses
@@ -318,6 +349,29 @@ func Leak() int32 {
         private static void Report(SyntaxNodeAnalysisContext context)
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, default(GSharp.Core.CodeAnalysis.Text.TextLocation)));
+        }
+    }
+
+    [GSharpDiagnosticAnalyzer]
+    public sealed class FieldLocationAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA0003",
+            "Field location",
+            "Field has a source location.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSymbolAction(
+                ctx => ctx.ReportDiagnostic(Diagnostic.Create(Rule, ctx.Symbol.Location)),
+                GSharp.Core.CodeAnalysis.Symbols.SymbolKind.Field);
         }
     }
 }

--- a/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/IncrementalGlobalScopeReuseTests.cs
@@ -24,6 +24,44 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// </summary>
 public class IncrementalGlobalScopeReuseTests
 {
+    [Fact]
+    public void BodyOnlyEdit_RepointsFieldLocation()
+    {
+        var original = Parse("A.gs", """
+            package P
+            class Cache {
+                var count int32
+                func Resize() {
+                    var size = 1
+                }
+                shared {
+                    var entries int32
+                }
+            }
+            """);
+        var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(original));
+        var instanceField = scope.Structs.Single().Fields.Single();
+        var staticField = scope.Structs.Single().StaticFields.Single();
+        var edited = Parse("A.gs", """
+            package P
+            class Cache {
+                var count int32
+                func Resize() {
+                    var size = 100000
+                }
+                shared {
+                    var entries int32
+                }
+            }
+            """);
+
+        Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, original, edited));
+        Assert.Same(edited.Text, instanceField.Location.Text);
+        Assert.Equal("count", instanceField.Location.Text!.ToString(instanceField.Location.Span));
+        Assert.Same(edited.Text, staticField.Location.Text);
+        Assert.Equal("entries", staticField.Location.Text!.ToString(staticField.Location.Span));
+    }
+
     /// <summary>
     /// A body-only edit to one file in a multi-file project reuses the cached
     /// bodies of every unchanged file (cache hits, same symbol identity) and
@@ -520,18 +558,25 @@ public class IncrementalGlobalScopeReuseTests
         var fileA = Parse("A.gs", """
             package P
             interface IGreeter {
+                shared {
+                    var Calls int32
+                }
                 func Hello() string {
                     return "hi"
                 }
             }
             """);
         var scope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(fileA));
+        var field = scope.Interfaces.Single().StaticFields.Single();
         var cache = new BoundBodyCache();
         Binder.BindProgram(scope, references: null, cache);
 
         var editedA = Parse("A.gs", """
             package P
             interface IGreeter {
+                shared {
+                    var Calls int32
+                }
                 func Hello() string {
                     return "hello"
                 }
@@ -539,6 +584,8 @@ public class IncrementalGlobalScopeReuseTests
             """);
 
         Assert.True(IncrementalGlobalScopeReuse.TryRepointBodyOnlyEdit(scope, fileA, editedA));
+        Assert.Same(editedA.Text, field.Location.Text);
+        Assert.Equal("Calls", field.Location.Text!.ToString(field.Location.Span));
         var fast = Binder.BindProgram(scope, references: null, cache, ImmutableHashSet.Create(editedA));
 
         var fullScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(editedA));


### PR DESCRIPTION
## Summary
- attach declaring syntax to source-bound field symbols
- preserve and repoint field locations through generic construction and incremental reuse
- cover regular, shared, interface, and primary-constructor field diagnostics

## Testing
- `dotnet test test/Core.Tests/Core.Tests.csproj --no-restore`
- `dotnet test test/LanguageServer.Tests/LanguageServer.Tests.csproj --no-restore`

Closes #3796