### PR TITLE
cs2gs: the translate pass is deterministic — the #3895 observation re-diagnosed, plus regression tests

### DIFF
--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -92,6 +92,17 @@ selfmig_hash_tree() {
 
 # Computes the four readability metrics over a migrated tree, into the caller's
 # `labels`, `lifts`, `long_lines` and `bangs` variables.
+#
+# Issue #3895: `bangs` is a function of the TREE, and a tree has two distinct
+# states in this pipeline. The migrate job measures the freshly-TRANSLATED tree;
+# the gate job measures it again after the validate shards' `!!` polish deltas
+# are replayed, and the polish strips whatever gsc reported as GS0536, so a gsc
+# change moves the second number without moving the first. The two numbers are
+# therefore NOT comparable with each other — only migrate-vs-migrate or
+# gate-vs-gate is. A `!!`-only diff across many otherwise-unrelated files is the
+# signature of comparing across that boundary, not of a nondeterministic
+# translator: five whole-repository `migrate --translate-only` passes over one
+# commit produce byte-identical trees (measured on #3895).
 selfmig_measure() {
   local migrated_dir=$1
   labels=$(selfmig_code_grep "$migrated_dir" '__(switchExit|iteratorExit|gotoCase|gotoDefault|patternGuardEnd)')

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3895TranslationDeterminismTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3895TranslationDeterminismTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue3895TranslationDeterminismTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3895: the corpus-wide <c>!!</c> count is a tracked #3501 gate metric
+/// (<c>nullAssertionCeiling</c>), and every ratchet decision assumes it is a
+/// FUNCTION OF THE INPUT. These tests pin that assumption where it is cheap to
+/// pin it: identical input must produce byte-identical G#, and the
+/// null-forgiveness decision must not depend on the order in which the
+/// compilation's syntax trees are visited.
+/// <para>
+/// The order-invariance half is the one with teeth. The oblivious-nullability
+/// taint analysis is a fixpoint over an edge set collected in ONE pass over
+/// <c>compilation.SyntaxTrees</c>; if any part of that collection ever starts
+/// reading the partially-built taint set, or if the propagation loop stops
+/// being monotone, the answer silently becomes a function of tree order — and
+/// tree order is set by MSBuild's <c>Compile</c> item list, which is an
+/// implementation detail no ratchet should depend on. Reversing the trees is a
+/// cheap, deterministic stand-in for "some other order".
+/// </para>
+/// <para>
+/// WHAT THESE TESTS DO NOT COVER. Both passes run in ONE process, so neither
+/// can observe a dependence on .NET's per-process string hash seed, on
+/// filesystem enumeration order, or on GC timing evicting a
+/// <c>ConditionalWeakTable</c> entry. A whole-corpus repeat run is the only
+/// thing that covers those, and issue #3895 records five of them.
+/// </para>
+/// </summary>
+public class Issue3895TranslationDeterminismTests
+{
+    // Deliberately NOT `#nullable enable`: the oblivious-nullability taint
+    // analysis — the thing that decides where `!!` lands — only runs on a
+    // compilation whose nullable context is disabled, which is the default for
+    // an in-memory load and is what the migration corpus mostly looks like.
+    private static readonly (string FileName, string Source)[] Sources =
+    {
+        ("Model.cs", @"
+namespace Demo
+{
+    public class Node
+    {
+        public string Name;
+        public Node Parent;
+
+        public static Node Find(string key)
+        {
+            return null;
+        }
+
+        public string Describe()
+        {
+            return null;
+        }
+    }
+}"),
+        ("Consumer.cs", @"
+namespace Demo
+{
+    public class Consumer
+    {
+        public int NameLength(string key)
+        {
+            Node node = Node.Find(key);
+            return node.Name.Length;
+        }
+
+        public string ParentName(Node node)
+        {
+            return node.Parent.Name;
+        }
+
+        public string Description(Node node)
+        {
+            return node.Describe().Trim();
+        }
+    }
+}"),
+        ("Relay.cs", @"
+namespace Demo
+{
+    public class Relay
+    {
+        private Node cached;
+
+        public Node Cached
+        {
+            get { return this.cached; }
+        }
+
+        public string Relayed(string key)
+        {
+            this.cached = Node.Find(key);
+            return this.cached.Describe();
+        }
+    }
+}"),
+    };
+
+    /// <summary>
+    /// Two independent translations of identical input must agree byte for
+    /// byte — not merely in their <c>!!</c> COUNT, which a compensating pair
+    /// of moves would keep constant.
+    /// </summary>
+    [Fact]
+    public void TranslatingTheSameSourcesTwice_ProducesByteIdenticalOutput()
+    {
+        IReadOnlyDictionary<string, string> first = TranslateAll(Sources);
+        IReadOnlyDictionary<string, string> second = TranslateAll(Sources);
+
+        AssertEmitsAssertions(first);
+        AssertSameOutput(first, second, "a second translation of identical input");
+    }
+
+    /// <summary>
+    /// Reversing the compilation's syntax-tree order must not move a single
+    /// character of any file's output. Each document is translated on its own,
+    /// so its text is a function of that document plus whole-program facts; a
+    /// whole-program fact that changed with visit order would be a
+    /// non-converged fixpoint, not a formatting difference.
+    /// </summary>
+    [Fact]
+    public void ReversingSyntaxTreeOrder_ProducesTheSamePerDocumentOutput()
+    {
+        IReadOnlyDictionary<string, string> forward = TranslateAll(Sources);
+        IReadOnlyDictionary<string, string> reversed = TranslateAll(Sources.Reverse().ToArray());
+
+        AssertEmitsAssertions(forward);
+        AssertSameOutput(forward, reversed, "a reversed syntax-tree order");
+    }
+
+    /// <summary>
+    /// The nullable TYPE decisions the same fixpoint drives, asserted
+    /// independently of the assertion sites: a declaration that renders
+    /// <c>T?</c> under one tree order must render <c>T?</c> under the other.
+    /// A promotion that flipped would move every downstream <c>!!</c> with it.
+    /// </summary>
+    [Fact]
+    public void NullablePromotions_AreInvariantUnderSyntaxTreeOrder()
+    {
+        IReadOnlyDictionary<string, string> forward = TranslateAll(Sources);
+        IReadOnlyDictionary<string, string> reversed = TranslateAll(Sources.Reverse().ToArray());
+
+        // Anti-vacuity: the fixture must actually promote something, or the
+        // comparison below compares two promotion-free trees.
+        Assert.Contains(forward, entry => entry.Value.Contains("?", StringComparison.Ordinal));
+
+        foreach (KeyValuePair<string, string> entry in forward)
+        {
+            Assert.Equal(
+                CountOccurrences(entry.Value, "?"),
+                CountOccurrences(reversed[entry.Key], "?"));
+            Assert.Equal(
+                CountOccurrences(entry.Value, "!!"),
+                CountOccurrences(reversed[entry.Key], "!!"));
+        }
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while (true)
+        {
+            index = text.IndexOf(needle, index, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                return count;
+            }
+
+            count++;
+            index += needle.Length;
+        }
+    }
+
+    private static void AssertEmitsAssertions(IReadOnlyDictionary<string, string> printed)
+    {
+        // Anti-vacuity guard: if the fixture ever stops emitting `!!`, these
+        // tests would keep passing while covering nothing this issue is about.
+        Assert.Contains(printed, entry => entry.Value.Contains("!!", StringComparison.Ordinal));
+    }
+
+    private static void AssertSameOutput(
+        IReadOnlyDictionary<string, string> expected,
+        IReadOnlyDictionary<string, string> actual,
+        string what)
+    {
+        Assert.Equal(expected.Keys.OrderBy(k => k, StringComparer.Ordinal), actual.Keys.OrderBy(k => k, StringComparer.Ordinal));
+        foreach (KeyValuePair<string, string> entry in expected)
+        {
+            string other = actual[entry.Key];
+            Assert.True(
+                string.Equals(entry.Value, other, StringComparison.Ordinal),
+                $"{entry.Key} translated differently under {what}.\n--- first ---\n{entry.Value}\n--- second ---\n{other}");
+        }
+    }
+
+    private static IReadOnlyDictionary<string, string> TranslateAll(
+        IReadOnlyList<(string FileName, string Source)> sources)
+    {
+        LoadedCSharpProject project = LoadBound(sources);
+        var printed = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (LoadedDocument document in project.Documents)
+        {
+            var context = new TranslationContext(
+                project.Compilation, document.SemanticModel, document.FilePath);
+            CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+            printed[System.IO.Path.GetFileName(document.FilePath)] = GSharpPrinter.Print(unit);
+        }
+
+        return printed;
+    }
+
+    private static LoadedCSharpProject LoadBound(IReadOnlyList<(string FileName, string Source)> sources)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(sources);
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Fixture should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        return project;
+    }
+}


### PR DESCRIPTION
Refs #3895. Refs #3501.

**The premise of #3895 does not hold, and the measurement says so at N=5.**
Reporting that loudly, as the issue asks.

## 1. The distribution (the issue's first ask)

Five whole-repository `cs2gs migrate --translate-only` passes over one commit
(`952af2784`), one machine, the same binary and the same corpus each time:

| run | gate `bangs` | raw `!!` over all `.gs` | `.gs` files |
|-----|--------------|--------------------------|-------------|
| 1 | 21779 | 29004 | 3777 |
| 2 | 21779 | 29004 | 3777 |
| 3 | 21779 | 29004 | 3777 |
| 4 | 21779 | 29004 | 3777 |
| 5 | 21779 | 29004 | 3777 |

**Spread: zero.** And not merely in the count — `diff -rq` between every pair
of migrated trees reports **nothing**. Byte-identical. A count that agreed
while placements moved would have shown up here; it did not.

(The absolute number is ~2x the 10637–10731 the issue quotes because #3900 put
`src/Core` and 16 apps back into the gate after that measurement. Irrelevant to
the spread.)

## 2. The mechanism, because there isn't one to fix

`--translate-only` builds the pipeline as `new MigrationPipeline(options, new
IMigrationStage[] { new TranslateStage() })`. `NullAssertionPolishPass` lives in
`CompileStage` and **never runs in the pass the issue measured**. The `!!` in
that tree are placed by the translator.

The translator's taint fixpoint (`ObliviousNullabilityAnalyzer.Compute`) is
monotone over an edge **`List`**, and nothing in edge collection reads the
partially-built taint set (the only `tainted.Contains` calls in the file are the
four inside the propagation loop). It converges on a change flag, not a round
count. Its caches are `ConditionalWeakTable`s keyed by `Compilation`, and their
symbol sets are only ever `Contains`-ed, never enumerated. Corpus discovery,
repository file inventory and transitive project references are all explicitly
ordered. There is no parallelism anywhere in the translate stack.

## 3. Where the 171 files actually came from

The issue's base commit `36a147f0f` is **exactly `df3f6a050^`** — the parent of
the #3889 merge. The two runs compared were pre-#3889 and post-#3889, not two
repeats of one binary.

Control experiment: same corpus, same commit, two `cs2gs` binaries differing
**only** in whether #3841's `IsIdentityCriticalDelegate` rule is active (patched
to `return false` and rebuilt):

* **10** files differ, and every one of them differs in delegate **spelling**,
  e.g. `.Single((p Parameter) -> …)` vs `.Single((p MetadataParameter) -> …)`;
* per-file `!!` counts: **identical in all 10** (141 either side);
* corpus-wide raw `!!`: **29004 both ways**.

So #3889's cs2gs half moves **zero** assertions and touches 10 files, not 171.

What #3889 *did* change is **gsc** — `Binder.ResolveEntryPoint`,
`FunctionEmitter`, `ReflectionMetadataEmitter`. gsc is what emits `GS0536`, and
`GS0536` is what the `!!` **polish** strips. That gives the leading explanation
for a `!!`-only diff across many otherwise-unrelated files: the two trees were
compared across the pre-polish / post-polish boundary (the migrate job measures
the freshly-translated tree; the gate job re-measures after the validate shards'
polish deltas are replayed). That is real, deterministic, attributable causation
— a gsc change moving the post-polish number — not noise.

**Consequence for the ratchet, which is the opposite of the issue's:** the
metric *is* a function of its input, small deltas *are* attributable, and the
~800 units of headroom are not being held hostage by noise. The rule that does
need stating is that a migrate-job `bangs` and a gate-job `bangs` are two
different measurements and must never be differenced against each other.

## 4. Same mechanism as #3782?

**No — and there is no second mechanism.** #3782/#3788 fixed a real dependence
(the polish loop's round cap vs. shard packing). This issue reports a dependence
that measurement cannot find: five repeats are byte-identical.

## 5. What this PR contains

* **`Issue3895TranslationDeterminismTests`** — three executing tests:
  * translating the same sources twice produces byte-identical output (not just
    an equal `!!` count);
  * reversing the compilation's syntax-tree order does not move a character;
  * reversing it does not move a single `?` or `!!` per file.

  Each has an anti-vacuity assert that the fixture actually emits `!!` and
  actually promotes, so the suite cannot pass by covering nothing.

  **What it does not cover, stated plainly:** both passes run in one process, so
  these tests cannot see a dependence on .NET's per-process string hash seed, on
  filesystem enumeration order, or on GC timing evicting a
  `ConditionalWeakTable` entry. The five-run whole-corpus repeat is what covers
  those, and it is the evidence in §1.

* **A comment on `selfmig_measure`** recording the two-measurement-points hazard
  from §3, so the next person differencing two `bangs` numbers is told which
  pairs are comparable.

## 6. Translation closure

No production cs2gs source changed — `Cs2Gs.Translator`, `Cs2Gs.CodeModel` and
`src/Core` are untouched, so the `Cs2Gs.Translator → Cs2Gs.CodeModel → src/Core`
closure is unaffected by construction. The new test file is nonetheless inside
the corpus and **was translated successfully by a whole-repository pass** (it is
present as `tools/cs2gs/Cs2Gs.Tests/Issue3895TranslationDeterminismTests.gs` in
the run that included it). It contributes **+12** to the corpus `!!` metric, from
the loader types the oblivious-taint pass promotes; `Cs2Gs.Tests` is not a green
app today, so this cannot move the green floor.

## 7. What I did not do

I did not touch `tools/cs2gs/selfmig-baseline.json`.

I could not reproduce the reporter's exact pair, because that needs both CI
artifact trees; §3 is inference from a controlled local A/B plus the commit
graph, not from those artifacts. If the two trees are still available, the
one-line check is whether the 171 files' `!!` differences are all *deletions*
on one side — that would confirm the polish boundary outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs