### PR TITLE
cs2gs: generate the mirror's solutions before anything runs in the mirror (#3862)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -233,6 +233,22 @@ public sealed class MigrationPipeline
                 this.options.RepositoryAdditionalFiles.Add(mirroredProject);
             }
 
+            // Issue #3862: the mirror must BE a repository before anything runs
+            // inside it, not only after. Repository-anchored code — a test that
+            // walks up from its output directory looking for `GSharp.sln`, an
+            // MSBuild target that resolves a path relative to the solution —
+            // executes during the per-app stage loop below (compile, ilverify
+            // and `dotnet test` all run in the mirror). Generating the
+            // solutions after that loop left every such probe looking at a tree
+            // whose root anchor did not exist yet, which failed 37 of the 86
+            // migrated `test/Sdk.Tests` tests. Nothing here depends on stage
+            // output: the project mapping is complete above.
+            RepositorySolutionGenerator.Generate(
+                this.options.SourceRoot,
+                destinationRoot,
+                this.options.GeneratedProjectPaths,
+                repositoryFiles);
+
             var loadedProjects = new Dictionary<string, LoadedCSharpProject>(StringComparer.OrdinalIgnoreCase);
             foreach (CorpusApp app in apps)
             {
@@ -304,11 +320,6 @@ public sealed class MigrationPipeline
                 }
             }
 
