### PR TITLE
bench: pin the JIT tier and add a NativeAOT row to the D11 concurrency benchmark

### DIFF
--- a/.github/workflows/concurrency-bench.yml
+++ b/.github/workflows/concurrency-bench.yml
@@ -43,7 +43,13 @@ jobs:
     timeout-minutes: 90
 
     steps:
+      # Nerdbank.GitVersioning walks history to compute the version height, so
+      # a shallow clone fails the build outright ("Shallow clone lacks the
+      # objects required to calculate version height"). Every other workflow
+      # here that builds the solution already passes fetch-depth: 0.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/concurrency-bench.yml
+++ b/.github/workflows/concurrency-bench.yml
@@ -14,6 +14,11 @@ name: concurrency-bench
 #   G# versus Go   — informational. It moves with the Go toolchain and the
 #                    machine, so it is reported and never gates.
 #
+# The G# side is measured twice: pinned-tier JIT (what a deployed program does)
+# and NativeAOT (what compares like-for-like with Go's ahead-of-time binary).
+# Each carries its own budget, because they regress for different reasons. See
+# the runner's docstring and issues #3901/#3902 for why the tier is pinned.
+#
 # Nightly by default. A PR can opt in with the `bench:concurrency` label when it
 # touches the runtime or the lowering; that run reports and does not gate,
 # because a shared CI runner is too noisy to fail a PR on.
@@ -61,6 +66,15 @@ jobs:
         with:
           go-version-file: bench/concurrency/go/go.mod
 
+      # ILC emits an object file and hands it to the platform linker, so the
+      # AOT row needs a toolchain the JIT row does not. Present on the current
+      # ubuntu image, installed explicitly so an image change fails loudly here
+      # rather than three steps later inside `dotnet publish`.
+      - name: Install NativeAOT prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang zlib1g-dev
+
       - name: Restore
         run: dotnet restore GSharp.sln --locked-mode
 
@@ -81,6 +95,7 @@ jobs:
           python3 build/run-concurrency-bench.py \
             --launches "${{ github.event.inputs.launches || '7' }}" \
             --go \
+            --aot \
             --json "$RUNNER_TEMP/concurrency.json" \
             --check-baseline bench/concurrency/baseline.json
         # A PR run reports; only the nightly gates.

--- a/bench/concurrency/README.md
+++ b/bench/concurrency/README.md
@@ -32,6 +32,7 @@ errata 12.
 | `gsharp/Bench.gs` | **The G# side.** Eight scenarios in the language itself, three in-process warm-up rounds, one `<name> ns_per_op <float>` line each. `GSHARP_BENCH_SCENARIO` runs one. |
 | `scenarios.json` | The registry: which G# scenario pairs with which Go row, and what each one measures. |
 | `baseline.json` | The recorded medians, ceilings and Go ratios. Written only by `--update-baseline`, never by hand. |
+| `aot/` | The NativeAOT measurement mode. Compiles no G# and holds no benchmark logic: it borrows the SDK's `PublishAot` pipeline and points ILC at the assembly gsc already emitted, so the AOT and JIT rows run byte-identical IL. |
 | `clr/` | C# baseline. Reproduces the exact call sequences the G# emitter produces today (`gs-*` rows), plus the CLR primitives ADR-0174 proposes (`best-*` rows). Kept as the spike reference now that the G# side exists. |
 | `go/` | Go baseline for the same scenarios. |
 
