### PR TITLE
cs2gs: a variadic carrier's sink contract is its own, never a promoted one (#3886)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3886VariadicCarrierSinkContractTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3886VariadicCarrierSinkContractTests.cs
@@ -1,0 +1,229 @@
+// <copyright file="Issue3886VariadicCarrierSinkContractTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3886: the sink contract used to decide whether an argument needs a
+/// <c>!!</c> bridge must agree with the signature the DECLARATION side
+/// actually emits.
+/// <para>
+/// <c>TranslateParameter</c> gates issue #1072 promotion on <c>!variadic</c> —
+/// "variadic params are never null-compared as a whole" — so an ADR-0173
+/// variadic carrier is always emitted <c>...T</c> however much null evidence
+/// (<c>if (paths is null) throw</c>) the oblivious-nullability fixpoint
+/// recorded against that parameter. The call side asked
+/// <c>ShouldPromoteToNullableReference</c> about the same parameter anyway,
+/// concluded the sink had widened to <c>...T?</c>, and dropped the bridge —
+/// so a promoted <c>string?</c> reached a non-null <c>...string</c> slot bare.
+/// </para>
+/// <para>
+/// That is the whole migrated <c>test/Compiler.Tests</c> compile wall:
+/// <c>test/Shared/EmittedFixture.cs</c> declares
+/// <c>LoadTogether(params string[] assemblyPaths)</c> opening with
+/// <c>if (assemblyPaths is null) throw</c>, and the one call site in
+/// <c>Issue2525ImportedIndexerHidingEmitTests</c> passing a promoted
+/// <c>ContractsPath</c> produced GS0154 plus fifteen cascade
+/// "Cannot find function/member" errors on the error-typed result.
+/// </para>
+/// </summary>
+public class Issue3886VariadicCarrierSinkContractTests
+{
+    /// <summary>
+    /// The wall shape: an argument in the EXPANDED tail of a null-guarded
+    /// source-declared <c>params T[]</c> must still be bridged, and the
+    /// bridged program must run.
+    /// </summary>
+    [Fact]
+    public void ExpandedArgument_NullGuardedSourceParams_AssertsNonNullAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static string Join(params string[] parts)
+                    {
+                        if (parts is null)
+                        {
+                            throw new ArgumentNullException(nameof(parts));
+                        }
+
+                        return string.Join("|", parts);
+                    }
+                }
+
+                public sealed class Result
+                {
+                    public Result(string first)
+                    {
+                        First = first;
+                    }
+
+                    public string First { get; }
+                }
+
+                public static class Caller
+                {
+                    public static string Go(bool emit)
+                    {
+                        var first = emit ? "a" : null;
+                        var result = new Result(first);
+                        return Fixture.Join(result.First, "b");
+                    }
+                }
+            }
+            """);
+
+        // The evidence that the sink really is non-null: the declaration is a
+        // bare `...string` carrier, so the promoted `string?` argument needs
+        // the bridge.
+        Assert.Contains("func Join(parts ...string)", printed, StringComparison.Ordinal);
+        Assert.Contains("prop First string?", printed, StringComparison.Ordinal);
+        Assert.Contains("Fixture.Join(result.First!!, \"b\")", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go(true)", "a|b");
+    }
+
+    /// <summary>
+    /// The same defect through the DIRECT collection form
+    /// (<c>Join(paths)</c>, binding the params parameter itself rather than
+    /// its element): the emitted carrier is non-null, so a promoted
+    /// <c>[]string?</c> argument needs the bridge too.
+    /// </summary>
+    [Fact]
+    public void DirectCollectionArgument_NullGuardedSourceParams_AssertsNonNullAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static string Join(params string[] parts)
+                    {
+                        if (parts is null)
+                        {
+                            throw new ArgumentNullException(nameof(parts));
+                        }
+
+                        return string.Join("|", parts);
+                    }
+                }
+
+                public sealed class Bundle
+                {
+                    public Bundle(string[] parts)
+                    {
+                        Parts = parts;
+                    }
+
+                    public string[] Parts { get; }
+                }
+
+                public static class Caller
+                {
+                    public static string Go(bool emit)
+                    {
+                        var parts = emit ? new[] { "a", "b" } : null;
+                        var bundle = new Bundle(parts);
+                        return Fixture.Join(bundle.Parts);
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("func Join(parts ...string)", printed, StringComparison.Ordinal);
+        Assert.Contains("Fixture.Join(bundle.Parts!!)", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go(true)", "a|b");
+    }
+
+    /// <summary>
+    /// Precision guard: a genuinely non-null argument to the same null-guarded
+    /// variadic carrier gains no assertion. <c>!!</c> is a RUNTIME check in G#,
+    /// so a gratuitous one is a behaviour change, not a readability wart.
+    /// </summary>
+    [Fact]
+    public void ExpandedArgument_NonNullValue_StaysBare()
+    {
+        string printed = TranslateOblivious("""
+            using System;
+
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static string Join(params string[] parts)
+                    {
+                        if (parts is null)
+                        {
+                            throw new ArgumentNullException(nameof(parts));
+                        }
+
+                        return string.Join("|", parts);
+                    }
+                }
+
+                public static class Caller
+                {
+                    public static string Go(string first)
+                    {
+                        return Fixture.Join(first, "b");
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("Fixture.Join(first, \"b\")", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("first!!", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go(\"a\")", "a|b");
+    }
+
+    private static void AssertEvaluates(string printed, string expression, object expected)
+    {
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            printed + Environment.NewLine + expression);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(expected, result.Value);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            Microsoft.CodeAnalysis.NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -1302,12 +1302,47 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #3886: the DECLARATION side deliberately never promotes a
+            // variadic carrier — `TranslateParameter` gates promotion on
+            // `!variadic` because "variadic params are never null-compared as a
+            // whole" — so a `params T[]` parameter is always emitted `...T`,
+            // whatever null evidence (`if (paths is null) throw`, a body
+            // `paths == null` guard) the fixpoint recorded against it. Asking
+            // `ShouldPromoteToNullableReference` about that parameter HERE
+            // therefore reports a widening that the emitted G# signature does
+            // not have, and the sink-contract check silently suppresses the
+            // `!!` bridge every nullable argument to it needs. That is exactly
+            // the migrated test/Compiler.Tests wall: `EmittedFixture.
+            // LoadTogether(params string[] assemblyPaths)` opens with
+            // `if (assemblyPaths is null) throw`, so every expanded call site
+            // passing a promoted `string?` lost its bridge and produced GS0154
+            // (plus, in that file, fifteen cascade "cannot find function"
+            // errors on the error-typed result).
+            //
+            // Mirror the declaration rule: a variadic carrier's contract is
+            // whatever its own annotation says, never a promoted one.
+            if (IsVariadicCarrierParameter(targetSymbol))
+            {
+                return true;
+            }
+
             bool targetDeclaredInThisCompilation = targetSymbol?.DeclaringSyntaxReferences
                 .Any(reference => this.context.Compilation.ContainsSyntaxTree(reference.SyntaxTree)) == true;
 
             return !(targetDeclaredInThisCompilation
                 && this.ShouldPromoteToNullableReference(targetSymbol));
         }
+
+        // Issue #3886: whether <paramref name="symbol"/> is a parameter that
+        // `TranslateParameter` emits as an ADR-0173 variadic carrier (`...T` /
+        // `...List[T]`). Kept in lockstep with the `variadic` local there: only
+        // a genuine `params T[]` or a SUPPORTED params collection becomes a
+        // carrier — an unsupported shape (e.g. `params HashSet<T>`) gaps and
+        // keeps ordinary-parameter promotion.
+        private static bool IsVariadicCarrierParameter(ISymbol symbol) =>
+            symbol is IParameterSymbol { IsParams: true } parameter
+            && (parameter.Type is IArrayTypeSymbol
+                || IsSupportedParamsCollectionType(parameter.Type));
 
         // Issue #3865: true when <paramref name="targetSymbol"/> is a WRITE sink
         // (parameter, field or property) that exists only as CLR metadata and


### PR DESCRIPTION
Clears the migrated `test/Compiler.Tests` compile wall — **16 sites, 8
fingerprints, one root cause** — and files the two other defects the triage
turned up. Triage detail in #3886; `tools/cs2gs/selfmig-baseline.json` is
untouched.

## The wall was one error, not eight

Re-measured on `origin/main` @ `2b58cf48c` (nightly run 33819616178, shard 5).
Unchanged by #3871/#3875/#3878/#3881/#3884.

All 16 sites are in one file, one test method, a contiguous 19-line block:
`Issue2525ImportedIndexerHidingEmitTests.gs` lines 199-217. Line 199 is a real
GS0154; lines 201-217 are fifteen `Cannot find function/member` cascades on
the error-typed result of that call.

**The five "reflection" fingerprints (`GetType`, `GetMethod`,
`GetProperties`, `MetadataToken`, and the two the summary omitted,
`GetParameters` and `Invoke`) do not share a reflection mechanism. There is no
reflection defect.** Four-line proof, no reflection involved — filed as #3887:

```gs
func Go(maybe string?) int32 {
    let loaded = Fixture.Load(maybe)     // GS0154 — the only real error
    let first = loaded[0]
    return first.Length + first.IndexOf("x") + loaded.Length
}
```
```
(16,39): error GS0154: Parameter 'paths' requires a value of type 'string' but was given a value of type 'string?'.
(18,26): error GS0158: Cannot find member Length.
(18,41): error GS0159: Cannot find function IndexOf.
(18,63): error GS0158: Cannot find member Length.
```

## Root cause: a variadic carrier's sink contract

`TranslateParameter` deliberately never promotes a variadic carrier:

```csharp
// Issue #1072: ... (variadic params are never null-compared as a whole, so they are excluded).
if (!variadic && promoteNullability)
```

so `EmittedFixture.LoadTogether(params string[] assemblyPaths)` is always
emitted `func LoadTogether(assemblyPaths ...string)` — a non-null element —
however much null evidence exists. It opens with `if (assemblyPaths is null)
throw`, which IS evidence, so the fixpoint records the parameter as promoted.

The **call** side asked `ShouldPromoteToNullableReference` about that same
parameter (`TargetWillRemainNonNullableReference`), concluded the sink had
widened to `...string?`, and suppressed the `!!` bridge — including #3644's
expanded-params element bridge. A promoted `result.ContractsPath` (`string?`)
then reached the non-null slot bare.

The `is null` guard is the entire difference, on identical declarations:

| guard | emitted declaration | emitted call site |
|---|---|---|
| present | `func LoadTogether(assemblyPaths ...string)` | `LoadTogether(result.ContractsPath, output)` — **GS0154** |
| absent | `func LoadTogether(assemblyPaths ...string)` | `LoadTogether(result.ContractsPath!!, output)` — correct |

**Not #3859 residue**, despite sharing the parameter and the guard. #3859
touched `Patterns.cs` and `Statements.cs` (folding the emitted `args is null`
guard); it did not touch the promotion fixpoint or the sink-contract check,
and could neither have introduced nor fixed this. It cleared the GS0523
fingerprint from this same app — 9 fingerprints became 8 — and left this one
untouched, which is what the record shows.

#3644's own coverage missed it because its fixture calls `Path.Combine`, an
**imported** params target: `targetDeclaredInThisCompilation` is false there,
so the promotion clause is never reached. The defect needs a
**source-declared** params parameter — exactly what a `<Compile Include>`-
linked shared test fixture is.

## Fix

Mirror the declaration rule on the sink side. The only behavioural delta is
the promoted-source-declared-params case:

| target | before | after |
|---|---|---|
| imported params (oblivious) | no bridge | no bridge (earlier `IsImportedObliviousNullableTarget` still wins) |
| imported params (annotated) | bridge | bridge |
| source params, not promoted | bridge | bridge |
| source params, promoted | **no bridge — the bug** | **bridge** |

This also repairs the DIRECT collection form (`LoadTogether(paths)`, binding
the parameter itself), which had the same suppression.

## Test evidence

`tools/cs2gs/Cs2Gs.Tests/Issue3886VariadicCarrierSinkContractTests.cs`, three
tests. Each one **executes**: translate → `AssertBinds` → `EmittedOracle.
Evaluate` compiles the emitted G# and runs it, asserting the returned value.
Binding alone has passed a wrong fix six times on this effort, so no test here
stops at binding.

| test | on `origin/main` | with this PR |
|---|---|---|
| `ExpandedArgument_NullGuardedSourceParams_AssertsNonNullAndRuns` | **fails** (no `!!`; emitted G# does not bind) | passes, evaluates `"a\|b"` |
| `DirectCollectionArgument_NullGuardedSourceParams_AssertsNonNullAndRuns` | **fails** (same, direct-collection shape) | passes, evaluates `"a\|b"` |
| `ExpandedArgument_NonNullValue_StaysBare` | passes (anti-vacuity guard rail) | passes, evaluates `"a\|b"` |

The third is the precision guard and passes on main too: `!!` is a **runtime**
check in G#, so a gratuitous one is a behaviour change, not a readability
wart. It asserts a genuinely non-null argument to the same null-guarded
carrier stays bare.

No diagnostic was weakened — the fix makes cs2gs emit an assertion the C#
contract already required, and gsc's GS0154 is correct both before and after.

## Blast radius

`EmittedFixture.LoadTogether` is the only non-test-fixture `params` parameter
in the repository with a null guard, so the corpus-wide `!!` delta is a
handful of sites. `nullAssertionCeiling` is unaffected.

## Also filed, not fixed here

- **#3887** — gsc reports `Cannot find member/function` on an error-typed
  receiver. 1 real error presented as 16, and the cascade named the wrong
  subsystem. Fourth `Cannot find X` mask on this effort (#3842, #3880, #3883).
  Wants its own change with diagnostic-count tests.
- **#3888** — cs2gs never widens a params **element**, so an expanded `null`
  literal argument translates to `nil` against a `...T` carrier. Latent (no
  corpus site reaches it), pre-existing, and byte-identical before and after
  this PR.

## Unrelated observation

`test/Core.Tests` now **compiles clean** but fails test-parity with
`NO-TESTS-RAN` — xunit discovery throws `MissingMethodException: Void
System.AttributeUsageAttribute..ctor(Int32)` against the migrated assembly.
That is #3869's guard doing its job on a different (gsc emit) defect; not
touched here.

## Which commit each measurement used (#3882 note)

PR #3882 (ADR-0174 wave 2, +27,657/−5,096 over 416 files) merged while this
was in flight. Both sides of every measurement here are on **`2b58cf48c`**,
which predates it — the wall count from nightly 33819616178, and the
translator before/after. Nothing here straddles that merge.

#3882 is not a confound for this diagnosis:

- it does **not** touch `Issue2525ImportedIndexerHidingEmitTests.cs` or
  `test/Shared/EmittedFixture.cs` (`git diff 2b58cf48c..36a147f0f` on both is
  empty), so the 16 sites and their cause are unchanged;
- its one edit to `CSharpToGSharpTranslator.Constructors.cs` is
  `MapReturnType`'s `ValueTask` unwrap for `suspend func` — it does not touch
  the `!variadic && promoteNullability` gate this PR mirrors.

It *did* add ~745 lines to `test/Compiler.Tests`, so the app's total on the
next nightly may differ from 16 for reasons that are #3882's, not this PR's.
This branch is rebased onto `36a147f0f` and the 63 tests in the affected
families (#3886/#3644/#1072/#3865/#3676/#3501-residual) pass there.
