### PR TITLE
selfmig: test-parity must prove tests RAN, and cs2gs must keep `ref` on a `ref struct` (#3869)

### DIFF
--- a/tools/cs2gs/Cs2Gs.CodeModel/Ast/TypeDeclaration.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Ast/TypeDeclaration.cs
@@ -36,6 +36,7 @@ public sealed class TypeDeclaration : GMember
     /// <param name="hasBody">Whether to render a body block (false emits the bodyless primary-ctor form).</param>
     /// <param name="attributes">The type attributes.</param>
     /// <param name="isUnsafe">Whether the type is <c>unsafe</c> (its body is an unsafe context).</param>
+    /// <param name="isRefLike">Whether the type is a by-ref-like <c>ref struct</c> (ADR-0058 / issue #367).</param>
     public TypeDeclaration(
         TypeDeclarationKind kind,
         string name,
@@ -52,7 +53,8 @@ public sealed class TypeDeclaration : GMember
         bool isPartial = false,
         bool hasBody = true,
         IReadOnlyList<AttributeUse> attributes = null,
-        bool isUnsafe = false)
+        bool isUnsafe = false,
+        bool isRefLike = false)
     {
         Kind = kind;
         Name = name;
@@ -70,6 +72,7 @@ public sealed class TypeDeclaration : GMember
         HasBody = hasBody;
         Attributes = attributes ?? new List<AttributeUse>();
         IsUnsafe = isUnsafe;
+        IsRefLike = isRefLike;
     }
 
     /// <summary>Gets the aggregate kind.</summary>
@@ -126,6 +129,16 @@ public sealed class TypeDeclaration : GMember
     /// issue #1014); its whole body is an unsafe context.
     /// </summary>
     public bool IsUnsafe { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the type is a by-ref-like
+    /// <c>ref struct</c> (ADR-0058 / issue #367). Dropping this modifier is not
+    /// cosmetic: it changes the emitted type's CLR identity — without
+    /// <c>System.Runtime.CompilerServices.IsByRefLikeAttribute</c> a type that
+    /// holds a <c>Span[T]</c> instance field cannot be loaded by the runtime at
+    /// all (<c>TypeLoadException</c> out of <c>GetExportedTypes()</c>, #3869).
+    /// </summary>
+    public bool IsRefLike { get; }
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
+++ b/tools/cs2gs/Cs2Gs.CodeModel/Printing/GSharpPrinter.cs
@@ -1859,6 +1859,16 @@ public static class GSharpPrinter
             sb.Append("partial ");
         }
 
+        if (declaration.IsRefLike)
+        {
+            // ADR-0058 / issue #367: `ref` immediately precedes `struct`
+            // (`ref struct Window { ... }`). gsc stamps such a type with
+            // `System.Runtime.CompilerServices.IsByRefLikeAttribute`; without
+            // it the emitted type is an ordinary struct and the CLR refuses to
+            // load it once it holds a by-ref-like instance field (#3869).
+            sb.Append("ref ");
+        }
+
         sb.Append(RenderKindKeyword(declaration.Kind));
         sb.Append(' ');
         sb.Append(declaration.Name);

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -112,6 +112,240 @@ public sealed class TestParityStage : IMigrationStage
                 RegexOptions.Multiline | RegexOptions.CultureInvariant);
     }
 
