### PR TITLE
cs2gs: an imported oblivious target needs no `!!` bridge (#3865)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2511NullableIndexArgumentForgivenessTranslationTests.cs
@@ -94,11 +94,25 @@ public sealed class Issue2511NullableIndexArgumentForgivenessTranslationTests
             }
             """);
 
-        Assert.Contains("imported!![key!!] = \"value\"", printed, StringComparison.Ordinal);
-        Assert.Contains("let first = imported!![key!!]", printed, StringComparison.Ordinal);
+        // Issue #3865: the RECEIVER assertions stay — `imported` is a value read
+        // whose imported oblivious type gsc maps to `T?`, so `imported!!` is
+        // what makes the indexer access bind at all. The KEY assertions are
+        // gone: `ImportedLookup.this[string key]` is declared in a
+        // `#nullable disable` region, so gsc imports the parameter as `string?`
+        // and it accepts a nullable key with no bridge. `!!` is a RUNTIME check
+        // in G#, so asserting there turned a legal null key into a throw.
+        // `Issue3865ImportedObliviousArgumentAssertionTests` compiles and RUNS
+        // this exact shape to prove the removal is gratuitous, not lost
+        // checking. `GenericLookup<TKey>.this[TKey key]` declares a TYPE
+        // PARAMETER, which carries no obliviousness signal, so its key keeps the
+        // assertion — the control that pins the exclusion.
+        Assert.Contains("imported!![key] = \"value\"", printed, StringComparison.Ordinal);
+        Assert.Contains("let first = imported!![key]", printed, StringComparison.Ordinal);
         Assert.Contains("let second = generic[key!!]", printed, StringComparison.Ordinal);
+        // `third` reads `imported[key!]` — a USER-AUTHORED C# suppression, which
+        // is preserved as `!!` regardless of the target contract.
         Assert.Contains("let third = imported!![key!!]", printed, StringComparison.Ordinal);
-        Assert.Contains("imported?[key!!]", printed, StringComparison.Ordinal);
+        Assert.Contains("imported?[key]", printed, StringComparison.Ordinal);
         Assert.DoesNotContain("key!!!!", printed, StringComparison.Ordinal);
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2521ImportedInitializerTargetContractTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2521ImportedInitializerTargetContractTranslationTests.cs
@@ -300,12 +300,31 @@ public sealed class Issue2521ImportedInitializerTargetContractTranslationTests
 
         string compact = Compact(Translate(consumer, new[] { consumer.Compilation }));
 
+        // Issue #3865: the contract still cannot be PROMOTED by consumer taint —
+        // that is what this test pins and it still holds. What changed is the
+        // bridge: `Issue2521.PrebuiltTarget` is compiled `#nullable disable`, so
+        // every one of these sinks is an imported OBLIVIOUS reference type, and
+        // gsc's import rule (`ClrNullability.IsPositionNonNull`: non-null iff the
+        // byte is 1) maps oblivious and absent metadata alike to `T?`. The
+        // already-emitted contract these sinks bind to is therefore `string?`,
+        // which accepts the nullable value with no assertion. `!!` is a RUNTIME
+        // null check in G#, so emitting one here made a legal null assignment
+        // throw; `Issue3865ImportedObliviousArgumentAssertionTests` compiles and
+        // RUNS the initializer/indexer shapes to prove it.
+        //
+        // `GenericTarget<T>.Value` declares the TYPE PARAMETER `T`, which
+        // carries no obliviousness signal, so it keeps its assertion — the
+        // control for the exclusion. Note this test's source-referenced sibling
+        // (`ImportedTargets_UseAlreadyEmittedContracts_ForAllInitializerSinks`)
+        // deliberately still asserts everywhere: a project cs2gs is itself
+        // migrating has no frozen contract to read.
         Assert.Contains(
-            "Target{Value: source.Value!!, InitValue: source.Value!!, BaseValue: source.Value!!}",
+            "Target{Value: source.Value, InitValue: source.Value, BaseValue: source.Value}",
             compact);
-        Assert.Contains("T{Value: source.Value!!}", compact);
-        Assert.Contains("ImportedBag(){ source.Value!! }", compact);
-        Assert.Contains("[\"key\"] = source.Value!!", compact);
+        Assert.Contains("GenericTarget[string]{Value: source.Value!!}", compact);
+        Assert.Contains("ImportedBag(){ source.Value }", compact);
+        Assert.Contains("[\"key\"] = source.Value", compact);
+        Assert.DoesNotContain("Target{Value: source.Value!!", compact);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3865ImportedObliviousArgumentAssertionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3865ImportedObliviousArgumentAssertionTests.cs
@@ -1,0 +1,467 @@
+// <copyright file="Issue3865ImportedObliviousArgumentAssertionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3865: cs2gs emitted a <c>!!</c> on arguments passed to IMPORTED
+/// parameters that carry no nullable metadata at all (oblivious).
+/// <para>
+/// gsc's import rule is the INVERSE of C#'s. <c>ClrNullability.IsPositionNonNull</c>
+/// reads "non-null iff the byte is <c>1</c>", so an oblivious byte (<c>0</c>)
+/// and absent metadata BOTH map to <c>T?</c>. An imported oblivious parameter
+/// therefore already accepts a nullable value, and the assertion is not a
+/// widening bridge — it is pure runtime overhead that CHANGES BEHAVIOUR:
+/// G#'s <c>x!!</c> lowers to <c>dup; brtrue; pop; newobj NullReferenceException;
+/// throw</c>, unlike C#'s erased <c>x!</c>. A legal C# call such as
+/// <c>string.Equals(null, "root", StringComparison.OrdinalIgnoreCase)</c>
+/// (which returns <c>false</c>) became a crash in the migrated artifact —
+/// invisible to translate, compile and ILVerify, observable only by running it.
+/// </para>
+/// <para>
+/// The trigger looked context-sensitive on issue #3862 ("the same
+/// <c>BuildTask.cs</c> translates clean standalone and with <c>!!</c>
+/// in-corpus") because the in-memory test harness compiles against the running
+/// runtime's fully annotated net10.0 reference assemblies, while the real
+/// <c>src/Sdk/Gsharp.NET.Sdk</c> targets <b>netstandard2.0</b>, whose reference
+/// assemblies contain ZERO <c>NullableAttribute</c>. Under netstandard2.0 even
+/// <c>string.IsNullOrEmpty</c>, <c>string.Equals</c> and <c>bool.TryParse</c>
+/// are oblivious, so there was only ever ONE mechanism, not two.
+/// </para>
+/// <para>
+/// The tests below model that faithfully: the "imported" library is emitted to
+/// a real metadata image (no <c>DeclaringSyntaxReference</c>, exactly like a
+/// framework or NuGet reference) from a nullable-DISABLED compilation, and the
+/// consumer that calls it is nullable-ENABLED, mirroring
+/// <c>&lt;Nullable&gt;enable&lt;/Nullable&gt;</c> on a netstandard2.0 project.
+/// </para>
+/// </summary>
+public class Issue3865ImportedObliviousArgumentAssertionTests
+{
+    // A nullable-DISABLED library: `Sink.Accept(string)` and `Sink.Field` carry
+    // no nullable metadata, exactly like netstandard2.0's `string.Equals` or
+    // `Microsoft.Build.Utilities.TaskLoggingHelper.LogError`.
+    private const string ObliviousLibrarySource = @"
+using System;
+
+namespace Imported
+{
+    public static class Sink
+    {
+        public static bool Accept(string value)
+        {
+            return value == null;
+        }
+
+        public static bool AcceptTwo(string first, string second)
+        {
+            return first == null && second == null;
+        }
+    }
+
+    public class Holder
+    {
+        public string Field;
+    }
+
+    public class Target
+    {
+        public string Value { get; set; }
+    }
+
+    public sealed class Lookup
+    {
+        public string this[string key]
+        {
+            get { return key == null ? ""<null-key>"" : ""hit""; }
+            set { }
+        }
+    }
+}";
+
+    // The same library, nullable-ENABLED, declaring the parameter NON-nullable.
+    // gsc imports that as a genuine non-null `string`, so a nullable argument
+    // still needs the `!!` bridge — the anti-vacuity control for the fix.
+    private const string AnnotatedLibrarySource = @"
+#nullable enable
+using System;
+
+namespace Imported
+{
+    public static class Sink
+    {
+        public static bool Accept(string value)
+        {
+            return value.Length == 0;
+        }
+
+        public static bool AcceptTwo(string first, string second)
+        {
+            return first.Length == second.Length;
+        }
+    }
+
+    public class Holder
+    {
+        public string Field = string.Empty;
+    }
+
+    public class Target
+    {
+        public string Value { get; set; } = string.Empty;
+    }
+
+    public sealed class Lookup
+    {
+        public string this[string key]
+        {
+            get { return key.Length == 0 ? ""empty"" : ""hit""; }
+            set { }
+        }
+    }
+}";
+
+    private const string ConsumerSource = @"
+#nullable enable
+using Imported;
+
+namespace Consumer
+{
+    public class Caller
+    {
+        public string? Maybe { get; set; }
+
+        public bool Call() => Sink.Accept(this.Maybe);
+    }
+}";
+
+    [Fact]
+    public void ObliviousImportedParameter_NullableArgument_EmitsNoRuntimeAssertion()
+    {
+        string printed = TranslateAgainstLibrary(ObliviousLibrarySource, ConsumerSource);
+
+        Assert.Contains("Sink.Accept(this.Maybe)", Compact(printed), StringComparison.Ordinal);
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnnotatedNonNullImportedParameter_NullableArgument_StillAssertsAntiVacuityControl()
+    {
+        // Anti-vacuity guard rail: this assertion is required, and it passes on
+        // `origin/main` too. Were the fix over-broad (dropping `!!` at every
+        // imported target rather than only oblivious ones), this would fail.
+        string printed = TranslateAgainstLibrary(AnnotatedLibrarySource, ConsumerSource);
+
+        Assert.Contains("Sink.Accept(this.Maybe!!)", Compact(printed), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ObliviousImportedField_NullableAssignment_EmitsNoRuntimeAssertion()
+    {
+        const string Source = @"
+#nullable enable
+using Imported;
+
+namespace Consumer
+{
+    public class Caller
+    {
+        public string? Maybe { get; set; }
+
+        public void Store(Holder holder)
+        {
+            holder.Field = this.Maybe;
+        }
+    }
+}";
+
+        string printed = TranslateAgainstLibrary(ObliviousLibrarySource, Source);
+
+        Assert.Contains("holder.Field = this.Maybe", Compact(printed), StringComparison.Ordinal);
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ObliviousImportedParameter_SubstitutedGenericTargetStillAsserts()
+    {
+        // A generic BCL target such as `List<string>.Add(T item)` declares its
+        // parameter as the TYPE PARAMETER `T` (`NullableAnnotation.None`), which
+        // says nothing about obliviousness — gsc binds the substituted `string`
+        // as non-null. The fix keys off the ORIGINAL definition's type and
+        // excludes type parameters, so this still asserts. Passes on
+        // `origin/main` as well; it exists to pin the exclusion.
+        const string Source = @"
+#nullable enable
+using System.Collections.Generic;
+
+namespace Consumer
+{
+    public class Caller
+    {
+        public string? Maybe { get; set; }
+
+        public void Fill(List<string> items)
+        {
+            items.Add(this.Maybe);
+        }
+    }
+}";
+
+        string printed = TranslateAgainstLibrary(ObliviousLibrarySource, Source);
+
+        Assert.Contains("items.Add(this.Maybe!!)", Compact(printed), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The defect class is definitionally invisible to translate, compile and
+    /// ILVerify, so the regression has to EXECUTE. Compiles the translated G#
+    /// with the real gsc against the real oblivious library image and asserts
+    /// the program prints what the equivalent C# prints instead of throwing
+    /// <see cref="NullReferenceException"/>.
+    /// </summary>
+    [Fact]
+    public void ObliviousImportedParameter_NullArgument_RunsWithoutThrowing()
+    {
+        const string Source = @"
+#nullable enable
+using System;
+using Imported;
+
+namespace Consumer
+{
+    public static class Program
+    {
+        public static string? Maybe { get; set; }
+
+        public static void Main()
+        {
+            Console.WriteLine(""before"");
+            Console.WriteLine(Sink.Accept(Maybe));
+            Console.WriteLine(Sink.AcceptTwo(Maybe, Maybe));
+            Console.WriteLine(""after"");
+        }
+    }
+}";
+
+        (string printed, ImmutableArray<byte> libraryImage) =
+            TranslateAgainstLibraryWithImage(ObliviousLibrarySource, Source, OutputKind.ConsoleApplication);
+
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+
+        (int exit, string stdout) = CompileAndRun(printed, libraryImage);
+
+        // C# semantics for the identical program: `value == null` is `true`.
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            new[] { "before", "True", "True", "after" },
+            stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(l => l.Trim()).ToArray());
+    }
+
+    /// <summary>
+    /// The same executing proof for the two OTHER sink shapes whose existing
+    /// expectations this fix changes — an imported oblivious PROPERTY in an
+    /// object initializer (issue #2521's prebuilt-metadata case) and an imported
+    /// oblivious INDEXER key argument (issue #2511's <c>ImportedLookup</c>
+    /// case). Both used to carry a <c>!!</c>; this run is the evidence that
+    /// removing it is a gratuitous-assertion removal and not lost checking —
+    /// gsc compiles the assertion-free form with zero diagnostics AND the
+    /// program produces the value the equivalent C# produces instead of
+    /// throwing.
+    /// </summary>
+    [Fact]
+    public void ObliviousImportedInitializerAndIndexerSinks_RunWithoutThrowing()
+    {
+        const string Source = @"
+#nullable enable
+using System;
+using Imported;
+
+namespace Consumer
+{
+    public static class Program
+    {
+        public static string? Maybe { get; set; }
+
+        public static void Main()
+        {
+            Console.WriteLine(""before"");
+            Target target = new Target { Value = Maybe };
+            Console.WriteLine(target.Value == null);
+            Lookup lookup = new Lookup();
+            lookup[Maybe] = ""v"";
+            Console.WriteLine(lookup[Maybe]);
+            Console.WriteLine(""after"");
+        }
+    }
+}";
+
+        (string printed, ImmutableArray<byte> libraryImage) =
+            TranslateAgainstLibraryWithImage(ObliviousLibrarySource, Source, OutputKind.ConsoleApplication);
+
+        Assert.DoesNotContain("!!", printed, StringComparison.Ordinal);
+
+        (int exit, string stdout) = CompileAndRun(printed, libraryImage);
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            new[] { "before", "True", "<null-key>", "after" },
+            stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(l => l.Trim()).ToArray());
+    }
+
+    // ---- harness -----------------------------------------------------------
+
+    private static string Compact(string printed) =>
+        string.Join(" ", printed.Split((char[])null, StringSplitOptions.RemoveEmptyEntries));
+
+    private static string TranslateAgainstLibrary(
+        string librarySource, string consumerSource, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary)
+        => TranslateAgainstLibraryWithImage(librarySource, consumerSource, outputKind).Printed;
+
+    private static (string Printed, ImmutableArray<byte> LibraryImage) TranslateAgainstLibraryWithImage(
+        string librarySource, string consumerSource, OutputKind outputKind)
+    {
+        ImmutableArray<byte> image = EmitLibraryImage(librarySource);
+
+        // A METADATA reference (not a compilation reference): the imported
+        // symbols have no `DeclaringSyntaxReference` at all, which is what a
+        // framework/NuGet reference looks like and what the fix keys off.
+        var references = CSharpProjectLoader.RuntimeReferences()
+            .Concat(new MetadataReference[] { MetadataReference.CreateFromImage(image) })
+            .ToList();
+
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            consumerSource, new CSharpParseOptions(LanguageVersion.Latest), path: "Consumer.cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Consumer",
+            new[] { tree },
+            references,
+            new CSharpCompilationOptions(outputKind)
+                .WithNullableContextOptions(NullableContextOptions.Enable));
+
+        List<Diagnostic> errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        Assert.True(
+            errors.Count == 0,
+            "Consumer should bind with no C# errors: " + string.Join(Environment.NewLine, errors));
+
+        var document = new LoadedDocument("Consumer.cs", tree, compilation.GetSemanticModel(tree));
+        var context = new TranslationContext(compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return (GSharpPrinter.Print(unit), image);
+    }
+
+    private static ImmutableArray<byte> EmitLibraryImage(string librarySource)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            librarySource, new CSharpParseOptions(LanguageVersion.Latest), path: "Imported.cs");
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Imported",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Disable));
+
+        using var stream = new MemoryStream();
+        EmitResult result = compilation.Emit(stream);
+        Assert.True(
+            result.Success,
+            "Imported library must emit: " + string.Join(
+                Environment.NewLine, result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return ImmutableArray.Create(stream.ToArray());
+    }
+
+    private static (int Exit, string Stdout) CompileAndRun(string printed, ImmutableArray<byte> libraryImage)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-3865-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+
+        string libraryPath = Path.Combine(workDir, "Imported.dll");
+        File.WriteAllBytes(libraryPath, libraryImage.ToArray());
+
+        string gsPath = Path.Combine(workDir, "Program.gs");
+        File.WriteAllText(gsPath, printed);
+
+        string dllPath = Path.Combine(workDir, "Program.dll");
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /reference:\"{libraryPath}\" /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+            "gsc must compile the translated program with zero errors. Output:\n" + compileOut
+                + "\n\nTranslated G#:\n" + printed);
+
+        WriteRuntimeConfig(Path.Combine(workDir, "Program.runtimeconfig.json"));
+        return RunDotnet($"\"{dllPath}\"");
+    }
+
+    private static void WriteRuntimeConfig(string path)
+    {
+        if (File.Exists(path))
+        {
+            return;
+        }
+
+        File.WriteAllText(
+            path,
+            "{\n  \"runtimeOptions\": {\n    \"tfm\": \"net10.0\",\n"
+                + "    \"framework\": { \"name\": \"Microsoft.NETCore.App\", \"version\": \""
+                + Environment.Version.Major + ".0.0\" }\n  }\n}\n");
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -1283,11 +1283,88 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #3865: an IMPORTED target with no nullable metadata at all
+            // is oblivious, and gsc's import rule is the INVERSE of C#'s —
+            // `ClrNullability.IsPositionNonNull` reads "non-null iff the byte is
+            // 1", so oblivious AND absent metadata both map to `T?`. The
+            // imported parameter/field therefore already accepts a nullable
+            // value and no `!!` bridge is needed. This is the write-side mirror
+            // of the read-side rule `IsImportedObliviousNullableMember` has
+            // applied since issue #2113.
+            //
+            // Getting this backwards is not a readability wart: `x!!` is a
+            // RUNTIME assertion in G# (it lowers to `dup; brtrue; pop; newobj
+            // NullReferenceException; throw`), unlike C#'s erased `x!`, so a
+            // gratuitous assertion on a legitimately-null argument turns a legal
+            // C# call into a crash that translate, compile and ILVerify all pass.
+            if (this.IsImportedObliviousNullableTarget(targetSymbol))
+            {
+                return false;
+            }
+
             bool targetDeclaredInThisCompilation = targetSymbol?.DeclaringSyntaxReferences
                 .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree)) == true;
 
             return !(targetDeclaredInThisCompilation
                 && this.ShouldPromoteToNullableReference(targetSymbol));
+        }
+
+        // Issue #3865: true when <paramref name="targetSymbol"/> is a WRITE sink
+        // (parameter, field or property) that exists only as CLR metadata and
+        // whose own declared reference type carries no nullable annotation.
+        //
+        // Scope, and why each restriction is load-bearing:
+        //
+        //  * Metadata only. A symbol with any `DeclaringSyntaxReference`, or one
+        //    declared in an assembly cs2gs is itself migrating, gets a G#
+        //    declaration whose nullability this translator decides
+        //    (`ShouldPromoteToNullableReference`); an oblivious source parameter
+        //    can legitimately be emitted non-nullable, and a nullable argument to
+        //    it really does need the bridge. Only a contract already frozen in
+        //    metadata is read by gsc's import rule.
+        //  * ORIGINAL definition's type. `List<string>.Add(T item)` substitutes
+        //    to `string`, but the DECLARED parameter type is the type parameter
+        //    `T`, whose `NullableAnnotation.None` says nothing about
+        //    obliviousness — gsc binds the substituted `string` as non-null. Only
+        //    a member whose own declared type is a concrete oblivious reference
+        //    type qualifies, exactly as `IsImportedObliviousNullableMember` scopes
+        //    the read side.
+        private bool IsImportedObliviousNullableTarget(ISymbol targetSymbol)
+        {
+            if (targetSymbol is not (IParameterSymbol or IFieldSymbol or IPropertySymbol))
+            {
+                return false;
+            }
+
+            ISymbol original = targetSymbol.OriginalDefinition;
+            if (!original.DeclaringSyntaxReferences.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            // A sibling/repository project loaded as a plain metadata reference
+            // has no syntax either, but cs2gs is emitting its declaration in this
+            // same run — its contract is not frozen, so it stays on the
+            // promotion path above.
+            if (original.ContainingAssembly?.Name is { } assemblyName
+                && (assemblyName == this.context.Compilation.AssemblyName
+                    || (this.context.RepositoryCompilations ?? this.context.SiblingCompilations)?.Any(
+                        compilation => compilation.AssemblyName == assemblyName) == true))
+            {
+                return false;
+            }
+
+            ITypeSymbol declaredType = original switch
+            {
+                IParameterSymbol parameter => parameter.Type,
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
+                _ => null,
+            };
+
+            return declaredType is { IsReferenceType: true }
+                and not ITypeParameterSymbol
+                && declaredType.NullableAnnotation == NullableAnnotation.None;
         }
 
         // A skipped source-generated property is recreated from its hand-written


### PR DESCRIPTION
Fixes #3865.

## The mechanism — there is only ONE, and it is the target framework

#3865 filed two mechanisms and marked the second "still open": oblivious
`Microsoft.Build.*` targets were understood, but `string.IsNullOrEmpty`,
`string.Equals` and `bool.TryParse` are `Annotated`, so they should never have
triggered a `!!` — and a standalone translation of the identical `BuildTask.cs`
emitted none. That framing is wrong, and so is "context-sensitive".

`src/Sdk/Gsharp.NET.Sdk` targets **`netstandard2.0`**. The netstandard reference
assemblies contain **zero** `NullableAttribute`:

```
$ strings ~/.nuget/packages/netstandard.library/2.0.3/build/netstandard2.0/ref/netstandard.dll \
    | grep -c NullableAttribute
0
```

So *under that TFM* `string.IsNullOrEmpty(string)`, `string.Equals(string,
string, StringComparison)` and `bool.TryParse(string, out bool)` are
`NullableAnnotation.None` — oblivious, exactly like `TaskLoggingHelper.LogError`.
Mechanism 2 **is** mechanism 1.

The standalone run disagreed because it did not use the project's references at
all: `CSharpProjectLoader.LoadInMemory` falls back to
`CSharpProjectLoader.RuntimeReferences()`, i.e. the running **net10.0** runtime's
fully annotated assemblies. Same file, different reference set — not different
corpus context, no taint fixpoint involved, no promoted upstream local.

## Why the assertion is wrong even where the target really is oblivious

gsc's import rule is the **inverse** of C#'s, and it is stated in one place —
`ClrNullability.IsPositionNonNull`:

> G# reads "non-null iff the byte is `1`", so oblivious **and** absent metadata
> mean nullable.

An imported oblivious parameter/field/property is therefore already `T?` in G#
and accepts a nullable value with no bridge. cs2gs's
`TargetWillRemainNonNullableReference` only bailed on
`NullableAnnotation.Annotated`, so it read obliviousness as "requires non-null" —
the precise opposite of what gsc does — and asserted.

That is a **behaviour** bug, not a readability one. G#'s `x!!` is a runtime check
(`dup; brtrue; pop; newobj NullReferenceException; throw`); C#'s `x!` is erased.
`string.Equals(null, "root", OrdinalIgnoreCase)` is legal C# returning `false`;
the migrated form threw.

The read side has had the correct rule since #2113
(`IsImportedObliviousNullableMember`, "gsc maps every such imported reference
type to `T?`"). This PR adds its **write-side mirror**.

## The fix

`IsImportedObliviousNullableTarget`, consulted from
`TargetWillRemainNonNullableReference`. Both restrictions are load-bearing:

* **Metadata only.** A target with any `DeclaringSyntaxReference`, or one in an
  assembly cs2gs is migrating in the same run, has no frozen contract — cs2gs
  decides its emitted nullability, an oblivious source parameter can legitimately
  be emitted non-nullable, and a nullable argument to it really does need the
  bridge. Those stay on the existing promotion path untouched.
* **ORIGINAL definition's type.** `List<string>.Add(T item)` substitutes to
  `string`, but the *declared* parameter is the type parameter `T`, whose
  `NullableAnnotation.None` carries no obliviousness signal — gsc binds the
  substituted `string` as non-null. Same scoping the read-side rule uses.

`NullAssertionPolishPass` could not have helped: it strips only GS0536-redundant
assertions, and `this.DebugType!!` is not redundant.

## `test/Sdk.Tests` parity — 16 → 4

Same tree, same gsc (`0.4.403+b30fca9f3d`), same SDK package; the only difference
is the translator.

| | `test/Sdk.Tests` test-parity |
| --- | --- |
| `origin/main` `350342303` (post-#3864) | Failed **16** / Passed 70 / Total 86 |
| this PR | Failed **4** / Passed 82 / Total 86 |

The 12 failing cases that cleared are exactly the `!!`-NRE family, across 11
test methods:
`BuildTask_EmitsGsDiagArguments`, `BuildTask_ForwardsWarningsNotAsErrors_…`,
`BuildTask_OmitsTheSwitchWhenNothingIsDemoted`,
`DeeperEditorConfig_OverridesAncestor_AndRootStopsTheChain`,
`GsAnalyzers_ForwardAsGsAnalyzerArguments`,
`LogCompilerLine_LocationlessGS9998_…`, `LogCompilerLine_WarningIsNotPromotedToError`,
`Optimization_ForwardsCompilerFlag`, `ReadsSeverities_MapsRoslynNames_…`,
`ResxLogicalName_GetsResourcesSuffix` and
`SkipCompilerExecution_ReturnsArgumentsWithoutWritingResponseFile` (one of them
contributing two failing cases). The remaining 4 are #3866's
(`NewLocalSignature_IsMappedIntoDelta`, `Sdk_Csproj_Packs_As_MSBuildSdk`,
`Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime`,
`Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build`) and are
unchanged on both sides.

All four sites named in #3865 are clean in the migrated tree:
`string.IsNullOrEmpty(this.DebugType)`, `string.Equals(key, "root", …)`,
`ParseBool(value string?) -> !string.IsNullOrEmpty(value) && bool.TryParse(value, …)`,
`this.Log!!.LogError(nil, code, nil, file, …)` — note the *receiver* `this.Log!!`
correctly stays, because that is a read of an imported oblivious member.

## Corpus-wide `!!` delta, and why each removal is gratuitous

Whole-repository `migrate --translate-only`, same excludes as the gate, counted
with the gate's own `selfmig_code_grep`:

| | `!!` (pre-polish) |
| --- | --- |
| `origin/main` | 21415 |
| this PR | **21340** |

**−75**, from 7 files. These are pre-polish counts, so they are not the gate's
10682 figure directly (the gate measures after stage 2's `NullAssertionPolishPass`);
none of these assertions is GS0536-redundant, so the ceiling should move by
about the same amount, well under it either way. 52/52 apps still translate green.

Every removal was checked, and the check is structural rather than eyeballed:
**C# never throws at these sites** — `x!` is erased — so removing the assertion
can only *restore* C# behaviour, never lose a check C# had. What was lost is a
G#-only runtime check the original program did not have. Concretely:

```
- let overrideReads = HashSet[string](StringComparer.Ordinal!!)
+ let overrideReads = HashSet[string](StringComparer.Ordinal)

- string.Join(", node.", dropped!!)
+ string.Join(", node.", dropped)

- Gen.ArrayOf(Gen.Choose(0, Methods.Length - 1)!!, candidateCount)
+ Gen.ArrayOf(Gen.Choose(0, Methods.Length - 1), candidateCount)
```

This is the inverse of #3854's trap: nothing here stopped being emitted because
gsc stopped objecting. gsc never objected — the sites still compile and ILVerify,
and the executing tests below show the runtime behaviour now matches C#.

## Tests

`Issue3865ImportedObliviousArgumentAssertionTests` — the "imported" library is a
real metadata image (no `DeclaringSyntaxReference`, like a framework/NuGet
reference) emitted from a nullable-**disabled** compilation, consumed by a
nullable-**enabled** one: the netstandard2.0-under-`<Nullable>enable</Nullable>`
shape faithfully.

Failing on `origin/main` — measured directly by reverting only the translator
file and rebuilding (3 of the 5 tests that existed at the time; the fourth bullet
was added afterwards and asserts the same absent `!!`):

* `ObliviousImportedParameter_NullableArgument_EmitsNoRuntimeAssertion`
* `ObliviousImportedField_NullableAssignment_EmitsNoRuntimeAssertion`
* `ObliviousImportedParameter_NullArgument_RunsWithoutThrowing` — **compiles the
  translated G# with the real gsc and runs it**; asserts `before/True/True/after`,
  which is what the equivalent C# prints. On `origin/main` it emits
  `Sink.Accept(Maybe!!)` and the program dies with `NullReferenceException`.
* `ObliviousImportedInitializerAndIndexerSinks_RunWithoutThrowing` — same, for
  the object-initializer property sink and the indexer key argument.

Passing on `origin/main` too, as anti-vacuity guard rails:

* `AnnotatedNonNullImportedParameter_NullableArgument_StillAssertsAntiVacuityControl`
  — an imported target annotated genuinely non-null still gets `!!`.
* `ObliviousImportedParameter_SubstitutedGenericTargetStillAsserts` —
  `List<string>.Add` still gets `!!`, pinning the type-parameter exclusion.

Two existing expectations change, both with the executing proof above behind
them:

* `Issue2511…ImportedGenericAndConditionalIndexes_AreForgivenWithoutDoubleAssertion`:
  the oblivious `ImportedLookup` **key** loses its `!!`; the `imported!!`
  *receiver* keeps it, `GenericLookup<TKey>`'s type-parameter key keeps it, and
  the user-authored `imported[key!]` suppression keeps it.
* `Issue2521…PrebuiltMetadataTarget_ConsumerTaintStillCannotPromoteItsContract`:
  the prebuilt target is compiled `#nullable disable`, so its sinks are oblivious
  metadata; `GenericTarget<T>.Value` keeps its assertion. What the test pins —
  that consumer taint cannot promote an imported contract — is unchanged, and its
  source-referenced sibling
  (`ImportedTargets_UseAlreadyEmittedContracts_ForAllInitializerSinks`) still
  asserts everywhere.

Full `Cs2Gs.Tests`: **2698 tests, 0 failures**.

Self-translation closure (cs2gs is inside its own corpus), on the migrated tree:

```
tools/cs2gs/Cs2Gs.Translator  PASS  PASS  PASS
tools/cs2gs/Cs2Gs.CodeModel   PASS  PASS  PASS
src/Core/Core.csproj          PASS  PASS  PASS
3/3 apps green; run PASSED.
```

No change to `src/Core` and no change to `tools/cs2gs/selfmig-baseline.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
