### PR TITLE
cs2gs: the #1072 promotion no longer widens an inferred generic sequence through a lambda parameter (#3855)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3855LambdaInferencePromotionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3855LambdaInferencePromotionTests.cs
@@ -1,0 +1,439 @@
+// <copyright file="Issue3855LambdaInferencePromotionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3855: in a nullable-OBLIVIOUS compilation the #1072 promotion
+/// (<c>PromoteIfUsedAsNullable</c>) renders a null-tested parameter <c>T?</c>.
+/// That is right for a parameter whose annotation is merely DESCRIPTIVE — the
+/// target type is already fixed, and widening an input position is
+/// contravariance, so a <c>(T?) -&gt; R</c> literal still converts to a
+/// <c>(T) -&gt; R</c> target.
+/// <para>
+/// It is wrong for a LAMBDA parameter that is an argument to a generic method
+/// with INFERRED type arguments. There the annotation is not checked against a
+/// target — it CHOOSES one. <c>xs.Where(d =&gt; d != null)</c> emitted
+/// <c>.Where((d T?) -&gt; d != nil)</c>, gsc inferred <c>TSource := T?</c>, and
+/// the whole sequence widened to <c>sequence[T?]</c>: every downstream member
+/// access then ran on a nullable receiver (<c>GS0158 Cannot find member</c> /
+/// <c>GS0154</c>) several lines away from the lambda that caused it.
+/// </para>
+/// <para>
+/// The canonical shape is the one from
+/// <c>CSharpToGSharpTranslator.PragmaSuppressions.cs</c> — a
+/// <c>Select(cast).Where(x =&gt; x is not null).OrderBy(...)</c> chain, which
+/// has now defeated two separate fixes (#3835's rewrite and #3854's cast
+/// lowering) — so it is asserted here both at the translation level and by
+/// EXECUTING the emitted G#.
+/// </para>
+/// </summary>
+public sealed class Issue3855LambdaInferencePromotionTests
+{
+    /// <summary>
+    /// The canonical #3855/#3843 chain, in a nullable-oblivious compilation:
+    /// <c>Select</c> an explicit cast, filter the nulls out at sequence level,
+    /// then reach a member on the surviving elements.
+    /// </summary>
+    private const string InequalityChainSource = @"
+namespace Demo
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class Node
+    {
+        public Node(int span) { this.Span = span; }
+
+        public int Span { get; set; }
+    }
+
+    public class Chain
+    {
+        public static int Total(IEnumerable<object> items)
+        {
+            var sum = 0;
+            foreach (var d in items
+                .Select(t => (Node)t)
+                .Where(d => d != null)
+                .OrderBy(d => d.Span))
+            {
+                sum += d.Span;
+            }
+
+            return sum;
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// The same chain spelled with the <c>is not null</c> pattern the real
+    /// <c>PragmaSuppressions.cs</c> uses — a second, independent entry into
+    /// <c>IsUsedAsNullable</c> (its <c>IsPatternExpressionSyntax</c> arm).
+    /// </summary>
+    private const string PatternChainSource = @"
+namespace Demo
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class Node
+    {
+        public Node(int span) { this.Span = span; }
+
+        public int Span { get; set; }
+    }
+
+    public class PatternChain
+    {
+        public static int Total(IEnumerable<object> items)
+        {
+            var sum = 0;
+            foreach (var d in items
+                .Select(t => (Node)t)
+                .Where(d => d is not null)
+                .OrderBy(d => d.Span))
+            {
+                sum += d.Span;
+            }
+
+            return sum;
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// The fix's boundary on the other side: a lambda handed to a NON-generic
+    /// callee has a fixed target type, so the #1072 promotion still applies.
+    /// Nothing infers from the annotation; the widened input position is plain
+    /// contravariance.
+    /// </summary>
+    private const string FixedTargetSource = @"
+namespace Demo
+{
+    using System;
+
+    public class FixedTarget
+    {
+        public static void Run(Action<string> handler)
+        {
+            handler(""x"");
+        }
+
+        public static void Go()
+        {
+            Run(s => { if (s == null) { return; } });
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// A generic callee whose type arguments are written EXPLICITLY infers
+    /// nothing, so the annotation is descriptive again and the promotion stands.
+    /// </summary>
+    private const string ExplicitTypeArgumentSource = @"
+namespace Demo
+{
+    using System;
+
+    public class ExplicitArgs
+    {
+        public static void Run<T>(Action<T> handler, T value)
+        {
+            handler(value);
+        }
+
+        public static void Go()
+        {
+            Run<string>(s => { if (s == null) { return; } }, ""x"");
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// A generic callee whose lambda parameter position is CONCRETE — the
+    /// method's type parameter appears only in the RESULT position — infers
+    /// nothing from this annotation either, so the promotion stands. This is
+    /// what keeps the rule narrower than "any lambda in any generic call".
+    /// </summary>
+    private const string ConcreteArrowPositionSource = @"
+namespace Demo
+{
+    using System;
+
+    public class ConcreteArrow
+    {
+        public static T Run<T>(Func<string, T> project)
+        {
+            return project(""x"");
+        }
+
+        public static int Go()
+        {
+            return Run(s => s == null ? 0 : s.Length);
+        }
+    }
+}
+";
+
+    [Fact]
+    public void InferredGenericCall_NullTestedLambdaParameter_IsNotWidenedToNullable()
+    {
+        string printed = Translate(InequalityChainSource);
+
+        // The whole point: the filter lambda keeps the element type the chain
+        // actually carries, so the ORDERING lambda four characters later sees
+        // the same type. Asserted on both lambdas, not just the promoted one —
+        // the pre-fix output was internally inconsistent on its face
+        // (`(d Node?)` feeding `(d Node)`).
+        Assert.Contains("(d Node) -> d != nil", printed, StringComparison.Ordinal);
+        Assert.Contains("(d Node) -> d.Span", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("(d Node?)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InferredGenericCall_IsNotNullPattern_IsNotWidenedToNullable()
+    {
+        string printed = Translate(PatternChainSource);
+
+        Assert.Contains("(d Node) -> d != nil", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("(d Node?)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing half. On <c>origin/main</c> the emitted G# does not even
+    /// compile (<c>GS0158 Cannot find member Span</c> plus <c>GS0129</c> on the
+    /// accumulation), so this pins BOTH that gsc accepts the emitted chain and
+    /// that it computes the same answer the C# does — 3 + 1 = 4 — rather than,
+    /// say, silently dropping the filtered elements.
+    /// </summary>
+    [Fact]
+    public void InferredGenericCall_TranslatedChainCompilesAndProducesTheCSharpAnswer()
+    {
+        string printed = Translate(InequalityChainSource);
+        string stdout = CompileAndRun(
+            printed,
+            "let xs = []object{ Node(3), Node(1) }\nSystem.Console.WriteLine(Chain.Total(xs).ToString())");
+
+        Assert.Equal("4", stdout.Trim());
+    }
+
+    /// <summary>
+    /// The <c>is not null</c> spelling must reach the same executable answer as
+    /// the <c>!= null</c> one — the two entries into <c>IsUsedAsNullable</c>
+    /// must not diverge.
+    /// </summary>
+    [Fact]
+    public void InferredGenericCall_PatternChainCompilesAndProducesTheCSharpAnswer()
+    {
+        string printed = Translate(PatternChainSource);
+        string stdout = CompileAndRun(
+            printed,
+            "let xs = []object{ Node(3), Node(1) }\nSystem.Console.WriteLine(PatternChain.Total(xs).ToString())");
+
+        Assert.Equal("4", stdout.Trim());
+    }
+
+    /// <summary>
+    /// The THIRD seam behind <c>PragmaSuppressions.cs</c> (the two above are the
+    /// #3843 cast lowering and the #3855 lambda promotion): the #3501 yield
+    /// element-taint rule already stands down for a yield a null guard
+    /// dominates (#3700/#3714), but its <c>IsNullTestOf</c> only recognised a
+    /// BARE test. The real shape conjoins the guard with the test it protects —
+    /// <c>if (text != null &amp;&amp; text.StartsWith("GSA")) { yield return
+    /// text; }</c> — so the iterator's element widened to <c>string?</c> and the
+    /// widened element then failed every non-nullable consumer downstream
+    /// (<c>GS0155</c> at <c>state[id] = disable</c>).
+    /// </summary>
+    private const string ConjoinedYieldGuardSource = @"
+namespace Demo
+{
+    using System.Collections.Generic;
+
+    public class Ids
+    {
+        public static IEnumerable<string> Names(IEnumerable<string> raw)
+        {
+            foreach (string candidate in raw)
+            {
+                string text = candidate.Length == 0 ? null : candidate;
+                if (text != null && text.StartsWith(""G""))
+                {
+                    yield return text;
+                }
+            }
+        }
+
+        public static int Count(IEnumerable<string> raw)
+        {
+            var seen = new Dictionary<string, bool>();
+            foreach (string id in Names(raw))
+            {
+                seen[id] = true;
+            }
+
+            return seen.Count;
+        }
+    }
+}
+";
+
+    [Fact]
+    public void ConjoinedYieldGuard_DoesNotWidenTheIteratorElement()
+    {
+        string printed = Translate(ConjoinedYieldGuardSource);
+
+        Assert.Contains("Names(raw IEnumerable[string]) sequence[string]", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("sequence[string?]", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing half: the guard the analyzer now believes really does hold
+    /// at run time, so the narrowed element must not merely compile — it must
+    /// produce the same answer, and no <c>!!</c> in the emitted chain may throw.
+    /// </summary>
+    [Fact]
+    public void ConjoinedYieldGuard_CompilesAndProducesTheCSharpAnswer()
+    {
+        string printed = Translate(ConjoinedYieldGuardSource);
+        string stdout = CompileAndRun(
+            printed,
+            "let xs = []string{ \"Ga\", \"\", \"Gb\", \"z\" }\nSystem.Console.WriteLine(Ids.Count(xs).ToString())");
+
+        Assert.Equal("2", stdout.Trim());
+    }
+
+    [Fact]
+    public void FixedDelegateTarget_NullTestedLambdaParameter_IsStillPromoted()
+    {
+        string printed = Translate(FixedTargetSource);
+
+        Assert.Contains("(s string?)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExplicitTypeArguments_NullTestedLambdaParameter_IsStillPromoted()
+    {
+        string printed = Translate(ExplicitTypeArgumentSource);
+
+        Assert.Contains("(s string?)", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConcreteArrowPositionInGenericCall_NullTestedLambdaParameter_IsStillPromoted()
+    {
+        string printed = Translate(ConcreteArrowPositionSource);
+
+        Assert.Contains("(s string?)", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            Microsoft.CodeAnalysis.NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        Assert.DoesNotContain(
+            context.Diagnostics,
+            d => d.Severity == TranslationSeverity.Unsupported);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", result.Errors)
+                + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static string CompileAndRun(string printed, string entryStatements)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-3855-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        string gsPath = Path.Combine(workDir, "Snippet.gs");
+        string dllPath = Path.Combine(workDir, "Snippet.dll");
+        File.WriteAllText(
+            gsPath,
+            printed + Environment.NewLine + entryStatements + Environment.NewLine);
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated snippet with zero errors. Output:\n" + compileOut
+                + "\n\nTranslated G#:\n" + printed);
+
+        (int runExit, string stdout) = RunDotnet($"\"{dllPath}\"");
+        Assert.True(
+            runExit == 0,
+            "Translated snippet must run successfully. Output:\n" + stdout
+                + "\n\nTranslated G#:\n" + printed);
+        return stdout;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -125,6 +125,140 @@ public sealed partial class CSharpToGSharpTranslator
             type is { NullableAnnotation: NullableAnnotation.Annotated }
                 && (type.IsReferenceType || type is ITypeParameterSymbol);
 
+        // Issue #3855: true when <paramref name="parameter"/> is a lambda
+        // parameter whose rendered type ANNOTATION is an input to the enclosing
+        // call's type-argument inference, so promoting it (#1072) would widen an
+        // inferred type ARGUMENT rather than merely describe this one position.
+        //
+        // The distinction that matters is whether the target type is FIXED:
+        //
+        //   * fixed target (`Action<string> a = s => { if (s == null) … };`, a
+        //     non-generic callee, or a generic callee with EXPLICIT type
+        //     arguments) — the annotation only has to be COMPATIBLE with the
+        //     target, and widening an input position is contravariance, so a
+        //     `(string?) -> R` literal still converts to a `(string) -> R`
+        //     target. The promotion is a faithful, local statement about what
+        //     this body does with the value, and nothing else observes it.
+        //
+        //   * inferred target (`xs.Where(d => d != null)`) — the annotation is
+        //     not checked against a target, it CHOOSES one. gsc infers
+        //     `TSource := T?` from `(d T?) -> …`, so the element type of the
+        //     whole chain widens and every downstream member access runs on a
+        //     nullable receiver (GS0158 / GS0154). That consequence was never
+        //     what #1072 intended.
+        //
+        // Suppressing the promotion here does not cost the `== nil` guard the
+        // promotion existed to make legal: gsc admits `x == nil` / `x != nil`
+        // on a bare reference class (BoundBinaryOperator's imported-class and
+        // `StructSymbol { IsClass: true }` arms), so `(d T) -> d != nil` binds.
+        private bool LambdaParameterAnnotationFeedsTypeInference(ParameterSyntax parameter)
+        {
+            if (parameter.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>()
+                is not { } lambda)
+            {
+                return false;
+            }
+
+            // Only a lambda handed DIRECTLY to a call has its parameter type
+            // dictated by that call. Anywhere else (a local's initializer, a
+            // return, a collection element) the target type is already fixed.
+            SyntaxNode node = lambda;
+            while (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+            {
+                node = node.Parent;
+            }
+
+            if (node.Parent is not ArgumentSyntax argument
+                || argument.Parent?.Parent is not InvocationExpressionSyntax invocation)
+            {
+                return false;
+            }
+
+            if (this.context.GetSymbolInfo(invocation).Symbol
+                is not IMethodSymbol { IsGenericMethod: true })
+            {
+                return false;
+            }
+
+            // Explicit type arguments (`xs.Where<Node>(d => …)`) fix the target
+            // before the lambda is ever looked at — nothing is inferred.
+            if (HasExplicitTypeArguments(invocation.Expression))
+            {
+                return false;
+            }
+
+            ITypeSymbol parameterType =
+                (this.context.SemanticModel.GetOperation(argument) as IArgumentOperation)
+                    ?.Parameter?.OriginalDefinition.Type;
+            if (parameterType == null)
+            {
+                // The callee could not be resolved to a parameter position. The
+                // call IS generic and its type arguments ARE inferred, so the
+                // annotation cannot be shown to be inert; suppress.
+                return true;
+            }
+
+            int index = LambdaParameterIndex(lambda, parameter);
+            ITypeSymbol arrowPosition = DelegateParameterTypeAt(parameterType, index);
+
+            // Fall back to the whole delegate type when the arrow position
+            // cannot be isolated: a type-parameter-free delegate parameter
+            // (`Func<string, T>`'s input) proves the annotation is inert.
+            return MentionsMethodTypeParameter(arrowPosition ?? parameterType);
+        }
+
+        private static bool HasExplicitTypeArguments(ExpressionSyntax callee) => callee switch
+        {
+            GenericNameSyntax => true,
+            MemberAccessExpressionSyntax member => HasExplicitTypeArguments(member.Name),
+            MemberBindingExpressionSyntax binding => HasExplicitTypeArguments(binding.Name),
+            _ => false,
+        };
+
+        private static int LambdaParameterIndex(
+            AnonymousFunctionExpressionSyntax lambda,
+            ParameterSyntax parameter)
+        {
+            SeparatedSyntaxList<ParameterSyntax>? list = lambda switch
+            {
+                ParenthesizedLambdaExpressionSyntax paren => paren.ParameterList?.Parameters,
+                AnonymousMethodExpressionSyntax anonymous => anonymous.ParameterList?.Parameters,
+                _ => null,
+            };
+
+            return list?.IndexOf(parameter) ?? 0;
+        }
+
+        // The <paramref name="index"/>th arrow-parameter type of a delegate-typed
+        // (or `Expression<TDelegate>`-typed) callee parameter, or null when the
+        // shape is not a delegate at all.
+        private static ITypeSymbol DelegateParameterTypeAt(ITypeSymbol parameterType, int index)
+        {
+            if (parameterType is INamedTypeSymbol { Name: "Expression", TypeArguments.Length: 1, DelegateInvokeMethod: null } expression)
+            {
+                parameterType = expression.TypeArguments[0];
+            }
+
+            return parameterType is INamedTypeSymbol { DelegateInvokeMethod: { } invoke }
+                && index >= 0
+                && index < invoke.Parameters.Length
+                ? invoke.Parameters[index].Type
+                : null;
+        }
+
+        // True when <paramref name="type"/> mentions a METHOD type parameter
+        // anywhere — i.e. one the enclosing call has to infer. A CLASS type
+        // parameter is already fixed by the receiver and is not an inference
+        // input here.
+        private static bool MentionsMethodTypeParameter(ITypeSymbol type) => type switch
+        {
+            ITypeParameterSymbol { TypeParameterKind: TypeParameterKind.Method } => true,
+            IArrayTypeSymbol array => MentionsMethodTypeParameter(array.ElementType),
+            IPointerTypeSymbol pointer => MentionsMethodTypeParameter(pointer.PointedAtType),
+            INamedTypeSymbol named => named.TypeArguments.Any(MentionsMethodTypeParameter),
+            _ => false,
+        };
+
         private GTypeReference PromoteIfUsedAsNullable(GTypeReference type, ISymbol symbol)
         {
             if (type == null)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Types.cs
@@ -329,7 +329,20 @@ public sealed partial class CSharpToGSharpTranslator
             // G# arrow lambda always names the parameter type (ADR-0074).
             if (this.context.GetDeclaredSymbol(parameter) is IParameterSymbol symbol)
             {
-                return this.MapParameter(symbol, parameter);
+                // Issue #3855: the #1072 promotion is safe for a lambda
+                // parameter whose type is FIXED by the target delegate —
+                // widening an input position is contravariance, and a
+                // `(T?) -> R` literal still converts to a `(T) -> R` target.
+                // It is NOT safe when the annotation is an INPUT to the
+                // enclosing call's type-argument inference: there the widened
+                // annotation does not adapt to a fixed target, it CHOOSES the
+                // target, so `.Where((d T?) -> d != nil)` infers the whole
+                // sequence as `sequence[T?]` and every downstream member
+                // access runs on a nullable receiver.
+                return this.MapParameter(
+                    symbol,
+                    parameter,
+                    promoteNullability: !this.LambdaParameterAnnotationFeedsTypeInference(parameter));
             }
 
             GTypeReference type = parameter.Type != null

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -4154,6 +4154,25 @@ internal static class ObliviousNullabilityAnalyzer
 
         switch (condition)
         {
+            // Issue #3855 (the third seam behind PragmaSuppressions.cs): the
+            // guard is very often CONJOINED with the test it protects —
+            // `if (text != null && text.StartsWith("GSA")) { yield return
+            // text; }`. `A && B` being true implies BOTH conjuncts are true, so
+            // a null test in EITHER position proves the same thing the bare test
+            // does, and the whole conjunction can be walked.
+            //
+            // Restricted to the `whenTrueIsNull: false` direction on purpose.
+            // Every caller passing `false` asks about a POSITIVE position (an
+            // if-then, a `while`/`for` body, a ternary's true arm) where the
+            // condition really did evaluate true. The `true` direction is only
+            // ever asked from a NEGATED position — an `else` clause, or the code
+            // after an `if (...) return;` — where the fact available is
+            // `!(A && B)`, which proves nothing about either conjunct on its own.
+            case BinaryExpressionSyntax conjunction
+                when !whenTrueIsNull && conjunction.IsKind(SyntaxKind.LogicalAndExpression):
+                return IsNullTestOf(conjunction.Left, symbol, whenTrueIsNull)
+                    || IsNullTestOf(conjunction.Right, symbol, whenTrueIsNull);
+
             case BinaryExpressionSyntax binary
                 when binary.IsKind(whenTrueIsNull ? SyntaxKind.EqualsExpression : SyntaxKind.NotEqualsExpression):
                 return (IsSymbolIdentifier(binary.Left, symbol) && IsNullLiteral(binary.Right))


### PR DESCRIPTION
Fixes #3855, and the third seam behind `PragmaSuppressions.cs` along with it.

## The rule, and why this one

The #1072 promotion (`PromoteIfUsedAsNullable`) renders a null-tested parameter `T?` in an oblivious compilation. The question #3855 asks is *when is that annotation observed by anything other than this declaration.*

**A lambda parameter's target type is either FIXED or INFERRED, and only the second case is broken.**

* **Fixed** — a non-generic callee, an explicit-type-argument generic callee, a lambda stored into a delegate-typed local/field, a lambda whose arrow position is concrete. The annotation only has to be *compatible* with the target, and widening an input position is contravariance: a `(T?) -> R` literal still converts to a `(T) -> R` target. The promotion is a faithful local statement about what the body does and nothing else observes it. **Unchanged.**
* **Inferred** — `xs.Where(d => d != null)`. The annotation is not checked against a target, it *chooses* one. gsc infers `TSource := T?` from `(d T?) -> …`, the element type of the whole chain widens, and every downstream member access runs on a nullable receiver — `GS0158 Cannot find member SpanStart` four lines later. **Promotion stands down.**

So: **do not apply the #1072 promotion to a lambda parameter whose rendered annotation is an input to the enclosing call's type-argument inference** — the lambda is a direct argument to a generic invocation with *inferred* type arguments, and the delegate's arrow position at that index mentions a *method* type parameter.

`MapLambdaParameter` already had a `promoteNullability` flag on `MapParameter`; the whole change is deciding it. `LambdaParameterAnnotationFeedsTypeInference` lives in `CSharpToGSharpTranslator.Nullability.cs` beside the rule it guards.

### What I rejected

* **Option 2 — "promote, but exclude the annotation from inference inputs."** Closest to intent, and **not implementable**. cs2gs emits *source*: the `.gs` file has to be legal G# standing alone, and G# has no syntax for "this annotation is not an inference input". There is nowhere to hang the exclusion short of a language feature, and inventing one to serve a translator's internal bookkeeping is the wrong trade.
* **Option 3 — "promote only where the enclosing call's type arguments are explicit."** Sound but coarser: it also drops the promotion where the lambda's own arrow position is *concrete* (`Run<T>(Func<string, T> project)` — `T` is inferred from the result, never from `string`). The rule implemented here is option 3 plus that precision, so it is a strict subset of option 3's blast radius, and the extra check is one `MentionsMethodTypeParameter` walk.

**The promotion was not load-bearing for the guard it was introduced for.** `PromoteIfUsedAsNullable`'s own comment says gsc "only permits `== nil` on a nullable operand, otherwise GS0129". That is **not true for a reference class**: `BoundBinaryOperator`'s imported-class and `StructSymbol { IsClass: true }` arms admit `x == nil` / `x != nil` on a bare reference type. Verified by executing, not by reading — `(d Node) -> d != nil` binds, compiles and runs. This is why standing the promotion down costs nothing at the guard site.

## The third seam — yield-taint through a CONJOINED guard

`PragmaSuppressions.cs` trips on three independent defects. #3843/#3854 is one; #3855 is two; this is three, and it turned out to be two lines:

```csharp
if (text != null && text.StartsWith("GSA", StringComparison.Ordinal))
{
    yield return text;          // element widened to string?
}
```

The #3501 yield element-taint rule *already* stands down for a null-guard-dominated yield (#3700/#3714) — but `IsNullTestOf` only recognised a **bare** test. The guard is very often conjoined with the test it protects, so `DirectiveIds` emitted `sequence[string?]` and `state[id] = disable` reported `GS0155`.

`A && B` being true implies both conjuncts are true, so a null test in either position proves exactly what the bare test proves. **Restricted to the `whenTrueIsNull: false` direction on purpose**: every caller passing `false` asks about a *positive* position (if-then, `while`/`for` body, ternary true arm). The `true` direction is only ever asked from a *negated* position (an `else` clause, or after `if (…) return;`), where the available fact is `!(A && B)` — which proves nothing about either conjunct. Admitting the conjunction there would have been unsound.

Note the direction of both changes: each **removes** a `T?`, narrowing an over-wide annotation. Neither admits a `nil` anywhere, and no nullability check is weakened.

## The acceptance test — `PragmaSuppressions.cs` unmodified

Measured with `cs2gs validate` over the closure `Cs2Gs.Translator → Cs2Gs.CodeModel → src/Core`, closure kept whole:

| base | `Cs2Gs.Translator` compile | errors, all in `PragmaSuppressions.gs` |
|---|---|---|
| `origin/main` | FAIL(5) | GS0158 ×3, GS0154, **GS0155 `string?`→`string`** |
| **this PR** | FAIL(4) | GS0158 ×3, GS0154 |
| **this PR + #3854 merged** | **PASS** (+ ILVerify PASS + test-parity PASS) | **none** |

`src/Core` and `Cs2Gs.CodeModel` are **PASS compile + ILVerify + test-parity** on every one of those runs.

So this PR alone takes the file **5 → 4** — the yield-taint error is gone. The remaining 4 are #3854's: the explicit cast still lowers to `t.GetStructure() as PragmaWarningDirectiveTriviaSyntax`, so the sequence element is `T?` no matter what the lambda annotates. Measured, not reasoned: on a scratch branch with #3854 merged in (`measure/3855-plus-3854`, never pushed and not a base for this PR), the whole closure is **3/3 green — `Cs2Gs.Translator` PASS compile + ILVerify + test-parity**. The emitted chain is then internally consistent on its face:

```
.Select((t SyntaxTrivia) -> cast[PragmaWarningDirectiveTriviaSyntax](t.GetStructure()))
.Where((d PragmaWarningDirectiveTriviaSyntax) -> d != nil)
.OrderBy((d PragmaWarningDirectiveTriviaSyntax) -> d.SpanStart)
```

So the file needs #3854 **and** this PR: neither alone is sufficient, and with both, `PragmaSuppressions.cs` unmodified from `origin/main` compiles, ILVerifies and passes test parity. This PR is deliberately based on `origin/main`, not on #3854's branch.

## Blast radius — whole-repo, before vs after

Two `migrate --translate-only` passes over the whole repository, one built from `origin/main`, one from this branch, same `--exclude` set:

| | before | after |
|---|---|---|
| apps translating | 48/52 | 48/52 |
| `.gs` files changed | — | **14** (11 by translation behaviour + 3 whose C# source I edited) |
| sites changed | — | **12** lambda annotations + 3 lines in `PragmaSuppressions.gs` |
| `!!` null assertions | 18701 | 18722 |
| synthetic labels / `__local_` / lines>300 | 0 / 29 / 540 | 0 / 29 / 540 |

**The 48/52 is the baseline, not a regression** — `src/Repl`, `test/Compiler.Tests`, `test/Extensions.Tests`, `test/Interpreter.Tests` fail translate identically on `origin/main` in this environment (the `Gsharp.Extensions` Debug-prerequisite path). **No app moved in either direction.**

**The `!!` delta is +21 and every one of them is my own new source entering the corpus** — cs2gs is inside its own migration corpus, so the C# I added is translated too:

| file | before | after |
|---|---|---|
| `CSharpToGSharpTranslator.Nullability.gs` (my new helper) | 58 | 61 |
| `Issue3855LambdaInferencePromotionTests.gs` (new file) | 0 | 18 |
| **everything else, including every file the fix changed** | — | **0 net** |

`PragmaSuppressions.gs` is exactly `!!`-neutral: `-DirectiveIds(directive)!!`, `+yield text!!`. **The translation-behaviour change itself moves the corpus `!!` count by zero.**

Every one of the 12 lambda sites is the same shape:

```
- .Where((expr ExpressionSyntax?) -> expr != nil)
+ .Where((expr ExpressionSyntax)  -> expr != nil)
```

across `src/LanguageServer` (2), `test/Shared` (2), `Cs2Gs.CodeModel` (2), `Cs2Gs.Pipeline`, `Cs2Gs.Tests`, `Cs2Gs.Translator` (3), and one `.FirstOrDefault`/`.Any` variant each. Two of them leave a now-redundant `!!` on the narrowed parameter; gsc answers `warning GS0536 Redundant '!!'`, not an error, and the stage-2 polish pass removes it — measured, not assumed.

## Test evidence

`Issue3855LambdaInferencePromotionTests` — 9 tests, and the ones that matter **execute**: translate → `gsc /target:exe` → run → assert stdout.

* `InferredGenericCall_TranslatedChainCompilesAndProducesTheCSharpAnswer` and `…PatternChainCompiles…` run the `Select(cast).Where(x => x is not null).OrderBy(...)` chain — **the shape that has now defeated two separate fixes** — and assert it prints `4`, i.e. it both compiles and computes what the C# computes.
* `ConjoinedYieldGuard_CompilesAndProducesTheCSharpAnswer` executes the iterator and asserts `2`, so the guard the analyzer now believes is proven to hold at run time.
* Both `!= null` and `is not null` spellings are pinned — two independent entries into `IsUsedAsNullable`.

**Failing-on-main proof, and the anti-vacuity guard rails.** With the new arm disabled, **4 of 9 fail** (the two lambda ones and the two yield ones, both translation and executing halves). With the conjunction arm disabled, the 2 yield tests fail. The other **3 pass on `main` by design** and are there to fail if the rule over-reaches:

* `FixedDelegateTarget_…_IsStillPromoted` — non-generic callee.
* `ExplicitTypeArguments_…_IsStillPromoted` — `Run<string>(…)`.
* `ConcreteArrowPositionInGenericCall_…_IsStillPromoted` — `Func<string, T>`, where the method type parameter is in the result, not the argument.

**Suites.** `Cs2Gs.Tests` **1667/1667** locally. The full suites run in CI on this branch.

## Deconfliction

Touched only `CSharpToGSharpTranslator.Types.cs` (`MapLambdaParameter`), `CSharpToGSharpTranslator.Nullability.cs` (the new predicate) and `ObliviousNullabilityAnalyzer.cs` (`IsNullTestOf`). **No gsc change; `Conversion.cs` / `ConversionClassifier.cs` / `CastLowersToNullPreservingSafeCast` are untouched** — that is #3854's territory.

`tools/cs2gs/selfmig-baseline.json` is untouched.

Refs #3855, #3843, #3854, #3835, #1072, #3700, #3714, #3501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