@@ -40,8 +41,9 @@ errata 12.
 ```sh
 # The paired run: builds the G# program, launches both sides several times,
 # reports medians with a bootstrap confidence interval, and checks the gate.
-python3 build/run-concurrency-bench.py --go --check-baseline bench/concurrency/baseline.json
+python3 build/run-concurrency-bench.py --go --aot --check-baseline bench/concurrency/baseline.json
 
+# Drop --aot while iterating: it adds a NativeAOT publish (minutes) per run.
 # One scenario, fewer launches, while iterating
 python3 build/run-concurrency-bench.py --scenario rendezvous --launches 3
 
@@ -68,15 +70,30 @@ These are not optional. ADR-0174 §D11 makes them normative because ignoring
 any one of them produced a wrong conclusion at least once during the original
 spike:
 
-1. **Warm up.** Tiered JIT depresses cold CLR numbers by **2–3×**. The CLR
-   harness runs three rounds and only round 3 is reportable. A CLR-vs-Go
-   comparison taken from round 1 is invalid.
+1. **Warm up, and pin the JIT tier.** Tiered JIT depresses cold CLR numbers by
+   **2–3×**. The harness runs three rounds and only round 3 is reportable — but
+   rounds are not sufficient on their own. The runtime's call-counting delay is
+   100 ms and restarts on every new JIT compilation, so a bench process that
+   keeps first-calling methods can exit before counting ever begins: the
+   scenario's own loop gets promoted by on-stack replacement while every method
+   it calls stays at Tier0. That is a real measurement this harness reported for
+   weeks, and it moved `select-ready` by **3.4×** between launches of an
+   unchanged binary (issue #3901). The runner therefore sets
+   `DOTNET_TC_CallCountingDelayMs=0` for the JIT mode. Do not remove it, and do
+   not substitute `DOTNET_TieredCompilation=0`, which also discards dynamic PGO.
 2. **Release build, both sides.**
 3. **Multiple process launches.** In-process repetition alone understates
    variance. Report a confidence interval, not a single number.
 4. **Pin and record both toolchains and the hardware class.** The reference
    numbers in ADR-0174 are .NET 10.0.11 / Go 1.27.0, Apple silicon, 18 cores.
-5. **Separate the two gates.** Within-runtime regression (G# against its own
+5. **Measure the G# side in both modes.** `--aot` adds a NativeAOT row beside
+   the pinned-tier JIT row. Neither is "the" number: the JIT row is what a
+   deployed G# program does, the AOT row is what the language does once
+   compilation is out of the way, and it is the only mode that compares
+   like-for-like with Go's ahead-of-time binary. They differ per scenario rather
+   than by a constant, which is exactly why reporting one alone misleads. Each
+   carries its own ceiling in `baseline.json`.
+6. **Separate the two gates.** Within-runtime regression (G# against its own
    last recorded number) is stable and can gate a PR. The G#-vs-Go ratio
    depends on the Go toolchain and the machine and must stay informational.
    The runner enforces this: a scenario fails only when its median is above the

--- a/bench/concurrency/README.md
+++ b/bench/concurrency/README.md
@@ -90,9 +90,11 @@ spike:
    the pinned-tier JIT row. Neither is "the" number: the JIT row is what a
    deployed G# program does, the AOT row is what the language does once
    compilation is out of the way, and it is the only mode that compares
-   like-for-like with Go's ahead-of-time binary. They differ per scenario rather
-   than by a constant, which is exactly why reporting one alone misleads. Each
-   carries its own ceiling in `baseline.json`.
+   like-for-like with Go's ahead-of-time binary. Which one wins differs per
+   scenario **and per machine** — AOT takes the parking rows on a 20-core
+   workstation and loses most rows on the 4-vCPU CI runner — which is exactly
+   why reporting one alone misleads. Each carries its own ceiling in
+   `baseline.json`; compare a row only against runs of the same hardware class.
 6. **Separate the two gates.** Within-runtime regression (G# against its own
    last recorded number) is stable and can gate a PR. The G#-vs-Go ratio
    depends on the Go toolchain and the machine and must stay informational.

--- a/bench/concurrency/aot/BenchAot.csproj
+++ b/bench/concurrency/aot/BenchAot.csproj
@@ -1,0 +1,61 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    ADR-0174 D11: the NativeAOT measurement mode.
+
+    This project compiles no G# and contains no benchmark logic. It exists only
+    to borrow the supported `PublishAot` pipeline — ILCompiler restore, the
+    NativeAOT runtime pack, and the platform linker invocation — and point it at
+    the assembly gsc already emitted. Hand-rolling the `ilc` command line and the
+    link step would mean re-deriving a 250-line response file on every .NET
+    bump; this way the SDK owns it.
+
+    The substitution below replaces csc's output with the gsc-emitted assembly
+    after CoreCompile, so ILC compiles G#'s own IL — byte-identical to what the
+    JIT mode runs, which is the whole point of having both rows.
+
+    Invoked only by build/run-concurrency-bench.py with the AOT flag set.
+    Deliberately not in GSharp.sln and not in the PR gate; see README.md.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+
+    <!-- The gsc-emitted assembly is named Bench; the identity written into the
+         file must match the name ILC is handed, so AssemblyName follows it. -->
+    <AssemblyName>Bench</AssemblyName>
+
+    <!-- Tooling project (see ../../../Directory.Build.props). -->
+    <Nullable>annotations</Nullable>
+    <RunAnalyzers>false</RunAnalyzers>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+
+    <!-- The ILCompiler and NativeAOT runtime-pack versions are chosen by the
+         SDK from the pinned runtime version, not written here. A lock file
+         would add a second place to update on every SDK bump and would fail the
+         nightly silently when it went stale, so this project does not keep one. -->
+    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Resolved from the directory holding the emitted program, so the AOT and
+         JIT rows link the same runtime build. -->
+    <Reference Include="$(GsharpRuntimeDir)/Gsharp.Extensions.dll" />
+    <Reference Include="$(GsharpRuntimeDir)/Gsharp.Runtime.Channels.dll" />
+  </ItemGroup>
+
+  <Target Name="SubstituteGsharpBench" AfterTargets="CoreCompile"
+          Condition="'$(BenchAssembly)' != ''">
+    <Copy SourceFiles="$(BenchAssembly)" DestinationFiles="@(IntermediateAssembly)" />
+  </Target>
+
+  <Target Name="RequireBenchAssembly" BeforeTargets="CoreCompile"
+          Condition="'$(BenchAssembly)' == ''">
+    <Error Text="Set -p:BenchAssembly=&lt;path to the gsc-emitted Bench.dll&gt;. This project is driven by build/run-concurrency-bench.py --aot, not built directly." />
+  </Target>
+
+</Project>

--- a/bench/concurrency/aot/Shim.cs
+++ b/bench/concurrency/aot/Shim.cs
@@ -1,0 +1,10 @@
+// ADR-0174 D11. Placeholder so csc produces an assembly for the AOT publish to
+// replace; see BenchAot.csproj. The entry point that actually runs is the one
+// gsc emitted, which C# cannot name — ILC reads it from the assembly's metadata
+// and never needs a source-level reference to it.
+internal static class Shim
+{
+    private static void Main()
+    {
+    }
+}

--- a/bench/concurrency/baseline.json
+++ b/bench/concurrency/baseline.json
@@ -8,11 +8,17 @@
     "self-migration corpus uses. Do not hand-write a number here: a budget that",
     "was not measured is worse than no budget, because it looks like evidence.",
     "",
+    "Each scenario carries two budgets. The top-level numbers are the pinned-tier",
+    "JIT mode -- what a deployed G# program does at steady state. The nested",
+    "'aot' object is the NativeAOT mode, which is what compares like-for-like",
+    "with Go's ahead-of-time binary. They regress for different reasons, so",
+    "neither ceiling is allowed to stand in for the other.",
+    "",
     "target_vs_go is the ADR's aspiration; target_status stays 'provisional'",
     "until the ratio has met it on three separate nights on the same hardware",
     "class."
   ],
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "hardwareClass": null,
   "toolchain": {
     "dotnet": null,
@@ -28,7 +34,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "rendezvous": {
       "median_ns": null,
@@ -37,7 +49,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "closed-recv": {
       "median_ns": null,
@@ -46,7 +64,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "spawn": {
       "median_ns": null,
@@ -55,7 +79,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "select-ready": {
       "median_ns": null,
@@ -64,7 +94,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "select-park": {
       "median_ns": null,
@@ -73,7 +109,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "chunk64": {
       "median_ns": null,
@@ -82,7 +124,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     },
     "chunk1k": {
       "median_ns": null,
@@ -91,7 +139,13 @@
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
-      "history": []
+      "history": [],
+      "aot": {
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
+        "history": []
+      }
     }
   }
 }

--- a/build/generate-quality-dashboard.py
+++ b/build/generate-quality-dashboard.py
@@ -232,6 +232,10 @@ def concurrency_metrics(results: Path | None) -> dict | None:
     ceiling is still null has never been measured on a nightly; it is reported
     as such rather than silently omitted, because "no budget yet" is itself the
     status the ADR tracks.
+
+    Two G# numbers per scenario, never one: pinned-tier JIT and NativeAOT. A
+    single figure would have to pick which of those "G#" means, and the point of
+    measuring both is that the honest answer differs by row.
     """
     if results is None or not results.exists():
         return None
@@ -246,7 +250,9 @@ def concurrency_metrics(results: Path | None) -> dict | None:
     for scenario in registry:
         name = scenario["name"]
         gsharp = measured.get("gsharp", {}).get(scenario["gsharp"])
+        aot = measured.get("gsharp_aot", {}).get(scenario["gsharp"])
         recorded = baseline.get("scenarios", {}).get(name, {})
+        recorded_aot = recorded.get("aot", {})
         go_row = scenario.get("go")
         go = measured.get("go", {}).get(go_row) if go_row else None
         rows.append(
@@ -256,8 +262,12 @@ def concurrency_metrics(results: Path | None) -> dict | None:
                 "medianNs": gsharp["median_ns"] if gsharp else None,
                 "ci95Ns": gsharp["ci95_ns"] if gsharp else None,
                 "ceilingNs": recorded.get("ceiling_ns"),
+                "aotMedianNs": aot["median_ns"] if aot else None,
+                "aotCi95Ns": aot["ci95_ns"] if aot else None,
+                "aotCeilingNs": recorded_aot.get("ceiling_ns"),
                 "goMedianNs": go["median_ns"] if go else None,
                 "ratioVsGo": round(gsharp["median_ns"] / go["median_ns"], 2) if gsharp and go else None,
+                "aotRatioVsGo": round(aot["median_ns"] / go["median_ns"], 2) if aot and go else None,
                 "targetVsGo": recorded.get("target_vs_go"),
                 "targetStatus": recorded.get("target_status", "provisional"),
             }

--- a/build/run-concurrency-bench.py
+++ b/build/run-concurrency-bench.py
@@ -15,6 +15,25 @@ follow from that, and both are enforced here rather than left to discipline:
 Methodology, normative per D11: Release builds on both sides, three in-process
 warm-up rounds inside each program, and several process launches here, because
 in-process repetition alone understates variance.
+
+The G# side is measured in two modes, because "how fast is G#" has two honest
+answers and reporting one of them alone was how this harness first went wrong
+(issues #3901, #3902):
+
+  jit  CoreCLR with the JIT tiering delay pinned to zero. Without the pin, a
+       bench process is too short-lived for call counting to ever start: the
+       scenario's own loop is promoted by on-stack replacement while every
+       method it calls stays at Tier0, and whether that happens at all varies
+       between launches. That produced a 3.4x swing on select-ready from an
+       unchanged binary. Pinning keeps dynamic PGO, so this remains the
+       configuration G# actually ships into, measured at steady state.
+  aot  NativeAOT. Fully compiled before the process starts, so there is no tier
+       to win or lose, and it is the mode that compares like-for-like with Go's
+       ahead-of-time binary.
+
+Neither mode is "the" number. The JIT row is what a deployed G# program does;
+the AOT row is what the language is capable of once compilation is not in the
+way. Both are reported, and a budget may be recorded against either.
 """
 
 from __future__ import annotations
@@ -36,6 +55,11 @@ BENCH = REPO / "bench" / "concurrency"
 ROW = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+) ns_per_op (?P<value>[0-9]+(?:\.[0-9]+)?)$")
 GO_ROW = re.compile(r"^\[(?P<name>[^\]]+?)\s*\]\s+[0-9.]+ ms\s+(?P<value>[0-9.]+) ns/op$")
 
+# Pinning the tiering delay is normative, not a tuning knob; see the module
+# docstring. Without it the reported number depends on whether a 100 ms timer
+# happened to elapse before the process exited.
+PINNED_TIER_ENV = {"DOTNET_TC_CallCountingDelayMs": "0"}
+
 
 def load_scenarios() -> list[dict]:
     return json.loads((BENCH / "scenarios.json").read_text())["scenarios"]
@@ -45,7 +69,9 @@ def hardware_class() -> str:
     return f"{platform.system().lower()}-{platform.machine().lower()}-{os.cpu_count()}"
 
 
-def run_gsharp(launches: int, scenario: str | None, gsc: Path, extensions: Path, out: Path) -> dict[str, list[float]]:
+def compile_bench(gsc: Path, extensions: Path, out: Path) -> Path:
+    """Emit the G# benchmark once. Both measurement modes consume this same
+    assembly, so a difference between the rows is compilation, never source."""
     program = BENCH / "gsharp" / "Bench.gs"
     assembly = out / "Bench.dll"
     subprocess.run(
@@ -60,20 +86,58 @@ def run_gsharp(launches: int, scenario: str | None, gsc: Path, extensions: Path,
     # the program starts, prints its header, and dies on the first chunked
     # round with a FileNotFoundException.
     shutil.copy2(extensions, out / extensions.name)
+    return assembly
 
+
+def publish_aot(assembly: Path, out: Path) -> Path:
+    """Native-compile the emitted assembly through the SDK's AOT pipeline.
+
+    The shim project exists so the SDK owns the `ilc` response file and the link
+    step; see bench/concurrency/aot/BenchAot.csproj for why that indirection is
+    worth having.
+    """
+    publish = out / "aot"
+    result = subprocess.run(
+        [
+            "dotnet", "publish", str(BENCH / "aot" / "BenchAot.csproj"),
+            "-c", "Release",
+            "-r", aot_rid(),
+            "-o", str(publish),
+            f"-p:BenchAssembly={assembly}",
+            f"-p:GsharpRuntimeDir={assembly.parent}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "NativeAOT publish failed. On Linux this usually means clang or "
+            "zlib development headers are missing.\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+    binary = publish / "Bench"
+    if not binary.exists():
+        raise SystemExit(f"NativeAOT publish produced no binary at {binary}")
+
+    return binary
+
+
+def aot_rid() -> str:
+    machine = platform.machine().lower()
+    arch = "arm64" if machine in ("arm64", "aarch64") else "x64"
+    return f"{platform.system().lower()}-{arch}"
+
+
+def measure(command: list[str], launches: int, scenario: str | None, cwd: Path, extra_env: dict[str, str]) -> dict[str, list[float]]:
     samples: dict[str, list[float]] = {}
     env = dict(os.environ)
+    env.update(extra_env)
     if scenario:
         env["GSHARP_BENCH_SCENARIO"] = scenario
 
     for _ in range(launches):
-        result = subprocess.run(
-            ["dotnet", "exec", str(assembly)],
-            capture_output=True,
-            text=True,
-            cwd=out,
-            env=env,
-        )
+        result = subprocess.run(command, capture_output=True, text=True, cwd=cwd, env=env)
         if result.returncode != 0:
             # A benchmark that cannot run is a failure worth reading, not a
             # stack trace from subprocess about an exit code.
@@ -135,81 +199,119 @@ def summarize(samples: dict[str, list[float]]) -> dict[str, dict]:
     }
 
 
-def check(baseline: dict, measured: dict[str, dict], scenarios: list[dict]) -> int:
+def check_one(entry: dict, result: dict | None, label: str, gated: bool) -> bool:
+    """Check one scenario in one mode. Returns True when it regressed."""
+    if result is None:
+        print(f"  {label:<20} not measured")
+        return False
+
+    ceiling = entry.get("ceiling_ns")
+    if ceiling is None:
+        print(f"  {label:<20} {result['median_ns']:>9.2f} ns/op   (no ceiling recorded yet)")
+        return False
+
+    over = result["median_ns"] > ceiling
+    recorded_ci = entry.get("ci95_ns")
+    disjoint = (
+        recorded_ci is not None
+        and result["ci95_ns"] is not None
+        and result["ci95_ns"][0] > recorded_ci[1]
+    )
+    verdict = "REGRESSED" if (over and disjoint and gated) else "ok"
+    print(f"  {label:<20} {result['median_ns']:>9.2f} ns/op   ceiling {ceiling:>9.2f}   {verdict}")
+    return verdict == "REGRESSED"
+
+
+def check(baseline: dict, measured: dict[str, dict], measured_aot: dict[str, dict], scenarios: list[dict]) -> int:
     """The within-runtime gate. A scenario fails only when its median is above
     the recorded ceiling AND the confidence intervals do not overlap AND the
     hardware class matches — three conditions, because any one of them alone
-    produces false failures often enough to get the gate switched off."""
+    produces false failures often enough to get the gate switched off.
+
+    Each mode carries its own ceiling. A JIT regression and an AOT regression
+    mean different things — the first is a deployment regression, the second a
+    codegen or runtime one — so neither is allowed to mask the other."""
     failures = 0
     recorded_class = baseline.get("hardwareClass")
     current_class = hardware_class()
     if recorded_class is not None and recorded_class != current_class:
         print(f"note: baseline was recorded on '{recorded_class}', this is '{current_class}'; reporting only.")
 
+    gated = recorded_class is None or recorded_class == current_class
     for scenario in scenarios:
         name = scenario["name"]
         entry = baseline["scenarios"].get(name, {})
-        ceiling = entry.get("ceiling_ns")
-        result = measured.get(name)
-        if result is None:
-            print(f"  {name:<14} not measured")
-            continue
-
-        if ceiling is None:
-            print(f"  {name:<14} {result['median_ns']:>9.2f} ns/op   (no ceiling recorded yet)")
-            continue
-
-        over = result["median_ns"] > ceiling
-        recorded_ci = entry.get("ci95_ns")
-        disjoint = (
-            recorded_ci is not None
-            and result["ci95_ns"] is not None
-            and result["ci95_ns"][0] > recorded_ci[1]
-        )
-        gated = recorded_class is None or recorded_class == current_class
-        verdict = "REGRESSED" if (over and disjoint and gated) else "ok"
-        if verdict == "REGRESSED":
+        if check_one(entry, measured.get(name), f"{name} (jit)", gated):
             failures += 1
 
-        print(f"  {name:<14} {result['median_ns']:>9.2f} ns/op   ceiling {ceiling:>9.2f}   {verdict}")
+        if measured_aot:
+            if check_one(entry.get("aot", {}), measured_aot.get(name), f"{name} (aot)", gated):
+                failures += 1
 
     return failures
 
 
-def update(baseline: dict, measured: dict[str, dict], go_measured: dict[str, dict], scenarios: list[dict], allow_regression: str | None) -> int:
+def record(entry: dict, result: dict, label: str, allow_regression: str | None) -> str | None:
+    """Write one mode's measurement into its baseline entry, refusing to loosen
+    a ceiling without a stated reason. Returns an error message, or None."""
+    ceiling = round(result["median_ns"] * 1.15, 2)
+    previous = entry.get("ceiling_ns")
+    if previous is not None and ceiling > previous and not allow_regression:
+        return (
+            f"refusing to loosen '{label}' from {previous} to {ceiling} ns/op. "
+            'Pass --allow-regression "<reason>" if this is a deliberate, explained change.'
+        )
+
+    entry["median_ns"] = result["median_ns"]
+    entry["ci95_ns"] = result["ci95_ns"]
+    entry["ceiling_ns"] = ceiling
+    entry.setdefault("history", []).append(
+        {
+            "median_ns": result["median_ns"],
+            "samples": result["samples"],
+            "hardwareClass": hardware_class(),
+            "reason": allow_regression,
+        }
+    )
+    return None
+
+
+def update(
+    baseline: dict,
+    measured: dict[str, dict],
+    measured_aot: dict[str, dict],
+    go_measured: dict[str, dict],
+    scenarios: list[dict],
+    allow_regression: str | None,
+) -> int:
     for scenario in scenarios:
         name = scenario["name"]
+        entry = baseline["scenarios"].setdefault(name, {"history": []})
+
         result = measured.get(name)
-        if result is None:
+        if result is not None:
+            error = record(entry, result, f"{name} (jit)", allow_regression)
+            if error:
+                print(error, file=sys.stderr)
+                return 1
+
+        aot_result = measured_aot.get(name)
+        if aot_result is not None:
+            aot_entry = entry.setdefault("aot", {"history": []})
+            error = record(aot_entry, aot_result, f"{name} (aot)", allow_regression)
+            if error:
+                print(error, file=sys.stderr)
+                return 1
+
+        if result is None and aot_result is None:
             continue
 
-        entry = baseline["scenarios"].setdefault(name, {"history": []})
-        ceiling = round(result["median_ns"] * 1.15, 2)
-        previous = entry.get("ceiling_ns")
-        if previous is not None and ceiling > previous and not allow_regression:
-            print(
-                f"refusing to loosen '{name}' from {previous} to {ceiling} ns/op. "
-                "Pass --allow-regression \"<reason>\" if this is a deliberate, explained change.",
-                file=sys.stderr,
-            )
-            return 1
-
-        entry["median_ns"] = result["median_ns"]
-        entry["ci95_ns"] = result["ci95_ns"]
-        entry["ceiling_ns"] = ceiling
         go_row = scenario.get("go")
         if go_row and go_row in go_measured:
             entry["go_median_ns"] = go_measured[go_row]["median_ns"]
+
         entry.setdefault("target_vs_go", None)
         entry.setdefault("target_status", "provisional")
-        entry.setdefault("history", []).append(
-            {
-                "median_ns": result["median_ns"],
-                "samples": result["samples"],
-                "hardwareClass": hardware_class(),
-                "reason": allow_regression,
-            }
-        )
 
     baseline["hardwareClass"] = hardware_class()
     return 0
@@ -220,6 +322,11 @@ def main() -> int:
     parser.add_argument("--launches", type=int, default=7, help="process launches per side (default 7)")
     parser.add_argument("--scenario", help="run one scenario instead of all of them")
     parser.add_argument("--go", action="store_true", help="also run the Go side and report the ratio")
+    parser.add_argument(
+        "--aot",
+        action="store_true",
+        help="also measure a NativeAOT build of the same emitted assembly (adds a publish, minutes)",
+    )
     parser.add_argument("--check-baseline", metavar="PATH", help="fail when a scenario regressed past its ceiling")
     parser.add_argument("--update-baseline", metavar="PATH", help="record the measured medians")
     parser.add_argument("--allow-regression", metavar="REASON", help="permit --update-baseline to loosen a ceiling")
@@ -238,31 +345,68 @@ def main() -> int:
     out = REPO / "out" / "bench-concurrency"
     out.mkdir(parents=True, exist_ok=True)
 
-    measured = summarize(run_gsharp(args.launches, args.scenario, Path(args.gsc), Path(args.extensions), out))
+    assembly = compile_bench(Path(args.gsc), Path(args.extensions), out)
+    measured = summarize(measure(["dotnet", "exec", str(assembly)], args.launches, args.scenario, out, PINNED_TIER_ENV))
+
+    measured_aot: dict[str, dict] = {}
+    if args.aot:
+        binary = publish_aot(assembly, out)
+        measured_aot = summarize(measure([str(binary)], args.launches, args.scenario, out, {}))
+
     go_measured = summarize(run_go(args.launches)) if args.go else {}
 
-    print(f"hardware class: {hardware_class()}   launches: {args.launches}")
+    print(f"hardware class: {hardware_class()}   launches: {args.launches}   jit tier pinned")
+    header = f"  {'scenario':<14} {'jit ns/op':>12}"
+    if measured_aot:
+        header += f" {'aot ns/op':>12}"
+    if go_measured:
+        header += f" {'go ns/op':>12} {'jit/go':>8}"
+        if measured_aot:
+            header += f" {'aot/go':>8}"
+    print(header)
+
     for scenario in scenarios:
         name = scenario["name"]
         result = measured.get(name)
-        if result is None:
+        aot_result = measured_aot.get(name)
+        if result is None and aot_result is None:
             continue
 
-        line = f"  {name:<14} {result['median_ns']:>9.2f} ns/op"
+        line = f"  {name:<14} " + (f"{result['median_ns']:>12.2f}" if result else f"{'-':>12}")
+        if measured_aot:
+            line += " " + (f"{aot_result['median_ns']:>12.2f}" if aot_result else f"{'-':>12}")
+
         go_row = scenario.get("go")
-        if go_row and go_row in go_measured:
-            go_median = go_measured[go_row]["median_ns"]
-            line += f"   go {go_median:>9.2f} ns/op   ratio {result['median_ns'] / go_median:>5.2f}x"
+        go = go_measured.get(go_row) if go_row else None
+        if go_measured:
+            if go:
+                line += f" {go['median_ns']:>12.2f}"
+                line += f" {result['median_ns'] / go['median_ns']:>7.2f}x" if result else f" {'-':>8}"
+                if measured_aot:
+                    line += f" {aot_result['median_ns'] / go['median_ns']:>7.2f}x" if aot_result else f" {'-':>8}"
+            else:
+                line += f" {'-':>12} {'-':>8}" + (f" {'-':>8}" if measured_aot else "")
 
         print(line)
 
     if args.json:
-        Path(args.json).write_text(json.dumps({"gsharp": measured, "go": go_measured, "hardwareClass": hardware_class()}, indent=2) + "\n")
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    "gsharp": measured,
+                    "gsharp_aot": measured_aot,
+                    "go": go_measured,
+                    "hardwareClass": hardware_class(),
+                },
+                indent=2,
+            )
+            + "\n"
+        )
 
     if args.update_baseline:
         path = Path(args.update_baseline)
         baseline = json.loads(path.read_text())
-        code = update(baseline, measured, go_measured, scenarios, args.allow_regression)
+        code = update(baseline, measured, measured_aot, go_measured, scenarios, args.allow_regression)
         if code:
             return code
 
@@ -272,7 +416,7 @@ def main() -> int:
     if args.check_baseline:
         baseline = json.loads(Path(args.check_baseline).read_text())
         print("\nwithin-runtime gate:")
-        failures = check(baseline, measured, scenarios)
+        failures = check(baseline, measured, measured_aot, scenarios)
         if failures:
             print(f"\n{failures} scenario(s) regressed past their recorded ceiling.", file=sys.stderr)
             return 1

--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -41,8 +41,10 @@ selfmig_excludes=(
   # ADR-0174 D11: the concurrency benchmark's C# and Go sides are measurement
   # apparatus, not migration targets. Translating the CLR baseline would
   # measure the translator rather than the runtime, which is the one thing this
-  # harness must not do.
+  # harness must not do. The AOT project holds no logic at all — its only C# is
+  # a placeholder Main that the publish overwrites.
   --exclude bench/concurrency/clr
+  --exclude bench/concurrency/aot
 )
 
 # MSBuildWorkspace design-time project loads evaluate in Debug regardless of

--- a/build/verify-concurrency-bench.py
+++ b/build/verify-concurrency-bench.py
@@ -7,7 +7,11 @@ seconds rather than at 05:23 in a nightly nobody is watching.
 
 `--smoke` checks the pieces without measuring anything: the registry parses and
 every scenario it names is one the G# program knows; the baseline has an entry
-per scenario; the runner imports.
+per scenario in both measurement modes; the runner imports; the NativeAOT shim
+project is present and still substitutes the emitted assembly.
+
+Deliberately does not publish the AOT binary. That takes minutes, and this
+script runs on every PR.
 """
 
 from __future__ import annotations
@@ -44,8 +48,23 @@ def smoke() -> int:
 
     baseline = json.loads((BENCH / "baseline.json").read_text())
     for scenario in scenarios:
-        if scenario["name"] not in baseline["scenarios"]:
+        entry = baseline["scenarios"].get(scenario["name"])
+        if entry is None:
             failures.append(f"baseline.json has no entry for '{scenario['name']}'")
+        elif "aot" not in entry:
+            # Every scenario carries a budget per measurement mode; a missing
+            # one would silently stop gating that mode rather than fail.
+            failures.append(f"baseline.json has no 'aot' budget for '{scenario['name']}'")
+
+    aot_project = BENCH / "aot" / "BenchAot.csproj"
+    if not aot_project.exists():
+        failures.append("bench/concurrency/aot/BenchAot.csproj is missing; --aot cannot run")
+    else:
+        shim = aot_project.read_text()
+        # The whole mechanism is this one substitution: without it the AOT row
+        # would measure the placeholder Main and report nothing at all.
+        if "SubstituteGsharpBench" not in shim or "IntermediateAssembly" not in shim:
+            failures.append("BenchAot.csproj no longer substitutes the gsc-emitted assembly")
 
     runner = (REPO / "build" / "run-concurrency-bench.py").read_text()
     compile(runner, "run-concurrency-bench.py", "exec")
@@ -56,7 +75,10 @@ def smoke() -> int:
     if failures:
         return 1
 
-    print(f"concurrency benchmark harness OK: {len(scenarios)} scenarios, registry, baseline and runner agree.")
+    print(
+        f"concurrency benchmark harness OK: {len(scenarios)} scenarios, registry, "
+        "baseline (jit + aot), AOT shim and runner agree."
+    )
     return 0
 
 

--- a/docs/adr/0174-goroutines-and-channels-wave-2.md
+++ b/docs/adr/0174-goroutines-and-channels-wave-2.md
@@ -2471,13 +2471,24 @@ implementation had to refine it.
     Neither mode is *the* number, and the ADR should stop implying there is one.
     The JIT row is what a deployed G# program does; the AOT row is what the
     language does once compilation is out of the way, and it is the only mode
-    that compares like-for-like with Go's ahead-of-time binary. They differ per
-    scenario rather than by a constant — AOT is markedly better on the parking
-    rows (`select-park` ~950 vs ~1080 ns, `rendezvous` ~800–970 vs ~1000–1130)
-    and slightly worse on `select-ready`, where dynamic PGO wins. Each carries
-    its own ceiling in `baseline.json` (`schemaVersion: 2`), because a JIT
-    regression and an AOT regression mean different things and neither should
-    mask the other.
+    that compares like-for-like with Go's ahead-of-time binary.
+
+    **Which mode wins is hardware-dependent, and that is the finding.** On a
+    20-core workstation AOT takes the parking rows (`select-park` ~990 vs ~1050
+    ns, `rendezvous` ~960 vs ~1210) and loses `select-ready`, where dynamic PGO
+    is worth ~28%. On the 4-vCPU CI runner the ranking inverts almost
+    everywhere — `buf64` 230 (aot) vs 129 (jit), `rendezvous` 682 vs 520,
+    `select-ready` 265 vs 240 — with AOT ahead only on `closed-recv` and
+    `chunk64`. Dynamic PGO appears to matter more when there are fewer cores to
+    hide a bad inlining decision behind, though that mechanism is a guess and
+    has not been measured. What is not a guess is that a single G# figure would
+    have to pick a mode, and the pick would change the answer differently per
+    row and per machine.
+
+    Each mode therefore carries its own ceiling in `baseline.json`
+    (`schemaVersion: 2`): a JIT regression and an AOT regression mean different
+    things, neither should mask the other, and the hardware class already
+    recorded per run is what makes either comparable across nights.
 
     Consequences for the gates: **G3, G5, G6 and G7 must be resolved against
     pinned measurements**, not against anything recorded before this change.

--- a/docs/adr/0174-goroutines-and-channels-wave-2.md
+++ b/docs/adr/0174-goroutines-and-channels-wave-2.md
@@ -2439,6 +2439,53 @@ implementation had to refine it.
     `chunks(ch, n)`: that is the shape D10 exists to encourage, so it is the
     likeliest way to reach the degenerate case.
 
+33. **D11 measures two modes, and the JIT tier is pinned (Phase 5-2, revised).**
+    The harness as first shipped reported a number that depended on whether a
+    100 ms timer happened to elapse. The runtime's call-counting delay restarts
+    on every new JIT compilation, and a bench process that keeps first-calling
+    methods can exit before counting begins — so the scenario's own loop is
+    promoted by on-stack replacement while every method it calls stays at
+    Tier0. Measured on `linux-x86_64-20`: a default launch performs exactly
+    **one** Tier1 compilation in the whole process, that OSR; with
+    `DOTNET_TC_CallCountingDelayMs=0` it performs 132, and every row moves
+    1.5–3× (`closed-recv` 61 → 25 ns, `select-ready` 594 → 175, `chunk1k`
+    45 → 18). This is what produced the 3.4× session-to-session swing recorded
+    in issue #3901, and it means the D11 rows quoted before this change
+    described an unpromoted process rather than G# at steady state.
+
+    The runner therefore pins the delay for the JIT mode. `TieredCompilation=0`
+    was rejected: it also discards dynamic PGO, which is worth a consistent
+    ~28% on `select-ready` (177 vs 227 ns, both tightly clustered) — though not
+    the 5–8× a first analysis claimed, which did not reproduce outside a
+    synthetic C# probe.
+
+    A second mode, `--aot`, measures a NativeAOT build of **the same emitted
+    assembly**: `bench/concurrency/aot` borrows the SDK's `PublishAot` pipeline
+    and substitutes gsc's output for csc's after `CoreCompile`, so ILC compiles
+    G#'s own IL. ILC accepts it unmodified and with no trim or AOT warnings from
+    the bench, `Gsharp.Extensions` or the channel runtime — itself a result
+    worth recording, since nothing in the toolchain had been AOT-compiled
+    before. The G# entry point is `<Program>.Main`, unnameable from C#, which
+    does not matter: ILC reads it from metadata.
+
+    Neither mode is *the* number, and the ADR should stop implying there is one.
+    The JIT row is what a deployed G# program does; the AOT row is what the
+    language does once compilation is out of the way, and it is the only mode
+    that compares like-for-like with Go's ahead-of-time binary. They differ per
+    scenario rather than by a constant — AOT is markedly better on the parking
+    rows (`select-park` ~950 vs ~1080 ns, `rendezvous` ~800–970 vs ~1000–1130)
+    and slightly worse on `select-ready`, where dynamic PGO wins. Each carries
+    its own ceiling in `baseline.json` (`schemaVersion: 2`), because a JIT
+    regression and an AOT regression mean different things and neither should
+    mask the other.
+
+    Consequences for the gates: **G3, G5, G6 and G7 must be resolved against
+    pinned measurements**, not against anything recorded before this change.
+    The ranked plan for the remaining Go gap, including a working G6
+    inline-continuation prototype and the finding that `rendezvous`,
+    `select-ready` and `spawn` compare unequal work to their Go counterparts, is
+    issue #3902.
+
 ## Addendum A — The ten patterns, three ways
 
 The pattern study in the Context section gives ratings. This addendum gives

--- a/website/docs/project/quality-dashboard.mdx
+++ b/website/docs/project/quality-dashboard.mdx
@@ -69,10 +69,11 @@ investigate sustained movement, not a single run.
       <thead>
         <tr>
           <th>Scenario</th>
-          <th>G# ns/op</th>
-          <th>Ceiling</th>
+          <th>G# JIT ns/op</th>
+          <th>G# AOT ns/op</th>
           <th>Go ns/op</th>
-          <th>Ratio</th>
+          <th>JIT ÷ Go</th>
+          <th>AOT ÷ Go</th>
           <th>Target</th>
         </tr>
       </thead>
@@ -81,21 +82,32 @@ investigate sustained movement, not a single run.
           <tr key={row.name}>
             <td><code>{row.name}</code></td>
             <td>{row.medianNs ?? '—'}</td>
-            <td>{row.ceilingNs ?? 'not yet measured'}</td>
+            <td>{row.aotMedianNs ?? '—'}</td>
             <td>{row.goMedianNs ?? '—'}</td>
             <td>{row.ratioVsGo ? `${row.ratioVsGo}×` : '—'}</td>
+            <td>{row.aotRatioVsGo ? `${row.aotRatioVsGo}×` : '—'}</td>
             <td>{row.targetVsGo ? `${row.targetVsGo}× (${row.targetStatus})` : row.targetStatus}</td>
           </tr>
         ))}
       </tbody>
     </table>
     <p>
-      A ceiling of <em>not yet measured</em> means no nightly has recorded a
-      budget for that scenario, so nothing gates on it. A target stays{' '}
-      <em>provisional</em> until the ratio has met it on three separate nights
-      on the same hardware class. The G#-versus-Go ratio moves with the Go
-      toolchain and the machine and is reported, never gated; only the
-      within-runtime check can fail a run.
+      Two G# columns, because "how fast is G#" has two honest answers.{' '}
+      <strong>JIT</strong> is CoreCLR with the tiering delay pinned, which is
+      what a deployed G# program does at steady state; without the pin a
+      benchmark process is too short-lived for the runtime to finish promoting
+      its own hot code, and the reported number depends on whether it did.{' '}
+      <strong>AOT</strong> is NativeAOT: fully compiled before the process
+      starts, and the mode that compares like-for-like with Go's ahead-of-time
+      binary. Each carries its own budget, since they regress for different
+      reasons.
+    </p>
+    <p>
+      A target stays <em>provisional</em> until the ratio has met it on three
+      separate nights on the same hardware class. The G#-versus-Go ratios move
+      with the Go toolchain and the machine and are reported, never gated; only
+      the within-runtime check against a recorded ceiling can fail a run, and a
+      scenario with no recorded ceiling gates on nothing.
     </p>
   </>
 ) : (


### PR DESCRIPTION
## What this fixes

The D11 concurrency benchmark reported a number that depended on whether a 100 ms timer happened to
elapse. The runtime's call-counting delay restarts on every new JIT compilation, and a bench process
that keeps first-calling methods can exit before counting ever begins — so the scenario's own loop is
promoted by on-stack replacement while **every method it calls stays at Tier0**.

`DOTNET_JitDisasmSummary=1`, isolated `select-ready` launches on `linux-x86_64-20`:

| | Tier1 compiles in the process | reported |
|---|---|---|
| default | **1** (the OSR of the scenario's own `MoveNext`) | 561.88 ns |
| `TC_CallCountingDelayMs=0` | **132** | 180.69 ns |

That is the cause of the 3.4× session-to-session swing in #3901, which that issue could not explain.
175 ns under the pin is within noise of the 172.91 ns measured in an earlier session and since treated
as retracted — it was never wrong, it was the promoted-tier number. Every row moves: closed-recv
61 → 25 ns, chunk1k 45 → 18, buf64 290 → 219.

`TieredCompilation=0` was rejected as the knob because it also discards dynamic PGO, worth a consistent
~28% on `select-ready`. Not the 5–8× a first analysis claimed — that did not reproduce outside a
synthetic C# probe, and the correction is [on #3902](https://github.com/DavidObando/gsharp/issues/3902).

## The AOT row

`bench/concurrency/aot` measures a NativeAOT build of **the same emitted assembly**: it borrows the
SDK's `PublishAot` pipeline and substitutes gsc's output for csc's after `CoreCompile`, so ILC compiles
G#'s own IL rather than a transcription of it. Hand-rolling the `ilc` command line would have meant
re-deriving a 250-line response file and a link step on every .NET bump.

**ILC accepts gsc-emitted IL unmodified, with no trim or AOT warnings** from the bench,
`Gsharp.Extensions` or the channel runtime. That is worth recording on its own — nothing in this
toolchain had been AOT-compiled before. The G# entry point is `<Program>.Main`, unnameable from C#,
which turns out not to matter: ILC reads it from metadata.

## What a run looks like now

7 launches, this workstation:

```
hardware class: linux-x86_64-20   launches: 7   jit tier pinned
  scenario          jit ns/op    aot ns/op     go ns/op   jit/go   aot/go
  buf64                179.86       205.15        81.40    2.21x    2.52x
  rendezvous          1208.21       956.33       585.50    2.06x    1.63x
  closed-recv           22.74        23.88        30.70    0.74x    0.78x
  spawn                399.74       404.34       278.00    1.44x    1.45x
  select-ready         175.00       203.86        91.60    1.91x    2.23x
  select-park         1053.98       990.38            -        -        -
  chunk64               23.41        22.63         8.20    2.85x    2.76x
  chunk1k               14.81        18.39         1.70    8.71x   10.82x