+    /// <summary>
+    /// Issue #3869: the number of test cases the VSTest run summary reports as
+    /// having actually EXECUTED, summed across every summary line (one per
+    /// target framework / test assembly), or <see langword="null"/> when the
+    /// output carries no run summary at all — i.e. no test run ever happened.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <returns>The executed test-case total, or <see langword="null"/> if no run summary is present.</returns>
+    internal static int? ExecutedTestCount(string output)
+    {
+        if (string.IsNullOrEmpty(output))
+        {
+            return null;
+        }
+
+        MatchCollection matches = Regex.Matches(
+            output,
+            @"^\s*(?:Passed|Failed)!\s+-\s+Failed:.*?\bTotal:\s*(\d+)",
+            RegexOptions.Multiline | RegexOptions.CultureInvariant);
+        if (matches.Count == 0)
+        {
+            return null;
+        }
+
+        int total = 0;
+        foreach (Match match in matches)
+        {
+            total += int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Issue #3869: decides whether an exit-code-0 <c>dotnet test</c> run on a
+    /// mirrored test project is genuinely green.
+    /// <para>
+    /// <c>dotnet test</c> exits <b>0</b> when it discovers no tests at all — so
+    /// an assembly that cannot even be enumerated (e.g. a
+    /// <c>TypeLoadException</c> out of <c>GetExportedTypes()</c>, as when a
+    /// translator drops the <c>ref</c> from a <c>ref struct</c>) reports
+    /// "test-parity PASS" while running ZERO tests. Passing on the exit code
+    /// alone makes every future assembly-discovery defect turn the whole app
+    /// green: the #1831 class, one stage further along.
+    /// </para>
+    /// <para>
+    /// A green mirrored run must therefore show positive evidence that tests
+    /// RAN: a VSTest run summary, a non-zero executed count, and — so a
+    /// <i>silent</i> coverage drop is caught too — at least as many executed
+    /// cases as the original C# project has <c>[Fact]</c>-attributed test
+    /// methods. Only <c>[Fact]</c> is counted (never <c>[Theory]</c>, whose row
+    /// count is a runtime property of its data source), which makes
+    /// <paramref name="minimumExpected"/> a sound lower bound on the number of
+    /// discovered cases rather than a tuned threshold.
+    /// </para>
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <param name="minimumExpected">
+    /// The lower bound on executed cases derived from the original C# sources
+    /// (see <see cref="CountCSharpFactMethods"/>); 0 disables the comparison.
+    /// </param>
+    /// <returns>
+    /// <see langword="null"/> when the run is genuinely green, otherwise the
+    /// human-readable reason it is not.
+    /// </returns>
+    internal static string DescribeHollowTestRun(string output, int minimumExpected)
+    {
+        int? executed = ExecutedTestCount(output);
+        if (executed is null)
+        {
+            return "NO-TESTS-RAN: `dotnet test` exited 0 but produced no VSTest run summary — " +
+                "no test run completed. `dotnet test` exits 0 when it discovers nothing " +
+                "(e.g. the migrated assembly fails to type-load and xunit enumerates no types), " +
+                "so exit code 0 alone is not evidence of a passing suite (#3869).";
+        }
+
+        if (executed.Value == 0)
+        {
+            return "NO-TESTS-RAN: `dotnet test` exited 0 having executed 0 test cases. " +
+                "A zero-test run is not a pass (#3869).";
+        }
+
+        if (minimumExpected > 0 && executed.Value < minimumExpected)
+        {
+            return $"TEST-COVERAGE-DROP: only {executed.Value} test case(s) executed, but the " +
+                $"original C# project declares {minimumExpected} [Fact] test method(s) — each of " +
+                "which is exactly one test case. Tests were silently lost between the C# original " +
+                "and the migrated assembly (#3869).";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Issue #3869: counts the <c>[Fact]</c>-attributed test methods declared by
+    /// the ORIGINAL C# sources of this app — the authoritative lower bound on how
+    /// many test cases the migrated assembly must run. The inputs are the exact
+    /// C# files the translator consumed for THIS project
+    /// (<see cref="EmittedGsFile.CsFilePath"/>, excluding files pulled in from a
+    /// referenced project), so the count can never drift from what was migrated.
+    /// <para>
+    /// Only <c>[Fact]</c> methods in <c>public</c>, concrete, non-generic,
+    /// non-static types are counted (see <see cref="IsDiscoverableTestClass"/>):
+    /// a <c>[Theory]</c>'s case count is a property of its data source, xunit
+    /// does not discover non-public test classes, an abstract type contributes
+    /// cases only through its derivations, and a generic test class only through
+    /// its closures — counting any of those would make the bound unsound and
+    /// manufacture false failures on legitimately green apps.
+    /// </para>
+    /// </summary>
+    /// <param name="context">The stage context.</param>
+    /// <returns>The number of <c>[Fact]</c> test methods, or 0 when none can be determined.</returns>
+    internal static int CountCSharpFactMethods(StageExecutionContext context)
+    {
+        var counted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int facts = 0;
+        foreach (EmittedGsFile file in context.EmittedFiles)
+        {
+            if (file.IsFromReferencedProject ||
+                string.IsNullOrEmpty(file.CsFilePath) ||
+                !counted.Add(file.CsFilePath) ||
+                !File.Exists(file.CsFilePath))
+            {
+                continue;
+            }
+
+            string source;
+            try
+            {
+                source = File.ReadAllText(file.CsFilePath);
+            }
+            catch (IOException)
+            {
+                // The bound is best-effort evidence, never a reason to crash the
+                // stage: an unreadable input simply contributes nothing.
+                continue;
+            }
+
+            facts += CountFactMethods(source);
+        }
+
+        return facts;
+    }
+
+    /// <summary>
+    /// Issue #3869: the verdict half of <see cref="RunMirroredTestProject"/>,
+    /// split from the process invocation so BOTH directions of the gate — a
+    /// hollow run must fail, a genuinely green run must still pass — are
+    /// testable at stage-outcome level without shelling out to
+    /// <c>dotnet test</c>.
+    /// </summary>
+    /// <param name="context">The stage context.</param>
+    /// <param name="result">The captured <c>dotnet test</c> result.</param>
+    /// <returns>The stage outcome.</returns>
+    internal StageOutcome EvaluateMirroredTestRun(
+        StageExecutionContext context, ProcessRunResult result)
+    {
+        this.Note(context, result.Output ?? string.Empty);
+        if (result.ExitCode == 0)
+        {
+            // Issue #3869: exit code 0 is NOT evidence that tests ran. `dotnet
+            // test` exits 0 when it discovers nothing, so a migrated assembly
+            // that cannot be enumerated at all scored a full green here. Require
+            // positive evidence instead: a completed run, a non-zero executed
+            // count, and no silent drop against the C# original's [Fact] count.
+            int minimumExpected = CountCSharpFactMethods(context);
+            string hollow = DescribeHollowTestRun(result.Output ?? string.Empty, minimumExpected);
+            if (hollow is null)
+            {
+                string ranNote = $"mirrored test run: {ExecutedTestCount(result.Output)} case(s) executed " +
+                    $"(>= {minimumExpected} expected from the C# original's [Fact] methods).";
+                this.Note(context, ranNote);
+                return StageOutcome.Passed();
+            }
+
+            this.Note(context, "mirrored test-parity FAILED: " + hollow);
+            return StageOutcome.Failed(new[]
+            {
+                context.Triage.TestParityNoTestsRan(
+                    hollow, result.Output ?? string.Empty, EmittedGsRelative(context)),
+            });
+        }
+
+        // Issue #2867: a non-zero `dotnet test` exit means EITHER the project
+        // failed to build OR it built, ran, and the tests failed. Only the
+        // former is a translator/SDK regression; conflating them sends triage
+        // after the emitter when the real signal is a runtime failure, and
+        // discards the per-test outcomes.
+        string output = result.Output ?? "dotnet test failed without output.";
+        return StageOutcome.Failed(new[]
+        {
+            CompletedTestRun(output)
+                ? context.Triage.TestParityLibraryTestFailure(output, EmittedGsRelative(context))
+                : context.Triage.TestParityLibraryBuildFailure(output, EmittedGsRelative(context)),
+        });
+    }
+
+    private static int CountFactMethods(string source)
+    {
+        Microsoft.CodeAnalysis.CSharp.Syntax.CompilationUnitSyntax root =
+            Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseCompilationUnit(source);
+        return root.DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>()
+            .Count(method =>
+                HasFactAttribute(method) &&
+                method.Ancestors()
+                    .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax>()
+                    .All(IsDiscoverableTestClass));
+    }
+
+    /// <summary>
+    /// Whether a containing type declaration can itself host xunit-discoverable
+    /// test cases. Every condition here EXCLUDES cases from the bound, never adds
+    /// them: xunit only discovers tests on <c>public</c> classes, an abstract
+    /// type contributes cases only through its derivations, and a generic test
+    /// class only through its closures. Anything uncertain is left uncounted so
+    /// the bound stays a bound.
+    /// </summary>
+    private static bool IsDiscoverableTestClass(
+        Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax type) =>
+        type.TypeParameterList is null &&
+        type.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.PublicKeyword)) &&
+        !type.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AbstractKeyword)) &&
+        !type.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword));
+
+    private static bool HasFactAttribute(Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax method) =>
+        method.AttributeLists
+            .SelectMany(list => list.Attributes)
+            .Select(attribute => attribute.Name.ToString())
+            .Select(name => name.Contains('.') ? name.Substring(name.LastIndexOf('.') + 1) : name)
+            .Any(name =>
+                string.Equals(name, "Fact", StringComparison.Ordinal) ||
+                string.Equals(name, "FactAttribute", StringComparison.Ordinal));
+
     private static bool IsStdoutEligible(StageExecutionContext context) =>
         context.App.TargetKind == TargetKind.Exe &&
         !string.IsNullOrEmpty(context.App.StdoutGolden) &&
@@ -134,24 +368,7 @@ public sealed class TestParityStage : IMigrationStage
             context.ArtifactDir,
             context.Options.Config,
             context.Options.GeneratedProjectPaths);
