### PR TITLE
gsc: a user-defined conversion target beats `object` in overload ranking (#3866)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -3962,6 +3962,39 @@ internal static class ClrOverloadResolution
             return 1;
         }
 
+        // Issue #3866: a user-defined implicit conversion to a SPECIFIC target
+        // beats boxing/reference-converting the same argument to
+        // `System.Object`. C# §12.6.4.5 ranks two applicable candidates by
+        // "better conversion target", not by the mechanism of the conversion:
+        // `EntityHandle` converts implicitly to `object` and `object` does not
+        // convert back, so `EntityHandle` is the better target. Without this
+        // rule the ordinal comparison below let Boxing (4) beat
+        // UserDefinedImplicit (6), so
+        // `List[EntityHandle].Add(StandaloneSignatureHandle)` bound to the
+        // non-generic `IList.Add(object)` face instead of `Add(T)` via
+        // `StandaloneSignatureHandle`'s `op_Implicit` — a silent runtime
+        // divergence (`List<T>` throws ArgumentException from
+        // `IList.Add`), not a compile error.
+        //
+        // `System.Object` is the least specific possible target, so this can
+        // never demote a genuinely better candidate; unrelated non-object
+        // targets keep falling through to the ordinal comparison.
+        if (ka == ImplicitConversionKind.UserDefinedImplicit
+            && kb is ImplicitConversionKind.Reference or ImplicitConversionKind.Boxing
+            && IsSystemObject(paramB)
+            && !IsSystemObject(paramA))
+        {
+            return -1;
+        }
+
+        if (kb == ImplicitConversionKind.UserDefinedImplicit
+            && ka is ImplicitConversionKind.Reference or ImplicitConversionKind.Boxing
+            && IsSystemObject(paramA)
+            && !IsSystemObject(paramB))
+        {
+            return 1;
+        }
+
         if (ka != kb)
         {
             return ((int)ka).CompareTo((int)kb);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -840,6 +840,23 @@ internal sealed partial class OverloadResolver
             return CompareReferenceTargets(paramA, paramB);
         }
 
+        // Issue #3866: the user-symbolic path was missing the UserDefinedImplicit
+        // arm that `ClrOverloadResolution.CompareConversions` has had since
+        // Stream E. `ClassifyUserArgumentConversionKind` reports
+        // UserDefinedImplicit for BOTH `Wrapped -> Payload` (a real
+        // `op_Implicit`) and `Wrapped -> object` (where the operator is merely
+        // one of several routes and boxing would do), so the two candidates
+        // landed in the same bucket, tied at 0 and reported a spurious GS0266
+        // where C# §12.6.4.5 prefers the better conversion TARGET. Payload
+        // converts implicitly to object and object does not convert back, so
+        // Payload wins; genuinely unrelated targets still tie and stay
+        // ambiguous.
+        if (ka == ClrOverloadResolution.ImplicitConversionKind.UserDefinedImplicit
+            && paramA != null && paramB != null && !ReferenceEquals(paramA, paramB))
+        {
+            return CompareReferenceTargets(paramA, paramB);
+        }
+
         return 0;
     }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3866UserDefinedConversionVsObjectTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3866UserDefinedConversionVsObjectTests.cs
