### PR TITLE
gsc: clear the test/Core.Tests ILVerify wall — box the open-type-parameter `?.` probe, keep the symbolic parent on params/defaulted static calls (#3867, #3868, #3863)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3062,7 +3062,27 @@ internal sealed partial class ExpressionBinder
                 var refKinds = ComputeArgumentRefKinds(staticParameters);
                 overloads.ValidateRefArguments(staticArguments, refKinds, methodName, ce.Location);
 
-                BoundExpression staticCall = new BoundImportedCallExpression(ce, staticFn, staticArguments, refKinds, staticTypeArgSymbolsForCall);
+                // Issue #3868: the narrow #1330 path above declines params-
+                // expanded, defaulted and named-argument shapes, but the
+                // PARENT INSTANTIATION is not optional — a static call on
+                // `Verifier[X]` where `X` is a same-compilation user type must
+                // still be parented at the constructed `Verifier<X>` TypeSpec.
+                // Falling through with no container emitted the type-erased
+                // `Verifier<object>::M(...)`, which compiles clean, fails
+                // ilverify with UnsatisfiedMethodParentInst and throws
+                // TypeLoadException ("GenericArguments[0], 'System.Object' …
+                // violates the constraint of type parameter") the first time
+                // the method runs. Arguments and the return were bound against
+                // the erased closed method, which is exactly what the emitted
+                // signature encodes, so carrying the symbolic container changes
+                // only the parent token.
+                BoundExpression staticCall = new BoundImportedCallExpression(
+                    ce,
+                    staticFn,
+                    staticArguments,
+                    refKinds,
+                    staticTypeArgSymbolsForCall,
+                    classSymbol.SymbolicReceiver);
                 return WrapWithHandlerPrelude(staticCall, staticHandlerPrelude, ce);
             }
 

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -219,7 +219,15 @@ internal sealed partial class MethodBodyEmitter
                 // instance/extension paths do.
                 if (impCall.StaticContainerType != null)
                 {
-                    this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(impCall.Function.Method, impCall.StaticContainerType));
+                    // Issue #3868: pass the method type-argument vector too.
+                    // The #1330 path never supplied one (it declines generic
+                    // methods), but the params/defaulted fallback that now also
+                    // carries a symbolic container can, and dropping it would
+                    // emit the placeholder-closed MethodSpec.
+                    this.il.Call(this.outer.memberRefs.GetMethodEntityHandle(
+                        impCall.Function.Method,
+                        impCall.TypeArgumentSymbols,
+                        impCall.StaticContainerType));
                     break;
                 }
 
@@ -1789,7 +1797,43 @@ internal sealed partial class MethodBodyEmitter
         this.EmitExpression(nc.Receiver);
         this.EmitStoreVariable(nc.Capture);
         this.EmitLoadVariable(nc.Capture);
+
+        // Issue #3867: an OPEN type parameter receiver (`func F[T](v T)` then
+        // `v?.M()`) is neither a `NullableTypeSymbol` nor a known reference
+        // type, so it fell through to here and `brtrue`-d a raw `!!T` stack
+        // slot. `!!T` is not a branchable object reference — ilverify rejects
+        // it (StackUnexpected), and at runtime the null probe degenerates into
+        // a value test, so `F[int32](0)` took the NIL path and silently
+        // produced `nil` instead of calling `M()` on `0`. `box !!T` first
+        // (ECMA-335 §III.4.1: boxing an unconstrained type parameter yields
+        // `null` only for an empty `Nullable<T>`, a real object reference for
+        // every other value type, and the reference itself when `T` is a
+        // reference type) — exactly csc's lowering of `v?.M()`.
+        TypeSymbol? probeBoxType = GetOpenTypeParameterProbeBoxType(nc.Receiver.Type);
+        if (probeBoxType is not null)
+        {
+            this.il.OpCode(ILOpCode.Box);
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(probeBoxType));
+        }
+
         this.il.Branch(ILOpCode.Brtrue, nonNullTarget);
