### PR TITLE
cs2gs: object-initializer members keep C#'s implicit array covariance (#3858)

### DIFF
--- a/test/Core.Tests/CodeAnalysis/Emit/Issue3685CovariantArrayUpcastTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue3685CovariantArrayUpcastTests.cs
@@ -75,6 +75,49 @@ func Widen(dirs []DirectoryInfo) []FileSystemInfo {
     }
 
     [Fact]
+    public void CovariantUpcast_StoringAWrongElement_ThrowsArrayTypeMismatchException()
+    {
+        // Issue #3858: the covariant upcast is UNSOUND BY DESIGN, exactly as in
+        // C# — the widened static type admits a store the runtime array rejects,
+        // and the CLR throws ArrayTypeMismatchException. That hazard is why the
+        // conversion stays explicit-only (#2516); this is the executing witness
+        // that `cast[[]Base](derived)` preserves the CLR's element check rather
+        // than quietly producing a `Base[]` that would accept anything.
+        var result = EmittedOracle.Evaluate(@"
+import System
+import System.IO
+let dirs = []DirectoryInfo{ DirectoryInfo(""alpha"") }
+let widened = cast[[]FileSystemInfo](dirs)
+var caught = ""none""
+try {
+    widened[0] = FileInfo(""beta"")
+} catch (e ArrayTypeMismatchException) {
+    caught = ""ArrayTypeMismatchException""
+}
+caught
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ArrayTypeMismatchException", result.Value);
+    }
+
+    [Fact]
+    public void ValueElementUpcast_IsStillRejected()
+    {
+        // Anti-vacuity: C# array covariance is REFERENCE-element-only. `int[]`
+        // does NOT convert to `object[]` in C# — implicitly or explicitly — and
+        // the CLR has no such array relationship (the elements are 4-byte
+        // integers, not references), so `[]int32 -> []object` must stay an
+        // error rather than becoming a cast that corrupts memory.
+        var result = EmittedOracle.Evaluate(@"
+func Widen(values []int32) []object {
+    return cast[[]object](values)
+}
+0
+");
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    [Fact]
     public void UnrelatedElementTypes_AreStillRejected()
     {
         // The new arm requires an IMPLICIT element conversion, so it widens the

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3858CovariantArrayObjectInitializerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3858CovariantArrayObjectInitializerTranslationTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue3858CovariantArrayObjectInitializerTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3858 (the <c>test/Sdk.Tests</c> self-migration wall): a C#
+/// object-initializer member is an ASSIGNMENT position, so C# applies the same
+/// implicit array-covariance conversion there it applies to a plain assignment
+/// (<c>Compile = new[] { new TaskItem("Program.gs") }</c> into an
+/// <c>ITaskItem[]</c> property). Issue #3685 taught the translator to spell that
+/// upcast as <c>cast[[]Base](expr)</c> — G# slices are invariant by design
+/// (#2516) — but only at the argument / return / local-initializer /
+/// assignment-statement positions; the two object-initializer member builders
+/// dropped the conversion, and gsc reported GS0156 on every site.
+/// </summary>
+public class Issue3858CovariantArrayObjectInitializerTranslationTests
+{
+    [Fact]
+    public void CovariantArray_ObjectInitializerMember_EmitsExplicitCast()
+    {
+        // The wall's exact shape, with `IComparable`/`string` standing in for
+        // `ITaskItem`/`TaskItem`: a DERIVED-element array assigned to a member
+        // whose type has the BASE element, through an imported interface.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue3858
+{
+    public class Holder
+    {
+        public IComparable[] Items { get; set; }
+    }
+
+    public static class Maker
+    {
+        public static Holder Make(string[] names)
+        {
+            return new Holder { Items = names };
+        }
+    }
+}
+");
+
+        Assert.Contains("Items: cast[[]IComparable](names)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CovariantArray_ConstructionWithInitializerSuffix_EmitsExplicitCast()
+    {
+        // The `new T(args) { Field = value }` form is built by a second,
+        // independent member loop (issue #1728) — it needed the same fix.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue3858
+{
+    public class Holder
+    {
+        public Holder(int capacity) { }
+
+        public IComparable[] Items { get; set; }
+    }
+
+    public static class Maker
+    {
+        public static Holder Make(string[] names)
+        {
+            return new Holder(1) { Items = names };
+        }
+    }
+}
+");
+
+        Assert.Contains("Items = cast[[]IComparable](names)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void CovariantArray_ObjectInitializerFieldMember_EmitsExplicitCast()
+    {
+        // Fields take the same path as properties, and an inline `new[] { … }`
+        // (the literal shape every failing Sdk.Tests site uses) is the operand,
+        // not a named local.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue3858
+{
+    public class Holder
+    {
+        public IComparable[] Items;
+    }
+
+    public static class Maker
+    {
+        public static Holder Make()
+        {
+            return new Holder { Items = new[] { ""alpha"" } };
+        }
+    }
+}
+");
+
+        Assert.Contains("cast[[]IComparable](", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void SameElementArray_ObjectInitializerMember_IsNotWrapped()
+    {
+        // No conversion happens, so the member value must stay bare — the guard
+        // that keeps the cast off every array-typed initializer in the corpus.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue3858
+{
+    public class Holder
+    {
+        public string[] Items { get; set; }
+    }
+
+    public static class Maker
+    {
+        public static Holder Make(string[] names)
+        {
+            return new Holder { Items = names };
+        }
+    }
+}
+");
+
+        Assert.Contains("Items: names", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("cast[", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ValueElementArray_ObjectInitializerMember_IsNotWrapped()
+    {
+        // Anti-vacuity: C# array covariance is REFERENCE-element-only —
+        // `int[] -> object[]` is not a conversion C# performs at all, so a
+        // value-element array flowing into an `int[]` member must not acquire a
+        // cast (and no `[]int32 -> []object` upcast may be manufactured here).
+        string rendered = Render(@"
+namespace Corpus.Issue3858
+{
+    public class Holder
+    {
+        public int[] Values { get; set; }
+    }
+
+    public static class Maker
+    {
+        public static Holder Make(int[] values)
+        {
+            return new Holder { Values = values };
+        }
+    }
+}
+");
+
+        Assert.Contains("Values: values", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("cast[", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse and bind. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.DoesNotContain(context.Diagnostics, d => d.Severity == TranslationSeverity.Unsupported);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2922,7 +2922,16 @@ public sealed partial class CSharpToGSharpTranslator
                         }
                     }
 
-                    GExpression value = this.TranslateExpression(assignment.Right);
+                    // Issue #3860: an object-initializer member is an ASSIGNMENT
+                    // position, so C# performs the same implicit array-covariance
+                    // conversion here it performs for a plain assignment
+                    // (`Compile = new[] { new TaskItem(...) }` into an
+                    // `ITaskItem[]` property — the test/Sdk.Tests wall). G#
+                    // slices are invariant (#2516/#3685), so the upcast has to be
+                    // spelled; without it gsc reports GS0156.
+                    GExpression value = this.CoerceCovariantArrayConversion(
+                        assignment.Right,
+                        this.TranslateExpression(assignment.Right));
                     fieldInitializers.Add(new FieldInitializer(
                         this.EmittedName(name, name.Identifier),
                         this.ForgiveObjectInitializerValue(assignment, value)));
@@ -2991,11 +3000,16 @@ public sealed partial class CSharpToGSharpTranslator
                         }
                     }
 
+                    // Issue #3860: same array-covariance assignment position as in
+                    // TranslateObjectInitializerFields, for the construction-with-
+                    // initializer-suffix form `T(args) { Field = value }`.
                     memberInitializers.Add(new FieldInitializer(
                         this.EmittedName(name, name.Identifier),
                         this.ForgiveObjectInitializerValue(
                             assignment,
-                            this.TranslateExpression(assignment.Right))));
+                            this.CoerceCovariantArrayConversion(
+                                assignment.Right,
+                                this.TranslateExpression(assignment.Right)))));
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #3858.

## The wall

The migrated `test/Sdk.Tests` was red in the self-migration gate with one
diagnostic repeated across the app:

```
GS0156  Cannot convert type '[]Microsoft.Build.Utilities.TaskItem'
                          to 'Microsoft.Build.Framework.ITaskItem[]'
```

## Cause — one, and it is in cs2gs

C# array covariance (`TaskItem : ITaskItem`, so `TaskItem[]` widens implicitly
to `ITaskItem[]`) is not implicit in G#: slices are invariant by design (#2516),
and the covariant upcast must be spelled `cast[[]Base](expr)` (#3685). The
translator already knows this — `CoerceCovariantArrayConversion` is applied at
the argument, return, local-initializer and assignment-statement positions.

It was **not** applied to object-initializer members, which is exactly the shape
every failing site uses:

```csharp
var task = new BuildTask
{
    Compile = new[] { new TaskItem("Program.gs") },   // ITaskItem[] property
    References = Array.Empty<TaskItem>(),
};
```

A C# object-initializer member is an assignment position, so Roslyn records the
implicit conversion on the RHS; both member builders
(`TranslateObjectInitializerFields` for `T{ … }` and
`BuildConstructionWithInitializerSuffix` for `T(args) { … }`) called
`TranslateExpression` directly and dropped it.

## The fix

Route the object-initializer member RHS through
`CoerceCovariantArrayConversion`, at both builders, exactly as
`TranslateAssignmentValue` does. Nothing in the conversion rules moved: this
only makes the translator *spell* a conversion C# already performed.

## Reference vs value elements

Unchanged and matching C# exactly:

- **Reference elements** — covariant upcast is legal, explicit-only. `cast[[]B](d)`
  is a reference-level no-op on the same array instance.
- **Value elements** — rejected. `int[]` does not convert to `object[]` in C#,
  implicitly or explicitly, and gsc's `IsCovariantArrayUpcast` requires
  `IsReferenceLikeTarget` on both elements plus CLR assignability, so
  `[]int32 -> []object` stays an error. `CoerceCovariantArrayConversion`'s own
  guard is `IsReferenceType` on both elements, so it never wraps one either.

## Not #3854

PR #3854's reference-conversion classification work is adjacent code but not the
cause here. Nothing in `Conversion.cs`/`ConversionClassifier.cs` changed in this
PR — the gsc-side covariant arm from #3685 was already correct, which the
executable tests below demonstrate on `origin/main`.

## Evidence

Targeted self-migration run over the exact `test/Sdk.Tests` dependency closure
(`Sdk.Tests -> Gsharp.NET.Sdk -> {HotReload.Runtime, Compiler} -> Core ->
{InternalAnalyzers, Analyzers.Testing}`, everything else `--exclude`'d, so the
discovered set is the closure and no project reference dangles). Full pipeline:
translate + compile + ILVerify + test-parity.

**Before** (`c9943bee3`, `origin/main`): 6/7 green, `test/Sdk.Tests` red with
**15** GS0156 sites across 5 files (`BuildTaskDesignTimeTests`,
`Adr0169GsAnalyzerForwardingTests`, `Adr0169EditorConfigSeverityTests`,
`Issue3782WarningsNotAsErrorsTests`, `HotReloadArtifactsTaskTests`) — all one
message, all the object-initializer shape. The gate's "7 fingerprints" is a
deduplicated signature count, not the site count.

**After**: `test/Sdk.Tests` green (see the run summary in the PR discussion).

### Tests

`tools/cs2gs/Cs2Gs.Tests/Issue3858CovariantArrayObjectInitializerTranslationTests.cs`
— 5 tests, each round-trip **binding** the printed G# through gsc:

| test | on `origin/main` | with fix |
| --- | --- | --- |
| `CovariantArray_ObjectInitializerMember_EmitsExplicitCast` | FAIL | pass |
| `CovariantArray_ConstructionWithInitializerSuffix_EmitsExplicitCast` | FAIL | pass |
| `CovariantArray_ObjectInitializerFieldMember_EmitsExplicitCast` | FAIL | pass |
| `SameElementArray_ObjectInitializerMember_IsNotWrapped` | pass (guard rail) | pass |
| `ValueElementArray_ObjectInitializerMember_IsNotWrapped` | pass (guard rail) | pass |

`test/Core.Tests/CodeAnalysis/Emit/Issue3685CovariantArrayUpcastTests.cs` gains
two **executing** tests. Both pass on `origin/main` — no gsc change is claimed;
they are the runtime witness and the anti-vacuity guard for the conversion this
PR now emits:

- `CovariantUpcast_StoringAWrongElement_ThrowsArrayTypeMismatchException` —
  compiles, runs, and asserts that storing a `FileInfo` into a
  `cast[[]FileSystemInfo](dirs)` widened `DirectoryInfo[]` throws
  `ArrayTypeMismatchException`, exactly as C# does. The unsoundness is
  preserved, not papered over.
- `ValueElementUpcast_IsStillRejected` — `cast[[]object]([]int32)` is still a
  compile error.