```

Neither mode is "the" number, and the ADR no longer implies there is one. The JIT row is what a
deployed G# program does; the AOT row is what the language does once compilation is out of the way,
and it is the only mode that compares like-for-like with Go's ahead-of-time binary. They differ **per
scenario rather than by a constant** — AOT wins the parking rows, PGO wins `select-ready` — which is
exactly why reporting one alone misleads. Each carries its own ceiling, because a JIT regression and an
AOT regression mean different things.

## Not in this PR

- **Every median in `baseline.json` stays null.** Nothing here was measured by a nightly, and a budget
  that was not measured reads as evidence.
- **The unequal pairings are untouched.** `rendezvous` counts 1 hand-off against `go-pingpong`'s 2;
  `select-ready` does 4 channel ops against Go's 1; `spawn` times a send and a receive Go doesn't do.
  Verified in the sources, tracked in #3902 — fixing them changes what the scenarios measure, which is
  a separate decision.
- **Why the earlier session's launches promoted and current ones do not** is still open. Load was the
  obvious hypothesis; I tested it and it does not cleanly reproduce (negative result on #3901).

## Consequences

Gates **G3, G5, G6 and G7** must be resolved against pinned measurements, not against anything recorded
before this change. ADR errata 33 records that.

## Verification

End to end from a clean `out/` at the nightly's 7 launches: both modes plus Go, `--update-baseline`
recording both budgets, and the ratchet refusing to loosen an AOT ceiling without `--allow-regression`.
`verify-concurrency-bench.py --smoke` passes and deliberately does **not** publish the AOT binary — it
runs on every PR and that would cost minutes.

Labelled `bench:concurrency` so the workflow actually runs here rather than first executing at 05:23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
