### PR TITLE
cs2gs: nominal delegate identity for colliding overload sets (#3841); gsc: an async Main keeps its Task in metadata (#3883)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1523,11 +1523,16 @@ public sealed class Binder
             ?? ResolveEntryPointPackage(packageByTree, globalStatements, functions, packagesInOrder);
 
         // Issue #3883: a library has no entry point to resolve. Scanning for a
-        // static `Main` under /target:library used to pick one anyway, and the
-        // emitter then applied the CLR entry-point signature rewrite to it —
-        // erasing `Task<T>` from an `async func Main` in a DLL that can never
-        // be started as a process.
-        var entryPoint = isLibrary
+        // user-declared static `Main` under /target:library used to pick one
+        // anyway, and the emitter then applied the CLR entry-point signature
+        // rewrite to it — erasing `Task<T>` from an `async func Main` in a DLL
+        // that can never be started as a process.
+        //
+        // TLS in a library is a different case and keeps its existing shape:
+        // ADR-0066 D4 reports GS0285 and then CONTINUES, so the synthesized
+        // `<Main>$` is still produced and downstream consumers see a complete
+        // bound tree (BinderEntryPointTests pins this).
+        var entryPoint = isLibrary && globalStatements.Length == 0
             ? null
             : ResolveEntryPoint(binder, functions, structs, globalStatements, syntaxTrees, entryPointPackage, synthesizedEntryPoint);
 

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -1521,7 +1521,15 @@ public sealed class Binder
         // synthesized <Main>$ in emit.
         var entryPointPackage = synthesizedEntryPointPackage
             ?? ResolveEntryPointPackage(packageByTree, globalStatements, functions, packagesInOrder);
-        var entryPoint = ResolveEntryPoint(binder, functions, structs, globalStatements, syntaxTrees, entryPointPackage, synthesizedEntryPoint);
+
+        // Issue #3883: a library has no entry point to resolve. Scanning for a
+        // static `Main` under /target:library used to pick one anyway, and the
+        // emitter then applied the CLR entry-point signature rewrite to it —
+        // erasing `Task<T>` from an `async func Main` in a DLL that can never
+        // be started as a process.
+        var entryPoint = isLibrary
+            ? null
+            : ResolveEntryPoint(binder, functions, structs, globalStatements, syntaxTrees, entryPointPackage, synthesizedEntryPoint);
 
         // ADR-0156 Phase 3c (#3176): an interactive submission never runs a
         // user-declared entry point — `func Main()` in a cell is an ordinary

--- a/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/FunctionEmitter.cs
@@ -215,7 +215,11 @@ internal sealed class FunctionEmitter
             capturedAsyncStepping);
     }
 
