### PR TITLE
gsc + cs2gs: clear 6 of the 15 migrated Cs2Gs.Tests compile errors (#3880)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -4496,7 +4496,28 @@ public sealed class Binder
         // cs2gs fully-qualifies type references (including generic-math
         // constraints), so this is the common shape for translated code.
         var lastSegment = segmentTexts[totalSegments - 1];
-        var sourceType = LookupType(lastSegment, targetArity > 0 ? targetArity : -1);
+
+        // Issue #3880: the simple-name fallback below refuses to guess when two
+        // or more separately-imported packages declare the same simple name
+        // (#2455's ambiguity rule) — but here the reference is not ambiguous at
+        // all: its qualifier names the package outright. Publish that qualifier
+        // as the explicit package hint #2455 already honours for qualified
+        // CONSTRUCTION (`Pkg.Type{…}`), so `typeof(ImportedVisible.defer_)`
+        // resolves even when a second imported package also declares `defer_`.
+        // The hint is restored unconditionally: it is scoped to this one
+        // lookup, exactly as at the construction site.
+        var qualifierPackageHint = string.Join(".", segmentTexts, 0, totalSegments - 1);
+        var previousQualifierHint = scope.SetQualifiedConstructionPackageHint(qualifierPackageHint);
+        TypeSymbol? sourceType;
+        try
+        {
+            sourceType = LookupType(lastSegment, targetArity > 0 ? targetArity : -1);
+        }
+        finally
+        {
+            scope.SetQualifiedConstructionPackageHint(previousQualifierHint);
+        }
+
         if (sourceType != null && !ReferenceEquals(sourceType, TypeSymbol.Error))
         {
             if (targetArity == 0)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -1117,6 +1117,28 @@ internal sealed partial class OverloadResolver
                 continue;
             }
 
+            // A named argument may also address the trailing variadic parameter
+            // itself, exactly as C# permits for `params`: the name must be the
+            // variadic parameter's, it must sit in that parameter's own slot,
+            // and it must be the last argument (naming the variadic parameter
+            // and then continuing to supply elements positionally is not a
+            // spelling C# accepts either). Because the argument is already in
+            // its own slot no reordering is needed; the value that follows is
+            // either the whole carrier or a single expanded element, which
+            // PackOrPassThroughVariadicArguments then decides on by type.
+            var namesTrailingVariadic =
+                sourceIndex == fixedParameterCount &&
+                sourceIndex == argumentNames.Length - 1 &&
+                string.Equals(
+                    parameterNameAt(sourceIndex),
+                    name,
+                    StringComparison.Ordinal);
+
+            if (namesTrailingVariadic)
+            {
+                continue;
+            }
+
             if (sourceIndex >= fixedParameterCount ||
                 !string.Equals(
                     parameterNameAt(sourceIndex),

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3880QualifiedTypeAcrossCollidingImportsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3880QualifiedTypeAcrossCollidingImportsTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="Issue3880QualifiedTypeAcrossCollidingImportsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3880 (self-migration wall in <c>tools/cs2gs/Cs2Gs.Tests</c>): a FULLY
+/// QUALIFIED source-type reference — <c>typeof(ImportedVisible.defer_)</c> —
+/// reported GS0113 "type doesn't exist" whenever a second <em>imported</em>
+/// package also declared a type of that simple name.
+/// <para>
+/// The qualified type-clause path falls back to a simple-name lookup of the
+/// final segment, and #2455 makes that lookup refuse to guess between two
+/// separately-imported packages. But a qualified reference is not ambiguous:
+/// its qualifier names the package outright. The repair publishes that
+/// qualifier as the explicit package hint #2455 already honours for qualified
+/// CONSTRUCTION (<c>Pkg.Type{…}</c>).
+/// </para>
+/// <para>
+/// The message was also a masking shape: the type did exist, in a file that
+/// was compiled; only the lookup path could not see it. This is the shape
+/// cs2gs produces when it splits a multi-namespace C# file into one .gs per
+/// namespace and imports every one of them.
+/// </para>
+/// </summary>
+public class Issue3880QualifiedTypeAcrossCollidingImportsTests
+{
+    // Two packages that BOTH declare `Marker`, both imported by the consumer.
+    private const string AlphaPackage = @"
+package Alpha
+
+class Marker {
+}
+";
+
+    private const string BetaPackage = @"
+package Beta
+
+class Marker {
+}
+";
+
+    [Fact]
+    public void QualifiedTypeOf_ResolvesTheQualifiedPackagesType()
+    {
+        // Evaluated, not merely bound: the reflected NAMESPACE is what
+        // discriminates — resolving to the other package's same-named type
+        // would bind just as cleanly and answer "Alpha".
+        var result = Evaluate(@"
+import Alpha
+import Beta
+
+typeof(Beta.Marker).Namespace
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Beta", result.Value);
+    }
+
+    [Fact]
+    public void TheOtherQualifierStillSelectsTheOtherPackage()
+    {
+        // Anti-vacuity: the hint must SELECT a package, not merely stop the
+        // lookup from failing. Same file, other qualifier, other answer.
+        var result = Evaluate(@"
+import Alpha
+import Beta
+
+typeof(Alpha.Marker).Namespace
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Alpha", result.Value);
+    }
+
+    [Fact]
+    public void AQualifiedTypeClause_ResolvesInADeclaration()
+    {
+        // The same lookup reached through a declared type rather than through
+        // `typeof`, since the wall's file uses both spellings.
+        var result = Evaluate(@"
+import Alpha
+import Beta
+
+let m Beta.Marker = Beta.Marker{}
+m.GetType().Namespace
+");
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("Beta", result.Value);
+    }
+
+    [Fact]
+    public void AnUnqualifiedCollidingName_IsStillRejected()
+    {
+        // The #2455 rule the fix must leave alone: with no qualifier there is
+        // nothing to disambiguate with, so the bare name must keep failing
+        // rather than silently picking a package.
+        var result = Evaluate(@"
+import Alpha
+import Beta
+
+typeof(Marker).Namespace
+");
+
+        Assert.NotEmpty(result.Diagnostics);
+    }
+
+    private static EmittedOracleResult Evaluate(string consumer)
+        => EmittedOracle.Evaluate(new[] { AlphaPackage, BetaPackage, consumer });
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3880VariadicNamedArgumentTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3880VariadicNamedArgumentTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue3880VariadicNamedArgumentTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3880 (self-migration wall in <c>tools/cs2gs/Cs2Gs.Tests</c>): a named
+/// argument was allowed to address only the FIXED prefix of a variadic
+/// function's parameter list. Naming the trailing variadic parameter itself —
+/// <c>f(reason: "…", sources: ("Uri.cs", "…"))</c>, which is what C# spells for
+/// a <c>params</c> parameter and what cs2gs therefore emits — reported GS0246
+/// "named argument 'sources' does not match any parameter".
+/// <para>
+/// The argument is already sitting in the variadic parameter's own slot, so
+/// nothing needs reordering; the value that follows is either the whole carrier
+/// or a single expanded element, which the existing pack / pass-through path
+/// decides on by type. Both spellings are covered below, and the results are
+/// EVALUATED rather than merely bound — a name that resolved to the right
+/// parameter but packed the wrong way would still bind clean.
+/// </para>
+/// </summary>
+public class Issue3880VariadicNamedArgumentTests
+{
+    [Fact]
+    public void NamedVariadicArgument_SingleElement_IsExpanded()
+    {
+        var result = EmittedOracle.Evaluate(@"
+func total(scale int32, values ...int32) int32 {
+    var t = 0
+    for v in values {
+        t = t + (v * scale)
+    }
+    return t
+}
+total(scale: 10, values: 7)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(70, result.Value);
+    }
+
+    [Fact]
+    public void NamedVariadicArgument_WholeCarrier_IsPassedThrough()
+    {
+        // The pass-through half of the same call shape: the named value is the
+        // carrier itself, not one element. Three elements distinguish it from
+        // the expanded reading, which would have packed the slice as a single
+        // element and failed to convert.
+        var result = EmittedOracle.Evaluate(@"
+func total(scale int32, values ...int32) int32 {
+    var t = 0
+    for v in values {
+        t = t + (v * scale)
+    }
+    return t
+}
+total(scale: 2, values: []int32{1, 2, 3})
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(12, result.Value);
+    }
+
+    [Fact]
+    public void NamedVariadicArgument_OnAMethod_IsExpanded()
+    {
+        // The same rule reached through the method-call binding path rather
+        // than the free-function one; they validate named arguments through
+        // separate call sites into the shared helper.
+        var result = EmittedOracle.Evaluate(@"
+class Adder {
+    func total(scale int32, values ...int32) int32 {
+        var t = 0
+        for v in values {
+            t = t + (v * scale)
+        }
+        return t
+    }
+}
+Adder().total(scale: 3, values: 5)
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(15, result.Value);
+    }
+
+    [Fact]
+    public void NamedVariadicArgument_MustStillBeTheLastArgument()
+    {
+        // Anti-vacuity: the fix accepts the variadic parameter's name in its
+        // own slot as the LAST argument, which is all C# accepts for `params`.
+        // Naming it and then continuing positionally stays an error, so this
+        // is a narrowed rule and not a disabled one.
+        var result = EmittedOracle.Evaluate(@"
+func total(scale int32, values ...int32) int32 {
+    var t = 0
+    for v in values {
+        t = t + v
+    }
+    return t
+}
+total(scale: 1, values: 2, 3)
+");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0246");
+    }
+
+    [Fact]
+    public void AnUnknownName_IsStillRejected()
+    {
+        // The other anti-vacuity guard: a name that matches no parameter at all
+        // must keep reporting GS0246.
+        var result = EmittedOracle.Evaluate(@"
+func total(scale int32, values ...int32) int32 {
+    var t = 0
+    for v in values {
+        t = t + v
+    }
+    return t
+}
+total(scale: 1, nosuch: 2)
+");
+        Assert.Contains(result.Diagnostics, d => d.Id == "GS0246");
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3726InlineDataNullArgumentTaintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3726InlineDataNullArgumentTaintTests.cs
@@ -167,6 +167,78 @@ namespace Demo
         TranslationTestValidation.AssertBinds(declarations, printed);
     }
 
+    [Fact]
+    public void AWholeArrayNullRow_PromotesTheFirstParameter()
+    {
+        // Issue #3880: `[InlineData(null)]` binds the lone `null` as the params
+        // ARRAY, not as one element, and #3726 read that as naming no position.
+        // gsc does not agree: its GS0274 check reads the emitted
+        // `@InlineData(nil)` positionally and rejects a non-nullable parameter
+        // 0 — so the file cs2gs emitted contradicted itself, which is exactly
+        // the inconsistency #3726 set out to remove. Three sites in cs2gs's own
+        // test suite failed to compile after migration on this.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("""")]
+        public void Check(string name)
+        {
+            System.Console.WriteLine(Normalize(name));
+        }
+
+        private static string Normalize(string name)
+        {
+            return name == null ? string.Empty : name.Trim();
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(name string?)", printed);
+        Assert.Contains("@InlineData(nil)", printed);
+
+        // The #3704 guard: the row really does pass nil, so bridging the read
+        // with `!!` would turn a passing test into a runtime throw. `Normalize`
+        // is an oblivious sibling (this project has nullable disabled) that
+        // null-checks its own argument, exactly like the three cs2gs test
+        // methods this promotion unblocks.
+        Assert.Contains("Normalize(name)", printed);
+        Assert.DoesNotContain("Normalize(name!!)", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
+    [Fact]
+    public void AWholeArrayNullRow_ClaimsNothingBeyondTheFirstParameter()
+    {
+        // The claim is deliberately as narrow as gsc's own: a whole-array null
+        // is positional evidence for parameter 0 only. Widening every parameter
+        // would promote columns no row ever supplies null for.
+        string printed = Translate(
+            @"
+namespace Demo
+{
+    public class ProgramTests
+    {
+        [Theory]
+        [InlineData(null)]
+        public void Check(string first, string second)
+        {
+            System.Console.WriteLine(first);
+            System.Console.WriteLine(second);
+        }
+    }
+}",
+            out string declarations);
+
+        Assert.Contains("Check(first string?, second string)", printed);
+        TranslationTestValidation.AssertBinds(declarations, printed);
+    }
+
     // Returns the printed consumer file, and hands back the printed attribute
     // declarations too so callers can bind the pair.
     private static string Translate(string source, out string printedDeclarations)

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -357,14 +357,36 @@ internal static class ObliviousNullabilityAnalyzer
 
             TypedConstant row = attribute.ConstructorArguments[0];
 
+            if (row.Kind != TypedConstantKind.Array)
+            {
+                continue;
+            }
+
+            // Issue #3880: `[InlineData(null)]` is a WHOLE-ARRAY null — C#
+            // binds the lone `null` as the params array itself rather than as
+            // one element — and #3726 read that as naming no position and
+            // therefore as no evidence. That left cs2gs and gsc contradicting
+            // each other over the same source: gsc's GS0274 check reads the
+            // EMITTED `@InlineData(nil)` positionally and flags parameter 0,
+            // which is also what xunit does at run time for the single-column
+            // theories this spelling is used on. Match gsc exactly — position
+            // 0 only, so a longer parameter list gains no unsupported claim.
+            if (row.IsNull)
+            {
+                if (parameter.Ordinal == 0)
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
             // A data ROW never supplies more values than the method has
             // parameters; a params attribute that means something else — e.g.
             // `[MemberNotNull("Field")]`, whose strings name members rather
             // than line up with parameters — is filtered out by that shape
             // check plus the "the value must be a literal null" test below.
-            if (row.Kind != TypedConstantKind.Array
-                || row.IsNull
-                || row.Values.Length > method.Parameters.Length
+            if (row.Values.Length > method.Parameters.Length
                 || parameter.Ordinal >= row.Values.Length)
             {
                 continue;


### PR DESCRIPTION
Closes part of #3880 (full triage table there). Part of #3501, sibling of #3836.

## The wall

The gate reported **11 fingerprints** for the migrated `tools/cs2gs/Cs2Gs.Tests`; the deduplicated build log has **15 real sites across 9 files**, and those 15 collapse to **7 root causes**. Three of them are fixed here (6 sites); the other four are filed on #3880 with minimal repros.

Three of the seven causes were **masking shapes** — the printed diagnostic named something other than the real error. The six "cannot find X" errors do *not* share one mechanism; they span four causes.

## What this PR fixes

### 1. gsc: a named argument may address the trailing variadic parameter (1 site, GS0246)

`ValidateExpandedVariadicNamedArguments` accepted names only in the FIXED prefix of a variadic parameter list, so

```gs
TranslateEnabled(roundTripOnlyReason: "…", sources: ("Uri.cs", "…"))
```

reported `GS0246: named argument 'sources' does not match any parameter` — for the exact spelling C# accepts for `params`, and therefore the exact spelling cs2gs emits.

The argument already sits in the variadic parameter's own slot, so nothing needs reordering; the value is either the whole carrier or a single expanded element, which the existing `PackOrPassThroughVariadicArguments` decides on by type. The rule is narrowed to what C# allows, not disabled: the name must be the variadic parameter's, in its own slot, and **last**.

### 2. gsc: a fully qualified type resolves even when two imported packages collide (2 sites, GS0113 + one GS0159 cascade)

`typeof(ImportedVisible.defer_)` reported `Type 'ImportedVisible.defer_' doesn't exist` — for a type that *did* exist, in a file that *was* compiled. The qualified type-clause path falls back to a simple-name lookup of the final segment, and #2455 makes that lookup refuse to guess when two separately-imported packages declare the same simple name. Here `import $class` and `import ImportedVisible` both declare `defer_`.

But a qualified reference is not ambiguous: its qualifier names the package outright. The fix publishes that qualifier as the explicit package hint #2455 **already honours** for qualified construction (`Pkg.Type{…}`), scoped to the single lookup and restored in a `finally`. Deleting either import made the original compile, which is how the ten-line repro was bisected out of the real 434-file compilation.

The `GS0159 Cannot find function Append` on the next line was a cascade of this: `fixtureAssembly` was error-typed, so the argument to `.Append(…)` had no conversion.

### 3. cs2gs: `[InlineData(null)]` promotes the parameter it lines up with (3 sites, GS0274)

#3726 made a `null` in a data-row attribute promote the matching oblivious parameter, but deliberately excluded the whole-array form `[InlineData(null)]` on the grounds that C# binds the lone `null` as the params *array* and it therefore "names no position".

gsc does not agree, and gsc is the other half of this toolchain: its GS0274 check (#660) reads the **emitted** `@InlineData(nil)` positionally and rejects a non-nullable parameter 0 — which is also what xunit does at run time for the single-column theories this spelling is used on. So cs2gs was emitting a file that contradicted itself, which is the precise inconsistency #3726 set out to remove. The claim is kept as narrow as gsc's: position 0 only.

## Test evidence

Everything below **executes** — `EmittedOracle.Evaluate` compiles, emits, runs and returns the value, so a fix that binds cleanly but computes the wrong thing still fails.

| suite | tests | on this branch | on `origin/main` |
|---|---|---|---|
| `Issue3880VariadicNamedArgumentTests` | 5 | 5 pass | **3 fail**, 2 pass |
| `Issue3880QualifiedTypeAcrossCollidingImportsTests` | 4 | 4 pass | **3 fail**, 1 pass |
| `Issue3726InlineDataNullArgumentTaintTests` | 6 (2 new) | 6 pass | **2 fail**, 4 pass |

The tests that pass on `origin/main` are the deliberate anti-vacuity guard rails, and each fix has at least one:

- a named argument that matches no parameter still reports GS0246;
- naming the variadic parameter and *then* continuing positionally still reports GS0246 (so the rule is narrowed, not removed);
- an **unqualified** colliding name still fails — #2455's ambiguity rule is untouched;
- the *other* qualifier selects the *other* package, so the hint genuinely selects rather than merely unblocking (the reflected `Namespace` is the discriminator — resolving to the wrong package would bind just as cleanly);
- a `[InlineData(null)]` whole-array row still claims nothing beyond parameter 0.

The `[InlineData(null)]` test also asserts `Normalize(name)` is emitted **without** a `!!` bridge: the row really does pass nil, so bridging the read would convert a passing test into a runtime throw (#3704's shape).

Full `test/Core.Tests` was run locally on the final tree.

## No diagnostic was weakened

Each fix makes gsc accept code that is legal C# and legal G#, and each is paired with a test proving the neighbouring illegal spelling is still rejected. Nothing was suppressed or downgraded.

## Migration hazard (#3831 / #3836)

`ObliviousNullabilityAnalyzer.cs` lives in `Cs2Gs.Translator`, which is inside its own migration corpus and is a **banked green app** — so a change that CI compiles can still break the gate by existing. The edit adds only an `if (row.IsNull)` branch and a `parameter.Ordinal == 0` test, both of which already appear verbatim in the same method a few lines away, in a file that migrates green today. I was not able to run the `Cs2Gs.Translator → Cs2Gs.CodeModel → src/Core` closure migration to confirm this directly: another agent is building on the same machine, and a concurrent `dotnet build` swaps the newest `Gsharp.NET.Sdk` nupkg under a running migration and produces `MSB4236` failures that look like real regressions. Worth a closure run before merge if the machine is quiet.

## Expected gate effect

15 sites → **9**. `Cs2Gs.Tests` is not in `greenApps` and stays red on the four remaining causes, so the floor of 44 is unaffected; `selfmig-baseline.json` is untouched.

## Still open, on #3880

| cause | sites | why not here |
|---|---|---|
| ADR-0169 analyzer retarget: the migrated `InternalAnalyzers` are `GSharpDiagnosticAnalyzer`, so the Roslyn half of the parity tests cannot bind | 5 | needs a design call — `Cs2Gs.Tests` cannot both migrate itself and keep a Roslyn control for the analyzer-parity diff |
| `X.Member[i](args)` parses as a generic instantiation, never as indexer-then-invoke | 1 | grammar work |
| gsc erases the Task from an `async func Main` — any static `Main`, any target, including `/target:library` (metadata proof on the issue) | 1 | entry-point emit; csc's answer is to keep `Main` as `Task<int>` and synthesize a separate sync entry point |
| overload resolution has no "normal form beats expanded form" tie-break | 2 | Phase-2 scoring change with corpus-wide blast radius; explicitly **not** #3874 |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
