### PR TITLE
bench: the concurrency benchmark could not run, in three ways

### DIFF
--- a/.github/workflows/concurrency-bench.yml
+++ b/.github/workflows/concurrency-bench.yml
@@ -60,8 +60,12 @@ jobs:
 
       # Release on both sides is normative, not a preference: tiered JIT
       # depresses cold Debug numbers by 2-3x and a Debug comparison is invalid.
-      - name: Build (Release)
-        run: dotnet build src/Compiler src/Sdk/Gsharp.Extensions -c Release
+      # Two steps because `dotnet build` takes one project (MSB1008).
+      - name: Build gsc (Release)
+        run: dotnet build src/Compiler -c Release
+
+      - name: Build Gsharp.Extensions (Release)
+        run: dotnet build src/Sdk/Gsharp.Extensions -c Release
 
       - name: Verify the harness
         run: python3 build/verify-concurrency-bench.py --smoke

--- a/bench/concurrency/gsharp/Bench.gs
+++ b/bench/concurrency/gsharp/Bench.gs
@@ -164,11 +164,17 @@ func selectPark() TimeSpan {
 
 // D10: one lock acquisition and one park amortized across a batch. The two
 // sizes exist because the curve is the point, not either number.
+//
+// BOTH sides batch, which is what makes this comparable to Go's `chunked`
+// rows: those send whole `[]int` chunks through the channel, so a run moves
+// N/size channel operations rather than N. A producer that sent one element at
+// a time would measure the producer, not the chunked transport, and would
+// report a ratio tens of times worse than the thing it claims to compare.
 func chunked(size int32, count int32) TimeSpan {
     let ch = chan[int32](1024)
     let sw = Stopwatch.StartNew()
     scope {
-        go produce(ch, count)
+        go produceBatched(ch, count, size)
         var seen = 0
         for batch in chunks(ch, size) {
             seen = seen + batch.Length
@@ -178,6 +184,31 @@ func chunked(size int32, count int32) TimeSpan {
     sw.Stop()
     return sw.Elapsed
 }
+
+// One buffer, reused: the point of the row is the transport, not the
+// allocator. `size` is at most `maxChunk` for both scenarios.
+func produceBatched(ch chan[int32], count int32, size int32) {
+    var chunk = [1024]int32{}
+    var sent = 0
+    while sent < count {
+        var i = 0
+        while i < size && sent + i < count {
+            chunk[i] = sent + i
+            i = i + 1
+        }
+
+        var offset = 0
+        while offset < i {
+            let slice = ReadOnlyMemory[int32](chunk, offset, i - offset)
+            offset = offset + ch.SendBatch(slice)
+        }
+
+        sent = sent + i
+    }
+
+    ch.Close()
+}
+
 
 func run(name string) {
     if name == "buf64" {

--- a/build/run-concurrency-bench.py
+++ b/build/run-concurrency-bench.py
@@ -55,6 +55,12 @@ def run_gsharp(launches: int, scenario: str | None, gsc: Path, extensions: Path,
         stdout=subprocess.DEVNULL,
     )
 
+    # gsc copies the channel runtime beside an emitted program, but not
+    # Gsharp.Extensions: the `chunks` scenarios call into it, so without this
+    # the program starts, prints its header, and dies on the first chunked
+    # round with a FileNotFoundException.
+    shutil.copy2(extensions, out / extensions.name)
+
     samples: dict[str, list[float]] = {}
     env = dict(os.environ)
     if scenario:
@@ -63,12 +69,19 @@ def run_gsharp(launches: int, scenario: str | None, gsc: Path, extensions: Path,
     for _ in range(launches):
         result = subprocess.run(
             ["dotnet", "exec", str(assembly)],
-            check=True,
             capture_output=True,
             text=True,
             cwd=out,
             env=env,
         )
+        if result.returncode != 0:
+            # A benchmark that cannot run is a failure worth reading, not a
+            # stack trace from subprocess about an exit code.
+            raise SystemExit(
+                f"benchmark run failed (exit {result.returncode}):\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+
         for line in result.stdout.splitlines():
             match = ROW.match(line.strip())
             if match:


### PR DESCRIPTION
The `concurrency-bench` workflow added in #3882 could not run. Its first `workflow_dispatch` on `main` failed at the build step, and two more failures were waiting behind it.

## Summary

- **The build step was malformed.** `dotnet build src/Compiler src/Sdk/Gsharp.Extensions -c Release` passes two projects to one invocation; MSBuild rejects that with `MSB1008: Only one project can be specified`. Split into two steps, with a comment saying why.
- **The program then died on the first chunked round.** `gsc` copies the channel runtime beside an emitted program but not `Gsharp.Extensions`, and the `chunks` scenarios call into it — `FileNotFoundException` after the header line. The runner stages it now. It also reports the child's stdout/stderr on a non-zero exit instead of raising a bare `CalledProcessError`, which is what made this take a second look.
- **The chunk rows were not comparing the same thing.** Go's `chunked` scenarios send whole `[]int` chunks through the channel — N/size channel operations for N elements — while the G# producer sent one element at a time and batched only on the receive side. That measures the producer rather than the chunked transport. Both sides batch now, via `SendBatch` over a reused buffer.

## Why the third one mattered

Before: `chunk1k` reported 266x Go. After: `chunk64` goes from 222 to 53 ns/op and its ratio from 37x to 7.6x. Nothing gates on these yet, but the first nightly would have written the old figure into `baseline.json` and `target_vs_go` as though it were a channel comparison, and P5-3 sets budgets from exactly that file.

The residual `chunk1k` gap is real rather than a scenario defect: ADR-0174 D10 hands each chunk a fresh array so the receiver may keep it, where Go passes a slice reference. That is the trade decision gate **G7** exists to measure, and it now can be.

## Verification

- `python3 build/run-concurrency-bench.py --launches 1 --go --check-baseline bench/concurrency/baseline.json` — all eight scenarios run against both runtimes, ratios reported, JSON written, gate reports "no ceiling recorded yet" for every row.
- `python3 build/verify-concurrency-bench.py --smoke` — OK.
- `gsc` compiles `Bench.gs` clean in Release.

**No numbers are recorded in this PR.** The runs above are single-launch on a busy machine, which the methodology explicitly says is not reportable. `baseline.json` medians stay null until a nightly writes them.

## Note on how this was missed

Every scenario I verified by hand for #3882 was run from a directory where I had copied `Gsharp.Extensions.dll` manually, so that check could not have caught the staging bug — it passed for a reason that did not hold inside the runner. The runner itself was only ever exercised on `closed-recv`, which does not touch `chunks`. Running it once across all eight scenarios, as this PR now does, was the missing step.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): not applicable — this is harness plumbing, and its witness is that the harness now runs end to end where it previously exited at the first step. `verify-concurrency-bench.py --smoke` guards the registry/program/runner agreement on every PR.
- [ ] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