-    internal MethodDefinitionHandle EmitFunction(FunctionSymbol function, BoundBlockStatement body, bool isEntryPoint)
+    internal MethodDefinitionHandle EmitFunction(
+        FunctionSymbol function,
+        BoundBlockStatement body,
+        bool isEntryPoint,
+        bool isSynthesizedEntryPointStub = false)
     {
         // ADR-0086 / issue #727 + ADR-0092 / issue #758: P/Invoke functions
         // skip body emission. Classic @DllImport functions route through the
@@ -235,8 +239,8 @@ internal sealed class FunctionEmitter
         var bodySelection = this.SelectFunctionBody(function, body);
         var bodyEmission = this.EmitFunctionBody(function, bodySelection.Body, bodySelection.AsyncPlan, isEntryPoint);
         var signature = this.EncodeFunctionSignature(function, bodySelection.AsyncPlan, isEntryPoint);
-        var methodName = GetMethodMetadataName(function, isEntryPoint);
-        var methodAttributes = GetMethodAttributes(function, isEntryPoint);
+        var methodName = GetMethodMetadataName(function, isEntryPoint, isSynthesizedEntryPointStub);
+        var methodAttributes = GetMethodAttributes(function, isEntryPoint, isSynthesizedEntryPointStub);
         var parameterMetadata = this.EmitParameterMetadata(function, bodySelection.AsyncPlan);
         var handle = this.EmitMethodDefinition(
             function,
@@ -472,7 +476,10 @@ internal sealed class FunctionEmitter
         return sigBlob;
     }
 
-    private static string GetMethodMetadataName(FunctionSymbol function, bool isEntryPoint)
+    private static string GetMethodMetadataName(
+        FunctionSymbol function,
+        bool isEntryPoint,
+        bool isSynthesizedEntryPointStub = false)
     {
         // Synthesized entry point uses the C#-style mangled name; explicit Main / user funcs keep their source name.
         // ADR-0149: a method declared with an explicit-interface qualifier
@@ -487,7 +494,12 @@ internal sealed class FunctionEmitter
         // no clause of its own, so only the settable ExplicitInterfaceClauseTarget
         // (propagated from the owning PropertySymbol by
         // DeclarationBinder.ResolveExplicitInterfaceClauses) reflects it.
-        var methodName = isEntryPoint && function.Declaration is null
+        // Issue #3883: the synthesized stub that blocks on an authored async
+        // `Main` also takes the `<Main>$` metadata name — it must not collide
+        // with the authored `Main` (which is emitted alongside it, keeping its
+        // Task-returning signature), and csc names its equivalent stub the
+        // same way.
+        var methodName = isEntryPoint && (function.Declaration is null || isSynthesizedEntryPointStub)
             ? "<Main>$"
             : function.ExplicitInterfaceClauseTarget != null
                 ? ExplicitInterfaceMetadataNaming.GetMetadataName(function.Name, function.ExplicitInterfaceClauseTarget)
@@ -496,7 +508,10 @@ internal sealed class FunctionEmitter
         return methodName;
     }
 
-    private static MethodAttributes GetMethodAttributes(FunctionSymbol function, bool isEntryPoint)
+    private static MethodAttributes GetMethodAttributes(
+        FunctionSymbol function,
+        bool isEntryPoint,
+        bool isSynthesizedEntryPointStub = false)
     {
         // The synthesized entry point must remain Public so the runtime can find it.
         // ADR-0149: an explicit-interface qualifier clause member is ALWAYS
@@ -512,7 +527,7 @@ internal sealed class FunctionEmitter
         var effectiveAccessibility = function.ExplicitInterfaceClauseTarget != null
             ? Accessibility.Private
             : function.Accessibility;
-        var visibility = isEntryPoint && function.Declaration is null
+        var visibility = isEntryPoint && (function.Declaration is null || isSynthesizedEntryPointStub)
             ? MethodAttributes.Public
             : AccessibilityMap.ToMethodVisibility(effectiveAccessibility, AccessibilityMap.IsTopLevelProgramMember(function));
 

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -418,6 +418,13 @@ internal sealed class ReflectionMetadataEmitter
     // PR-E-11: widened to internal so the promoted MethodBodyEmitter can read it.
     internal StateMachineEmitter stateMachines;
 
+    // Issue #3883: the MethodDef row of the synthesized `<Main>$` entry-point
+    // stub that blocks on an AUTHORED async `Main`. Held separately from
+    // cache.FunctionHandles because the authored `Main` keeps its own
+    // (Task-returning) row there — the stub is a second, distinct MethodDef
+    // that nothing but the PE header's EntryPoint token references.
+    private MethodDefinitionHandle entryPointStubHandle;
+
     // Issue #2118: per-lambda-function ordered ORIGINAL enclosing type
     // parameters used as the MethodSpec type arguments when the lambda is
     // referenced (`ldftn <lambda><...enclosing args...>`) at its delegate
@@ -502,6 +509,46 @@ internal sealed class ReflectionMetadataEmitter
         smStruct.SetTypeParameters(smTPs);
         this.remaps.RegisterClassRemap(smStruct, remap);
     }
+
+    // Issue #3883: whether the entry point is an AUTHORED `async func Main`
+    // whose async builder exposes a Task. Such a Main must keep its
+    // Task/Task<T> return type in metadata — it is an ordinary, callable,
+    // awaitable member, possibly from another assembly — so the CLR
+    // entry-point signature rewrite (issue #1904) cannot be applied to its
+    // own MethodDef row. A separate `<Main>$` stub row is emitted instead,
+    // exactly as csc does. The TLS-synthesized entry point (Declaration is
+    // null) is excluded: it has no authored declaration to preserve, so
+    // rewriting it in place remains correct.
+    private bool EntryPointNeedsSeparateStub
+    {
+        get
+        {
+            var entryPoint = this.emitCtx.Program.EntryPoint;
+            if (entryPoint is not { Declaration: not null, IsAsync: true })
+            {
+                return false;
+            }
+
+            foreach (var plan in this.stateMachines.AsyncStateMachinePlans)
+            {
+                if (plan.KickoffMethod == entryPoint)
+                {
+                    return plan.StateMachine.BuilderInfo.TaskProperty != null;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    // Issue #3883: whether <paramref name="c"/> is the class that declares the
+    // authored async `Main`, and therefore owns the synthesized `<Main>$`
+    // entry-point stub's MethodDef row.
+    private bool ClassOwnsEntryPointStub(StructSymbol c)
+        => this.EntryPointNeedsSeparateStub
+            && this.emitCtx.Program.EntryPoint is { } entryPoint
+            && !c.StaticMethods.IsDefaultOrEmpty
+            && c.StaticMethods.Contains(entryPoint);
 
     // Issue #1467 / #1537: reifies every user-declared type nested inside a
     // generic type over an ordinal-aligned clone of the flattened enclosing +
@@ -1101,7 +1148,7 @@ internal sealed class ReflectionMetadataEmitter
             this.emitCtx,
             this.cache,
             this.wellKnown,
-            this.functions.EmitFunction,
+            (fn, fnBody, fnIsEntryPoint) => this.functions.EmitFunction(fn, fnBody, fnIsEntryPoint),
             this.signatures.EncodeTypeSymbol,
             this.customAttrEncoder.NextParameterHandle,
             this.memberRefs.GetTypeReference,
@@ -2101,6 +2148,16 @@ internal sealed class ReflectionMetadataEmitter
                     aggregateMethodHandles[m] = handle;
                     this.cache.MethodHandles[m] = handle;
                 }
+
+                // Issue #3883: one extra row on THIS class for the synthesized
+                // `<Main>$` stub that blocks on its authored async `Main`. It
+                // must live on the same type: the stub body is a second async
+                // kickoff, and the state-machine struct it initializes is a
+                // private nested type of this class.
+                if (this.ClassOwnsEntryPointStub(c))
+                {
+                    this.entryPointStubHandle = MetadataTokens.MethodDefinitionHandle(methodRow++);
+                }
             }
 
             // Issue #263: plan accessor method rows for static properties on classes.
@@ -2152,6 +2209,18 @@ internal sealed class ReflectionMetadataEmitter
         // a package-level <Program> row/emission — the per-package entry-point
         // reservation/emission below is skipped for it, and the emitted
         // TypeDef-owned MethodDef row is reused directly as the PE entry point.
+        //
+        // Issue #3883: when that class-scoped `Main` is ASYNC its own row can
+        // no longer double as the PE entry point — reusing it forces the CLR
+        // entry-point signature (void/int32) onto the user's declaration and
+        // erases `Task<T>` from metadata, so cross-assembly consumers see a
+        // synchronous method (`await Program.Main(args)` fails with GS0159 on
+        // ConfigureAwait). csc keeps the authored `Main` Task-shaped and
+        // synthesizes a SEPARATE `<Main>$` stub that blocks on it. The stub's
+        // row is reserved by PlanClassMethods on the SAME class (it reads the
+        // state machine's private fields, so a <Program>-hosted stub would
+        // fail CLR field-access checks); `entryPointIsClassOwned` stays true
+        // so no package-level row is reserved as well.
         var entryPointIsClassOwned = this.emitCtx.Program.EntryPoint is not null
             && aggregateMethodHandles.ContainsKey(this.emitCtx.Program.EntryPoint);
 
@@ -2907,7 +2976,10 @@ internal sealed class ReflectionMetadataEmitter
 
         foreach (var kvp in this.emitCtx.Program.Functions)
         {
-            if (kvp.Key == this.emitCtx.Program.EntryPoint)
+            // Issue #3883: an AUTHORED async `Main` is NOT skipped here — it
+            // needs its own ordinary (Task-returning) row alongside the
+            // separate `<Main>$` entry-point stub reserved further below.
+            if (kvp.Key == this.emitCtx.Program.EntryPoint && !this.EntryPointNeedsSeparateStub)
             {
                 continue;
             }
@@ -3081,7 +3153,22 @@ internal sealed class ReflectionMetadataEmitter
 
             if (this.emitCtx.Program.EntryPoint is not null && pkg == entryPointPackage && !entryPointIsClassOwned)
             {
-                this.cache.FunctionHandles[this.emitCtx.Program.EntryPoint] = MetadataTokens.MethodDefinitionHandle(nextRow++);
+                var entryRow = MetadataTokens.MethodDefinitionHandle(nextRow++);
+
+                // Issue #3883: for an authored async `Main` this row is the
+                // synthesized `<Main>$` stub, NOT the authored function — the
+                // authored function already has its own row (above, or on its
+                // owning class's TypeDef), and cache.FunctionHandles must keep
+                // pointing at THAT row so ordinary calls to `Main()` bind to
+                // the Task-returning member.
+                if (this.EntryPointNeedsSeparateStub)
+                {
+                    this.entryPointStubHandle = entryRow;
+                }
+                else
+                {
+                    this.cache.FunctionHandles[this.emitCtx.Program.EntryPoint] = entryRow;
+                }
             }
         }
 
@@ -3116,9 +3203,11 @@ internal sealed class ReflectionMetadataEmitter
         MethodDefinitionHandle entryHandle = default;
         if (this.emitCtx.Program.EntryPoint is not null)
         {
-            entryHandle = entryPointIsClassOwned
-                ? aggregateMethodHandles[this.emitCtx.Program.EntryPoint]
-                : this.cache.FunctionHandles[this.emitCtx.Program.EntryPoint];
+            entryHandle = this.EntryPointNeedsSeparateStub
+                ? this.entryPointStubHandle
+                : entryPointIsClassOwned
+                    ? aggregateMethodHandles[this.emitCtx.Program.EntryPoint]
+                    : this.cache.FunctionHandles[this.emitCtx.Program.EntryPoint];
         }
 
         // Pre-register SM class ctor handles so iterator kickoff bodies
@@ -3554,9 +3643,36 @@ internal sealed class ReflectionMetadataEmitter
                         // isEntryPoint through so EmitFunction applies the same
                         // async-Main sync-wrapper lowering (GetAwaiter().GetResult())
                         // used for package-scope entry points.
-                        var emittedHandle = this.functions.EmitFunction(m, staticBody, isEntryPoint: m == this.emitCtx.Program.EntryPoint);
+                        // Issue #3883: an authored async `Main` is emitted here
+                        // as an ORDINARY static method (Task-returning); the
+                        // CLR entry-point shape lives on the separate
+                        // `<Main>$` stub emitted right after this loop.
+                        var emittedHandle = this.functions.EmitFunction(
+                            m,
+                            staticBody,
+                            isEntryPoint: m == this.emitCtx.Program.EntryPoint && !this.EntryPointNeedsSeparateStub);
                         this.cache.MethodHandles[m] = emittedHandle;
                     }
+                }
+
+                // Issue #3883: the synthesized `<Main>$` entry-point stub for
+                // this class's authored async `Main` — a second kickoff body
+                // over the same state machine, encoded with the CLR
+                // entry-point signature and driven to completion
+                // synchronously. Its row was reserved by PlanClassMethods
+                // immediately after the static-method rows.
+                //
+                // ClassOwnsEntryPointStub is only true when Program.EntryPoint
+                // is non-null (it is one of this class's StaticMethods), so
+                // the two `!`s below are guarded by the preceding conjunct.
+                if (this.ClassOwnsEntryPointStub(c)
+                    && this.emitCtx.Program.Functions.TryGetValue(this.emitCtx.Program.EntryPoint!, out var stubBody))
+                {
+                    this.functions.EmitFunction(
+                        this.emitCtx.Program.EntryPoint!,
+                        stubBody,
+                        isEntryPoint: true,
+                        isSynthesizedEntryPointStub: true);
                 }
             }
 
@@ -3821,7 +3937,11 @@ internal sealed class ReflectionMetadataEmitter
             if (this.emitCtx.Program.EntryPoint is not null && pkg == entryPointPackage && !entryPointIsClassOwned)
             {
                 var entryBody = this.emitCtx.Program.Functions[this.emitCtx.Program.EntryPoint];
-                this.functions.EmitFunction(this.emitCtx.Program.EntryPoint, entryBody, isEntryPoint: true);
+                this.functions.EmitFunction(
+                    this.emitCtx.Program.EntryPoint,
+                    entryBody,
+                    isEntryPoint: true,
+                    isSynthesizedEntryPointStub: this.EntryPointNeedsSeparateStub);
             }
         }
 