-        this.Note(context, result.Output ?? string.Empty);
-        if (result.ExitCode == 0)
-        {
-            return StageOutcome.Passed();
-        }
-
-        // Issue #2867: a non-zero `dotnet test` exit means EITHER the project
-        // failed to build OR it built, ran, and the tests failed. Only the
-        // former is a translator/SDK regression; conflating them sends triage
-        // after the emitter when the real signal is a runtime failure, and
-        // discards the per-test outcomes.
-        string output = result.Output ?? "dotnet test failed without output.";
-        return StageOutcome.Failed(new[]
-        {
-            CompletedTestRun(output)
-                ? context.Triage.TestParityLibraryTestFailure(output, EmittedGsRelative(context))
-                : context.Triage.TestParityLibraryBuildFailure(output, EmittedGsRelative(context)),
-        });
+        return this.EvaluateMirroredTestRun(context, result);
     }
 
     private static bool IsTestProject(string projectPath)

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -514,6 +514,58 @@ public sealed class TriageBuilder
     }
 
     /// <summary>
+    /// Issue #3869: builds a triage artifact for a mirrored test project whose
+    /// <c>dotnet test</c> exited 0 without actually running its tests (or ran
+    /// materially fewer than the C# original declares). <c>dotnet test</c> exits
+    /// 0 when it discovers nothing, so a migrated assembly that fails to
+    /// type-load — and therefore enumerates no test classes at all — used to
+    /// score a full <c>test-parity PASS</c>. The diagnostic id is
+    /// <c>NO-TESTS-RAN</c>.
+    /// </summary>
+    /// <param name="reason">The machine-generated reason the run is not green.</param>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <param name="gsFile">The emitted G# library file (relative path), or null.</param>
+    /// <returns>The populated triage artifact.</returns>
+    public TriageArtifact TestParityNoTestsRan(string reason, string output, string gsFile = null)
+    {
+        string message = string.IsNullOrWhiteSpace(reason) ? "no tests ran" : reason.Trim();
+        if (!string.IsNullOrWhiteSpace(output))
+        {
+            message += "\n" + output.Trim();
+        }
+
+        var artifact = this.NewArtifact(MigrationStageKind.TestParity, TriageCategory.TestParityFailure);
+        artifact.Diagnostic = new TriageDiagnostic
+        {
+            Id = "NO-TESTS-RAN",
+            Message = message,
+            Severity = "error",
+        };
+        artifact.SourceLocation = new TriageSourceLocation
+        {
+            GsFile = gsFile,
+            GsLine = null,
+            GsColumn = null,
+            CsFile = null,
+            CsLine = null,
+            CsColumn = null,
+        };
+        artifact.OffendingCSharpConstruct = new TriageOffendingConstruct
+        {
+            Kind = "LibraryTestDiscovery",
+            Snippet = Truncate(message),
+        };
+        artifact.Fingerprint = Fingerprint.Compute(
+            artifact.Category,
+            artifact.Stage,
+            artifact.Diagnostic.Id,
+            artifact.OffendingCSharpConstruct.Kind,
+            message);
+        artifact.SuggestedIssue = this.TestParityIssue(artifact);
+        return artifact;
+    }
+
+    /// <summary>
     /// Issue #2867: builds a triage artifact for a mirrored test project that
     /// BUILT and RAN but whose tests failed. Reporting this as
     /// <c>LIBRARY-BUILD-FAILED</c> points investigation at the

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3869ModifierSweepTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3869ModifierSweepTests.cs
@@ -1,0 +1,178 @@
+// <copyright file="Issue3869ModifierSweepTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3869, sibling sweep. Dropping <c>ref</c> from a <c>ref struct</c> was
+/// not a one-off typo, it was a whole defect class: a type-declaration modifier
+/// that cs2gs silently discards even though G# can express it, and whose loss
+/// changes the emitted type's RUNTIME identity. This file pins the behaviour of
+/// every other C# type-declaration modifier so the next one cannot regress
+/// unnoticed — including the ones that turn out to be fine, which are exactly
+/// the assertions that would otherwise never be written.
+/// </summary>
+public sealed class Issue3869ModifierSweepTests
+{
+    /// <summary>
+    /// <c>partial</c> — preserved (ADR-0145 §C/§D preserve mode). It has no
+    /// runtime representation of its own, but losing it in preserve mode would
+    /// break the standalone-part contract.
+    /// </summary>
+    [Fact]
+    public void Partial_IsPreservedInPreserveMode()
+    {
+        string printed = Translate(
+            "namespace R { public partial class C { public int X; } }",
+            preservePartialParts: true);
+
+        Assert.Contains("partial class C", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>unsafe</c> — preserved (ADR-0122 / issue #1202). The body is an unsafe
+    /// context, which is what makes a <c>*T</c> member signature legal.
+    /// </summary>
+    [Fact]
+    public void Unsafe_IsPreserved()
+    {
+        string printed = Translate("namespace R { public unsafe struct S { public int X; } }");
+
+        Assert.Contains("unsafe struct S", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>sealed</c> — correctly dropped, and this is NOT a fidelity loss: G#
+    /// types are closed by default and opt INTO inheritance with <c>open</c>, so
+    /// a C# <c>sealed class</c> maps to a plain G# <c>class</c> and the emitted
+    /// type still carries the CLR <c>sealed</c> flag. (G#'s own <c>sealed</c>
+    /// keyword means a closed hierarchy, a different concept.) Emitting
+    /// <c>sealed</c> here would change the meaning, not preserve it.
+    /// </summary>
+    [Fact]
+    public void Sealed_MapsToAPlainClosedGSharpClass()
+    {
+        string printed = Translate("namespace R { public sealed class C { public int X; } }");
+
+        Assert.Contains("class C", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("open class C", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>abstract</c> — deliberately dropped in favour of <c>open</c>, with an
+    /// Info diagnostic recorded (ADR-0115 §B.4: G# has no abstract-class
+    /// modifier). Documented and reported, not silent.
+    /// </summary>
+    [Fact]
+    public void Abstract_MapsToOpen_AndIsReported()
+    {
+        LoadedCSharpProject project = Load("namespace R { public abstract class C { public int X; } }");
+        var translator = new CSharpToGSharpTranslator();
+        LoadedDocument document = project.Documents.Single();
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        string printed = GSharpPrinter.Print(translator.TranslateDocument(document, context));
+
+        Assert.Contains("open class C", printed, StringComparison.Ordinal);
+        Assert.Contains(
+            context.Diagnostics,
+            d => d.Message.Contains("abstract", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// <c>readonly struct</c> — the <c>readonly</c> IS dropped, and unlike
+    /// <c>ref</c> this is a LANGUAGE gap, not a translator gap: G# has no
+    /// <c>readonly struct</c> declaration form at all (gsc only stamps
+    /// <c>IsReadOnlyAttribute</c> on an <c>inline struct</c>,
+    /// <c>TypeDefEmitter</c>). Crucially it is not the #3869 defect class: the
+    /// attribute is a defensive-copy hint for C# consumers, not something the CLR
+    /// type loader enforces, so the emitted assembly still loads. Pinned here so
+    /// the distinction is on record rather than rediscovered.
+    /// </summary>
+    [Fact]
+    public void ReadOnlyStruct_LosesReadOnly_ALanguageGapNotATypeLoadHazard()
+    {
+        string printed = Translate("namespace R { public readonly struct S { public readonly int X; } }");
+
+        Assert.Contains("struct S", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("readonly struct", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>static class</c> — the class is emitted without a <c>static</c>
+    /// modifier (G# has none for aggregates), so the emitted type is not
+    /// <c>abstract sealed</c>. That is a shape difference, not a type-load
+    /// hazard: nothing in the CLR refuses to load a non-static class of static
+    /// members. Pinned so it is a known, deliberate divergence.
+    /// </summary>
+    [Fact]
+    public void StaticClass_LosesStatic_ButRemainsLoadable()
+    {
+        string printed = Translate(
+            "namespace R { public static class Helpers { public static int X() { return 1; } } }");
+
+        Assert.Contains("class Helpers", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("static class", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <c>ref struct</c> — the #3869 defect itself, and the ONLY modifier in this
+    /// sweep whose loss changes runtime type identity to the point of making the
+    /// assembly unloadable. Now preserved.
+    /// </summary>
+    [Fact]
+    public void RefStruct_IsPreserved()
+    {
+        string printed = Translate(
+            "using System; namespace R { public ref struct S { public Span<int> V; } }");
+
+        Assert.Contains("ref struct S", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A <c>ref struct</c> nested inside a class keeps its <c>ref</c> too — gsc's
+    /// aggregate-head detector accepts the contextual <c>ref</c> at nested
+    /// positions, so there is no reason for the translator to special-case them.
+    /// </summary>
+    [Fact]
+    public void NestedRefStruct_IsPreserved()
+    {
+        string printed = Translate(
+            "using System; namespace R { public class Outer { public ref struct Inner { public Span<int> V; } } }");
+
+        Assert.Contains("ref struct Inner", printed, StringComparison.Ordinal);
+    }
+
+    private static LoadedCSharpProject Load(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Repro.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+
+    private static string Translate(string source, bool preservePartialParts = false)
+    {
+        LoadedCSharpProject project = Load(source);
+        var translator = new CSharpToGSharpTranslator(preservePartialParts: preservePartialParts);
+        return string.Join(
+            Environment.NewLine,
+            project.Documents.Select(document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation, document.SemanticModel, document.FilePath);
+                CompilationUnit unit = translator.TranslateDocument(document, context);
+                return GSharpPrinter.Print(unit);
+            }));
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3869RefStructTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3869RefStructTranslationTests.cs
@@ -1,0 +1,258 @@
+// <copyright file="Issue3869RefStructTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3869 defect 1: cs2gs dropped the <c>ref</c> from a C# <c>ref struct</c>
+/// declaration. That is not a cosmetic loss — it changes the emitted type's CLR
+/// identity. Without
+/// <c>System.Runtime.CompilerServices.IsByRefLikeAttribute</c> the type is an
+/// ordinary struct, and a struct holding a by-ref-like instance field
+/// (<c>Span&lt;int&gt;</c>, including an auto-property's backing field) cannot be
+/// loaded by the runtime at all: <c>GetExportedTypes()</c> throws
+/// <c>TypeLoadException</c>, xunit discovers nothing, and the whole migrated
+/// test assembly silently runs zero tests.
+/// <para>
+/// G# has the construct (ADR-0058 / issue #367, <c>samples/UserRefStruct.gs</c>)
+/// and gsc emits the attribute (<c>TypeDefEmitter.EmitIsByRefLikeAttribute</c>),
+/// so this was purely a translator-side gap. The assertions below are therefore
+/// deliberately NOT binding-only: the emitted assembly is compiled by gsc, its
+/// metadata is read back, and the program is EXECUTED so the CLR type loader is
+/// the thing that passes the test.
+/// </para>
+/// </summary>
+public sealed class Issue3869RefStructTranslationTests
+{
+    private const string RefStructSource = """
+        using System;
+
+        namespace Repro
+        {
+            public ref struct Issue2852ImportedRefStruct
+            {
+                public Span<int> Values { get; set; }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The declaration keeps its <c>ref</c>: <c>ref struct Name { ... }</c>, the
+    /// spelling <c>samples/UserRefStruct.gs</c> uses and gsc's aggregate-head
+    /// parser accepts.
+    /// </summary>
+    [Fact]
+    public void RefStruct_KeepsTheRefModifier()
+    {
+        string printed = Translate(RefStructSource);
+
+        Assert.Contains("ref struct Issue2852ImportedRefStruct", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard: a PLAIN C# struct must not acquire a <c>ref</c> it
+    /// never had. Without this, "always emit ref" would pass the test above.
+    /// </summary>
+    [Fact]
+    public void PlainStruct_DoesNotGainARefModifier()
+    {
+        string printed = Translate("""
+            namespace Repro
+            {
+                public struct PlainPoint
+                {
+                    public int X { get; set; }
+                }
+            }
+            """);
+
+        Assert.Contains("struct PlainPoint", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("ref struct PlainPoint", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A C# <c>class</c> is never by-ref-like, whatever it holds.
+    /// </summary>
+    [Fact]
+    public void Class_DoesNotGainARefModifier()
+    {
+        string printed = Translate("""
+            namespace Repro
+            {
+                public class Holder
+                {
+                    public int X { get; set; }
+                }
+            }
+            """);
+
+        Assert.DoesNotContain("ref class", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing proof of the whole #3869 chain. The translated G# is
+    /// compiled by gsc into an executable that calls <c>GetExportedTypes()</c> on
+    /// itself — exactly the call xunit's assembly-info shim makes during
+    /// discovery. On <c>origin/main</c> (the <c>ref</c> dropped) the emitted type
+    /// carried no <c>IsByRefLikeAttribute</c> and this program died with
+    /// <c>System.TypeLoadException: A ByRef or ByRef-like type cannot be used as
+    /// the type for an instance field in a non-ByRef-like type</c>. It must now
+    /// load, enumerate, and exit 0 — and the metadata must actually carry the
+    /// attribute, so a fix that merely stopped the crash some other way cannot
+    /// pass.
+    /// </summary>
+    [Fact]
+    public void TranslatedRefStruct_CarriesIsByRefLike_AndTheAssemblyTypeLoads()
+    {
+        string compiler = FindCompiler();
+        Assert.NotNull(compiler);
+
+        string printed = Translate(RefStructSource);
+        Assert.Contains("ref struct Issue2852ImportedRefStruct", printed, StringComparison.Ordinal);
+
+        string workDir = NewDirectory("runtime");
+        string sourcePath = Path.Combine(workDir, "Repro.gs");
+        string outputPath = Path.Combine(workDir, "Repro.dll");
+        File.WriteAllText(
+            sourcePath,
+            printed + Environment.NewLine +
+            "System.Console.WriteLine(System.Reflection.Assembly.GetExecutingAssembly().GetExportedTypes().Length)" +
+            Environment.NewLine);
+
+        (int compileExit, string compileOutput) = RunDotnet(
+            $"\"{compiler}\" /target:exe /out:\"{outputPath}\" \"{sourcePath}\"",
+            workDir);
+        Assert.True(
+            compileExit == 0,
+            "gsc must compile the translated `ref struct`. Output:\n" + compileOutput +
+                "\nTranslated G#:\n" + printed);
+
+        using (var pe = new PEReader(File.OpenRead(outputPath)))
+        {
+            MetadataReader metadata = pe.GetMetadataReader();
+            TypeDefinition definition = metadata.TypeDefinitions
+                .Select(metadata.GetTypeDefinition)
+                .Single(candidate =>
+                    metadata.GetString(candidate.Name) == "Issue2852ImportedRefStruct");
+
+            Assert.Contains(
+                definition.GetCustomAttributes()
+                    .Select(metadata.GetCustomAttribute)
+                    .Select(attribute => AttributeTypeName(metadata, attribute)),
+                name => name == "IsByRefLikeAttribute");
+        }
+
+        // The load-bearing assertion: the CLR type loader, not the binder.
+        (int runExit, string runOutput) = RunDotnet($"\"{outputPath}\"", workDir);
+        Assert.True(
+            runExit == 0,
+            "The emitted assembly must type-load and enumerate its exported types " +
+                "(this is the call xunit discovery makes). Output:\n" + runOutput);
+        Assert.DoesNotContain("TypeLoadException", runOutput, StringComparison.Ordinal);
+    }
+
+    private static string AttributeTypeName(MetadataReader metadata, CustomAttribute attribute)
+    {
+        switch (attribute.Constructor.Kind)
+        {
+            case HandleKind.MemberReference:
+                MemberReference member = metadata.GetMemberReference(
+                    (MemberReferenceHandle)attribute.Constructor);
+                return member.Parent.Kind == HandleKind.TypeReference
+                    ? metadata.GetString(metadata.GetTypeReference((TypeReferenceHandle)member.Parent).Name)
+                    : string.Empty;
+            case HandleKind.MethodDefinition:
+                MethodDefinition method = metadata.GetMethodDefinition(
+                    (MethodDefinitionHandle)attribute.Constructor);
+                return metadata.GetString(metadata.GetTypeDefinition(method.GetDeclaringType()).Name);
+            default:
+                return string.Empty;
+        }
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Repro.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        var translator = new CSharpToGSharpTranslator();
+        return string.Join(
+            Environment.NewLine,
+            project.Documents.Select(document =>
+            {
+                var context = new TranslationContext(
+                    project.Compilation, document.SemanticModel, document.FilePath);
+                CompilationUnit unit = translator.TranslateDocument(document, context);
+                Assert.DoesNotContain(
+                    context.Diagnostics,
+                    diagnostic => diagnostic.Severity == TranslationSeverity.Unsupported);
+                return GSharpPrinter.Print(unit);
+            }));
+    }
+
+    private static string NewDirectory(string category)
+    {
+        string path = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue-3869-ref-struct",
+            category,
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    private static (int ExitCode, string Output) RunDotnet(string arguments, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory,
+        };
+        using Process process = Process.Start(startInfo);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3869ZeroTestFalseGreenTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3869ZeroTestFalseGreenTests.cs
@@ -1,0 +1,326 @@
+// <copyright file="Issue3869ZeroTestFalseGreenTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3869 defect 2 (the gate hole, and the more important half): the
+/// mirrored test-parity path used to pass on <c>result.ExitCode == 0</c> ALONE.
+/// <c>dotnet test</c> exits 0 when it discovers no tests, so a migrated assembly
+/// that cannot even be enumerated — <c>GetExportedTypes()</c> throwing
+/// <c>TypeLoadException</c>, xunit finding nothing — scored
+/// <c>test-parity PASS</c> while running ZERO tests. Any future
+/// assembly-discovery defect would have turned a whole app green the same way:
+/// the #1831 class, one stage further along.
+/// <para>
+/// The guard is proved in BOTH directions here. A gate that only ever fails is
+/// as useless as one that only ever passes, so the legitimately-green runs below
+/// are as load-bearing as the hollow ones.
+/// </para>
+/// </summary>
+public sealed class Issue3869ZeroTestFalseGreenTests
+{
+    /// <summary>The real captured output of the #3869 repro: discovery blew up, exit 0.</summary>
+    private const string TypeLoadFailureOutput = """
+        Determining projects to restore...
+        [xUnit.net 00:00:00.08] Exception discovering tests from GSharp.Core.Tests:
+        System.TypeLoadException: A ByRef or ByRef-like type cannot be used as the type for an instance field in a non-ByRef-like type.
+           at System.Reflection.RuntimeAssembly.GetExportedTypes()
+           at Xunit.Sdk.ReflectionAssemblyInfo.GetTypes(Boolean includePrivateTypes)
+        No test is available in /tmp/migrated/GSharp.Core.Tests.dll. Make sure that test discoverer & executors are registered.
+        """;
+
+    private const string GreenRunOutput = """
+        Determining projects to restore...
+        Passed!  - Failed:     0, Passed:   248, Skipped:     0, Total:   248, Duration: 4 s - GSharp.Core.Tests.dll (net10.0)
+        """;
+
+    /// <summary>
+    /// The #3869 repro itself: `dotnet test` exited 0 having discovered nothing.
+    /// This must FAIL, not pass.
+    /// </summary>
+    [Fact]
+    public void DiscoveryFailure_ExitZero_IsNotGreen()
+    {
+        string reason = TestParityStage.DescribeHollowTestRun(TypeLoadFailureOutput, minimumExpected: 0);
+
+        Assert.NotNull(reason);
+        Assert.Contains("NO-TESTS-RAN", reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A run summary that reports zero executed cases is likewise not a pass —
+    /// the summary line existing is not the same as tests having run.
+    /// </summary>
+    [Fact]
+    public void ZeroExecutedCases_IsNotGreen()
+    {
+        string reason = TestParityStage.DescribeHollowTestRun(
+            "Passed!  - Failed:     0, Passed:     0, Skipped:     0, Total:     0, Duration: 1 ms - X.dll (net10.0)",
+            minimumExpected: 0);
+
+        Assert.NotNull(reason);
+        Assert.Contains("NO-TESTS-RAN", reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Empty output (the process produced nothing at all) is not evidence of a
+    /// passing suite either.
+    /// </summary>
+    [Fact]
+    public void NoOutput_IsNotGreen()
+    {
+        Assert.NotNull(TestParityStage.DescribeHollowTestRun(string.Empty, minimumExpected: 0));
+    }
+
+    /// <summary>
+    /// THE OTHER DIRECTION. A genuinely-passing run must still pass — otherwise
+    /// the fix has merely broken the gate the opposite way.
+    /// </summary>
+    [Fact]
+    public void GenuineGreenRun_StillPasses()
+    {
+        Assert.Null(TestParityStage.DescribeHollowTestRun(GreenRunOutput, minimumExpected: 0));
+        Assert.Null(TestParityStage.DescribeHollowTestRun(GreenRunOutput, minimumExpected: 248));
+        Assert.Null(TestParityStage.DescribeHollowTestRun(GreenRunOutput, minimumExpected: 100));
+    }
+
+    /// <summary>
+    /// A multi-assembly / multi-TFM run reports one summary line per assembly;
+    /// the executed cases are the SUM, not the first line, so a legitimately
+    /// green two-assembly run must not be failed for "too few" tests.
+    /// </summary>
+    [Fact]
+    public void MultipleSummaryLines_AreSummed()
+    {
+        string output = """
+            Passed!  - Failed:     0, Passed:   120, Skipped:     1, Total:   121, Duration: 2 s - A.dll (net10.0)
+            Passed!  - Failed:     0, Passed:   130, Skipped:     0, Total:   130, Duration: 3 s - B.dll (net10.0)
+            """;
+
+        Assert.Equal(251, TestParityStage.ExecutedTestCount(output));
+        Assert.Null(TestParityStage.DescribeHollowTestRun(output, minimumExpected: 251));
+    }
+
+    /// <summary>
+    /// A SILENT coverage drop — the run is green, the tests that ran passed, but
+    /// materially fewer of them ran than the C# original declares — must fail
+    /// too. Exit code 0 plus "some tests ran" is still not parity.
+    /// </summary>
+    [Fact]
+    public void SilentCoverageDrop_IsNotGreen()
+    {
+        string reason = TestParityStage.DescribeHollowTestRun(GreenRunOutput, minimumExpected: 400);
+
+        Assert.NotNull(reason);
+        Assert.Contains("TEST-COVERAGE-DROP", reason, StringComparison.Ordinal);
+        Assert.Contains("248", reason, StringComparison.Ordinal);
+        Assert.Contains("400", reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The lower bound counts only <c>[Fact]</c> methods in public, concrete,
+    /// non-generic, non-static types. A <c>[Theory]</c>'s case count is a
+    /// property of its data source, xunit never discovers a non-public test
+    /// class, an abstract type contributes cases only through derivations, and a
+    /// generic test class only through closures — counting any of those would
+    /// make the bound unsound and manufacture false failures on legitimately
+    /// green apps. Every exclusion here can only LOWER the bound, which is the
+    /// direction that keeps a green app green.
+    /// </summary>
+    [Fact]
+    public void FactCount_IsASoundLowerBound()
+    {
+        StageExecutionContext context = ContextWithCSharpSource("""
+            using Xunit;
+
+            public class Concrete
+            {
+                [Fact] public void A() { }
+                [Fact] public void B() { }
+                [Xunit.Fact] public void FullyQualified() { }
+                [Theory] [InlineData(1)] public void NotCounted(int x) { }
+                public void PlainMethod() { }
+            }
+
+            public abstract class AbstractBase
+            {
+                [Fact] public void NotCountedEither() { }
+            }
+
+            public class Generic<T>
+            {
+                [Fact] public void NorThis() { }
+            }
+
+            internal class NotPublic
+            {
+                [Fact] public void XunitNeverDiscoversThis() { }
+            }
+
+            public static class StaticHolder
+            {
+                [Fact] public static void NorThisOne() { }
+            }
+            """);
+
+        Assert.Equal(3, TestParityStage.CountCSharpFactMethods(context));
+    }
+
+    /// <summary>
+    /// Files pulled in from a referenced project belong to another app's count;
+    /// counting them here would manufacture a coverage-drop failure.
+    /// </summary>
+    [Fact]
+    public void FactCount_IgnoresReferencedProjectFiles()
+    {
+        StageExecutionContext context = ContextWithCSharpSource(
+            "using Xunit; public class Own { [Fact] public void A() { } }");
+        string foreignPath = Path.Combine(NewDirectory(), "Foreign.cs");
+        File.WriteAllText(foreignPath, "using Xunit; public class Foreign { [Fact] public void B() { } [Fact] public void C() { } }");
+        context.EmittedFiles.Add(new EmittedGsFile("Foreign.gs", "Foreign.gs", foreignPath, string.Empty)
+        {
+            IsFromReferencedProject = true,
+        });
+
+        Assert.Equal(1, TestParityStage.CountCSharpFactMethods(context));
+    }
+
+    /// <summary>
+    /// A project with no <c>[Fact]</c> at all (e.g. all <c>[Theory]</c>) yields a
+    /// bound of 0, which disables the comparison rather than failing every such
+    /// app: the zero-test guard alone still applies.
+    /// </summary>
+    [Fact]
+    public void NoFacts_DisablesTheComparison_ButNotTheZeroGuard()
+    {
+        StageExecutionContext context = ContextWithCSharpSource(
+            "using Xunit; public class OnlyTheories { [Theory] [InlineData(1)] public void T(int x) { } }");
+
+        Assert.Equal(0, TestParityStage.CountCSharpFactMethods(context));
+        Assert.Null(TestParityStage.DescribeHollowTestRun(GreenRunOutput, minimumExpected: 0));
+        Assert.NotNull(TestParityStage.DescribeHollowTestRun(TypeLoadFailureOutput, minimumExpected: 0));
+    }
+
+    /// <summary>
+    /// Stage-outcome level, direction 1: the exact #3869 run — `dotnet test`
+    /// exit 0, discovery blown up by <c>TypeLoadException</c>, zero tests — must
+    /// produce a FAILED stage carrying a <c>NO-TESTS-RAN</c> artifact. On
+    /// <c>origin/main</c> this same input returned
+    /// <see cref="StageStatus.Passed"/> with no artifacts, which is how
+    /// <c>test/Core.Tests</c> scored a full green on an assembly that cannot be
+    /// enumerated.
+    /// </summary>
+    [Fact]
+    public void Stage_HollowRun_Fails()
+    {
+        StageExecutionContext context = ContextWithCSharpSource(
+            "using Xunit; public class Own { [Fact] public void A() { } }");
+
+        StageOutcome outcome = new TestParityStage().EvaluateMirroredTestRun(
+            context, new ProcessRunResult(0, TypeLoadFailureOutput, string.Empty, false));
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.NotEqual(StageStatus.Passed, outcome.Status);
+        Assert.NotEqual(StageStatus.Skipped, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "NO-TESTS-RAN");
+    }
+
+    /// <summary>
+    /// Stage-outcome level, direction 2 — the half without which the fix would
+    /// have made the gate useless the opposite way: a legitimately green run
+    /// (tests discovered, executed, all passing, count at or above the C#
+    /// original's <c>[Fact]</c> bound) must still PASS with no artifacts.
+    /// </summary>
+    [Fact]
+    public void Stage_GenuineGreenRun_StillPasses()
+    {
+        StageExecutionContext context = ContextWithCSharpSource(
+            "using Xunit; public class Own { [Fact] public void A() { } [Fact] public void B() { } }");
+
+        StageOutcome outcome = new TestParityStage().EvaluateMirroredTestRun(
+            context, new ProcessRunResult(0, GreenRunOutput, string.Empty, false));
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+        Assert.Empty(outcome.Artifacts);
+    }
+
+    /// <summary>
+    /// A non-zero exit still classifies as before (#2867): build failure vs test
+    /// failure. The #3869 guard must not have swallowed that distinction.
+    /// </summary>
+    [Fact]
+    public void Stage_FailingTests_StillReportAsTestFailure_NotNoTestsRan()
+    {
+        StageExecutionContext context = ContextWithCSharpSource(
+            "using Xunit; public class Own { [Fact] public void A() { } }");
+
+        StageOutcome outcome = new TestParityStage().EvaluateMirroredTestRun(
+            context,
+            new ProcessRunResult(
+                1,
+                "Failed!  - Failed:     2, Passed:   246, Skipped:     0, Total:   248, Duration: 4 s - X.dll (net10.0)",
+                string.Empty,
+                false));
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-TESTS-FAILED");
+        Assert.DoesNotContain(outcome.Artifacts, a => a.Diagnostic.Id == "NO-TESTS-RAN");
+    }
+
+    private static StageExecutionContext ContextWithCSharpSource(string source)
+    {
+        string dir = NewDirectory();
+        string csPath = Path.Combine(dir, "Own.cs");
+        File.WriteAllText(csPath, source);
+
+        string projectPath = Path.Combine(dir, "Own.Tests.csproj");
+        File.WriteAllText(projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+            </Project>
+            """);
+
+        var app = new CorpusApp("test/Own.Tests", projectPath, TargetKind.Library);
+        var options = new PipelineOptions { OutputRoot = dir };
+        var triage = new TriageBuilder("run_1", "2026-09-03T00:00:00Z", "0.0.0", app.Id);
+        var context = new StageExecutionContext(app, options, new GscInvoker(FindCompiler()), dir, triage);
+        context.EmittedFiles.Add(new EmittedGsFile("Own.gs", "Own.gs", csPath, string.Empty));
+        return context;
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(
+                    dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return "gsc.dll";
+    }
+
+    private static string NewDirectory()
+    {
+        string path = Path.Combine(
+            AppContext.BaseDirectory, "issue-3869-zero-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs
@@ -1626,6 +1626,19 @@ public sealed partial class CSharpToGSharpTranslator
                 (otherParts != null && otherParts.Any(p => p.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword))));
             bool isPartial = sourceWasPartial && (this.preservePartialParts || this.markMergedTypePartial);
 
+            // ADR-0058 / issue #367 (issue #3869): a C# `ref struct` is by-ref-like.
+            // Dropping the modifier does not merely lose a hint — it changes the
+            // emitted type's CLR identity: without `IsByRefLikeAttribute` the type
+            // is an ordinary struct, and one holding a `Span<T>` instance field
+            // then fails to type-load (`TypeLoadException` out of
+            // `GetExportedTypes()`), which silently emptied a whole migrated test
+            // assembly. `symbol.IsRefLikeType` is the semantic truth; the syntactic
+            // `ref` modifier (on this part or any other part of a partial type) is
+            // the fallback when the type did not bind.
+            bool isRefLike = symbol?.IsRefLikeType == true ||
+                node.Modifiers.Any(SyntaxKind.RefKeyword) ||
+                (otherParts != null && otherParts.Any(p => p.Modifiers.Any(SyntaxKind.RefKeyword)));
+
             return new TypeDeclaration(
                 kind.Value,
                 this.EmittedName(symbol, node.Identifier.ValueText),
@@ -1640,7 +1653,8 @@ public sealed partial class CSharpToGSharpTranslator
                 isAbstract: false,
                 attributes: this.MapAttributes(mergedAttributeLists),
                 isUnsafe: isUnsafe,
-                isPartial: isPartial);
+                isPartial: isPartial,
+                isRefLike: isRefLike);
         }
 
         private bool ShouldAttachOwnedExtensions(


### PR DESCRIPTION
Fixes #3869. Two defects, one chain — the gate hole first, because it is what made the other one invisible.

## The six-step chain, reproduced independently

Confirmed end to end rather than inherited:

1. **cs2gs drops `ref`.** On `origin/main` the printer had no code path that could emit `ref` before an aggregate keyword and `TypeDeclaration` had no by-ref-like flag at all, so `public ref struct X` could only ever come out as `struct X`. The two new translation tests fail on `30469e05f`.
2. **The emitted type carries a `Span<int>` field with no `IsByRefLike`.** Reproduced directly against gsc: a `.gs` file spelling `struct Issue2852ImportedRefStruct { prop Values Span[int32] }` **compiles clean** (`Wrote Bad.dll`, exit 0). Note this also means gsc's GS0219 by-ref-like escape check does not fire on an auto-property's backing field — see "gsc follow-up" below.
3. **`GetExportedTypes()` throws.** Running that assembly: `System.TypeLoadException: A ByRef or ByRef-like type cannot be used as the type for an instance field in a non-ByRef-like type. at System.Reflection.RuntimeAssembly.GetExportedTypes()`. The same source with `ref struct` loads and enumerates fine.
4. **xunit discovers nothing** — the issue's captured discovery log.
5. **`dotnet test` exits 0.** Reproduced with a minimal xunit project containing no test methods: exit code **0**, output `No test is available in …`, and **no VSTest run summary line at all**.
6. **`TestParityStage` passed on the exit code alone** — the pass path was literally `if (result.ExitCode == 0) { return StageOutcome.Passed(); }`.

## Defect A — the gate hole

`RunMirroredTestProject`'s green path now requires positive evidence that tests ran:

* a VSTest run summary must exist (step 5's input has none),
* the executed-case total must be non-zero (summed across every summary line, so multi-assembly / multi-TFM runs are not mis-scored),
* and the total must be at least the number of `[Fact]` test methods the **original C# sources** declare, so a *silent* coverage drop fails too.

The bound counts only `[Fact]` in **public, concrete, non-generic, non-static** types. `[Theory]` is never counted (its case count is a property of its data source), and every exclusion can only lower the bound — it is a bound, not a tuned threshold. Measured against the real `test/Extensions.Tests`: bound **110**, actual C# run **173**. The C# inputs come from `EmittedGsFile.CsFilePath` (excluding files pulled in from referenced projects), which is the exact set the translator consumed and survives the migrate→validate manifest, so it cannot drift from what was migrated.

Failures land as a new `NO-TESTS-RAN` triage artifact. The `#2867` non-zero-exit classification (build failure vs test failure) is untouched.

The verdict is split out as `TestParityStage.EvaluateMirroredTestRun` so **both directions** are provable without shelling out to `dotnet test`:

* `Stage_HollowRun_Fails` — the verbatim #3869 output, exit 0 → `Failed` + `NO-TESTS-RAN`.
* `Stage_GenuineGreenRun_StillPasses` — a real passing run → `Passed`, no artifacts. **Without this the fix would just break the gate the other way.**
* `Stage_FailingTests_StillReportAsTestFailure_NotNoTestsRan` — #2867 behaviour preserved.

Plus unit-level coverage of the predicate: zero-total, empty output, multi-summary summing, coverage drop, and four `[Fact]`-counting soundness cases.

**`tools/cs2gs/selfmig-baseline.json` is deliberately untouched.** See "gate impact" below — I have not adjusted any floor.

## Defect B — `ref struct` fidelity

G# has the construct (ADR-0058 / #367, `samples/UserRefStruct.gs`) and gsc emits `IsByRefLikeAttribute` (`TypeDefEmitter`), so this was a translator gap, confirmed — no language work needed.

* `TypeDeclaration` gains `IsRefLike`.
* `GSharpPrinter` emits `ref ` immediately before the aggregate keyword.
* The translator sets it from `symbol.IsRefLikeType`, falling back to the syntactic `ref` modifier on this part or any other part of a partial type.

The proof is **executing, not binding-only**: gsc compiles the translated G#, the emitted metadata is asserted to carry `IsByRefLikeAttribute`, and the program is then run so that `GetExportedTypes()` — the exact call xunit discovery makes — is what has to succeed.

## Failing-on-main / anti-vacuity

Ran on a clean `30469e05f` worktree:

```
Failed  Issue3869RefStructTranslationTests.RefStruct_KeepsTheRefModifier
Failed  Issue3869RefStructTranslationTests.TranslatedRefStruct_CarriesIsByRefLike_AndTheAssemblyTypeLoads
Passed  Issue3869RefStructTranslationTests.PlainStruct_DoesNotGainARefModifier
Passed  Issue3869RefStructTranslationTests.Class_DoesNotGainARefModifier
Failed! - Failed: 2, Passed: 2, Total: 4
```

The two passes are the guard rails: they pass on main and must keep passing, so "always emit `ref`" cannot satisfy the suite.

The gate-hole tests cannot be run against main at all — `DescribeHollowTestRun` / `EvaluateMirroredTestRun` have no representation there, because main's entire decision was the exit code. The empirical stand-in is step 5 above: a zero-test `dotnet test` exits 0 and emits no summary, which is precisely the input the new guard rejects and the old code accepted.

## Sibling-modifier sweep

`Issue3869ModifierSweepTests` pins every C# type-declaration modifier, including the ones that are fine — those are the assertions that otherwise never get written.

| modifier | behaviour | verdict |
| --- | --- | --- |
| `ref struct` | **was dropped**, now preserved | the #3869 defect; the only one whose loss makes the assembly **unloadable** |
| `partial` | preserved (ADR-0145 preserve mode) | fine |
| `unsafe` | preserved (ADR-0122 / #1202) | fine |
| `sealed` | dropped — **correctly**: G# types are closed by default and opt in with `open`, so the emitted type still carries the CLR `sealed` flag. Emitting G#'s `sealed` (a closed *hierarchy*) would change the meaning | fine |
| `abstract` | dropped in favour of `open`, with an Info diagnostic (ADR-0115 §B.4) | known, reported |
| `readonly struct` | `readonly` **is** dropped — but this is a **language** gap, not a translator gap: G# has no `readonly struct` form (gsc stamps `IsReadOnlyAttribute` only on `inline struct`). Not the #3869 class: it is a defensive-copy hint, not something the type loader enforces | divergence, loadable |
| `static class` | `static` dropped (no G# aggregate form), so the type is not `abstract sealed` | divergence, loadable |

Also checked: a `ref struct` **nested** inside a class keeps its `ref` (gsc's aggregate-head detector accepts the contextual `ref` at nested positions).

## Gate impact — please read

I could not run the full 51-app gate locally (hours), so I cannot give measured before/after test-parity for every app; **CI's gate run on this PR is the measurement**. What I can bound is the blast radius. Only apps that take the *mirrored* test-parity path can change, and of the 44 currently-green apps exactly **three** do:

* `test/Extensions.Tests` (110 `[Fact]`, C# runs 173)
* `tools/cs2gs/corpus/L2-Library.Tests` (6 `[Fact]`)
* `tools/cs2gs/corpus/L3-Library.Tests` (11 `[Fact]`)

Every other green app is either a non-test project (`no parity oracle` path, untouched) or a stdout-parity app (untouched). If any of those three flips red, it is a **newly-revealed hollow PASS**, not a regression — I have not touched `selfmig-baseline.json` and have not tuned anything to preserve the count. If the green count legitimately drops, that is for @DavidObando to ratchet, not for this PR to paper over.

## gsc follow-up worth filing separately

Step 2 above shows gsc compiles a **plain** `struct` with a `Span[int32]` **auto-property** without a GS0219 by-ref-like escape error, producing an assembly the CLR cannot load. GS0219 documents "storing it in a field of a non-ref-struct (instance …)", so the property's backing field looks like a gap in that check. Fixing it would have turned #3869 into a compile error instead of a silent zero-test run — a second, independent guard on the same hazard. Not in scope here.

## Test evidence

* `Issue3869*` — 24 tests, all green.
* Closure runs (translate + round-trip-parse, zero Unsupported diagnostics) on every file this PR changes or adds: `Cs2Gs.Pipeline/TestParityStage.cs`, `Cs2Gs.Pipeline/TriageBuilder.cs`, `Cs2Gs.CodeModel/Ast/TypeDeclaration.cs`, `Cs2Gs.CodeModel/Printing/GSharpPrinter.cs`, `Cs2Gs.Translator/CSharpToGSharpTranslator.Declarations.cs`, and the three new test files — cs2gs is inside its own corpus, so the change has to survive its own translation.
* `build/nullable_hygiene.py`: OK.
* Full `Cs2Gs.Tests` suite run locally.

**Deconfliction:** this PR touches `TestParityStage` / `TriageBuilder` and type-declaration translation only. It does **not** touch the nullability/taint path (#3865).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