+    }
+
+    // Issue #3867: the type to `box` before a null-conditional receiver's
+    // `brtrue` probe, or null when the receiver already occupies the stack as
+    // an object reference. Only OPEN type parameters need it: `T` (whose CLR
+    // representation is unknown at emit time) and `T?` over an open `T` that
+    // the `NullableTypeSymbol` branch above did not claim — boxing the
+    // underlying `T` there is still correct, since an empty `Nullable<T>`
+    // boxes to `null`.
+    private static TypeSymbol? GetOpenTypeParameterProbeBoxType(TypeSymbol? receiverType)
+    {
+        return receiverType switch
+        {
+            TypeParameterSymbol typeParameter => typeParameter,
+            NullableTypeSymbol { UnderlyingType: TypeParameterSymbol underlying } => underlying,
+            _ => null,
+        };
     }
 
     private void EmitTupleLiteral(BoundTupleLiteralExpression tuple)

--- a/test/Compiler.Tests/Emit/Issue3867NullConditionalTypeParameterEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3867NullConditionalTypeParameterEmitTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue3867NullConditionalTypeParameterEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3867 — a null-conditional access whose receiver is an OPEN type
+/// parameter (<c>func F[T](v T)</c> then <c>v?.M()</c>) probed the receiver with
+/// a bare <c>brtrue</c> over the raw <c>!!T</c> stack slot. <c>!!T</c> is not a
+/// branchable object reference, so:
+/// <list type="bullet">
+/// <item>ilverify rejected the body with <c>StackUnexpected</c> (7 of the 19
+/// findings in the migrated <c>test/Core.Tests</c>, issue #3863); and</item>
+/// <item>at runtime the null probe degenerated into a VALUE test, so
+/// <c>F[int32](0)</c> silently took the nil path and produced <c>nil</c>
+/// instead of calling the member on <c>0</c>.</item>
+/// </list>
+/// The receiver is now boxed before the probe, exactly as csc lowers
+/// <c>v?.M()</c> (ECMA-335 §III.4.1: boxing an unconstrained type parameter
+/// yields <c>null</c> only for an empty <c>Nullable&lt;T&gt;</c>, a real object
+/// reference for any other value type, and the reference itself for a reference
+/// type).
+/// <para>
+/// The <c>Nullable&lt;user value type&gt;</c> arm of the same probe already had
+/// coverage in <c>Issue1475NullConditionalUserValueTypeEmitTests</c>; these
+/// tests pin the open-type-parameter arm. Every test EXECUTES the emitted
+/// assembly — ilverify alone would have accepted a body that still answered
+/// <c>nil</c> for a zero-valued struct.
+/// </para>
+/// </summary>
+public class Issue3867NullConditionalTypeParameterEmitTests
+{
+    /// <summary>
+    /// The runtime half: a zero-valued <c>int32</c> flowing through
+    /// <c>value?.ToString()</c> on an unconstrained <c>T</c> must render
+    /// <c>"0"</c>. Before the fix this printed <c>&lt;nil&gt;</c> — a silent
+    /// wrong answer that compiled clean.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_UnconstrainedTypeParameter_ZeroValuedStruct_IsNotNil()
+    {
+        var source = """
+            package N3867A
+            import System
+            class C3867A {
+                shared {
+                    func Render[T](value T) string {
+                        return value?.ToString() ?? "<nil>"
+                    }
+                }
+            }
+            func Main() {
+                Console.WriteLine(C3867A.Render[int32](0))
+                Console.WriteLine(C3867A.Render[int32](7))
+                Console.WriteLine(C3867A.Render[string]("hi"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            $"0{Environment.NewLine}7{Environment.NewLine}hi{Environment.NewLine}",
+            output);
+    }
+
+    /// <summary>
+    /// A user struct type argument whose default instance is all-zero: the same
+    /// value test that swallowed <c>int32(0)</c> swallows it too. Also proves
+    /// the boxed probe still dispatches through <c>constrained. !!T</c> to the
+    /// struct's own <c>ToString</c> rather than boxing away the override.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_UnconstrainedTypeParameter_ZeroValuedUserStruct_IsNotNil()
+    {
+        var source = """
+            package N3867B
+            import System
+            struct Pt3867B {
+                var X int32
+                override func ToString() string {
+                    return "Pt(" + this.X.ToString() + ")"
+                }
+            }
+            class C3867B {
+                shared {
+                    func Render[T](value T) string {
+                        return value?.ToString() ?? "<nil>"
+                    }
+                }
+            }
+            func Main() {
+                Console.WriteLine(C3867B.Render[Pt3867B](Pt3867B{X: 0}))
+                Console.WriteLine(C3867B.Render[Pt3867B](Pt3867B{X: 5}))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            $"Pt(0){Environment.NewLine}Pt(5){Environment.NewLine}",
+            output);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard for the two tests above: a REFERENCE type argument
+    /// must still take the nil path when the value really is nil. A "box
+    /// everything and always branch" fix would pass the tests above and fail
+    /// this one.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_UnconstrainedTypeParameter_NilReference_StillTakesNilPath()
+    {
+        var source = """
+            package N3867C
+            import System
+            class C3867C {
+                shared {
+                    func Render[T](value T) string {
+                        return value?.ToString() ?? "<nil>"
+                    }
+                }
+            }
+            func Main() {
+                var s string? = nil
+                Console.WriteLine(C3867C.Render[string?](s))
+                Console.WriteLine(C3867C.Render[string?]("here"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            $"<nil>{Environment.NewLine}here{Environment.NewLine}",
+            output);
+    }
+
+    /// <summary>
+    /// The instance-member shape the migrated <c>test/Core.Tests</c> handler
+    /// fixtures actually use: a generic method on a STRUCT whose body discards
+    /// the result of a call taking <c>value?.ToString()</c>. This is the exact
+    /// body that produced <c>StackUnexpected</c> on
+    /// <c>PrefixedInterpolatedStringHandler::AppendFormatted(!!0)</c>.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_GenericMethodOnStruct_AppendsZeroValuedStruct()
+    {
+        var source = """
+            package N3867D
+            import System
+            import System.Text
+            struct H3867D {
+                var builder StringBuilder
+                func AppendFormatted[T](value T) {
+                    this.builder.Append(value?.ToString())
+                }
+                override func ToString() string {
+                    return this.builder.ToString()
+                }
+            }
+            func Main() {
+                var h = H3867D{builder: StringBuilder()}
+                h.AppendFormatted[int32](0)
+                h.AppendFormatted[string]("x")
+                Console.WriteLine(h.ToString())
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal($"0x{Environment.NewLine}", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3867_exe_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var dllPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            var args = new[]
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args);
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath);
+
+            var rtConfig = Path.ChangeExtension(dllPath, ".runtimeconfig.json");
+            if (!File.Exists(rtConfig))
+            {
+                File.WriteAllText(rtConfig, """
+                    {
+                      "runtimeOptions": {
+                        "tfm": "net10.0",
+                        "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                      }
+                    }
+                    """);
+            }
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best-effort temp cleanup; a locked file must not fail the test.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Best-effort temp cleanup.
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3868SymbolicStaticContainerEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3868SymbolicStaticContainerEmitTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue3868SymbolicStaticContainerEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using GSharp.Compiler;
+using GSharp.Compiler.Tests.Fixtures;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3868 — a static call on an imported generic type closed over a
+/// SAME-COMPILATION user type (<c>Verifier[MyType].M(...)</c>) is parented at
+/// the constructed <c>Verifier&lt;MyType&gt;</c> TypeSpec by the #1330 symbolic
+/// path. That path declined <c>params</c>-expanded and defaulted-parameter call
+/// shapes and fell through to the ordinary resolution, which emitted the
+/// type-erased <c>Verifier&lt;object&gt;</c> parent (ADR-0004 / #313: a
+/// same-compilation type has no CLR <c>Type</c> during binding, so it rides
+/// through imported-member resolution as <c>object</c>).
+/// <para>
+/// The result compiled clean, failed ilverify with
+/// <c>UnsatisfiedMethodParentInst</c> (11 of the 19 findings in the migrated
+/// <c>test/Core.Tests</c>, issue #3863) and threw
+/// <c>TypeLoadException: GenericArguments[0], 'System.Object' … violates the
+/// constraint of type parameter</c> the first time the call ran. Every test
+/// here EXECUTES the emitted program, because ilverify accepts a wrong parent
+/// instantiation whenever the constraint happens to be satisfiable.
+/// </para>
+/// </summary>
+public class Issue3868SymbolicStaticContainerEmitTests
+{
+    private static readonly string FixtureAssemblyPath = typeof(Issue3868Base).Assembly.Location;
+
+    /// <summary>
+    /// The regression: the <c>params</c> and defaulted shapes must reach the
+    /// real <c>Issue3868Verifier&lt;MyAnalyzer&gt;</c>. Before the fix this
+    /// aborted with <c>TypeLoadException</c> on the first variadic call.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_ParamsAndDefaultedStaticCalls_UseTheRealTypeArgument()
+    {
+        var source = """
+            package N3868A
+            import System
+            import GSharp.Compiler.Tests.Fixtures
+
+            class MyAnalyzer3868 : Issue3868Base {
+                override func Name() string {
+                    return "mine"
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Issue3868Verifier[MyAnalyzer3868].Variadic("s"))
+                Console.WriteLine(Issue3868Verifier[MyAnalyzer3868].Variadic("s", "A"))
+                Console.WriteLine(Issue3868Verifier[MyAnalyzer3868].Variadic("s", "A", "B"))
+                Console.WriteLine(Issue3868Verifier[MyAnalyzer3868].Defaulted("s"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "variadic:mine:s:0",
+                "variadic:mine:s:1",
+                "variadic:mine:s:2",
+                "defaulted:mine:s:d") + Environment.NewLine,
+            output);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard: the fixed-arity and fully-supplied shapes were
+    /// ALREADY correct on <c>origin/main</c> (they take the #1330 symbolic
+    /// path). They must stay correct — a fix that changed how the symbolic
+    /// container is chosen would show up here.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_FixedAndFullySuppliedStaticCalls_StayCorrect()
+    {
+        var source = """
+            package N3868B
+            import System
+            import GSharp.Compiler.Tests.Fixtures
+
+            class MyAnalyzer3868B : Issue3868Base {
+                override func Name() string {
+                    return "mineB"
+                }
+            }
+
+            func Main() {
+                Console.WriteLine(Issue3868Verifier[MyAnalyzer3868B].Fixed("s"))
+                Console.WriteLine(Issue3868Verifier[MyAnalyzer3868B].Defaulted("s", "t"))
+            }
+            """;
+
+        var output = CompileAndRun(source);
+
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "fixed:mineB:s",
+                "defaulted:mineB:s:t") + Environment.NewLine,
+            output);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> against the host reference closure
+    /// plus this test assembly (which hosts the fixture), emits into the test
+    /// output directory so the fixture assembly resolves by ordinary app-dir
+    /// probing, ILVerifies, then RUNS the program and returns its stdout.
+    /// </summary>
+    /// <param name="source">G# source to compile.</param>
+    /// <returns>The program's stdout.</returns>
+    private static string CompileAndRun(string source)
+    {
+        var outputDir = Path.GetDirectoryName(FixtureAssemblyPath)
+            ?? throw new InvalidOperationException("fixture assembly has no directory");
+        var stem = "gs3868_" + Guid.NewGuid().ToString("N");
+        var srcPath = Path.Combine(Path.GetTempPath(), stem + ".gs");
+        var dllPath = Path.Combine(outputDir, stem + ".dll");
+        var rtConfig = Path.Combine(outputDir, stem + ".runtimeconfig.json");
+
+        try
+        {
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + dllPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (var reference in ReferenceAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(srcPath);
+
+            using var stdoutWriter = new StringWriter();
+            using var stderrWriter = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(stdoutWriter);
+            Console.SetError(stderrWriter);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{stdoutWriter}\nstderr:\n{stderrWriter}");
+
+            IlVerifier.Verify(dllPath, new[] { FixtureAssemblyPath });
+
+            File.WriteAllText(rtConfig, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = outputDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(rtConfig);
+            psi.ArgumentList.Add(dllPath);
+
+            using var proc = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start dotnet exec");
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(60_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            foreach (var path in new[] { srcPath, dllPath, rtConfig, Path.ChangeExtension(dllPath, ".pdb") })
+            {
+                try
+                {
+                    File.Delete(path);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup; a locked artifact must not fail the test.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> ReferenceAssemblies()
+        => ReferenceClosure.TrustedPlatformAssemblies()
+            .Append(FixtureAssemblyPath)
+            .Distinct(StringComparer.Ordinal);
+}

--- a/test/Compiler.Tests/Fixtures/Issue3868SymbolicStaticContainerFixtures.cs
+++ b/test/Compiler.Tests/Fixtures/Issue3868SymbolicStaticContainerFixtures.cs
@@ -1,0 +1,50 @@
+// <copyright file="Issue3868SymbolicStaticContainerFixtures.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace GSharp.Compiler.Tests.Fixtures;
+
+/// <summary>
+/// Issue #3868 fixture: the base an in-source G# type derives from so it can
+/// satisfy <see cref="Issue3868Verifier{TA}"/>'s type constraint. Shaped after
+/// <c>GSharp.Core.CodeAnalysis.Analyzers.GSharpDiagnosticAnalyzer</c>, whose
+/// verifier surfaced the defect in the migrated <c>test/Core.Tests</c>.
+/// </summary>
+public class Issue3868Base
+{
+    /// <summary>Gets the tag this instance contributes; overridden in G#.</summary>
+    /// <returns>The tag.</returns>
+    public virtual string Name() => "base";
+}
+
+/// <summary>
+/// Issue #3868 fixture: a generic static class whose type parameter carries
+/// BOTH a base-type and a <c>new()</c> constraint — the shape of
+/// <c>GSharpAnalyzerVerifier&lt;TAnalyzer&gt;</c>. The constraint is what turns
+/// a type-erased <c>&lt;object&gt;</c> parent instantiation from a silent
+/// mis-emit into an ilverify <c>UnsatisfiedMethodParentInst</c> and a runtime
+/// <c>TypeLoadException</c>.
+/// </summary>
+/// <typeparam name="TA">The user type under test.</typeparam>
+public static class Issue3868Verifier<TA>
+    where TA : Issue3868Base, new()
+{
+    /// <summary>A fixed-arity static: already emitted correctly before #3868.</summary>
+    /// <param name="s">Any tag.</param>
+    /// <returns>The recorded line.</returns>
+    public static string Fixed(string s) => "fixed:" + new TA().Name() + ":" + s;
+
+    /// <summary>The <c>params</c> shape the #1330 symbolic path declined.</summary>
+    /// <param name="s">Any tag.</param>
+    /// <param name="ids">Trailing variadic tags.</param>
+    /// <returns>The recorded line.</returns>
+    public static string Variadic(string s, params string[] ids)
+        => "variadic:" + new TA().Name() + ":" + s + ":" + ids.Length;
+
+    /// <summary>The defaulted-parameter shape the #1330 symbolic path declined.</summary>
+    /// <param name="s">Any tag.</param>
+    /// <param name="t">A defaulted tag.</param>
+    /// <returns>The recorded line.</returns>
+    public static string Defaulted(string s, string t = "d")
+        => "defaulted:" + new TA().Name() + ":" + s + ":" + t;
+}

--- a/test/Core.Tests/ilverify.allow-unsafe
+++ b/test/Core.Tests/ilverify.allow-unsafe
@@ -1,0 +1,23 @@
+# Issue #1933 / #1985 unsafe-IL allowance, scoped to the fixture types below
+# (issue #3863). `Core.Tests.csproj` sets <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+# and Issue2852ImportedPointerFields exists precisely to be an unmanaged-pointer
+# fixture:
+#
+#     public unsafe struct Issue2852ImportedPointerFields
+#     {
+#         public int* Pointer { get; set; }
+#         public delegate* unmanaged<int, int> FunctionPointer { get; set; }
+#     }
+#
+# A property setter that stores an unmanaged pointer is unverifiable BY
+# CONSTRUCTION — ilverify reports `UnmanagedPointer` ("Unmanaged pointers are
+# not a verifiable type") for it, and the CSC-COMPILED baseline of this very
+# project fails identically:
+#
+#     [IL]: Error [UnmanagedPointer]: [out/bin/Release/Core.Tests/GSharp.Core.Tests.dll :
+#       GSharp.Core.Tests.CodeAnalysis.Binding.Issue2852ImportedPointerFields::set_Pointer(int32*)]
+#       [offset 0x00000001] Unmanaged pointers are not a verifiable type.
+#
+# so it is not a gsc emit defect. The allowance is type-scoped, not app-wide:
+# any unsafe-IL finding elsewhere in Core.Tests still gates.
+GSharp.Core.Tests.CodeAnalysis.Binding.Issue2852ImportedPointerFields


### PR DESCRIPTION
Clears the `test/Core.Tests` ILVerify wall from #3863 (#3501 self-migration). Nineteen findings, three genuinely distinct causes — the triage did not collapse this time; the full root-cause table is on #3863.

Two of the three are gsc defects that **compile clean and then produce a wrong answer at runtime**, so every regression test here EXECUTES the emitted assembly rather than only ILVerifying it.

## 1. #3867 — `?.` on an open type parameter emitted `brtrue` over a raw `!!T`

`MethodBodyEmitter.EmitNullConditionalReceiverProbe` had a `Nullable<T>` value-type arm (added for #1700/#1475, which probes correctly via `box; brtrue`) and a "reference-typed" fallback that stores/reloads the receiver and branches on it directly. An **open type parameter** receiver is neither, so it landed in the fallback and branched on a value that is not an object reference.

* ilverify: `StackUnexpected` — 7 of the 19, all `AppendFormatted<T>` bodies in the migrated handler fixtures, whose only common ingredient is `value?.ToString()` on an unconstrained `T`.
* runtime: the null probe degenerated into a **value** test, so `Render[int32](0)` printed `<nil>` instead of `0`. Every zero/default-valued struct flowing through a `?.` on an open type parameter was silently nil.

Fix: `box !!T` before the probe (ECMA-335 §III.4.1 — boxing an unconstrained type parameter yields `null` only for an empty `Nullable<T>`, a real object reference for any other value type, and the reference itself for a reference type). This is csc's own lowering. `T?` over an open `T` boxes the underlying, which is equally correct.

## 2. #3868 — a `params`/defaulted static call on a generic type closed over a same-compilation type emitted `Verifier`1<object>`

A same-compilation user type has no CLR `Type` during binding, so it rides through imported-member resolution erased to `object` (ADR-0004 / #313). #1330 undoes that for static calls on a constructed generic type by hanging a symbolic container off `BoundImportedCallExpression.StaticContainerType`. That path is guarded by `!staticIsExpanded && staticMapping.IsDefault && argumentNames.IsDefault`, and the fallback below it built the call **with no container**, emitting the erased parent.

* ilverify: `UnsatisfiedMethodParentInst` — 11 of the 19, matching *exactly* the 11 generic-form `GSharpAnalyzerVerifier<T>.VerifyAnalyzer(source, params string[] ids)` call sites in `test/Core.Tests` (9 in `Adr0169AnalyzerVerifierTests`, 2 in `Issue3795SymbolContainmentTests`); the lambda-host fingerprints are those same sites lowered into `Assert.Throws` display classes.
* runtime: `TypeLoadException: GenericArguments[0], 'System.Object', on 'Verifier`1[TA]' violates the constraint of type parameter 'TA'` on the first call.

Fix: carry `classSymbol.SymbolicReceiver` on the fallback node too — the parent instantiation is not an optimisation — and pass the method type-argument vector alongside the container in the emitter (`GetMethodEntityHandle(method, typeArgSymbols, containingTypeSymbol)` already supports both; the old two-argument call dropped the vector, which the #1330 path never populated but this one can). Arguments and the return are still bound against the erased closed method, which is exactly what the emitted member signature encodes, so only the parent token changes.

## 3. `UnmanagedPointer` — corpus configuration, not a gsc defect

`test/Core.Tests/ilverify.allow-unsafe`, scoped (#1985) to `GSharp.Core.Tests.CodeAnalysis.Binding.Issue2852ImportedPointerFields`. This is not a suppression of convenience: the **csc-compiled** baseline of the same project fails identically —

```
[IL]: Error [UnmanagedPointer]: [out/bin/Release/Core.Tests/GSharp.Core.Tests.dll :
  GSharp.Core.Tests.CodeAnalysis.Binding.Issue2852ImportedPointerFields::set_Pointer(int32*)]
  [offset 0x00000001] Unmanaged pointers are not a verifiable type.
```

`Core.Tests.csproj` sets `AllowUnsafeBlocks` and that fixture exists precisely to be an unmanaged-pointer struct. The marker is type-scoped, so an unsafe-IL finding anywhere else in `test/Core.Tests` still gates.

## Tests

`test/Compiler.Tests/Emit/Issue3867NullConditionalTypeParameterEmitTests.cs` and `Issue3868SymbolicStaticContainerEmitTests.cs`. All six compile, ILVerify **and run** the emitted program and assert on its stdout — ILVerify alone would have accepted #3867's body while it still answered `nil` for a zero-valued struct, and accepts a wrong parent instantiation whenever the constraint happens to be satisfiable.

Each file carries an anti-vacuity guard: #3867's nil-reference case (a "box and always branch" fix would break it) and #3868's fixed-arity / fully-supplied shapes, which already took the #1330 symbolic path and pass on `origin/main`. See the anti-vacuity section below for exactly which tests pass on `origin/main` and which do not.

## Before / after

Targeted migration of the `test/Core.Tests` dependency chain (`InternalAnalyzers` → `Core` → `Analyzers.Testing` → `Core.Tests`), same pipeline as the nightly, SDK repacked on both sides.

| | translate | compile | ilverify | test-parity |
|---|---|---|---|---|
| before (`2ff9533a4`, gsc `0.4.401+2ff9533a43`) | PASS | PASS | **FAIL(19)** — 11 `UnsatisfiedMethodParentInst` + 7 `StackUnexpected` + 1 `UnmanagedPointer` | skip |
| after (this branch, gsc `0.4.403+ff785ba53e`) | PASS | PASS | **PASS** | PASS |

**19 → 1 raw finding, and that one is the `UnmanagedPointer` the type-scoped marker allows.** The other 18 are gone from the emitted IL, not filtered: the marker names one type and one type only, so had either gsc fix been incomplete the stage would still be red.

### The layer behind it — filed as #3869, not fixed here

`test/Core.Tests` now reaches `test-parity` for the first time, and that stage reports PASS **while running zero tests**: cs2gs drops the `ref` from `public ref struct Issue2852ImportedRefStruct`, so the emitted type holds a `Span<int>` field without `IsByRefLike`, `GetExportedTypes()` throws `TypeLoadException`, xunit discovers nothing, `dotnet test` exits 0 and `TestParityStage` passes on the exit code alone. Reporting it as the new state rather than claiming the app is genuinely green. (Also note: the local subset run's mirror-fidelity check trips on `test/Shared/EmittedFixture.gs`, which is an artifact of excluding `test/Compiler.Tests` while including `test/Core.Tests` — both link that file. The nightly excludes neither.)

## Anti-vacuity

On `origin/main`'s compiler, of the six new tests **5 fail and 1 passes** — the one that passes is #3868's `FixedAndFullySuppliedStaticCalls_StayCorrect`, the shape that already took the #1330 symbolic path.

With `GSHARP_SKIP_ILVERIFY=1` (so the tests can only fail on their runtime assertions) **4 still fail on `origin/main`**:

```
EndToEnd_ParamsAndDefaultedStaticCalls_UseTheRealTypeArgument
  Unhandled exception. System.TypeLoadException: GenericArguments[0], 'System.Object',
    on 'GSharp.Compiler.Tests.Fixtures.Issue3868Verifier`1[TA]' violates the constraint of type parameter 'TA'.

EndToEnd_UnconstrainedTypeParameter_ZeroValuedStruct_IsNotNil
  Expected: "0\n7\nhi\n"
  Actual:   "<nil>\n7\nhi\n"

EndToEnd_GenericMethodOnStruct_AppendsZeroValuedStruct
  Expected: "0x\n"
  Actual:   "x\n"

EndToEnd_UnconstrainedTypeParameter_ZeroValuedUserStruct_IsNotNil
```

i.e. these are not tests that merely watch ILVerify stop complaining — they observe the wrong answers directly. `EndToEnd_UnconstrainedTypeParameter_NilReference_StillTakesNilPath` passes on `origin/main` in that mode (it fails only ILVerify there); it is kept as the guard against a "box and always branch" mis-fix.

Closes #3867. Closes #3868.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