@@ -1,0 +1,173 @@
+// <copyright file="Issue3866UserDefinedConversionVsObjectTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3866: <c>List[EntityHandle].Add(x)</c>, where <c>x</c> reaches
+/// <c>EntityHandle</c> through a user-defined <c>op_Implicit</c>, bound to the
+/// NON-GENERIC <c>System.Collections.IList.Add(object)</c> face instead of
+/// <c>Add(T)</c>.
+/// <para><c>ClrOverloadResolution.CompareConversions</c> ranked candidates by
+/// the ordinal of <see cref="object"/>-taking
+/// <c>ImplicitConversionKind.Boxing</c> (4) against
+/// <c>ImplicitConversionKind.UserDefinedImplicit</c> (6) and so preferred
+/// boxing to <c>object</c>. C# §12.6.4.5 ranks by "better conversion target",
+/// not by the mechanism of the conversion, and <c>System.Object</c> is the
+/// least specific target there is.</para>
+/// <para>The divergence was SILENT at compile time: the migrated
+/// <c>Gsharp.HotReload.Runtime.HotReloadDeltaBuilder.MapStandaloneSignature</c>
+/// compiled and passed ILVerify, then threw
+/// <c>ArgumentException: The value "System.Reflection.Metadata.StandaloneSignatureHandle"
+/// is not of type "System.Reflection.Metadata.EntityHandle"</c> from
+/// <c>List&lt;T&gt;.IList.Add</c> at run time. So these tests EXECUTE: binding
+/// alone cannot tell the two faces apart.</para>
+/// </summary>
+public class Issue3866UserDefinedConversionVsObjectTests
+{
+    /// <summary>
+    /// The exact BCL shape the migrated <c>HotReloadDeltaBuilder</c> hit:
+    /// <c>StandaloneSignatureHandle</c> has an <c>op_Implicit</c> to
+    /// <c>EntityHandle</c>, and <c>List&lt;EntityHandle&gt;</c> exposes both
+    /// <c>Add(EntityHandle)</c> and <c>IList.Add(object)</c>. On
+    /// <c>origin/main</c> this throws <see cref="System.ArgumentException"/>.
+    /// </summary>
+    [Fact]
+    public void ListAdd_ImportedHandleWithImplicitConversion_BindsToGenericAdd()
+    {
+        var source = @"
+import System
+import System.Collections.Generic
+import System.Reflection.Metadata
+import System.Reflection.Metadata.Ecma335
+
+func run() int32 {
+    let list = List[EntityHandle]()
+    let handle = MetadataTokens.StandaloneSignatureHandle(1)
+
+    // On main this bound to IList.Add(object) and threw at run time.
+    list.Add(handle)
+
+    if list.Count != 1 {
+        return -10
+    }
+
+    // The stored element must be a real EntityHandle, not a boxed
+    // StandaloneSignatureHandle: reading it back through the generic indexer
+    // is what proves the element type was converted rather than boxed.
+    if list[0].Kind != HandleKind.StandaloneSignature {
+        return -20
+    }
+
+    if MetadataTokens.GetToken(list[0]) != MetadataTokens.GetToken(handle) {
+        return -30
+    }
+
+    return 1
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
+    /// <summary>
+    /// The same ranking question with source-declared types, so the rule is
+    /// pinned independently of any BCL detail: a G# <c>func operator implicit</c>
+    /// target must beat an <c>object</c> parameter on the same argument.
+    /// </summary>
+    [Fact]
+    public void OverloadPair_UserDefinedConversionTarget_BeatsObjectParameter()
+    {
+        var source = @"
+import System
+
+struct Wrapped {
+    var value int32
+}
+
+struct Payload {
+    var value int32
+}
+
+func operator implicit (w Wrapped) Payload {
+    return Payload{value: w.value}
+}
+
+func Accept(p Payload) int32 { return p.value }
+func Accept(o object) int32 { return -1 }
+
+func run() int32 {
+    let w = Wrapped{value: 7}
+
+    // `Wrapped -> Payload` is user-defined; `Wrapped -> object` is boxing.
+    // Payload is the better conversion target, so the Payload overload wins.
+    if Accept(w) != 7 {
+        return -10
+    }
+
+    // A value with no better target still reaches the object overload.
+    if Accept(""s"") != -1 {
+        return -20
+    }
+
+    return 1
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+
+    /// <summary>
+    /// Anti-vacuity guard rail: an argument whose ONLY conversion to the
+    /// candidate set is boxing must still reach the <c>object</c> overload, and
+    /// an exact match must still beat both. This test passes on
+    /// <c>origin/main</c> — it exists so the fix above cannot be "everything
+    /// now prefers the non-object candidate".
+    /// </summary>
+    [Fact]
+    public void OverloadPair_ObjectCandidate_StillWinsWhenItIsTheOnlyApplicableOne()
+    {
+        var source = @"
+import System
+
+struct Unrelated {
+    var value int32
+}
+
+func Accept(s string) int32 { return 1 }
+func Accept(o object) int32 { return 2 }
+
+func run() int32 {
+    if Accept(""s"") != 1 {
+        return -10
+    }
+
+    if Accept(Unrelated{value: 3}) != 2 {
+        return -20
+    }
+
+    if Accept(42) != 2 {
+        return -30
+    }
+
+    return 1
+}
+
+run()
+";
+        var result = EmittedOracle.Evaluate(source);
+        Assert.Empty(result.Diagnostics.Where(d => d.IsError));
+        Assert.Equal(1, result.Value);
+    }
+}


### PR DESCRIPTION
Part of #3866.

## The defect is gsc's, not cs2gs's, and it reproduces in eleven lines

#3866 recorded the `HotReloadDeltaBuilder` failure as needing "a minimal repro
before it can be attributed to gsc or to cs2gs". It is **gsc**, and the repro
needs no translation at all — this is hand-written G# compiled by `gsc` directly:

```
package Repro

import System
import System.Collections.Generic
import System.Reflection.Metadata
import System.Reflection.Metadata.Ecma335

var list = List[EntityHandle]()
var handle = MetadataTokens.StandaloneSignatureHandle(1)
list.Add(handle)
Console.WriteLine(list.Count)
Console.WriteLine(list[0].Kind)
```

On `origin/main` (`4ed74c3f4`) this **compiles clean** and then throws at run time:

```
Unhandled exception. System.ArgumentException: The value
  "System.Reflection.Metadata.StandaloneSignatureHandle" is not of type
  "System.Reflection.Metadata.EntityHandle" and cannot be used in this generic
  collection. (Parameter 'value')
   at System.Collections.Generic.List`1.System.Collections.IList.Add(Object item)
```

— byte-for-byte the migrated `MapStandaloneSignature` failure in #3866 §B. So the
migration is faithful; the compiler is wrong.

## Mechanism: the ranking is by conversion MECHANISM, and C# ranks by TARGET

`ClrOverloadResolution.CompareConversions` compares two applicable candidates by
the ordinal of `ImplicitConversionKind`:

```
Reference = 3, Boxing = 4, … UserDefinedImplicit = 6
```

For `list.Add(handle)` the two candidates are

| candidate | conversion | kind |
| --- | --- | --- |
| `List<EntityHandle>.Add(EntityHandle)` | `StandaloneSignatureHandle` → `EntityHandle` via `op_Implicit` | `UserDefinedImplicit` (6) |
| `System.Collections.IList.Add(object)` | box | `Boxing` (4) |

4 < 6, so the **`object`** face won, and `List<T>`'s explicit `IList.Add`
implementation rejects the boxed handle at run time.

C# §12.6.4.5 does not rank by mechanism at all. It asks which **target** is
better: an implicit conversion `EntityHandle → object` exists and
`object → EntityHandle` does not, so `EntityHandle` is the better target and
`Add(T)` wins. `System.Object` is the least specific target there is.

That the divergence is silent — no diagnostic, and ILVerify passes, because both
call sequences are perfectly verifiable IL — is why this survived translate,
compile and ILVerify and only surfaced when `Sdk.Tests` finally executed the
migrated SDK.

## The fix

Two arms, one rule, both narrowly scoped to an `object` target so they can never
demote a genuinely better candidate.

**`ClrOverloadResolution.CompareConversions`** (imported members): a
`UserDefinedImplicit` conversion to a non-`object` target beats a
`Reference`/`Boxing` conversion to `System.Object`. This directly mirrors the
existing #377 arm three lines above it, which already had to make exactly this
correction for interpolated-string targets.

**`OverloadResolver.CompareUserConversions`** (source-declared members) was
missing the `UserDefinedImplicit` "better conversion target" arm that the CLR
path has had since Stream E. `ClassifyUserArgumentConversionKind` reports
`UserDefinedImplicit` for both `Wrapped → Payload` (a real `op_Implicit`) and
`Wrapped → object` (where the operator is merely one available route and boxing
would do), so both candidates landed in the same bucket, tied at 0, and produced
a spurious **GS0266** where C# picks `Payload`. Added the same
`CompareReferenceTargets` tie-break the CLR path already applies. Genuinely
unrelated targets still tie and stay ambiguous.

No check and no diagnostic is weakened: nothing that bound before stops binding,
and the fixed site now runs the *generic* `Add`, which is what the C# original
did.

## Evidence — the tests EXECUTE

`test/Core.Tests/CodeAnalysis/Binding/Issue3866UserDefinedConversionVsObjectTests.cs`,
three `[Fact]`s through `EmittedOracle.Evaluate` (compile + run + assert; binding
alone cannot tell the two `Add` faces apart, which is the whole point).

On `origin/main` (`4ed74c3f4`), with only the test file added:

```
Failed OverloadPair_UserDefinedConversionTarget_BeatsObjectParameter
  Assert.Empty() Failure: Collection was not empty
  Collection: [Call to 'Accept' is ambiguous between multiple overloads. …]
Failed ListAdd_ImportedHandleWithImplicitConversion_BindsToGenericAdd
  Assert.Empty() Failure: Collection was not empty
  Collection: [The value "System.Reflection.Metadata.StandaloneSignatureHandle"
               is not of type "System.Reflection.Metadata.EntityHandle" …]

Failed!  - Failed: 2, Passed: 1, Skipped: 0, Total: 3
```

The one that **passes on main** is deliberate:
`OverloadPair_ObjectCandidate_StillWinsWhenItIsTheOnlyApplicableOne` is the
anti-vacuity guard rail — an argument whose only route into the candidate set is
boxing must still reach `Accept(object)`, and an exact `string` match must still
beat both. Without it "the fix" could be "nothing ever prefers `object` again".

With the fix: `Passed! - Failed: 0, Passed: 3, Total: 3`.

The `ListAdd` test asserts on the *stored element*, not merely on binding: it
reads `list[0].Kind` back through the generic indexer and compares
`MetadataTokens.GetToken(list[0])` with the original handle's token, so a boxed
element could not satisfy it.

## App-level proof: `test/Sdk.Tests` goes 4 → 3, and the tests genuinely ran

Targeted self-migration over the exact `test/Sdk.Tests` dependency closure
(everything else excluded), Release, packed SDK repacked from this commit —
note the moniker, `0.4.408+150ab96317`, is this branch's HEAD, so the mirror was
built by the fixed compiler and not a stale `gsc.dll`:

```
cs2gs migrate — run 2026-09-04T00-08-28Z_6f787c
gsc: 0.4.408+150ab96317

app                                                     translate  compile  ilverify  test-parity
src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/…   PASS       PASS     PASS      PASS
src/Analyzers/InternalAnalyzers/…                       PASS       PASS     PASS      PASS
src/Compiler/Compiler.csproj                            PASS       PASS     PASS      PASS
src/Core/Core.csproj                                    PASS       PASS     PASS      PASS
src/Sdk/Gsharp.HotReload.Runtime/…                      PASS       PASS     PASS      PASS
src/Sdk/Gsharp.NET.Sdk/…                                PASS       PASS     PASS      PASS
test/Sdk.Tests/Sdk.Tests.csproj                         PASS       PASS     PASS      FAIL(1)
```

```
Failed!  - Failed: 3, Passed: 83, Skipped: 0, Total: 86 - GSharp.Sdk.Tests.dll
```

**52 → 16 → 4 → 3.** `NewLocalSignature_IsMappedIntoDelta` — the
`HotReloadDeltaBuilder` failure — is gone.

Per #3872 the parity signal is now honest, so this is checked rather than
assumed: **86 tests executed**, the same total as before the fix, so nothing was
silently un-discovered.

### The 3-plus-1 split in #3866 holds exactly

The three that remain are #3866 §A verbatim, all `FileNotFoundException`, all
reading a `.cs`/`.csproj` path the mirror correctly does not have:

```
Failed Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime
Failed Sdk_Csproj_Packs_As_MSBuildSdk
  <mirror>/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj
Failed Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build
  <mirror>/src/Sdk/Gsharp.HotReload.Runtime/HotReloadAgent.cs
```

They are **not** fixed here and **not** the same root as #3850 — see the
follow-up issue for why, and why patching them is a policy decision about the
parity oracle rather than a bug fix. No new failure appeared from #3878's
ref-returning-property gap in this app.

### The migration was faithful; the compiler was not

The mirrored `HotReloadDeltaBuilder.gs:741` reads

```
newStandaloneSignatures.Add(handle)
```

— exactly the C# — so cs2gs was never at fault here, which is what #3866 asked
to have settled.

## Regression surface

* `test/Core.Tests` in full: `Passed! - Failed: 0, Passed: 8612, Total: 8612`.
* The six non-test apps above all stay green through translate + compile +
  ILVerify + parity, and `src/Core` — which contains this change — ILVerifies
  clean after translation, so the fix survives its own migration.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
