### PR TITLE
bench: the benchmark workflow needs a full clone

### DIFF
--- a/.github/workflows/concurrency-bench.yml
+++ b/.github/workflows/concurrency-bench.yml
@@ -43,7 +43,13 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      # Nerdbank.GitVersioning walks history to compute the version height, so
+      # a shallow clone fails the build outright ("Shallow clone lacks the
+      # objects required to calculate version height"). Every other workflow
+      # here that builds the solution already passes fetch-depth: 0.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
`concurrency-bench` still cannot run on `main`. This is the one-line fix that missed #3890's merge.

## What happens today

Both attempts die in the first build step, before any benchmark code executes:

```
Nerdbank.GitVersioning.GitException: Shallow clone lacks the objects required
to calculate version height. Use full clones or clones with a history at least
as deep as the last version height resetting change.
```

- run [33827266655](https://github.com/DavidObando/gsharp/actions/runs/33827266655) — `workflow_dispatch` on `main`
- run [33831122135](https://github.com/DavidObando/gsharp/actions/runs/33831122135) — the labelled PR run on #3890

`actions/checkout@v5` defaults to `fetch-depth: 1`, and NBGV walks history to compute the version height. Every other workflow here that builds the solution already passes `fetch-depth: 0`; this one did not.

## Why it is a separate PR

It was authored alongside #3890 but pushed after that PR was merged, so the squash took the earlier state. `origin/main`'s workflow still has the bare `actions/checkout@v5`.

## Standing back

This is the fourth defect in a workflow that had never been executed once, each only reachable after the previous was fixed:

1. `dotnet build` given two projects — `MSB1008` (#3890)
2. `Gsharp.Extensions` not staged beside the emitted program — `FileNotFoundException` (#3890)
3. chunk scenarios not comparing the same thing across runtimes (#3890)
4. shallow clone — this PR

A fifth, adjacent: the `bench:concurrency` label the pull-request path gates on did not exist in the repository, so that opt-in was unreachable. I created it and applied it to #3890, which is how run 33831122135 exists at all.

The honest lesson is that none of this was findable from unit tests or from running the Python runner locally. A new CI job needs one real execution before it is claimed to work.

## Verification

The change is three lines of YAML and cannot be verified locally. Label this PR `bench:concurrency` to make the workflow run on it — that is the whole point of the opt-in path, and it is now the only way to prove this before merge.

`python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): not applicable — CI configuration. The witness is the two linked runs failing at the checkout-dependent step, and a labelled run on this PR passing it.
- [ ] Self-review verdict recorded when one was run (MERGEABLE / BLOCKER / SHOULD-FIX / NIT), with residuals filed as issues rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
