### PR TITLE
selfmig: take test/Core.Tests green — doc @param mismatch + params `is null` guard (#3501)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs
@@ -19,7 +19,8 @@ public class OverloadResolutionPropertyTests
     /// <summary>
     /// Resolving the same candidate set and arguments repeatedly is deterministic.
     /// </summary>
-    /// <param name="scenario">The generated overload-resolution input.</param>
+    /// <param name="candidates">The generated candidate method set.</param>
+    /// <param name="argTypes">The generated argument types.</param>
     /// <returns><see langword="true"/> when both attempts produce the same result.</returns>
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Resolution_is_deterministic(MethodInfo[] candidates, Type[] argTypes)
@@ -35,7 +36,8 @@ public class OverloadResolutionPropertyTests
     /// <summary>
     /// Resolution results maintain their public shape invariants.
     /// </summary>
-    /// <param name="scenario">The generated overload-resolution input.</param>
+    /// <param name="candidates">The generated candidate method set.</param>
+    /// <param name="argTypes">The generated argument types.</param>
     /// <returns><see langword="true"/> when the outcome and payload agree.</returns>
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Outcome_payloads_match_outcome(MethodInfo[] candidates, Type[] argTypes)
@@ -57,7 +59,8 @@ public class OverloadResolutionPropertyTests
     /// <summary>
     /// Every reported best or ambiguous method came from the original candidate set.
     /// </summary>
-    /// <param name="scenario">The generated overload-resolution input.</param>
+    /// <param name="candidates">The generated candidate method set.</param>
+    /// <param name="argTypes">The generated argument types.</param>
     /// <returns><see langword="true"/> when all returned methods were supplied as candidates.</returns>
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Resolution_only_returns_input_candidates(MethodInfo[] candidates, Type[] argTypes)
@@ -77,7 +80,8 @@ public class OverloadResolutionPropertyTests
     /// <summary>
     /// An applicable identity conversion wins over widening, boxing, and reference conversions.
     /// </summary>
-    /// <param name="scenario">The generated exact-match scenario.</param>
+    /// <param name="argumentType">The generated argument type whose exact one-parameter method must win.</param>
+    /// <param name="distractors">The generated non-exact candidates competing with it.</param>
     /// <returns><see langword="true"/> when the exact candidate resolves.</returns>
     [Property(MaxTest = 200, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Exact_match_is_preferred(Type argumentType, MethodInfo[] distractors)
@@ -96,7 +100,9 @@ public class OverloadResolutionPropertyTests
     /// <summary>
     /// Numeric better-conversion ordering is antisymmetric and drives overload choice.
     /// </summary>
-    /// <param name="scenario">The generated numeric-betterness scenario.</param>
+    /// <param name="source">The generated source type of the single argument.</param>
+    /// <param name="firstIndex">Index selecting the first numeric candidate.</param>
+    /// <param name="secondIndex">Index selecting the second numeric candidate.</param>
     /// <returns><see langword="true"/> when the expected numeric target resolves.</returns>
     [Property(MaxTest = 300, Arbitrary = [typeof(OverloadResolutionGenerators)])]
     public bool Numeric_betterness_is_antisymmetric_and_selects_expected_candidate(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs
@@ -3,9 +3,14 @@
 // </copyright>
 
 using System;
+using System.Collections.Immutable;
+using System.Linq;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -125,6 +130,80 @@ public class Issue3501ResidualSyntheticRetargetTests
         Assert.DoesNotContain("true &&", printed, StringComparison.Ordinal);
         Assert.Contains(".Length > 0", printed, StringComparison.Ordinal);
         TranslationTestValidation.AssertBinds(printed);
+    }
+
+    [Fact]
+    public void ParamsArrayIsNullPattern_FoldsAway()
+    {
+        // The `is null` spelling of the same guard — the shape
+        // test/Shared/EmittedFixture.cs uses, which is LINKED into both
+        // Core.Tests and Compiler.Tests, so the surviving `== nil` reported
+        // GS0523 in both migrated apps. Only the `== null` binary spelling was
+        // folded before; the constant-null PATTERN fell through.
+        string printed = Translate("""
+            using System;
+
+            public class C
+            {
+                public static int Count(params string[] paths)
+                {
+                    if (paths is null)
+                    {
+                        throw new ArgumentNullException(nameof(paths));
+                    }
+
+                    return paths.Length;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain("== nil", printed, StringComparison.Ordinal);
+        AssertBindsWithoutNilCompareWarning(printed);
+    }
+
+    [Fact]
+    public void ParamsArrayIsNotNullPattern_FoldsAway()
+    {
+        // `args is not null` is the negated spelling of the same dead guard.
+        string printed = Translate("""
+            public class C
+            {
+                public static int Count(params string[] paths)
+                {
+                    return paths is not null ? paths.Length : 0;
+                }
+            }
+            """);
+
+        Assert.DoesNotContain("!= nil", printed, StringComparison.Ordinal);
+        AssertBindsWithoutNilCompareWarning(printed);
+    }
+
+    [Fact]
+    public void NonParamsArrayIsNullPattern_KeepsTheGuard()
+    {
+        // Anti-vacuity guard for the two tests above: an ORDINARY (non-params)
+        // nullable array parameter keeps its `is null` guard — the fold is
+        // keyed on `params`, not on "array compared to null".
+        string printed = Translate("""
+            using System;
+
+            public class C
+            {
+                public static int Count(string[]? paths)
+                {
+                    if (paths is null)
+                    {
+                        throw new ArgumentNullException(nameof(paths));
+                    }
+
+                    return paths.Length;
+                }
+            }
+            """);
+
+        Assert.Contains("== nil", printed, StringComparison.Ordinal);
+        AssertBindsWithoutNilCompareWarning(printed);
     }
 
     [Fact]
@@ -548,6 +627,30 @@ public class Issue3501ResidualSyntheticRetargetTests
         // print completes instead of throwing on a null member.
         string printed = GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
         Assert.Contains("DualMapFixture", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Binds the translated G# and asserts it reports no GS0523 ("comparison
+    /// of non-nullable … with 'nil' is always …"). GS0523 is a WARNING, so
+    /// <see cref="TranslationTestValidation.AssertBinds(string[])"/> alone does
+    /// not see it — but the migrated tree builds with TreatWarningsAsErrors, so
+    /// in the self-migration gate it is a hard failure.
+    /// </summary>
+    private static void AssertBindsWithoutNilCompareWarning(string printed)
+    {
+        TranslationTestValidation.AssertBinds(printed);
+
+        var trees = ImmutableArray.Create(SyntaxTree.Parse(SourceText.From(printed)));
+        BoundGlobalScope scope = Binder.BindGlobalScope(previous: null, trees, references: null);
+        var nilCompareWarnings = scope.Diagnostics
+            .Concat(Binder.BindProgram(scope).Diagnostics)
+            .Where(diagnostic => diagnostic.Id == "GS0523")
+            .ToArray();
+        Assert.True(
+            nilCompareWarnings.Length == 0,
+            "Translated G# must not report GS0523. Reported:\n"
+                + string.Join("\n", nilCompareWarnings.Select(warning => warning.ToString()))
+                + "\n\nPrinted:\n" + printed);
     }
 
     private static string Translate(string source)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -1108,6 +1108,17 @@ public sealed partial class CSharpToGSharpTranslator
         {
             switch (pattern)
             {
+                case ConstantPatternSyntax paramsNull
+                    when paramsNull.Expression.IsKind(SyntaxKind.NullLiteralExpression)
+                        && this.IsParamsArrayOperand(receiverSyntax):
+                    // ADR-0159 / issue #3501: `args is null` where `args` is a
+                    // C# `params` array. A G# variadic parameter always
+                    // materializes an array, so the compare is statically
+                    // decided and gsc reports GS0523 — fold it the same way the
+                    // `args == null` spelling is folded (see
+                    // TryFoldParamsArrayNullCheck).
+                    return LiteralExpression.Bool(false);
+
                 case ConstantPatternSyntax constant
                     when constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
                     // `x is null` → `x == nil`.
@@ -1208,7 +1219,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return LiteralExpression.Bool(true);
 
                 case UnaryPatternSyntax unary when unary.IsKind(SyntaxKind.NotPattern):
-                    return this.TranslateNotPatternTest(receiver, unary.Pattern, receiverType, isNestedPatternMember);
+                    return this.TranslateNotPatternTest(receiver, unary.Pattern, receiverType, receiverSyntax, isNestedPatternMember);
 
                 case BinaryPatternSyntax binaryPattern
                     when binaryPattern.OperatorToken.IsKind(SyntaxKind.OrKeyword)
@@ -1365,10 +1376,23 @@ public sealed partial class CSharpToGSharpTranslator
         }
 
         private GExpression TranslateNotPatternTest(
-            GExpression receiver, PatternSyntax inner, ITypeSymbol receiverType = null, bool isNestedPatternMember = false)
+            GExpression receiver,
+            PatternSyntax inner,
+            ITypeSymbol receiverType = null,
+            ExpressionSyntax receiverSyntax = null,
+            bool isNestedPatternMember = false)
         {
             switch (inner)
             {
+                case ConstantPatternSyntax paramsNull
+                    when paramsNull.Expression.IsKind(SyntaxKind.NullLiteralExpression)
+                        && this.IsParamsArrayOperand(receiverSyntax):
+                    // ADR-0159 / issue #3501: `args is not null` on a C#
+                    // `params` array — always true for a G# variadic, which
+                    // materializes an array; the `!= nil` spelling would be
+                    // GS0523 (see TryFoldParamsArrayNullCheck).
+                    return LiteralExpression.Bool(true);
+
                 case ConstantPatternSyntax constant
                     when constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
                     // `x is not null` → `x != nil`.
@@ -1427,7 +1451,7 @@ public sealed partial class CSharpToGSharpTranslator
                     return new UnaryExpression(
                         "!",
                         new ParenthesizedExpression(
-                            this.TranslatePatternTest(receiver, inner, receiverType, isNestedPatternMember: isNestedPatternMember)));
+                            this.TranslatePatternTest(receiver, inner, receiverType, receiverSyntax, isNestedPatternMember)));
             }
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -1614,8 +1614,7 @@ public sealed partial class CSharpToGSharpTranslator
             ExpressionSyntax operand = binary.Right.IsKind(SyntaxKind.NullLiteralExpression) ? binary.Left
                 : binary.Left.IsKind(SyntaxKind.NullLiteralExpression) ? binary.Right
                 : null;
-            if (operand == null
-                || this.context.GetSymbolInfo(operand).Symbol is not IParameterSymbol { IsParams: true })
+            if (!this.IsParamsArrayOperand(operand))
             {
                 return false;
             }
@@ -1623,6 +1622,20 @@ public sealed partial class CSharpToGSharpTranslator
             folded = LiteralExpression.Bool(!isEquals);
             return true;
         }
+
+        /// <summary>
+        /// ADR-0159 / issue #3501: true when <paramref name="operand"/> reads a
+        /// C# <c>params</c> parameter. Such a parameter translates to a G#
+        /// variadic, which always materializes an array, so any nil comparison
+        /// against it is statically decided and gsc reports GS0523. Shared by
+        /// the <c>args == null</c> binary spelling
+        /// (<see cref="TryFoldParamsArrayNullCheck"/>) and the <c>args is
+        /// null</c> / <c>args is not null</c> pattern spelling
+        /// (<c>TranslatePatternTest</c> / <c>TranslateNotPatternTest</c>).
+        /// </summary>
+        private bool IsParamsArrayOperand(ExpressionSyntax operand)
+            => operand != null
+                && this.context.GetSymbolInfo(operand).Symbol is IParameterSymbol { IsParams: true };
 
         /// <summary>
         /// Issue #3501: true when the arm a <c>goto case</c>/<c>goto


### PR DESCRIPTION
Takes `test/Core.Tests` — the smallest remaining wall in the #3501 self-migration gate, 2 errors on gate run 33743456719 (44/52, `0753a162c`) — to zero, and clears one of `test/Compiler.Tests`' 9 fingerprints with the same change.

The two errors are unrelated to each other. Both are gsc **warnings** that become errors because the migrated tree inherits the repo's `TreatWarningsAsErrors=true`.

## 1. `GS0229` — `Documentation @param 'scenario' does not match any parameter of 'Resolution_is_deterministic'`

**Not a translation defect.** `test/Core.Tests/CodeAnalysis/Binding/OverloadResolutionPropertyTests.cs` documents five FsCheck property methods with a `<param name="scenario">` tag naming a parameter none of them has (they take `candidates`/`argTypes`, `argumentType`/`distractors`, `source`/`firstIndex`/`secondIndex`). cs2gs translates the doc comment faithfully to `/// @param scenario …`; gsc's `DocumentationValidator.ValidateParamMatches` then reports the mismatch.

csc agrees this is a defect. The equivalent C# compiled with `GenerateDocumentationFile=true` gives:

```
warning CS1572: XML comment has a param tag for 'scenario', but there is no parameter by that name
warning CS1573: Parameter 'candidates' has no matching param tag in the XML comment for 'C.M(int, int)'
```

It went unseen only because `build/gsharp.build.props` sets `<Nullable>disable` for test projects and nothing turns on doc generation for them, so csc never emits CS1572. Fixed at the source: the tags now name the real parameters. GS0229 is exactly CS1572 — nothing to change in gsc or cs2gs.

## 2. `GS0523` — `Comparison of non-nullable '[]string' with 'nil' is always false`

**Neither of the two shapes that were hypothesised.** The C# did not declare `string[]?` and lose the annotation, and it is not a pointless comparison C# merely warns about. The operand is a C# **`params` array**:

```csharp
// test/Shared/EmittedFixture.cs (#3830)
public static Assembly[] LoadTogether(params string[] assemblyPaths)
{
    if (assemblyPaths is null)
    {
        throw new ArgumentNullException(nameof(assemblyPaths));
    }
```

A `params string[]` translates to a G# variadic `paths ...string`, whose parameter type is a bare `[]string` — which under ADR-0159 can never be nil. Verified directly against gsc, which reproduces the fingerprint's exact wording and type spelling:

```
probe.gs(6,8,6,20): warning GS0523: Comparison of non-nullable '[]string' with 'nil'
is always false — a bare (non-'?') collection-typed value can never be nil (ADR-0159); …
        if paths == nil {
```

**This is an established, already-decided shape, not a new policy question.** cs2gs has folded exactly this guard since the `Diagnostic.Create` blocker: `TryFoldParamsArrayNullCheck` in `CSharpToGSharpTranslator.Statements.cs` folds `args == null` / `args != null` on a `params` parameter to its constant, and `CSharpToGSharpTranslator.Patterns.cs` skips the same guard for a `params` recursive-pattern subject (`args is { Length: > 0 }`).

**The gap is the spelling.** The fold matched only `BinaryExpressionSyntax`. `EmittedFixture.cs` writes the guard as the constant-null **pattern** `assemblyPaths is null`, which is an `IsPatternExpressionSyntax`, so it fell straight through to `x == nil`. This PR extends the fold to the pattern spelling — `args is null` → `false`, `args is not null` → `true` — keyed on the same `params` predicate, now extracted as the shared `IsParamsArrayOperand`.

### The `Compiler.Tests` GS0523 is the same root cause, not just the same message

`test/Shared/EmittedFixture.cs` is `<Compile Include>`-linked into **both** `Core.Tests` and `Compiler.Tests`. One source line, one translation, two migrated apps. Fixing it clears Core.Tests' second error and one of Compiler.Tests' nine.

## Not a suppression

The folded output is legal, not merely quiet — it compiles clean and runs:

```
$ gsc probe2.gs /out:probe2.dll     # `if false { throw … }` + `return paths.Length`
Wrote probe2.dll
$ dotnet probe2.dll
2
```

No diagnostic was weakened, no `/nowarn` added, no `!` introduced. `GS0523` still fires on every non-`params` bare collection.

## Tests

Three new cases in `Cs2Gs.Tests/Issue3501ResidualSyntheticRetargetTests.cs`, beside the existing `params` fold tests:

- `ParamsArrayIsNullPattern_FoldsAway`
- `ParamsArrayIsNotNullPattern_FoldsAway`
- `NonParamsArrayIsNullPattern_KeepsTheGuard` — anti-vacuity: an ordinary `string[]?` parameter keeps its `is null` guard, so the fold is keyed on `params`, not on "array compared to null".

They assert on the printed G# **and** bind it and assert no `GS0523` is reported. `TranslationTestValidation.AssertBinds` alone cannot gate this — GS0523 is a warning and `AssertBinds` only filters `IsError` — so the helper re-binds and checks the id explicitly.

**Failing-on-main proof.** With the two new `case` guards disabled (`&& false`), both fold tests fail with the pre-fix output, while the anti-vacuity test keeps passing:

```
ParamsArrayIsNullPattern_FoldsAway [FAIL]
  Assert.DoesNotContain() Failure: Sub-string found
  String: ···"           if paths == nil {\n            "···
ParamsArrayIsNotNullPattern_FoldsAway [FAIL]
  String: ···"    return if paths != nil { paths!!.Leng"···
Failed! - Failed: 2, Passed: 3
```

Restored, the whole `Issue3501ResidualSyntheticRetargetTests` class passes 19/19 and `GoldenTests` passes 42/42 — no golden churn.

## Still outstanding

The end-to-end migrated-run before/after for both apps is still in flight locally (whole-repo `migrate` + `validate --app`); it will be attached when it lands. `tools/cs2gs/selfmig-baseline.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs