### PR TITLE
gsc: typeof of a source unbound generic delegate (#3838); implicit this in a DIM body (#3840)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -462,6 +462,32 @@ internal sealed partial class ExpressionBinder
                     return BindAccessorStep(inheritedClrHead, null, rightPart);
                 }
             }
+            else if (TryResolveInterfaceInstancePropertyByBareName(name, out _, out _)
+                && !(TryResolveColorColorType(
+                        name,
+                        leftName,
+                        out var dimColorClass,
+                        out var dimColorStruct,
+                        out var dimColorInterface,
+                        out var dimColorEnum)
+                    && RightPartLooksLikeStaticMember(
+                        dimColorClass,
+                        dimColorStruct,
+                        dimColorInterface,
+                        dimColorEnum,
+                        rightPart)))
+            {
+                // Issue #3840: an unqualified accessor chain inside a DEFAULT
+                // INTERFACE METHOD body whose head names the enclosing
+                // interface's own property (`Count.ToString()`) binds as
+                // `this.Count.ToString()`. Mirrors the inherited-CLR arm above,
+                // including #687's type/value collision rule (a same-named type
+                // wins on the static-member shape, by falling through to the
+                // source-type arms below).
+                return TryBindInterfaceInstancePropertyByBareName(leftName, out var dimHead)
+                    ? BindAccessorStep(dimHead, null, rightPart)
+                    : new BoundErrorExpression(null);
+            }
             else if (TryBindSubmissionStaticMember(leftName, out var submissionHead)
                 && submissionHead is not BoundErrorExpression)
             {

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -49,6 +49,20 @@ internal sealed partial class ExpressionBinder
                 return resolvedInheritedWrite;
             }
 
+            // Issue #3840: a bare write inside a DEFAULT INTERFACE METHOD body
+            // resolves to `this.Member = value` on the enclosing interface's
+            // own property — the write half of the bare-name READ fallback in
+            // BindNameExpression.
+            if (TryBindInterfaceInstancePropertyWriteByBareName(
+                    name,
+                    syntax.IdentifierToken.Location,
+                    syntax.Expression,
+                    syntax.EqualsToken.Location,
+                    out var interfaceWrite))
+            {
+                return interfaceWrite;
+            }
+
             // ADR-0156 Phase 2: a bare write to a top-level global declared by
             // a prior interactive submission stores to the static field on
             // that submission's <Program> container (newest submission first).
@@ -1291,6 +1305,26 @@ internal sealed partial class ExpressionBinder
                 }
             }
 
+            // Issue #3840: a bare compound write (`Count += 1`) inside a
+            // DEFAULT INTERFACE METHOD body reads and stores the enclosing
+            // interface's own property through the implicit `this`, reusing
+            // the very same helper the `this.Count += 1` spelling uses.
+            if (TryResolveInterfaceInstancePropertyByBareName(name, out var ifaceReceiver, out var ifaceThis))
+            {
+                SyntaxFacts.TryGetCompoundAssignmentBaseOperator(syntax.OperatorToken.Kind, out var ifaceBaseOperator);
+                var ifaceCompound = TryBindInterfaceCompoundAssignment(
+                    ifaceThis,
+                    ifaceReceiver,
+                    name,
+                    bareName,
+                    syntax,
+                    ifaceBaseOperator);
+                if (ifaceCompound != null)
+                {
+                    return ifaceCompound;
+                }
+            }
+
             // ADR-0156 Phase 2: a bare compound write (`counter += 1`) to a
             // top-level global declared by a prior interactive submission
             // reads and stores the static field on that submission's
@@ -1688,6 +1722,69 @@ internal sealed partial class ExpressionBinder
             converted,
             substitutedType,
             effectiveInterface);
+    }
+
+    /// <summary>
+    /// Issue #3840: tries to bind a bare (unqualified) simple write
+    /// <c>Member = value</c> inside a DEFAULT INTERFACE METHOD body to an
+    /// instance property of the enclosing interface, producing exactly the
+    /// <see cref="BoundPropertyAssignmentExpression"/> the <c>this.Member =
+    /// value</c> qualified path produces. A resolved-but-unsettable property
+    /// reports "cannot assign" rather than GS0125, matching that path.
+    /// </summary>
+    /// <param name="name">The bare identifier text.</param>
+    /// <param name="nameLocation">The identifier location, for diagnostics.</param>
+    /// <param name="valueSyntax">The RHS value syntax.</param>
+    /// <param name="assignLocation">The location of the assignment operator, for diagnostics.</param>
+    /// <param name="bound">The bound assignment (or an error expression) on success.</param>
+    /// <returns><see langword="true"/> when the enclosing interface declares a property of that name.</returns>
+    private bool TryBindInterfaceInstancePropertyWriteByBareName(
+        string name,
+        TextLocation nameLocation,
+        ExpressionSyntax valueSyntax,
+        TextLocation assignLocation,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out BoundExpression? bound)
+    {
+        bound = null;
+        if (!TryResolveInterfaceInstancePropertyByBareName(name, out var receiver, out var thisInterface)
+            || !TypeMemberModel.TryGetPropertyWithOwner(thisInterface, name, out var property, out var propertyOwner))
+        {
+            return false;
+        }
+
+        if (!property.HasSetter)
+        {
+            Diagnostics.ReportCannotAssign(assignLocation, name);
+            _ = BindExpression(valueSyntax);
+            bound = new BoundErrorExpression(null);
+            return true;
+        }
+
+        var effectiveInterface = Invariant.Required(
+            propertyOwner as InterfaceSymbol,
+            "an interface property has an effective interface owner");
+        if (!AccessibilityChecker.IsAccessible(property.SetterAccessibility, effectiveInterface, this.function))
+        {
+            Diagnostics.ReportMemberInaccessible(
+                nameLocation,
+                property.Name,
+                effectiveInterface.Name,
+                property.SetterAccessibility);
+        }
+
+        var propertyType = effectiveInterface.SubstituteMemberType(property.Type);
+        var value = BindAssignmentRhs(valueSyntax, propertyType);
+        var converted = conversions.BindConversion(valueSyntax.Location, value, propertyType);
+        EnforceInitOnlyAssignment(property, receiver, assignLocation);
+        bound = new BoundPropertyAssignmentExpression(
+            null,
+            receiver,
+            null,
+            property,
+            converted,
+            ReferenceEquals(propertyType, property.Type) ? null : propertyType,
+            effectiveInterface);
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -53,12 +53,12 @@ internal sealed partial class ExpressionBinder
             // resolves to `this.Member = value` on the enclosing interface's
             // own property — the write half of the bare-name READ fallback in
             // BindNameExpression.
-            if (TryBindInterfaceInstancePropertyWriteByBareName(
-                    name,
-                    syntax.IdentifierToken.Location,
-                    syntax.Expression,
-                    syntax.EqualsToken.Location,
-                    out var interfaceWrite))
+            var interfaceWrite = TryBindInterfaceInstancePropertyWriteByBareName(
+                name,
+                syntax.IdentifierToken.Location,
+                syntax.Expression,
+                syntax.EqualsToken.Location);
+            if (interfaceWrite != null)
             {
                 return interfaceWrite;
             }
@@ -1736,28 +1736,24 @@ internal sealed partial class ExpressionBinder
     /// <param name="nameLocation">The identifier location, for diagnostics.</param>
     /// <param name="valueSyntax">The RHS value syntax.</param>
     /// <param name="assignLocation">The location of the assignment operator, for diagnostics.</param>
-    /// <param name="bound">The bound assignment (or an error expression) on success.</param>
-    /// <returns><see langword="true"/> when the enclosing interface declares a property of that name.</returns>
-    private bool TryBindInterfaceInstancePropertyWriteByBareName(
+    /// <returns>The bound assignment (or an error expression), or <see langword="null"/> when the name is not an interface property.</returns>
+    private BoundExpression? TryBindInterfaceInstancePropertyWriteByBareName(
         string name,
         TextLocation nameLocation,
         ExpressionSyntax valueSyntax,
-        TextLocation assignLocation,
-        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out BoundExpression? bound)
+        TextLocation assignLocation)
     {
-        bound = null;
         if (!TryResolveInterfaceInstancePropertyByBareName(name, out var receiver, out var thisInterface)
             || !TypeMemberModel.TryGetPropertyWithOwner(thisInterface, name, out var property, out var propertyOwner))
         {
-            return false;
+            return null;
         }
 
         if (!property.HasSetter)
         {
             Diagnostics.ReportCannotAssign(assignLocation, name);
             _ = BindExpression(valueSyntax);
-            bound = new BoundErrorExpression(null);
-            return true;
+            return new BoundErrorExpression(null);
         }
 
         var effectiveInterface = Invariant.Required(
@@ -1776,7 +1772,7 @@ internal sealed partial class ExpressionBinder
         var value = BindAssignmentRhs(valueSyntax, propertyType);
         var converted = conversions.BindConversion(valueSyntax.Location, value, propertyType);
         EnforceInitOnlyAssignment(property, receiver, assignLocation);
-        bound = new BoundPropertyAssignmentExpression(
+        return new BoundPropertyAssignmentExpression(
             null,
             receiver,
             null,
@@ -1784,7 +1780,6 @@ internal sealed partial class ExpressionBinder
             converted,
             ReferenceEquals(propertyType, property.Type) ? null : propertyType,
             effectiveInterface);
-        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Literals.cs
@@ -294,6 +294,14 @@ internal sealed partial class ExpressionBinder
     {
         StructSymbol { IsGenericDefinition: true } structSymbol => structSymbol.TypeParameters.Length,
         InterfaceSymbol { IsGenericDefinition: true } interfaceSymbol => interfaceSymbol.TypeParameters.Length,
+
+        // Issue #3838: a NAMED generic delegate declared in source is a real
+        // CLR type too (#3149 reifies it), so `typeof(Mapper[_])` has to reach
+        // it exactly as `typeof(Slot[_])` reaches a source class. Omitting the
+        // case made every source generic delegate unreachable through the only
+        // spelling that can select an arity, reported as GS0113 carrying the
+        // arity-mangled name the caller never wrote.
+        DelegateTypeSymbol { IsGenericDefinition: true } delegateSymbol => delegateSymbol.TypeParameters.Length,
         _ => -1,
     };
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -690,6 +690,17 @@ internal sealed partial class ExpressionBinder
                 return inheritedClrMember;
             }
 
+            // Issue #3840: a bare identifier inside a DEFAULT INTERFACE METHOD
+            // body may name the enclosing interface's own instance property.
+            // The implicit-member pseudo-variables are only seeded for a
+            // StructSymbol receiver, so this is the interface analog — bare and
+            // `this.`-qualified access behave identically in a DIM exactly as
+            // they already do in a class body.
+            if (TryBindInterfaceInstancePropertyByBareName(syntax, out var interfaceMember))
+            {
+                return interfaceMember;
+            }
+
             if (binderCtx.InConstructorInitializer
                 && IsConstructorInitializerInstanceMethod(name))
             {
@@ -2617,6 +2628,76 @@ internal sealed partial class ExpressionBinder
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Issue #3840: resolves a bare (unqualified) identifier inside a DEFAULT
+    /// INTERFACE METHOD body to an instance property of the enclosing interface
+    /// (or any base interface), returning the effective <c>this</c> receiver and
+    /// the interface it is typed as. The implicit-member pseudo-variables seeded
+    /// in <see cref="Binder"/> only cover a <see cref="StructSymbol"/> receiver,
+    /// so inside a DIM the same spelling that works in a class body reported
+    /// GS0125 — even though <c>this.Name</c> binds and dispatches correctly.
+    /// Shared by the bare-name READ, WRITE and COMPOUND-WRITE fallbacks so all
+    /// three behave identically to their <c>this.</c>-qualified paths, mirroring
+    /// the inherited-CLR-member trio of issue #1584.
+    /// </summary>
+    /// <param name="name">The bare identifier text.</param>
+    /// <param name="receiver">The effective <c>this</c> receiver on success.</param>
+    /// <param name="interfaceType">The enclosing interface the receiver is typed as, on success.</param>
+    /// <returns><see langword="true"/> when the enclosing interface declares an instance property of that name.</returns>
+    private bool TryResolveInterfaceInstancePropertyByBareName(
+        string name,
+        [NotNullWhen(true)] out BoundExpression? receiver,
+        [NotNullWhen(true)] out InterfaceSymbol? interfaceType)
+    {
+        receiver = null;
+        interfaceType = null;
+
+        var effThis = GetEffectiveThisParameter();
+        if (effThis?.Type is not InterfaceSymbol thisInterface)
+        {
+            return false;
+        }
+
+        // ADR-0118 / issue #944: an indexer has the CLR name `Item` but is never
+        // reachable by bare name — only through `this[i]`.
+        if (!TypeMemberModel.TryGetProperty(thisInterface, name, out var property, out _)
+            || property.IsIndexer)
+        {
+            return false;
+        }
+
+        receiver = new BoundVariableExpression(null, effThis);
+        interfaceType = thisInterface;
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3840: tries to bind a bare identifier inside a default interface
+    /// method body as a read of the enclosing interface's own instance property,
+    /// by routing it through the very same accessor step that binds
+    /// <c>this.Name</c> — so accessibility, generic substitution and the
+    /// <c>callvirt get_X</c> dispatch are resolved once, in one place.
+    /// </summary>
+    /// <param name="syntax">The bare name syntax.</param>
+    /// <param name="bound">The bound property read on success.</param>
+    /// <returns><see langword="true"/> when the name resolved to an interface property.</returns>
+    private bool TryBindInterfaceInstancePropertyByBareName(
+        NameExpressionSyntax syntax,
+        [NotNullWhen(true)] out BoundExpression? bound)
+    {
+        bound = null;
+        if (!TryResolveInterfaceInstancePropertyByBareName(
+                syntax.IdentifierToken.ValueText,
+                out var receiver,
+                out _))
+        {
+            return false;
+        }
+
+        bound = BindAccessorStep(receiver, classSymbol: null, rightPart: syntax);
+        return true;
     }
 
     private static TypeSymbol GetInheritedClrMemberType(

--- a/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
+++ b/src/Core/CodeAnalysis/Emit/ImportedMemberRefFactory.cs
@@ -439,6 +439,13 @@ internal sealed class ImportedMemberRefFactory
         {
             StructSymbol { IsGenericDefinition: true } structSym => structSym,
             InterfaceSymbol { IsGenericDefinition: true } interfaceSym => interfaceSym,
+
+            // Issue #3838: a source-declared generic DELEGATE is reified as a
+            // real TypeDef (#3149), so its open definition needs the same
+            // TypeDef-row `ldtoken` as a struct or interface. Without this the
+            // binder fix alone compiles and then dies at run time with
+            // BadImageFormatException on the `Mapper<!0>` TypeSpec.
+            DelegateTypeSymbol { IsGenericDefinition: true } delegateSym => delegateSym,
             _ => null,
         };
 
@@ -460,6 +467,13 @@ internal sealed class ImportedMemberRefFactory
                 return true;
             case InterfaceSymbol interfaceSym when this.cache.InterfaceTypeDefs.TryGetValue(interfaceSym, out var interfaceHandle):
                 handle = interfaceHandle;
+                return true;
+
+            // Issue #3838: see TryGetOpenGenericDefinition.
+            case DelegateTypeSymbol delegateSym when this.cache.DelegateTypeDefs.TryGetValue(
+                delegateSym.Definition ?? delegateSym,
+                out var delegateHandle):
+                handle = delegateHandle;
                 return true;
             default:
                 handle = default;

--- a/test/Compiler.Tests/Emit/Issue3838SourceOpenGenericDelegateTypeOfEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3838SourceOpenGenericDelegateTypeOfEmitTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue3838SourceOpenGenericDelegateTypeOfEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3838 end-to-end: <c>typeof(Mapper[_])</c> over a NAMED GENERIC
+/// DELEGATE declared in the compilation being built must bind and emit an
+/// <c>ldtoken</c> that loads.
+/// <para>
+/// Two independent halves, both required. The binder's declared-type fallback
+/// for the explicit-arity unbound-generic spelling (#3678/#3677) only
+/// recognised <c>StructSymbol</c> and <c>InterfaceSymbol</c> definitions, so a
+/// source generic delegate reported GS0113 carrying the arity-mangled metadata
+/// name the caller never wrote. Fixing only that half compiles and then dies at
+/// run time with <see cref="BadImageFormatException"/>, because the emitter's
+/// open-generic-definition <c>ldtoken</c> arm had the same missing case and
+/// fell back to the generic-REFERENCE TypeSpec (<c>Mapper&lt;!0&gt;</c>), whose
+/// VAR slot has no binding in that scope. That is why this test EXECUTES the
+/// emitted assembly rather than asserting on binding alone.
+/// </para>
+/// </summary>
+public class Issue3838SourceOpenGenericDelegateTypeOfEmitTests
+{
+    [Fact]
+    public void SourceOpenGenericDelegateTypeOf_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Demo
+            import System
+
+            delegate Mapper[T](value T) int32;
+            delegate Pair[A, B](a A, b B) string;
+            delegate Plain(value int32) int32;
+
+            Console.WriteLine(typeof(Mapper[_]).FullName)
+            Console.WriteLine(typeof(Mapper[_]).IsGenericTypeDefinition)
+            Console.WriteLine(typeof(Pair[_, _]).FullName)
+            Console.WriteLine(typeof(Mapper[_]).MakeGenericType(typeof(string)).GetGenericArguments()[0].FullName)
+
+            // Anti-vacuity: these spellings already worked before #3838 and must
+            // keep working — the fix must not disturb the bound or non-generic
+            // delegate paths.
+            Console.WriteLine(typeof(Plain).FullName)
+            Console.WriteLine(typeof(Mapper[int32]).IsGenericTypeDefinition)
+            """;
+
+        var expected = string.Join(
+            Environment.NewLine,
+            "Demo.Mapper`1",
+            "True",
+            "Demo.Pair`2",
+            "System.String",
+            "Demo.Plain",
+            "False") + Environment.NewLine;
+
+        Assert.Equal(expected, CompileVerifyAndRun(Source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3838_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var runtimeOutput = process!.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"runtime failed:\n{runtimeOutput}\n{runtimeError}");
+            return runtimeOutput.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3840DefaultInterfaceMethodBareMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3840DefaultInterfaceMethodBareMemberEmitTests.cs
@@ -1,0 +1,284 @@
+// <copyright file="Issue3840DefaultInterfaceMethodBareMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3840 end-to-end: an UNQUALIFIED read/write of the enclosing
+/// interface's own property from inside a DEFAULT INTERFACE METHOD body must
+/// bind to the implicit <c>this</c> receiver, exactly as the same spelling does
+/// in a class body.
+/// <para>
+/// The implicit-member pseudo-variables the binder seeds into a member body's
+/// scope were only ever built for a <see cref="GSharp.Core.CodeAnalysis.Symbols.StructSymbol"/>
+/// receiver, so inside a DIM the bare spelling reported GS0125 "Variable 'Name'
+/// doesn't exist" while <c>this.Name</c> bound and dispatched correctly — the
+/// two spellings disagreed only in an interface.
+/// </para>
+/// <para>
+/// The test EXECUTES the emitted assembly through an implementation that does
+/// NOT override the default methods, so the assertions prove the DIM body ran
+/// and read the implementation's state (guarding the emitted-session DIM
+/// dispatch of #572/#608), not merely that the binder stopped objecting.
+/// </para>
+/// </summary>
+public class Issue3840DefaultInterfaceMethodBareMemberEmitTests
+{
+    [Fact]
+    public void BareInterfaceMemberInsideDefaultMethodBody_VerifiesAndRuns()
+    {
+        const string Source = """
+            package Demo
+            import System
+
+            interface IBase {
+                prop Name string {
+                    get;
+                    set;
+                }
+            }
+
+            interface IGreeter : IBase {
+                prop Count int32 {
+                    get;
+                    set;
+                }
+
+                func Tag() string {
+                    return "tag"
+                }
+
+                // Bare READ of an own property, of an INHERITED interface's
+                // property, and of a sibling default method.
+                func Greeting() string {
+                    return "Hello, " + Name + "! " + Tag()
+                }
+
+                // Bare WRITE (own and inherited).
+                func Rename(next string) {
+                    Name = next
+                }
+
+                // Bare COMPOUND write.
+                func Bump() {
+                    Count += 2
+                }
+
+                // Bare name as the HEAD of an accessor chain.
+                func Describe() string {
+                    return Count.ToString() + "/" + Name.Length.ToString()
+                }
+            }
+
+            interface IBox[T] {
+                prop Value T {
+                    get;
+                    set;
+                }
+
+                func Describe() string {
+                    return "box:" + Value.ToString()
+                }
+            }
+
+            // Neither implementation overrides a default method.
+            class Greeter : IGreeter {
+                prop Name string {
+                    get;
+                    set;
+                }
+
+                prop Count int32 {
+                    get;
+                    set;
+                }
+            }
+
+            class IntBox : IBox[int32] {
+                prop Value int32 {
+                    get;
+                    set;
+                }
+            }
+
+            let greeter IGreeter = Greeter()
+            greeter.Rename("world")
+            greeter.Bump()
+            greeter.Bump()
+            Console.WriteLine(greeter.Greeting())
+            Console.WriteLine(greeter.Describe())
+
+            let box IBox[int32] = IntBox()
+            box.Value = 41
+            Console.WriteLine(box.Describe())
+            """;
+
+        var expected = string.Join(
+            Environment.NewLine,
+            "Hello, world! tag",
+            "4/5",
+            "box:41") + Environment.NewLine;
+
+        Assert.Equal(expected, CompileVerifyAndRun(Source));
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard: a bare name inside a DIM that names NOTHING on the
+    /// interface must still report GS0125. The fix must not turn the diagnostic
+    /// off, only route the names that genuinely resolve.
+    /// </summary>
+    [Fact]
+    public void UnknownBareNameInsideDefaultMethodBody_StillReportsUndefinedVariable()
+    {
+        const string Source = """
+            package Demo
+
+            interface IGreeter {
+                prop Name string {
+                    get;
+                }
+
+                func Greeting() string {
+                    return "Hello, " + Nope
+                }
+            }
+            """;
+
+        var (exitCode, output) = Compile(Source);
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("GS0125", output, StringComparison.Ordinal);
+        Assert.Contains("Nope", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard: a bare WRITE to a get-only interface property inside
+    /// a DIM must report "cannot assign", not silently succeed and not fall back
+    /// to GS0125 "doesn't exist".
+    /// </summary>
+    [Fact]
+    public void BareWriteToGetOnlyInterfaceProperty_ReportsCannotAssign()
+    {
+        const string Source = """
+            package Demo
+
+            interface IGreeter {
+                prop Name string {
+                    get;
+                }
+
+                func Rename(next string) {
+                    Name = next
+                }
+            }
+            """;
+
+        var (exitCode, output) = Compile(Source);
+        Assert.NotEqual(0, exitCode);
+        Assert.DoesNotContain("GS0125", output, StringComparison.Ordinal);
+        Assert.Contains("Name", output, StringComparison.Ordinal);
+    }
+
+    private static (int ExitCode, string Output) Compile(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3840_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            try
+            {
+                var exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:library",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+                return (exitCode, stdout + stderr.ToString());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Directory.CreateTempSubdirectory("gs_issue3840_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(directory, "test.gs");
+            var outputPath = Path.Combine(directory, "test.dll");
+            File.WriteAllText(sourcePath, source);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(new[]
+                {
+                    "/out:" + outputPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    sourcePath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:\n{stdout}\n{stderr}");
+            IlVerifier.Verify(outputPath);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = directory,
+            };
+            startInfo.ArgumentList.Add("exec");
+            startInfo.ArgumentList.Add("--runtimeconfig");
+            startInfo.ArgumentList.Add(Path.ChangeExtension(outputPath, ".runtimeconfig.json"));
+            startInfo.ArgumentList.Add(outputPath);
+
+            using var process = Process.Start(startInfo);
+            var runtimeOutput = process!.StandardOutput.ReadToEnd();
+            var runtimeError = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, $"runtime failed:\n{runtimeOutput}\n{runtimeError}");
+            return runtimeOutput.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Two independent gsc binder defects from the `test/Interpreter.Tests` self-migration wall (#3837 RC2 and RC5). They do **not** share a root; each is fixed here with an executing regression test.

Fixes #3838. Fixes #3840.

## #3838 — `typeof` of a source-declared unbound generic delegate

`typeof(Mapper[_])` on a `delegate Mapper[T](value T) int32;` declared in the same compilation reported `GS0113: Type 'Mapper`1' doesn't exist`.

**Two halves, both required.**

1. **Binder** (`ExpressionBinder.Literals.cs`) — the declared-type fallback for the explicit-arity unbound-generic spelling, added by #3678/#3677, recognises a generic *definition* through `DeclaredGenericDefinitionArity`, which matched only `StructSymbol` and `InterfaceSymbol`. A source generic delegate is neither, so the arity-bearing spelling — the only one that can select an arity — could not reach it. (`PrefixMatchesDeclaringPackage` in the same file already knew about `DelegateTypeSymbol`, which is what made the omission visible.)
2. **Emitter** (`ImportedMemberRefFactory.cs`) — `TryGetOpenGenericDefinition` / `TryGetUserTypeDef` had the identical missing case, so `ldtoken` of the open definition fell back to the generic-REFERENCE TypeSpec `Mapper<!0>`, whose VAR slot has no binding in that scope. **Fixing only the binder half compiles clean, IL-verifies, and then dies at run time with `BadImageFormatException`** — exactly the failure #3678's own test documents for structs. This is why the regression test executes.

Bound (`typeof(Mapper[int32])`) and non-generic (`typeof(Plain)`) delegate spellings were already fine and are asserted here as anti-vacuity controls.

## #3840 — implicit `this` in a default interface method body

An unqualified read of the interface's own property from a DIM body reported `GS0125: Variable 'Name' doesn't exist`, while `this.Name` bound and dispatched correctly — the two spellings disagreed only in an interface.

**Mechanism.** `Binder.cs` seeds each member body's scope with `ImplicitFieldVariableSymbol` / `ImplicitPropertyVariableSymbol` pseudo-variables for the receiver's members, under `if (function.ReceiverType is StructSymbol receiverStruct)`. A DIM's receiver is an `InterfaceSymbol`, so nothing is seeded and every bare member name falls through to the undefined-variable diagnostic.

Rather than generalise `ImplicitPropertyVariableSymbol.StructType` (a `StructSymbol` threaded through ~10 call sites into `BoundPropertyAccessExpression`), this follows the established shape of #1582/#1584 for inherited CLR members: one resolver plus fallbacks in the four bare-name positions, each routing to the *same* code the `this.`-qualified spelling already uses.

- READ — `BindNameExpression` (`ExpressionBinder.cs`), routed through `BindAccessorStep` so accessibility, generic substitution and `callvirt get_X` dispatch stay in one place.
- WRITE — `BindAssignmentExpression` (`ExpressionBinder.Assignments.cs`).
- COMPOUND WRITE — reuses the existing `TryBindInterfaceCompoundAssignment` verbatim.
- ACCESSOR-CHAIN HEAD — `ExpressionBinder.Access.Accessor.cs`, so `Count.ToString()` binds as `this.Count.ToString()` instead of `GS0157: Cannot find type Count`. Mirrors the inherited-CLR arm including #687's type/value collision rule.

Every fallback runs **after** the existing resolution chain (variable → method group → submission static → imported static → inherited CLR), so only spellings that previously errored can now resolve; nothing that used to bind changes meaning. Indexers are excluded (ADR-0118 / #944: `Item` is reachable only through `this[i]`).

**No diagnostic was weakened.** Two guard-rail tests assert that a bare name naming nothing on the interface still reports GS0125, and that a bare write to a get-only interface property reports "cannot assign" rather than GS0125 — the second one *fails on `main`* because `main` reports GS0125 there.

## Test evidence

`test/Compiler.Tests/Emit/Issue3838SourceOpenGenericDelegateTypeOfEmitTests.cs`, `test/Compiler.Tests/Emit/Issue3840DefaultInterfaceMethodBareMemberEmitTests.cs` — all compile + ILVerify + `dotnet exec` + assert printed output. The #3840 fixture dispatches through implementations that do **not** override the default methods, so the assertions prove the DIM bodies ran and read the implementation's state.

**Failing-on-`origin/main` proof** (`fb3c60ab0`), same tests, `src/` reverted:

```
Failed BareInterfaceMemberInsideDefaultMethodBody_VerifiesAndRuns
  error GS0125: Variable 'Name' doesn't exist.        (bare read)
  error GS0125: Variable 'Name' doesn't exist.        (bare write, inherited interface)
  error GS0125: Variable 'Count' doesn't exist.       (bare compound write)
  error GS0157: Cannot find type Count.               (accessor-chain head)
  error GS0157: Cannot find type Name.
  error GS0157: Cannot find type Value.               (generic interface)
Failed BareWriteToGetOnlyInterfaceProperty_ReportsCannotAssign
  Assert.DoesNotContain() Failure: "error GS0125: Variable 'Name'…"
Failed SourceOpenGenericDelegateTypeOf_VerifiesAndRuns
  error GS0113: Type 'Mapper`1' doesn't exist.  (x3)
  error GS0113: Type 'Pair`2' doesn't exist.

Failed: 3, Passed: 1
```

The one that **passes on `main`** is `UnknownBareNameInsideDefaultMethodBody_StillReportsUndefinedVariable` — the anti-vacuity guard, which is exactly what a guard rail should do.

## Self-migration measurement

Whole-repository `cs2gs migrate --translate-only` (52/52 apps translated) followed by `cs2gs validate --app test/Interpreter.Tests/Interpreter.Tests.csproj`, against a Release solution build so the **packed SDK nupkg** carries this commit's compiler (`Gsharp.NET.Sdk.0.4.407-g68459b0c09`) — a rebuilt `gsc.dll` alone silently reuses the old one.

**`test/Interpreter.Tests` compile fingerprints: 6 → 3.**

Everything left is somebody else's:

```
Issue2918InlineLambdaErasedReceiverEmittedOracleTests.gs(17,10): GS0264  Add((T) -> bool) already declared     #3841 (cs2gs)
Issue2918InlineLambdaErasedReceiverEmittedOracleTests.gs(25,5):  GS0264  .ctor((T) -> bool) already declared   #3841 (cs2gs)
Issue3004ManagedByRefAutoDereferenceFixture.gs(17,42):           GS0252  ref return                            #3839 (other agent)
```

Both `GS0113` sites (#3838, `Issue3149NamedDelegateReificationDriverTests.gs:123,244`) and the `GS0125` site (#3840, `ProbeRefTypes.gs:13`) are gone. The app still stops at `compile-error`, so the layer behind the wall (ILVerify, then test-parity) is not yet visible for this app — it becomes reachable once #3841 and #3839 land.

## Not in scope

- #3841 (RC3) — re-diagnosed as a **cs2gs** defect, not the ADR-level type-system question the issue assumed; see https://github.com/DavidObando/gsharp/issues/3841#issuecomment-5532685577. gsc already declares and dispatches a `Predicate[T]` / `Func[T, bool]` overload set correctly.
- #3874 — a genuine gsc gap found behind #3841: overload resolution erases CLR delegate identity **after generic substitution**. Filed separately, latent for this app.
- #3839 (RC4) is another agent's.
