### PR TITLE
gsc: a nullable delegate source needs the null-guarded adaptation path

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs
@@ -155,23 +155,20 @@ internal sealed partial class MethodBodyEmitter
     }
 
     /// <summary>
-    /// Issue #2083: returns true when <paramref name="source"/> is a read of
-    /// a field-like event's compiler-synthesized backing field — the only
-    /// case, so far, where the emitter *knows* a statically non-nullable
-    /// delegate-typed source can genuinely be <c>null</c> at runtime (an
-    /// unsubscribed event's backing field is null even though the event's
-    /// declared type isn't nullable). Every other non-nullable source
-    /// (a plain local, parameter, or ordinary field) is expected to hold a
-    /// real delegate; if it doesn't, that is a null-safety bug the emitted
-    /// code should surface loudly rather than mask. Reached either through a
-    /// direct field access (<c>this.MyEvent</c>) or the implicit bare-name
-    /// field variable synthesized for in-class event reads (issue #1213);
-    /// both route through the same underlying <see cref="FieldSymbol"/>, and
-    /// smart-cast narrowing (<see cref="BoundFieldAccessExpression.NarrowedType"/>)
-    /// does not change which field is read.
+    /// Returns true when <paramref name="source"/> can legitimately contain a
+    /// null delegate: either its effective type is nullable, or it reads a
+    /// field-like event's compiler-synthesized backing field (which is null
+    /// before the first subscription despite its non-nullable declared type).
+    /// Smart-cast narrowing changes the effective type, so a guarded nullable
+    /// source remains on the branch-free non-null path.
     /// </summary>
     private static bool IsKnownLegitimateNullDelegateSource(BoundExpression source)
     {
+        if (source.Type is NullableTypeSymbol)
+        {
+            return true;
+        }
+
         return source switch
         {
             BoundFieldAccessExpression fieldAccess => fieldAccess.Field?.IsEventBackingField == true,
@@ -184,27 +181,20 @@ internal sealed partial class MethodBodyEmitter
     /// Issue #2066 / #2083: emits the shared <c>dup / ldvirtftn / newobj</c>
     /// delegate-to-delegate adaptation sequence.
     ///
-    /// When <see cref="IsKnownLegitimateNullDelegateSource"/> recognizes
-    /// <paramref name="source"/> as a case the emitter knows can legitimately
-    /// be <c>null</c> despite its non-nullable static type (currently: a
-    /// field-like event's backing field, e.g. an unsubscribed field-like
-    /// event snapshotted into a delegate-typed local), the sequence is
-    /// guarded so a <c>null</c> source flows through as <c>null</c> instead
-    /// of unconditionally rebuilding a delegate — without the guard,
+    /// When <see cref="IsKnownLegitimateNullDelegateSource"/> recognizes a
+    /// source that can legitimately be <c>null</c>, the sequence is guarded
+    /// so a <c>null</c> source flows through as <c>null</c> instead of
+    /// unconditionally rebuilding a delegate — without the guard,
     /// `ldvirtftn` resolves the (non-null) Invoke method pointer even over a
     /// `null` instance reference, and the subsequent `newobj` then throws
     /// <see cref="ArgumentException"/> at runtime ("Delegate to an instance
     /// method cannot have null 'this'") because the CLR delegate ctor
     /// requires a non-null target for an instance-method pointer.
     ///
-    /// For every other source, that same throw is the *desired* pre-#2079
-    /// fail-fast behavior: a plain non-nullable local/parameter/field that is
-    /// unexpectedly null at runtime indicates a null-safety bug (e.g. a
-    /// nullability escape via interop), and silently producing a null
-    /// delegate instead of throwing would mask it. So the guard is only
-    /// emitted for the known-legitimate-null sources; every other case emits
-    /// the plain (unguarded, branch-free) sequence, matching prior behavior
-    /// and avoiding the extra branch/label on the common non-nullable path.
+    /// For every other source, that same throw is the desired fail-fast
+    /// behavior: a non-nullable local/parameter/field that is unexpectedly
+    /// null at runtime indicates a null-safety bug. Every non-nullable case
+    /// therefore keeps the plain branch-free sequence.
     ///
     /// The null path (guarded case only) must not leave the un-adapted
     /// source value (statically typed as the *source* delegate type, e.g.

--- a/test/Compiler.Tests/Emit/Issue2083NonEventNullDelegateSourceEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2083NonEventNullDelegateSourceEmitTests.cs
@@ -24,6 +24,30 @@ namespace GSharp.Compiler.Tests.Emit;
 public class Issue2083NonEventNullDelegateSourceEmitTests
 {
     [Fact]
+    public void NullableFunctionLocal_NullAtRuntime_AdaptsToNullableNamedDelegate()
+    {
+        var source = """
+            package Issue2083Pkg
+            import System
+
+            delegate Handler() void;
+
+            func UseHandler(h Handler?) {
+                h?()
+                Console.WriteLine("ok")
+            }
+
+            let missing (() -> void)? = nil
+            UseHandler(missing)
+            """;
+
+        var (exitCode, stdout, stderr) = CompileAndRun(source);
+        Assert.Equal(0, exitCode);
+        Assert.Equal($"ok{Environment.NewLine}", stdout);
+        Assert.Equal(string.Empty, stderr);
+    }
+
+    [Fact]
     public void NonEventNonNullableFieldSource_NullAtRuntime_ThrowsInsteadOfSilentlyNull()
     {
         var source = """


### PR DESCRIPTION
Fixes #3893

## Summary

- Admit any source whose effective type is `NullableTypeSymbol` to the null-guarded delegate adaptation path, so a `T?` delegate holding `nil` flows through as `nil` instead of throwing `ArgumentException: Delegate to an instance method cannot have null 'this'`.
- Keep non-nullable sources on the plain branch-free sequence, preserving the #2083 fail-fast contract.
- Rewrite the doc comments on `IsKnownLegitimateNullDelegateSource` and `EmitNullGuardedDelegateToDelegateAdaptation`, which described only the event-backing-field case.

`ldvirtftn` resolves the `Invoke` pointer even over a `null` instance; the CLR delegate constructor is what throws, because an instance-method pointer requires a non-null target. The predicate previously matched on the *shape* of the source (is it a field-like event's backing field?) rather than its nullability, so an ordinary `T?` — for which `null` is a legitimate value — took the unguarded path.

No change needed for smart-cast narrowing: `BoundExpression.Type` already resolves to `NarrowedType ?? Variable.Type`, so a narrowed nullable keeps the branch-free path and the common case is unaffected.

## Verification

- **Release solution build** (`GSharp.sln`, `-c Release`): Build succeeded, **0 Warning(s), 0 Error(s)**.
- **Targeted suite** `Compiler.Tests --filter FullyQualifiedName~Issue2083NonEventNullDelegateSourceEmitTests`: **2 passed, 0 failed**.
- **Witness (ADR-0154)** — new test reverted against the pre-fix product hunk (`git checkout beb9d2fac~1 -- src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Closures.cs`), test file kept:

  | | pre-fix | post-fix |
  |---|---|---|
  | `NullableFunctionLocal_NullAtRuntime_AdaptsToNullableNamedDelegate` (new) | **FAIL** | PASS |
  | `NonEventNonNullableFieldSource_NullAtRuntime_ThrowsInsteadOfSilentlyNull` (existing) | PASS | PASS |
  | totals | `Failed: 1, Passed: 1` | `Failed: 0, Passed: 2` |

  The new test discriminates, and the existing #2083 guard test passes in both states — evidence the fail-fast contract is not regressed rather than merely asserted.
- **NOT RUN**: the full `Compiler.Tests` suite and the wider test matrix. The change is confined to one predicate in the delegate-adaptation emitter, and the Release solution build is clean; happy to run more if you want it before merge.
- **Corpus**: found via the Oahu corpus, which re-ran 15/15 apps green (translate / compile / ilverify / test-parity) on a compiler carrying this fix. Note the corpus never went red for this bug — the IL is verifiable and the mirror's tests pass; only running the app surfaced it.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): the new test fails on the pre-change code and passes with it, per the table above.
- [x] Self-review verdict recorded when one was run: MERGEABLE. One residual, not blocking — the corpus gates cannot catch a runtime-only emit defect of this shape; worth considering whether a corpus app should exercise a nil delegate, but that is a separate change and does not belong in this diff.