-            RepositorySolutionGenerator.Generate(
-                this.options.SourceRoot,
-                destinationRoot,
-                this.options.GeneratedProjectPaths,
-                repositoryFiles);
             if (runResult.Succeeded)
             {
                 try

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3862MirrorSolutionOrderingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3862MirrorSolutionOrderingTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="Issue3862MirrorSolutionOrderingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3862: the mirror must BE a repository before anything executes
+/// inside it, not only after the run. Compile, ILVerify and <c>dotnet test</c>
+/// all run in the destination tree during the per-app stage loop, and the code
+/// they run probes the repository layout — <c>test/Sdk.Tests/RepoRoot.cs</c>
+/// walks up from its output directory looking for a file literally named
+/// <c>GSharp.sln</c>. Generating the mirrored solutions only after the stage
+/// loop left every such probe looking at a root anchor that did not exist yet.
+/// </summary>
+public sealed class Issue3862MirrorSolutionOrderingTests : IDisposable
+{
+    private const string LegacySolution = """
+        Microsoft Visual Studio Solution File, Format Version 12.00
+        Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Widget", "src\Widget\Widget.csproj", "{2E0F0D1B-5E52-4A2A-9C7C-1E5B0F6A7B31}"
+        EndProject
+        Global
+        	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        		Debug|Any CPU = Debug|Any CPU
+        	EndGlobalSection
+        	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        		{2E0F0D1B-5E52-4A2A-9C7C-1E5B0F6A7B31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        	EndGlobalSection
+        EndGlobal
+
+        """;
+
+    private readonly string root;
+
+    /// <summary>Initializes a new isolated test directory.</summary>
+    public Issue3862MirrorSolutionOrderingTests()
+    {
+        this.root = Path.Combine(
+            Path.GetTempPath(),
+            "issue-3862-solution-ordering",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(this.root);
+    }
+
+    /// <summary>Removes the isolated test directory.</summary>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(this.root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Every stage of every app observes the mirrored solution pair already on
+    /// disk. This is the contract the migrated <c>test/Sdk.Tests</c> depends
+    /// on: its tests run inside the mirror during stage 4 and resolve the
+    /// repository root from the legacy <c>.sln</c>.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task MirroredSolutionsExist_BeforeAnyStageRunsInTheMirror()
+    {
+        string compiler = FindCompiler();
+        if (compiler is null)
+        {
+            // The pipeline cannot run without a built gsc; a fabricated pass
+            // would be worse than an honest no-op (issue #1749).
+            return;
+        }
+
+        string source = Path.Combine(this.root, "source");
+        string destination = Path.Combine(this.root, "destination");
+        string projectDirectory = Path.Combine(source, "src", "Widget");
+        Directory.CreateDirectory(projectDirectory);
+        string projectPath = Path.Combine(projectDirectory, "Widget.csproj");
+        File.WriteAllText(
+            projectPath,
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup>" +
+            "<TargetFramework>net10.0</TargetFramework>" +
+            "<Nullable>enable</Nullable>" +
+            "</PropertyGroup></Project>");
+        File.WriteAllText(
+            Path.Combine(projectDirectory, "Widget.cs"),
+            "namespace Widget { public static class Answer { public static int Value() => 42; } }");
+        File.WriteAllText(Path.Combine(source, "Product.sln"), LegacySolution);
+
+        var probe = new MirrorProbeStage(destination);
+        var options = new PipelineOptions
+        {
+            GscPath = compiler,
+            SourceRoot = source,
+            OutputRoot = destination,
+            ArtifactRoot = Path.Combine(this.root, "runs"),
+            OutputLayout = MigrationOutputLayout.Repository,
+            Config = "Release",
+        };
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[] { new TranslateStage(), probe });
+
+        await pipeline.RunAsync(
+            new[]
+            {
+                new CorpusApp(
+                    "src/Widget/Widget.csproj",
+                    projectPath,
+                    TargetKind.Library,
+                    relativeProjectPath: Path.Combine("src", "Widget", "Widget.csproj")),
+            });
+
+        // The probe ran (otherwise the assertion below is vacuous) and saw the
+        // repository anchor both in its legacy and its converted spelling.
+        Assert.NotEmpty(probe.Observations);
+        Assert.All(probe.Observations, observation => Assert.True(
+            observation.LegacySolutionExists && observation.ConvertedSolutionExists,
+            $"stage observed sln={observation.LegacySolutionExists}, " +
+            $"slnx={observation.ConvertedSolutionExists}"));
+
+        // And the retargeting is the one #3772 established, not a stale copy.
+        Assert.Contains(
+            "Widget.gsproj",
+            File.ReadAllText(Path.Combine(destination, "Product.sln")),
+            StringComparison.Ordinal);
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Records what the mirror looked like at the moment a stage ran, which is
+    /// the only place the ordering defect is observable.
+    /// </summary>
+    private sealed class MirrorProbeStage : IMigrationStage
+    {
+        private readonly string destinationRoot;
+
+        internal MirrorProbeStage(string destinationRoot)
+        {
+            this.destinationRoot = destinationRoot;
+            this.Observations = new List<MirrorObservation>();
+        }
+
+        public MigrationStageKind Kind => MigrationStageKind.Compile;
+
+        internal List<MirrorObservation> Observations { get; }
+
+        public Task<StageOutcome> ExecuteAsync(
+            StageExecutionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            this.Observations.Add(new MirrorObservation(
+                File.Exists(Path.Combine(this.destinationRoot, "Product.sln")),
+                File.Exists(Path.Combine(this.destinationRoot, "Product.slnx"))));
+            return Task.FromResult(StageOutcome.Passed());
+        }
+    }
+
+    private readonly record struct MirrorObservation(
+        bool LegacySolutionExists,
+        bool ConvertedSolutionExists);
+}


### PR DESCRIPTION
Part of #3862.

## The wall

With #3861 merged, the migrated `test/Sdk.Tests` clears translate, compile and
ILVerify for the first time and fails at **test-parity**: `Failed 52 / Passed 34
/ Total 86`. The single largest family — **39 of the 52** — is

```
System.TypeInitializationException : The type initializer for
  'GSharp.Sdk.Tests.RepoRoot' threw an exception.
---- System.InvalidOperationException : Could not locate GSharp.sln walking up
     from <mirror>/out/bin/Release/Sdk.Tests/.
```

## It is not #3772's shape

#3772/#3783 was "the mirror has only `GSharp.slnx`". That is fixed and stayed
fixed: `RepositorySolutionGenerator` mirrors every `.sln` under its own name
with retargeted project paths. The mirror ends the run with a correct
`GSharp.sln` — which is why the walk looks fine when you inspect the tree
afterwards, and why #3862 recorded the two probe-based hypotheses it ruled out.

The defect is **ordering**. `MigrationPipeline.RunAsync` called
`RepositorySolutionGenerator.Generate` *after* the per-app stage loop, and every
stage runs **inside the destination tree**: `SdkCompileRunner` builds there,
ILVerify reads there, and `TestMirroredProject` runs `dotnet test` on the
mirrored `.gsproj` with its output in `<mirror>/out/bin/<Config>/<App>/`. So
throughout the entire loop the mirror had no root anchor at all.

Observed directly, mid-run, on `origin/main` (`2ff9533a4`):

```
$ ls <mirror>/ | grep -i sln     # while test-parity was executing
$ echo $?
1
```

`test/Sdk.Tests/RepoRoot.cs` walks `.../Sdk.Tests` → `Release` → `bin` → `out`
→ `<mirror>` → off the top, and throws from a static initializer, taking
`RepoRoot`, `TemplatesLayoutTests` and `BootstrapSdkLayoutTests` with it.

### Why CI has not been reporting it

The nightly gate runs `migrate --translate-only` and then `validate` shards
against the *finished* tree, so the shards see a complete mirror. The
single-job reference path `build/run-cs2gs-selfmig.sh` — and every local
targeted `migrate` used to reproduce a failure — does not. The two paths
disagreed; they should not.

## The fix

Move the `Generate` call up beside the other mirror-construction steps, before
the stage loop. Nothing in it depends on stage output: `GeneratedProjectPaths`
is complete above it, and `RepositoryMirror.MirrorExcludedProjects` has already
run. `RepositoryOrphanSourceTranslator` stays where it is — it *does* depend on
the translate stage having written the `.gs` files.

No probe is loosened and no check is weakened: `RepoRoot.cs` still requires a
file literally named `GSharp.sln`, and it now finds one because the mirror is a
repository at the moment code runs in it.

## Before / after

Targeted self-migration over the exact `test/Sdk.Tests` dependency closure
(`Sdk.Tests → Gsharp.NET.Sdk → {HotReload.Runtime, Compiler} → Core →
{InternalAnalyzers, Analyzers.Testing}`, everything else `--exclude`d), full
pipeline, gsc `0.4.401-g2ff9533a43`:

| | `test/Sdk.Tests` test-parity | mirror root during stage loop |
| --- | --- | --- |
| `origin/main` `2ff9533a4` | **Failed 52** / Passed 34 / Total 86 | no `GSharp.sln`, no `GSharp.slnx` |
| this PR | **Failed 16** / Passed 70 / Total 86 | `GSharp.sln` + `GSharp.slnx` present from the start |

The other seven apps in the closure are PASS/PASS/PASS/PASS on both sides.

`test/Sdk.Tests` is still red, for reasons that were masked behind the type
initializer and are filed separately (see below) — no `greenFloor` or
`greenApps` movement is claimed or taken.

## Test

`Issue3862MirrorSolutionOrderingTests` runs the pipeline in repository layout
with a **probe stage** that records, at the moment it executes, whether the
mirrored `.sln` and `.slnx` are on disk. On `origin/main` the probe observes
`sln=False, slnx=False` and the test fails; with the fix it observes both and
the retargeted legacy solution names the generated `.gsproj`. The assertion is
guarded against vacuity — the test fails if the probe never ran.

## The rest of #3862, filed with evidence

Removing this family unmasks the rest. Measured by taking the migrated tree,
making the anchor present, and rerunning `dotnet test` on the mirrored project:
**52 → 16 → 4**.

- **12 — `!!` on legitimately-null arguments.** gsc's `!!` is a *runtime*
  assertion that throws `NullReferenceException` (IL and an executable probe in
  the issue); C#'s `!` is erased. cs2gs adds it at sites the C# original relies
  on accepting null (`string.IsNullOrEmpty(this.DebugType!!)`,
  `Log.LogError(…, file!!, …)`, `ParseBool(value!!)`). Deleting exactly those
  assertions and rebuilding the mirrored SDK compiles with **0 errors** and
  takes the run to 4 failures — so the binder never wanted them.
- **3 — layout tests read `.cs`/`.csproj` the mirror spells `.gs`/`.gsproj`.**
  Same policy question as #3772, one layer down.
- **1 — `HotReloadDeltaBuilder` loses an implicit handle conversion**, adding a
  boxed `StandaloneSignatureHandle` through `IList.Add` to a
  `List<EntityHandle>`. A real silent runtime divergence.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