--- a/test/Compiler.Tests/Issue3883AsyncMainMetadataTests.cs
+++ b/test/Compiler.Tests/Issue3883AsyncMainMetadataTests.cs
@@ -1,0 +1,460 @@
+// <copyright file="Issue3883AsyncMainMetadataTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3883: gsc used to erase the <c>Task</c> from an <c>async func Main</c>
+/// in metadata. <c>Binder.ResolveEntryPoint</c> (#1996) treats ANY static
+/// <c>Main</c> as an entry-point candidate — even under
+/// <c>/target:library</c> — and the emitter then rewrote that method's own
+/// signature to the CLR entry-point shape (#1904), so consumers in another
+/// assembly saw a synchronous <c>int32</c> method. The failure surfaced as a
+/// masking <c>GS0159 Cannot find function ConfigureAwait</c> at the caller,
+/// never naming the rewritten signature.
+/// <para>
+/// The fix follows csc: a library resolves no entry point at all, and an
+/// executable keeps its authored <c>Main</c> Task-shaped while a SEPARATE
+/// synthesized <c>&lt;Main&gt;$</c> stub carries the CLR entry-point shape and
+/// drives the task to completion.
+/// </para>
+/// <para>
+/// Every assertion here is cross-assembly or reflective on purpose: the
+/// same-assembly call path binds against the source symbol rather than the
+/// emitted one, so it stayed green throughout the defect and hides it
+/// completely.
+/// </para>
+/// </summary>
+public class Issue3883AsyncMainMetadataTests
+{
+    private const string ClassScopedAsyncMainLibrary = """
+        package Probe.Lib
+
+        import System
+        import System.Threading.Tasks
+
+        class Runner {
+            shared {
+                public async func Main() int32 {
+                    await Task.Yield()
+                    return 41
+                }
+
+                public async func Sibling() string {
+                    await Task.Yield()
+                    return "sibling"
+                }
+            }
+        }
+        """;
+
+    private const string PackageScopedAsyncMainApp = """
+        package Probe.PkgApp
+
+        import System
+        import System.Threading.Tasks
+
+        async func Main() int32 {
+            await Task.Yield()
+            Console.WriteLine("pkg main ran")
+            return 7
+        }
+        """;
+
+    private const string ClassScopedAsyncMainApp = """
+        package Probe.ClsApp
+
+        import System
+        import System.Threading.Tasks
+
+        class Program {
+            shared {
+                public async func Main() int32 {
+                    await Task.Yield()
+                    Console.WriteLine("class main ran")
+                    return 5
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The reflection proof from the issue. A <c>/target:library</c> has no
+    /// entry point to resolve, so an <c>async func Main</c> in it is an
+    /// ordinary member and must keep <c>Task&lt;int32&gt;</c> — exactly like
+    /// the <c>Sibling</c> control that differs only in its NAME.
+    /// </summary>
+    [Fact]
+    public void AsyncMainInLibrary_KeepsItsTaskInMetadata()
+    {
+        using var work = new Workspace();
+        string libPath = work.CompileLibrary("Probe.Lib.dll", "Lib.gs", ClassScopedAsyncMainLibrary);
+
+        Assert.Equal("System.Threading.Tasks.Task`1<Int32>", ReturnTypeOf(libPath, "Runner", "Main"));
+
+        // Anti-vacuity control: `Sibling` was ALWAYS Task-shaped, so a fix that
+        // broke async return encoding generally would fail here too.
+        Assert.Equal("System.Threading.Tasks.Task`1<String>", ReturnTypeOf(libPath, "Runner", "Sibling"));
+
+        // A library must carry no PE entry point at all.
+        Assert.Equal(0, EntryPointToken(libPath));
+        IlVerifier.Verify(libPath, Array.Empty<string>());
+    }
+
+    /// <summary>
+    /// The discriminating test: another assembly awaits the library's
+    /// <c>Main</c>. On origin/main this does not even compile
+    /// (<c>GS0159 Cannot find function ConfigureAwait</c>, because
+    /// <c>Runner.Main()</c> had become <c>int32</c>); it must now compile, RUN,
+    /// and produce the awaited value.
+    /// </summary>
+    [Fact]
+    public void ConsumerInAnotherAssembly_CanAwaitTheLibrarysAsyncMain()
+    {
+        using var work = new Workspace();
+        string libPath = work.CompileLibrary("Probe.Lib.dll", "Lib.gs", ClassScopedAsyncMainLibrary);
+
+        string stdout = work.CompileAndRunApp(
+            "Probe.Consumer.dll",
+            "Consumer.gs",
+            """
+            package Probe.Consumer
+
+            import System
+            import Probe.Lib
+
+            async func Sum() int32 {
+                let value = await Runner.Main().ConfigureAwait(false)
+                return value + 1
+            }
+
+            Console.WriteLine(Sum().GetAwaiter().GetResult())
+            """,
+            new[] { libPath });
+
+        Assert.Equal("42" + Environment.NewLine, stdout);
+    }
+
+    /// <summary>
+    /// An executable's authored class-scoped <c>Main</c> keeps its
+    /// <c>Task&lt;T&gt;</c> and gains a sibling <c>&lt;Main&gt;$</c> stub that
+    /// is the real PE entry point — csc's shape. The stub must live on the SAME
+    /// type: its body is a second async kickoff over a state machine that is a
+    /// private nested type of that class, so a <c>&lt;Program&gt;</c>-hosted
+    /// stub fails the CLR's field-access check at run time
+    /// (<c>FieldAccessException</c>), which is why this test RUNS the program.
+    /// </summary>
+    [Fact]
+    public void AsyncMainInExecutable_KeepsItsTaskAndGetsASeparateEntryPointStub()
+    {
+        using var work = new Workspace();
+        string appPath = work.CompileApp("Probe.ClsApp.dll", "ClsApp.gs", ClassScopedAsyncMainApp, Array.Empty<string>());
+
+        Assert.Equal("System.Threading.Tasks.Task`1<Int32>", ReturnTypeOf(appPath, "Program", "Main"));
+        Assert.Equal("Int32", ReturnTypeOf(appPath, "Program", "<Main>$"));
+        Assert.Equal(TokenOf(appPath, "Program", "<Main>$"), EntryPointToken(appPath));
+
+        IlVerifier.Verify(appPath, Array.Empty<string>());
+        Assert.Equal("class main ran" + Environment.NewLine, work.Run(appPath, expectedExitCode: 5));
+    }
+
+    /// <summary>
+    /// Same for a package-scope <c>async func Main</c>, whose row lives on the
+    /// package's <c>&lt;Program&gt;</c> type rather than a user class.
+    /// </summary>
+    [Fact]
+    public void PackageScopeAsyncMain_KeepsItsTaskAndGetsASeparateEntryPointStub()
+    {
+        using var work = new Workspace();
+        string appPath = work.CompileApp("Probe.PkgApp.dll", "PkgApp.gs", PackageScopedAsyncMainApp, Array.Empty<string>());
+
+        Assert.Equal("System.Threading.Tasks.Task`1<Int32>", ReturnTypeOf(appPath, "<Program>", "Main"));
+        Assert.Equal("Int32", ReturnTypeOf(appPath, "<Program>", "<Main>$"));
+        Assert.Equal(TokenOf(appPath, "<Program>", "<Main>$"), EntryPointToken(appPath));
+
+        IlVerifier.Verify(appPath, Array.Empty<string>());
+        Assert.Equal("pkg main ran" + Environment.NewLine, work.Run(appPath, expectedExitCode: 7));
+    }
+
+    /// <summary>
+    /// A SYNC <c>Main</c> is untouched by this change: it keeps its own name
+    /// and row as the entry point, with no <c>&lt;Main&gt;$</c> stub. Without
+    /// this guard the fix could have renamed every entry point.
+    /// </summary>
+    [Fact]
+    public void SyncMain_IsUnchanged_NoStubAndNoRename()
+    {
+        using var work = new Workspace();
+        string appPath = work.CompileApp(
+            "Probe.SyncApp.dll",
+            "SyncApp.gs",
+            """
+            package Probe.SyncApp
+
+            import System
+
+            class Program {
+                shared {
+                    public func Main() int32 {
+                        Console.WriteLine("sync main ran")
+                        return 9
+                    }
+                }
+            }
+            """,
+            Array.Empty<string>());
+
+        Assert.Equal("Int32", ReturnTypeOf(appPath, "Program", "Main"));
+        Assert.DoesNotContain("<Main>$", MethodNames(appPath), StringComparer.Ordinal);
+        Assert.Equal(TokenOf(appPath, "Program", "Main"), EntryPointToken(appPath));
+        Assert.Equal("sync main ran" + Environment.NewLine, work.Run(appPath, expectedExitCode: 9));
+    }
+
+    /// <summary>
+    /// Top-level statements still lower to the synthesized <c>&lt;Main&gt;$</c>
+    /// with the CLR entry-point signature — issue #1904's behaviour, which this
+    /// change must not disturb (there is no authored declaration to preserve).
+    /// </summary>
+    [Fact]
+    public void TopLevelAwait_StillRewritesTheSynthesizedEntryPointInPlace()
+    {
+        using var work = new Workspace();
+        string appPath = work.CompileApp(
+            "Probe.TlsApp.dll",
+            "TlsApp.gs",
+            """
+            package Probe.TlsApp
+
+            import System
+            import System.Threading.Tasks
+
+            await Task.Yield()
+            Console.WriteLine("tls ran")
+            """,
+            Array.Empty<string>());
+
+        Assert.Equal("Void", ReturnTypeOf(appPath, "<Program>", "<Main>$"));
+        Assert.Equal("tls ran" + Environment.NewLine, work.Run(appPath, expectedExitCode: 0));
+    }
+
+    private static string ReturnTypeOf(string assemblyPath, string typeName, string methodName)
+        => Methods(assemblyPath).Single(m => m.Type == typeName && m.Method == methodName).ReturnType;
+
+    private static int TokenOf(string assemblyPath, string typeName, string methodName)
+        => Methods(assemblyPath).Single(m => m.Type == typeName && m.Method == methodName).Token;
+
+    private static IEnumerable<string> MethodNames(string assemblyPath)
+        => Methods(assemblyPath).Select(m => m.Method).ToList();
+
+    private static List<(string Type, string Method, string ReturnType, int Token)> Methods(string assemblyPath)
+    {
+        var result = new List<(string Type, string Method, string ReturnType, int Token)>();
+        using FileStream stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        foreach (TypeDefinitionHandle typeHandle in reader.TypeDefinitions)
+        {
+            TypeDefinition type = reader.GetTypeDefinition(typeHandle);
+            string typeName = reader.GetString(type.Name);
+            foreach (MethodDefinitionHandle methodHandle in type.GetMethods())
+            {
+                MethodDefinition method = reader.GetMethodDefinition(methodHandle);
+                MethodSignature<string> signature = method.DecodeSignature(SignatureNames.Instance, genericContext: null);
+                result.Add((
+                    typeName,
+                    reader.GetString(method.Name),
+                    signature.ReturnType,
+                    MetadataTokens.GetToken(methodHandle)));
+            }
+        }
+
+        return result;
+    }
+
+    private static int EntryPointToken(string assemblyPath)
+    {
+        using FileStream stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        return peReader.PEHeaders.CorHeader.EntryPointTokenOrRelativeVirtualAddress;
+    }
+
+    /// <summary>
+    /// Renders metadata signature types as short display strings for the
+    /// assertions above.
+    /// </summary>
+    private sealed class SignatureNames : ISignatureTypeProvider<string, object>
+    {
+        internal static readonly SignatureNames Instance = new();
+
+        public string GetArrayType(string elementType, ArrayShape shape) => elementType + "[]";
+
+        public string GetByReferenceType(string elementType) => elementType + "&";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature) => "fnptr";
+
+        public string GetGenericInstantiation(string genericType, System.Collections.Immutable.ImmutableArray<string> typeArguments)
+            => genericType + "<" + string.Join(",", typeArguments) + ">";
+
+        public string GetGenericMethodParameter(object genericContext, int index) => "!!" + index;
+
+        public string GetGenericTypeParameter(object genericContext, int index) => "!" + index;
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        public string GetPointerType(string elementType) => elementType + "*";
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+        {
+            TypeDefinition definition = reader.GetTypeDefinition(handle);
+            string ns = reader.GetString(definition.Namespace);
+            string name = reader.GetString(definition.Name);
+            return ns.Length == 0 ? name : ns + "." + name;
+        }
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+        {
+            TypeReference reference = reader.GetTypeReference(handle);
+            string ns = reader.GetString(reference.Namespace);
+            string name = reader.GetString(reference.Name);
+            return ns.Length == 0 ? name : ns + "." + name;
+        }
+
+        public string GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+    }
+
+    /// <summary>
+    /// A throwaway directory that compiles G# sources with the in-process gsc
+    /// entry point and runs the results out of process.
+    /// </summary>
+    private sealed class Workspace : IDisposable
+    {
+        private readonly string root = Directory.CreateTempSubdirectory("gs_issue3883_").FullName;
+
+        public string CompileLibrary(string outputName, string fileName, string source)
+            => this.CompileCore(outputName, fileName, source, "/target:library", Array.Empty<string>());
+
+        public string CompileApp(string outputName, string fileName, string source, IReadOnlyList<string> references)
+            => this.CompileCore(outputName, fileName, source, "/target:exe", references);
+
+        public string CompileAndRunApp(
+            string outputName,
+            string fileName,
+            string source,
+            IReadOnlyList<string> references)
+        {
+            string appPath = this.CompileApp(outputName, fileName, source, references);
+            return this.Run(appPath, expectedExitCode: 0);
+        }
+
+        public string Run(string appPath, int expectedExitCode)
+        {
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = this.root,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(appPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(appPath);
+
+            using Process process = Process.Start(psi)
+                ?? throw new InvalidOperationException("failed to start dotnet exec");
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(60_000), "dotnet exec timed out");
+            Assert.True(
+                process.ExitCode == expectedExitCode,
+                $"expected exit {expectedExitCode}, got {process.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(this.root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A best-effort cleanup; a locked file must not fail the test.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Same.
+            }
+        }
+
+        private string CompileCore(
+            string outputName,
+            string fileName,
+            string source,
+            string targetSwitch,
+            IReadOnlyList<string> references)
+        {
+            string sourcePath = Path.Combine(this.root, fileName);
+            string outputPath = Path.Combine(this.root, outputName);
+            File.WriteAllText(sourcePath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outputPath,
+                targetSwitch,
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+
+            foreach (string reference in ReferenceClosure.TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            foreach (string reference in references)
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(sourcePath);
+
+            using var stdout = new StringWriter();
+            using var stderr = new StringWriter();
+            TextWriter previousOut = Console.Out;
+            TextWriter previousError = Console.Error;
+            Console.SetOut(stdout);
+            Console.SetError(stderr);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed for {outputName}:\n{stdout}{stderr}");
+            return outputPath;
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3841DelegateOverloadSetTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3841DelegateOverloadSetTranslationTests.cs
@@ -1,0 +1,330 @@
+// <copyright file="Issue3841DelegateOverloadSetTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3841 — a legal C# overload set that discriminates on DELEGATE
+/// IDENTITY (<c>Add(Predicate&lt;T&gt;)</c> / <c>Add(Func&lt;T, bool&gt;)</c>)
+/// was translated into two members with the same G# signature, and gsc
+/// correctly rejected the result with <c>GS0264</c>.
+/// <para>
+/// The issue was filed as a G# type-system gap wanting an ADR. It is not one:
+/// gsc already declares and dispatches such an overload set when the delegate
+/// types are spelled nominally. The duplicate is manufactured by cs2gs —
+/// issue #2835's nominal-identity rule was scoped to SOURCE-declared
+/// delegates, so imported ones (<c>Predicate</c>, <c>Func</c>) still erased to
+/// the arrow form.
+/// </para>
+/// <para>
+/// Preserving every imported delegate's nominal name would rewrite
+/// <c>Func</c>/<c>Action</c> across the corpus for no benefit, so the rule is
+/// scoped to the members that actually collide. The
+/// <c>NonCollidingDelegates_StillRenderInArrowForm</c> test is the guard on
+/// that scoping.
+/// </para>
+/// </summary>
+public class Issue3841DelegateOverloadSetTranslationTests
+{
+    // Both the CLOSED shape (which gsc can also DISPATCH today) and the
+    // GENERIC shape from the migrated fixture that reported the GS0264
+    // (test/Interpreter.Tests/Issue2918InlineLambdaErasedReceiverEmittedOracleTests.cs).
+    private const string Source = @"
+using System;
+
+namespace Overloads
+{
+    public sealed class ClosedDelegateOverloads
+    {
+        public string Add(Predicate<int> callback) => ""pred"";
+
+        public string Add(Func<int, bool> callback) => ""func"";
+    }
+
+    public sealed class ClosedConstructorOverloads
+    {
+        public ClosedConstructorOverloads(Predicate<int> callback)
+        {
+            Kind = ""pred"";
+        }
+
+        public ClosedConstructorOverloads(Func<int, bool> callback)
+        {
+            Kind = ""func"";
+        }
+
+        public string Kind;
+    }
+
+    public sealed class Issue2948MethodDelegateOverloads<T>
+    {
+        public string Add(Predicate<T> callback) => ""pred"";
+
+        public string Add(Func<T, bool> callback) => ""func"";
+    }
+
+    public sealed class Issue2948ConstructorDelegateOverloads<T>
+    {
+        public Issue2948ConstructorDelegateOverloads(Predicate<T> callback)
+        {
+            Kind = ""pred"";
+        }
+
+        public Issue2948ConstructorDelegateOverloads(Func<T, bool> callback)
+        {
+            Kind = ""func"";
+        }
+
+        public string Kind;
+    }
+
+    public sealed class NonCollidingDelegates
+    {
+        public int Length(Func<string, int> length)
+        {
+            return length(""x"");
+        }
+
+        public void Sink(Action<string> sink)
+        {
+            sink(""y"");
+        }
+
+        public bool Test(Predicate<string> test)
+        {
+            return test(""z"");
+        }
+
+        public string Both(Predicate<string> test, Func<string, int> length)
+        {
+            return test(""z"").ToString() + length(""x"").ToString();
+        }
+    }
+
+    public static class Program
+    {
+        public static bool Always(int value)
+        {
+            return true;
+        }
+
+        public static void Main()
+        {
+            var methods = new ClosedDelegateOverloads();
+            Predicate<int> predicate = Always;
+            Func<int, bool> function = Always;
+            Console.WriteLine(methods.Add(predicate));
+            Console.WriteLine(methods.Add(function));
+            Console.WriteLine(new ClosedConstructorOverloads(predicate).Kind);
+            Console.WriteLine(new ClosedConstructorOverloads(function).Kind);
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// The colliding method overload set keeps both nominal delegate names, so
+    /// the two members no longer print the same signature.
+    /// </summary>
+    [Fact]
+    public void CollidingMethodOverloadSet_KeepsNominalDelegateNames()
+    {
+        string rendered = Render();
+
+        Assert.Contains("Add(callback Predicate[int32])", rendered, StringComparison.Ordinal);
+        Assert.Contains("Add(callback Func[int32, bool])", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Add(callback (int32) -> bool)", rendered, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The same for the <c>.ctor</c> shape, which is the second of the two
+    /// fingerprints this issue split out of #3837.
+    /// </summary>
+    [Fact]
+    public void CollidingConstructorOverloadSet_KeepsNominalDelegateNames()
+    {
+        string rendered = Render();
+
+        Assert.Contains("init(callback Predicate[int32])", rendered, StringComparison.Ordinal);
+        Assert.Contains("init(callback Func[int32, bool])", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("init(callback (int32) -> bool)", rendered, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The generic shape from the migrated Interpreter.Tests fixture — the two
+    /// members that actually reported the <c>GS0264</c>. Its type argument is
+    /// an open <c>T</c>, so the collision rule must fire on the erased shapes
+    /// rather than on any closed type.
+    /// </summary>
+    [Fact]
+    public void GenericFixtureShape_KeepsNominalDelegateNames()
+    {
+        string rendered = Render();
+
+        Assert.Contains("Add(callback Predicate[T])", rendered, StringComparison.Ordinal);
+        Assert.Contains("Add(callback Func[T, bool])", rendered, StringComparison.Ordinal);
+        Assert.Contains("init(callback Predicate[T])", rendered, StringComparison.Ordinal);
+        Assert.Contains("init(callback Func[T, bool])", rendered, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The scoping guard. Delegate parameters that do NOT participate in a
+    /// colliding overload set keep ADR-0115 §B.8's arrow form — including a
+    /// <c>Predicate</c> and a <c>Func</c> on unrelated members and even side by
+    /// side in one signature. Without this, the fix would be a corpus-wide
+    /// readability regression rather than a targeted one.
+    /// </summary>
+    [Fact]
+    public void NonCollidingDelegates_StillRenderInArrowForm()
+    {
+        string rendered = Render();
+
+        Assert.Contains("Length(length (string) -> int32)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Sink(sink (string) -> void)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Test(test (string) -> bool)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Both(test (string) -> bool, length (string) -> int32)", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Predicate[string]", rendered, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing proof. Binding alone would pass a fix that preserved the
+    /// names but crossed the wires, so the translated program is compiled by
+    /// the real gsc and RUN: each call must reach the overload C# would have
+    /// reached.
+    /// <para>
+    /// Only the CLOSED shapes are exercised at run time. gsc cannot yet
+    /// DISPATCH the generic shape — <c>Add(Predicate[T])</c> vs
+    /// <c>Add(Func[T, bool])</c> on a substituted receiver reports
+    /// <c>GS0266</c> — which is a separate, already-filed gsc defect (#3874)
+    /// in applicability after generic substitution, not in the declaration
+    /// model. The generic shapes are still COMPILED here (the classes are
+    /// declared in the same program), which is what #3841 asked for.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void TranslatedProgram_DispatchesEachDelegateOverloadLikeCSharp()
+    {
+        string printed = Render();
+        (int exitCode, string stdout) = CompileAndRun(printed);
+
+        Assert.Equal(0, exitCode);
+        string[] lines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .ToArray();
+        Assert.True(
+            lines.SequenceEqual(new[] { "pred", "func", "pred", "func" }),
+            "wrong overload reached: [" + string.Join(", ", lines) + "]\n\nTranslated G#:\n" + printed);
+    }
+
+    private static string Render() => GSharpPrinter.Print(Translate(Source));
+
+    private static CompilationUnit Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Overloads.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return new CSharpToGSharpTranslator().TranslateDocument(document, context);
+    }
+
+    private static (int ExitCode, string Stdout) CompileAndRun(string printed)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(AppContext.BaseDirectory, "issue-3841-e2e", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            string gsPath = Path.Combine(workDir, "Program.gs");
+            File.WriteAllText(gsPath, printed);
+
+            string dllPath = Path.Combine(workDir, "Program.dll");
+            (int compileExit, string compileOut) = RunDotnet(
+                $"\"{compiler}\" /target:exe /out:\"{dllPath}\" \"{gsPath}\"");
+            Assert.True(
+                compileExit == 0 && !compileOut.Contains("error", StringComparison.OrdinalIgnoreCase),
+                "gsc must compile the translated program with zero errors. Output:\n" + compileOut
+                    + "\n\nTranslated G#:\n" + printed);
+
+            return RunDotnet($"\"{dllPath}\"");
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static (int ExitCode, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(psi)
+            ?? throw new InvalidOperationException("failed to start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string configuration in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(directory.FullName, "out", "bin", configuration, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a locked file must not fail the test.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Same.
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -994,7 +994,14 @@ public sealed partial class CSharpToGSharpTranslator
                     $"params collection of type '{parameterType}' has no gsc construction form.");
             }
 
-            GTypeReference type = this.typeMapper.Map(parameterType, this.context, symbol.Locations.FirstOrDefault());
+            // Issue #3841: routed through MapParameterType (not Map) so a
+            // delegate parameter keeps its nominal name when the arrow form
+            // would collide with a sibling overload's erased signature.
+            GTypeReference type = this.typeMapper.MapParameterType(
+                symbol,
+                parameterType,
+                this.context,
+                symbol.Locations.FirstOrDefault());
 
             // Issue #1072: a non-nullable reference/array parameter that is
             // null-checked or null-assigned in the method body is really nullable;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -994,14 +994,7 @@ public sealed partial class CSharpToGSharpTranslator
                     $"params collection of type '{parameterType}' has no gsc construction form.");
             }
 
-            // Issue #3841: routed through MapParameterType (not Map) so a
-            // delegate parameter keeps its nominal name when the arrow form
-            // would collide with a sibling overload's erased signature.
-            GTypeReference type = this.typeMapper.MapParameterType(
-                symbol,
-                parameterType,
-                this.context,
-                symbol.Locations.FirstOrDefault());
+            GTypeReference type = this.typeMapper.Map(parameterType, this.context, symbol.Locations.FirstOrDefault());
 
             // Issue #1072: a non-nullable reference/array parameter that is
             // null-checked or null-assigned in the method body is really nullable;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -2666,25 +2666,49 @@ public sealed class CSharpTypeMapper
         INamedTypeSymbol type,
         HashSet<INamedTypeSymbol> critical)
     {
-        List<IMethodSymbol> methods = type.GetMembers().OfType<IMethodSymbol>().ToList();
-        for (var i = 0; i < methods.Count; i++)
+        // Only same-name members can be an overload set, so the quadratic
+        // comparison below runs per NAME rather than per type — a type with
+        // hundreds of distinctly-named members costs nothing here.
+        var byName = new Dictionary<string, List<IMethodSymbol>>(StringComparer.Ordinal);
+        foreach (ISymbol member in type.GetMembers())
         {
-            for (var j = i + 1; j < methods.Count; j++)
+            if (member is IMethodSymbol method && method.Parameters.Length > 0)
             {
-                IMethodSymbol left = methods[i];
-                IMethodSymbol right = methods[j];
-                if (!string.Equals(left.Name, right.Name, StringComparison.Ordinal)
-                    || left.MethodKind != right.MethodKind
-                    || left.Arity != right.Arity
-                    || left.Parameters.Length != right.Parameters.Length
-                    || !ParametersEraseAlike(left, right))
+                if (!byName.TryGetValue(method.Name, out List<IMethodSymbol> bucket))
                 {
-                    continue;
+                    bucket = new List<IMethodSymbol>();
+                    byName[method.Name] = bucket;
                 }
 
-                for (var k = 0; k < left.Parameters.Length; k++)
+                bucket.Add(method);
+            }
+        }
+
+        foreach (List<IMethodSymbol> overloads in byName.Values)
+        {
+            if (overloads.Count < 2)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < overloads.Count; i++)
+            {
+                for (var j = i + 1; j < overloads.Count; j++)
                 {
-                    AddIfDistinctDelegates(left.Parameters[k].Type, right.Parameters[k].Type, critical);
+                    IMethodSymbol left = overloads[i];
+                    IMethodSymbol right = overloads[j];
+                    if (left.MethodKind != right.MethodKind
+                        || left.Arity != right.Arity
+                        || left.Parameters.Length != right.Parameters.Length
+                        || !ParametersEraseAlike(left, right))
+                    {
+                        continue;
+                    }
+
+                    for (var k = 0; k < left.Parameters.Length; k++)
+                    {
+                        AddIfDistinctDelegates(left.Parameters[k].Type, right.Parameters[k].Type, critical);
+                    }
                 }
             }
         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -148,6 +148,19 @@ public sealed class CSharpTypeMapper
 
     private Dictionary<CSharpCompilation, Dictionary<string, HashSet<string>>> sourceNestedSimpleNames;
 
+    /// <summary>
+    /// Issue #3841: the constructed delegate types whose CLR identity is
+    /// load-bearing in the compilation currently being translated, computed
+    /// once per compilation by <see cref="CollectIdentityCriticalDelegates(Compilation)"/>.
+    /// </summary>
+    private HashSet<INamedTypeSymbol> identityCriticalDelegates;
+
+    /// <summary>
+    /// Issue #3841: the compilation <see cref="identityCriticalDelegates"/> was
+    /// computed for; a different one recomputes the set.
+    /// </summary>
+    private Compilation identityCriticalDelegatesCompilation;
+
     private HashSet<string> sourceDeclaredTypeNames;
 
     /// <summary>
@@ -483,56 +496,6 @@ public sealed class CSharpTypeMapper
         }
 
         return this.Map(type, context, location);
-    }
-
-    /// <summary>
-    /// Issue #3841: maps a METHOD/CONSTRUCTOR PARAMETER's type, keeping a
-    /// delegate parameter's nominal name (<c>Predicate[T]</c>) instead of the
-    /// arrow form (<c>(T) -&gt; bool</c>) when — and only when — the arrow form
-    /// would give two members of the same overload set identical G# signatures.
-    /// <para>
-    /// Issue #2835 established that CLR delegates are nominally typed and
-    /// scoped identity preservation to SOURCE-declared delegates. That leaves
-    /// imported delegates erased, so a legal C# overload set such as
-    /// <c>Add(Predicate&lt;T&gt;)</c> / <c>Add(Func&lt;T, bool&gt;)</c> is
-    /// translated into two members with the same signature and gsc correctly
-    /// rejects the result with <c>GS0264</c>. gsc itself declares and
-    /// dispatches that overload set fine — the duplicate is manufactured here.
-    /// </para>
-    /// <para>
-    /// Preserving every imported delegate's nominal name would rewrite
-    /// <c>Func</c>/<c>Action</c> across the whole corpus for no benefit, so the
-    /// rule is scoped to the colliding members: a parameter keeps its nominal
-    /// delegate name only when some sibling overload's parameters erase to the
-    /// same arrow shape at every position.
-    /// </para>
-    /// </summary>
-    /// <param name="parameter">The parameter symbol being translated.</param>
-    /// <param name="parameterType">
-    /// The type to map. Normally <c>parameter.Type</c>; for a variadic
-    /// (<c>params T[]</c>) parameter the caller passes the ELEMENT type
-    /// instead, in which case no collision rule applies.
-    /// </param>
-    /// <param name="context">The translation context that accumulates diagnostics.</param>
-    /// <param name="location">The originating C# source location for diagnostics.</param>
-    /// <returns>The canonical G# type reference for the parameter.</returns>
-    public GTypeReference MapParameterType(
-        IParameterSymbol parameter,
-        ITypeSymbol parameterType,
-        TranslationContext context,
-        Location location)
-    {
-        if (parameter != null
-            && SymbolEqualityComparer.Default.Equals(parameter.Type, parameterType)
-            && parameterType is INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: not null }
-            && OverloadSetErasesToDuplicate(parameter))
-        {
-            // MapEventType is the existing identity-preserving entry point
-            // (an event's handler type is ABI-sensitive for the same reason).
-            return this.MapEventType(parameterType, context, location);
-        }
-
-        return this.Map(parameterType, context, location);
     }
 
     /// <summary>
@@ -1525,9 +1488,17 @@ public sealed class CSharpTypeMapper
             // reasoning `MapEventType` already applies to an event's own handler
             // type, now extended to every type position. Imported/BCL delegates
             // keep the arrow form.
+            //
+            // Issue #3841: ALSO except an imported delegate whose identity is
+            // load-bearing in this compilation — one that discriminates an
+            // overload set the arrow form would collapse into a single G#
+            // signature (`Add(Predicate<T>)` / `Add(Func<T, bool>)`, GS0264).
+            // Scoped to the exact CONSTRUCTED delegate types involved, so every
+            // other Func/Action keeps the arrow form. See
+            // IsIdentityCriticalDelegate.
             if (named.TypeKind == TypeKind.Delegate && named.DelegateInvokeMethod != null)
             {
-                if (IsSourceDeclaredDelegate(named))
+                if (IsSourceDeclaredDelegate(named) || this.IsIdentityCriticalDelegate(named, context))
                 {
                     return named.IsGenericType
                         ? new NamedTypeReference(
@@ -2610,40 +2581,137 @@ public sealed class CSharpTypeMapper
     }
 
     /// <summary>
-    /// Issue #3841: whether <paramref name="parameter"/>'s owning member has a
-    /// sibling in the same overload set whose parameters erase to the SAME G#
-    /// arrow shape at every position — i.e. whether printing the arrow form
-    /// here would manufacture a duplicate signature (GS0264 / duplicate
-    /// <c>init</c>).
+    /// Issue #3841: whether <paramref name="named"/> is a delegate type whose
+    /// IDENTITY is load-bearing somewhere in the compilation being translated,
+    /// i.e. it appears in a parameter position of an overload set that would
+    /// otherwise erase to one G# signature (<c>Add(Predicate&lt;T&gt;)</c> /
+    /// <c>Add(Func&lt;T, bool&gt;)</c>). Such a delegate keeps its nominal name
+    /// in EVERY type position within that compilation.
+    /// <para>
+    /// The set is keyed on the CONSTRUCTED type, not the definition: a
+    /// compilation with a colliding <c>Func&lt;int, bool&gt;</c> overload keeps
+    /// <c>Func[int32, bool]</c> nominal, while every other <c>Func</c>
+    /// instantiation in that same compilation still renders in ADR-0115 §B.8
+    /// arrow form. That is what keeps this from being a corpus-wide
+    /// readability regression.
+    /// </para>
+    /// <para>
+    /// The whole compilation is in scope (not just the colliding declarations)
+    /// because the identity has to survive on the VALUE side too. Fixing only
+    /// the declarations turns "does not compile (GS0264)" into "compiles and
+    /// reaches the wrong overload": a local written
+    /// <c>Predicate&lt;int&gt; p = Always;</c> that erased to
+    /// <c>(int32) -&gt; bool</c> makes gsc pick the <c>Func</c> member for both
+    /// calls — verified by the executing regression test.
+    /// </para>
     /// </summary>
-    /// <param name="parameter">The parameter symbol being translated.</param>
-    /// <returns><see langword="true"/> when the overload set collides after erasure.</returns>
-    private static bool OverloadSetErasesToDuplicate(IParameterSymbol parameter)
+    /// <param name="named">The candidate delegate type.</param>
+    /// <param name="context">The translation context that owns the compilation.</param>
+    /// <returns><see langword="true"/> when the delegate's identity is load-bearing.</returns>
+    private bool IsIdentityCriticalDelegate(INamedTypeSymbol named, TranslationContext context)
     {
-        if (parameter.ContainingSymbol is not IMethodSymbol method
-            || method.ContainingType is not INamedTypeSymbol containingType)
+        if (context?.Compilation == null)
         {
             return false;
         }
 
-        foreach (ISymbol candidate in containingType.GetMembers(method.Name))
+        if (!ReferenceEquals(this.identityCriticalDelegatesCompilation, context.Compilation))
         {
-            if (candidate is not IMethodSymbol sibling
-                || SymbolEqualityComparer.Default.Equals(sibling, method)
-                || sibling.MethodKind != method.MethodKind
-                || sibling.Arity != method.Arity
-                || sibling.Parameters.Length != method.Parameters.Length)
+            this.identityCriticalDelegatesCompilation = context.Compilation;
+            this.identityCriticalDelegates = CollectIdentityCriticalDelegates(context.Compilation);
+        }
+
+        return this.identityCriticalDelegates.Contains(named);
+    }
+
+    /// <summary>
+    /// Issue #3841: walks every type declared in <paramref name="compilation"/>
+    /// and collects the delegate types that discriminate an otherwise-colliding
+    /// overload set. See <see cref="IsIdentityCriticalDelegate"/>.
+    /// </summary>
+    /// <param name="compilation">The compilation being translated.</param>
+    /// <returns>The constructed delegate types whose identity must be preserved.</returns>
+    private static HashSet<INamedTypeSymbol> CollectIdentityCriticalDelegates(Compilation compilation)
+    {
+        var critical = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var pending = new Stack<INamespaceOrTypeSymbol>();
+        pending.Push(compilation.Assembly.GlobalNamespace);
+        while (pending.Count > 0)
+        {
+            INamespaceOrTypeSymbol current = pending.Pop();
+            foreach (ISymbol member in current.GetMembers())
             {
-                continue;
+                if (member is INamespaceOrTypeSymbol nested and (INamespaceSymbol or INamedTypeSymbol))
+                {
+                    pending.Push(nested);
+                }
             }
 
-            if (ParametersEraseAlike(method, sibling))
+            if (current is INamedTypeSymbol type)
             {
-                return true;
+                CollectIdentityCriticalDelegates(type, critical);
             }
         }
 
-        return false;
+        return critical;
+    }
+
+    /// <summary>
+    /// Issue #3841: adds <paramref name="type"/>'s erasure-colliding delegate
+    /// parameter types to <paramref name="critical"/>.
+    /// </summary>
+    /// <param name="type">The declared type to inspect.</param>
+    /// <param name="critical">The accumulating set.</param>
+    private static void CollectIdentityCriticalDelegates(
+        INamedTypeSymbol type,
+        HashSet<INamedTypeSymbol> critical)
+    {
+        List<IMethodSymbol> methods = type.GetMembers().OfType<IMethodSymbol>().ToList();
+        for (var i = 0; i < methods.Count; i++)
+        {
+            for (var j = i + 1; j < methods.Count; j++)
+            {
+                IMethodSymbol left = methods[i];
+                IMethodSymbol right = methods[j];
+                if (!string.Equals(left.Name, right.Name, StringComparison.Ordinal)
+                    || left.MethodKind != right.MethodKind
+                    || left.Arity != right.Arity
+                    || left.Parameters.Length != right.Parameters.Length
+                    || !ParametersEraseAlike(left, right))
+                {
+                    continue;
+                }
+
+                for (var k = 0; k < left.Parameters.Length; k++)
+                {
+                    AddIfDistinctDelegates(left.Parameters[k].Type, right.Parameters[k].Type, critical);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Issue #3841: records a pair of DISTINCT delegate types that erase to the
+    /// same arrow. Positions where the two overloads agree exactly carry no
+    /// identity burden and are left alone.
+    /// </summary>
+    /// <param name="left">The first overload's parameter type.</param>
+    /// <param name="right">The second overload's parameter type.</param>
+    /// <param name="critical">The accumulating set.</param>
+    private static void AddIfDistinctDelegates(
+        ITypeSymbol left,
+        ITypeSymbol right,
+        HashSet<INamedTypeSymbol> critical)
+    {
+        if (SymbolEqualityComparer.Default.Equals(left, right)
+            || left is not INamedTypeSymbol { TypeKind: TypeKind.Delegate } leftDelegate
+            || right is not INamedTypeSymbol { TypeKind: TypeKind.Delegate } rightDelegate)
+        {
+            return;
+        }
+
+        critical.Add(leftDelegate);
+        critical.Add(rightDelegate);
     }
 
     /// <summary>
@@ -2655,6 +2723,7 @@ public sealed class CSharpTypeMapper
     /// <returns><see langword="true"/> when the two erase to one signature.</returns>
     private static bool ParametersEraseAlike(IMethodSymbol left, IMethodSymbol right)
     {
+        var sawDelegateDifference = false;
         for (var i = 0; i < left.Parameters.Length; i++)
         {
             IParameterSymbol a = left.Parameters[i];
@@ -2665,9 +2734,14 @@ public sealed class CSharpTypeMapper
             {
                 return false;
             }
+
+            sawDelegateDifference |= !SymbolEqualityComparer.Default.Equals(a.Type, b.Type);
         }
 
-        return true;
+        // Two members that agree at every position are not an overload set at
+        // all (C# would have rejected them); only a difference that erasure
+        // hides makes this collision cs2gs's to repair.
+        return sawDelegateDifference;
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -486,6 +486,56 @@ public sealed class CSharpTypeMapper
     }
 
     /// <summary>
+    /// Issue #3841: maps a METHOD/CONSTRUCTOR PARAMETER's type, keeping a
+    /// delegate parameter's nominal name (<c>Predicate[T]</c>) instead of the
+    /// arrow form (<c>(T) -&gt; bool</c>) when — and only when — the arrow form
+    /// would give two members of the same overload set identical G# signatures.
+    /// <para>
+    /// Issue #2835 established that CLR delegates are nominally typed and
+    /// scoped identity preservation to SOURCE-declared delegates. That leaves
+    /// imported delegates erased, so a legal C# overload set such as
+    /// <c>Add(Predicate&lt;T&gt;)</c> / <c>Add(Func&lt;T, bool&gt;)</c> is
+    /// translated into two members with the same signature and gsc correctly
+    /// rejects the result with <c>GS0264</c>. gsc itself declares and
+    /// dispatches that overload set fine — the duplicate is manufactured here.
+    /// </para>
+    /// <para>
+    /// Preserving every imported delegate's nominal name would rewrite
+    /// <c>Func</c>/<c>Action</c> across the whole corpus for no benefit, so the
+    /// rule is scoped to the colliding members: a parameter keeps its nominal
+    /// delegate name only when some sibling overload's parameters erase to the
+    /// same arrow shape at every position.
+    /// </para>
+    /// </summary>
+    /// <param name="parameter">The parameter symbol being translated.</param>
+    /// <param name="parameterType">
+    /// The type to map. Normally <c>parameter.Type</c>; for a variadic
+    /// (<c>params T[]</c>) parameter the caller passes the ELEMENT type
+    /// instead, in which case no collision rule applies.
+    /// </param>
+    /// <param name="context">The translation context that accumulates diagnostics.</param>
+    /// <param name="location">The originating C# source location for diagnostics.</param>
+    /// <returns>The canonical G# type reference for the parameter.</returns>
+    public GTypeReference MapParameterType(
+        IParameterSymbol parameter,
+        ITypeSymbol parameterType,
+        TranslationContext context,
+        Location location)
+    {
+        if (parameter != null
+            && SymbolEqualityComparer.Default.Equals(parameter.Type, parameterType)
+            && parameterType is INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: not null }
+            && OverloadSetErasesToDuplicate(parameter))
+        {
+            // MapEventType is the existing identity-preserving entry point
+            // (an event's handler type is ABI-sensitive for the same reason).
+            return this.MapEventType(parameterType, context, location);
+        }
+
+        return this.Map(parameterType, context, location);
+    }
+
+    /// <summary>
     /// Issue #2282: maps a C# anonymous type (<c>new { A = 1, B = "x" }</c>) to
     /// a synthesized G# <c>data class</c> whose primary-constructor parameters
     /// carry the SAME member names, instead of the earlier positional-tuple
@@ -2557,6 +2607,111 @@ public sealed class CSharpTypeMapper
     {
         INamedTypeSymbol definition = named.OriginalDefinition ?? named;
         return definition.Locations.Any(l => l.IsInSource);
+    }
+
+    /// <summary>
+    /// Issue #3841: whether <paramref name="parameter"/>'s owning member has a
+    /// sibling in the same overload set whose parameters erase to the SAME G#
+    /// arrow shape at every position — i.e. whether printing the arrow form
+    /// here would manufacture a duplicate signature (GS0264 / duplicate
+    /// <c>init</c>).
+    /// </summary>
+    /// <param name="parameter">The parameter symbol being translated.</param>
+    /// <returns><see langword="true"/> when the overload set collides after erasure.</returns>
+    private static bool OverloadSetErasesToDuplicate(IParameterSymbol parameter)
+    {
+        if (parameter.ContainingSymbol is not IMethodSymbol method
+            || method.ContainingType is not INamedTypeSymbol containingType)
+        {
+            return false;
+        }
+
+        foreach (ISymbol candidate in containingType.GetMembers(method.Name))
+        {
+            if (candidate is not IMethodSymbol sibling
+                || SymbolEqualityComparer.Default.Equals(sibling, method)
+                || sibling.MethodKind != method.MethodKind
+                || sibling.Arity != method.Arity
+                || sibling.Parameters.Length != method.Parameters.Length)
+            {
+                continue;
+            }
+
+            if (ParametersEraseAlike(method, sibling))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3841: whether two same-name, same-arity members' parameter lists
+    /// print identically in G# once delegate types are erased to arrow form.
+    /// </summary>
+    /// <param name="left">The first member.</param>
+    /// <param name="right">The second member.</param>
+    /// <returns><see langword="true"/> when the two erase to one signature.</returns>
+    private static bool ParametersEraseAlike(IMethodSymbol left, IMethodSymbol right)
+    {
+        for (var i = 0; i < left.Parameters.Length; i++)
+        {
+            IParameterSymbol a = left.Parameters[i];
+            IParameterSymbol b = right.Parameters[i];
+            if (a.RefKind != b.RefKind
+                || a.IsParams != b.IsParams
+                || !TypesEraseAlike(a.Type, b.Type))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3841: whether two C# types render as the SAME G# type once
+    /// delegate types are erased to their arrow form. Identical types trivially
+    /// qualify; two distinct delegate types qualify when their invoke
+    /// signatures agree position by position (this is exactly what
+    /// <see cref="MapDelegate"/> prints), which is how <c>Predicate&lt;T&gt;</c>
+    /// and <c>Func&lt;T, bool&gt;</c> collide.
+    /// </summary>
+    /// <param name="left">The first type.</param>
+    /// <param name="right">The second type.</param>
+    /// <returns><see langword="true"/> when both erase to one G# spelling.</returns>
+    private static bool TypesEraseAlike(ITypeSymbol left, ITypeSymbol right)
+    {
+        if (SymbolEqualityComparer.Default.Equals(left, right))
+        {
+            return true;
+        }
+
+        if (left is not INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: not null } leftDelegate
+            || right is not INamedTypeSymbol { TypeKind: TypeKind.Delegate, DelegateInvokeMethod: not null } rightDelegate)
+        {
+            return false;
+        }
+
+        IMethodSymbol leftInvoke = leftDelegate.DelegateInvokeMethod;
+        IMethodSymbol rightInvoke = rightDelegate.DelegateInvokeMethod;
+        if (leftInvoke.Parameters.Length != rightInvoke.Parameters.Length
+            || !TypesEraseAlike(leftInvoke.ReturnType, rightInvoke.ReturnType))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < leftInvoke.Parameters.Length; i++)
+        {
+            if (leftInvoke.Parameters[i].RefKind != rightInvoke.Parameters[i].RefKind
+                || !TypesEraseAlike(leftInvoke.Parameters[i].Type, rightInvoke.Parameters[i].Type))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private ArrowTypeReference MapDelegate(IMethodSymbol invoke, TranslationContext context, Location location)


### PR DESCRIPTION
Fixes #3841. Fixes #3883.

Two defects that both affect ordinary code, not only the migration corpus. They
share no root cause — one is cs2gs type mapping, the other gsc entry-point
emit — but both were found behind masking diagnostics on #3501.

## #3841 — cs2gs manufactured the duplicate signature (no ADR needed)

The issue was filed as a G# type-system gap. It is not one, and the
re-diagnosis on the issue is confirmed: gsc already declares AND dispatches a
`Predicate[int32]` / `Func[int32, bool]` overload set correctly.

`CSharpTypeMapper` applied #2835's nominal-delegate-identity rule only to
SOURCE-declared delegates, so imported ones (`Predicate`, `Func`) still erased
to the arrow form — and a legal C# overload set became two members with one G#
signature, which gsc correctly rejected with `GS0264`.

The fix preserves nominal identity only where erasure is load-bearing: a
per-compilation set of the CONSTRUCTED delegate types that discriminate an
overload set the arrow form would collapse. Every other `Func`/`Action` keeps
ADR-0115 §B.8 arrow form; `NonCollidingDelegates_StillRenderInArrowForm` is the
guard on that scoping.

**Scoping the fix to the DECLARATIONS alone was not enough**, and the executing
test is what caught it: with only the declaration sites repaired, a local
written `Predicate<int> p = Always;` still erased to `(int32) -> bool`, gsc
picked the `Func` member for BOTH calls, and the program compiled, ILVerified
and printed `func func func func` instead of `pred func pred func`. That is
strictly worse than the `GS0264` it replaced. The rule therefore covers every
type position in a compilation that contains a colliding overload set.

gsc still cannot DISPATCH the generic shape (`Add(Predicate[T])` vs
`Add(Func[T, bool])` on a substituted receiver reports `GS0266`); that is the
separately-filed #3874, in applicability after generic substitution, not in the
declaration model. The declaration side — what #3841 is about — is clear.

## #3883 — gsc erased the Task from an `async func Main`

Two independent halves:

1. `Binder.ResolveEntryPoint` scanned for a static `Main` even under
   `/target:library`, and the emitter then rewrote that method's own signature
   to the CLR entry-point shape. A library now resolves no entry point at all.
   (TLS in a library keeps its ADR-0066 D4 recovery shape: GS0285 and a
   synthesized `<Main>$`.)
2. For an executable, the authored `Main` was itself rewritten. It now keeps
   its `Task<T>` and a SEPARATE synthesized `<Main>$` stub carries the CLR
   entry-point shape and drives the task synchronously — csc's shape.

The stub is emitted on the SAME type as the authored `Main`, not on the
package's `<Program>`: its body is a second async kickoff over a state machine
that is a private nested type of that class, and a `<Program>`-hosted stub dies
at run time with `FieldAccessException`. That was found by running the program,
not by compiling it.

## Tests

All executing, all cross-assembly where the defect requires it.

- `test/Compiler.Tests/Issue3883AsyncMainMetadataTests.cs` — 6 tests: reflection
  over the emitted metadata plus compile + ILVerify + RUN. The discriminating
  one is `ConsumerInAnotherAssembly_CanAwaitTheLibrarysAsyncMain`; the
  same-assembly path binds clean and hides the defect entirely.
- `tools/cs2gs/Cs2Gs.Tests/Issue3841DelegateOverloadSetTranslationTests.cs` —
  5 tests, including `TranslatedProgram_DispatchesEachDelegateOverloadLikeCSharp`
  (translate → real gsc → run → assert each call reached the overload C# would
  have reached) and the arrow-form scoping guard.

Failing-on-`origin/main` proof and anti-vacuity guard rails are in the PR
discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
