### PR TITLE
selfmig: a test-parity failure allow-list, seeded with #3885's three Sdk.Tests cases

### DIFF
--- a/build/merge-selfmig-runs.py
+++ b/build/merge-selfmig-runs.py
@@ -14,6 +14,9 @@ single whole run would have produced:
   * an app that failed translate was never handed to a shard, so its later
     stages are filled in as ``skipped`` — the same shape the whole run's
     short-circuit produces;
+  * ``allowedTestFailures``/``staleAllowListEntries`` (issue #3885) come from
+    the shard too: they are a stage-4 verdict, and dropping them here would make
+    an allow-listed pass indistinguishable from an unconditional one;
   * ``succeeded`` is the conjunction, ``unverified`` is recomputed with the
     whole run's rule (nothing failed, but something was skipped);
   * an app that translated but that no shard reported on is a sharding bug, not
@@ -53,6 +56,12 @@ def merge_app(migrate_app: dict, shard_app: dict | None) -> dict:
         "stages": stages,
         "artifacts": list(migrate_app.get("artifacts", [])),
         "fingerprints": list(migrate_app.get("fingerprints", [])),
+        # Issue #3885: the test-parity allow-list verdict is produced by the
+        # shard that ran stage 4, and it has to survive the merge -- a run that
+        # is green only because of the allow-list must still say which failures
+        # it excused, and which entries no longer fire.
+        "allowedTestFailures": [],
+        "staleAllowListEntries": [],
     }
 
     if not translated:
@@ -75,6 +84,8 @@ def merge_app(migrate_app: dict, shard_app: dict | None) -> dict:
     merged["succeeded"] = bool(shard_app.get("succeeded", False))
     merged["artifacts"] += list(shard_app.get("artifacts", []))
     merged["fingerprints"] += list(shard_app.get("fingerprints", []))
+    merged["allowedTestFailures"] = list(shard_app.get("allowedTestFailures", []))
+    merged["staleAllowListEntries"] = list(shard_app.get("staleAllowListEntries", []))
     if not merged["succeeded"]:
         merged["failureCategory"] = shard_app.get("failureCategory")
     else:

--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -188,6 +188,39 @@ selfmig_apply_baseline() {
     fi
   fi
 
+  # Issue #3885: the test-parity failure allow-list. An app whose mirrored test
+  # failures are a SUBSET of its allow-list entries reports green — but the run
+  # must never be silent about it, or the list becomes the dangerous kind. Both
+  # halves are printed whatever the gate verdict:
+  #
+  #   * every allow-listed failure that actually occurred, so a green app that
+  #     is green only because of the list still says which tests it excused;
+  #   * every entry that did NOT fire in a completed run, i.e. the test now
+  #     passes and the entry is stale.
+  #
+  # Staleness is ADVISORY, deliberately. It is reported exactly as loudly as
+  # `greenApps` reports newly-green apps to bank, and like that report it does
+  # not set `status`: making it fatal would turn the PR that FIXES a test red,
+  # which is precisely the wrong incentive to build into a gate. The subset rule
+  # itself is what stays hard.
+  if [[ -n "$run_json" && -f "$run_json" ]]; then
+    local allowed stale
+    allowed=$(jq -r '[.apps[] | . as $app | (.allowedTestFailures // [])[]
+      | $app.appId + ": " + .] | .[]' "$run_json")
+    stale=$(jq -r '[.apps[] | . as $app | (.staleAllowListEntries // [])[]
+      | $app.appId + ": " + .] | .[]' "$run_json")
+
+    if [[ -n "$allowed" ]]; then
+      echo "self-migration: allow-listed test-parity failures (#3885) — these did NOT fail the gate:"
+      echo "$allowed" | sed 's/^/  ~ /'
+    fi
+
+    if [[ -n "$stale" ]]; then
+      echo "self-migration: allow-list entries no longer failing — remove from the allow-list:"
+      echo "$stale" | sed 's/^/  - /'
+    fi
+  fi
+
   if (( status == 0 )); then
     echo "Self-migration gate PASSED."
   fi

--- a/tools/cs2gs/Cs2Gs.Cli/Program.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/Program.cs
@@ -208,6 +208,21 @@ internal static class Program
                     Console.WriteLine($"    -> {app.FailureCategory}: {artifact}");
                 }
             }
+
+            // Issue #3885 requirement 3: an app that is green ONLY because of
+            // the test-parity allow-list must say so in the same place its
+            // verdict is printed. An allow-list that is invisible on a passing
+            // run is the dangerous kind.
+            foreach (string allowed in app.AllowedTestFailures)
+            {
+                Console.WriteLine($"    ~> allow-listed test failure: {allowed}");
+            }
+
+            foreach (string stale in app.StaleAllowListEntries)
+            {
+                Console.WriteLine(
+                    $"    ~> allow-list entry no longer failing — remove from the allow-list: {stale}");
+            }
         }
 
         Console.WriteLine();
@@ -231,7 +246,8 @@ internal static class Program
             return helpRequested ? 0 : 1;
         }
 
-        (string corpus, List<string> appIds, PipelineOptions options, string baselinePath, bool baselineStrict, bool translateOnly) = parsed.Value;
+        (string corpus, List<string> appIds, PipelineOptions options, string baselinePath,
+            bool baselineStrict, bool translateOnly, string allowListPath) = parsed.Value;
 
         // Issue #3732: canonicalize, not merely absolutize. A root reached
         // through a symlink (`/tmp` and `$TMPDIR` are both links on macOS)
@@ -243,6 +259,20 @@ internal static class Program
         corpus = options.SourceRoot;
         options.OutputRoot = CanonicalRootPath.Resolve(options.OutputRoot);
         options.ArtifactRoot = CanonicalRootPath.Resolve(options.ArtifactRoot);
+
+        // Issue #3885: the test-parity failure allow-list, read from the source
+        // repository. A malformed list stops the run here — degrading to "allow
+        // nothing" would surface as an unrelated wall of parity failures.
+        try
+        {
+            options.TestParityAllowList = TestParityAllowList.LoadForRepository(
+                options.SourceRoot, allowListPath);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException || ex is IOException)
+        {
+            Console.Error.WriteLine("cs2gs: " + ex.Message);
+            return 1;
+        }
 
         IReadOnlyList<CorpusApp> apps;
         if (options.OutputLayout == MigrationOutputLayout.Repository)
@@ -539,6 +569,7 @@ internal static class Program
         helpRequested = false;
         string corpus = null;
         string baselinePath = null;
+        string allowListPath = null;
         bool baselineStrict = false;
         bool translateOnly = false;
         var appIds = new List<string>();
@@ -587,6 +618,9 @@ internal static class Program
                     case "--baseline":
                         baselinePath = NextValue(args, ref i, arg);
                         break;
+                    case "--test-allowlist":
+                        allowListPath = NextValue(args, ref i, arg);
+                        break;
                     case "--baseline-strict":
                         baselineStrict = true;
                         break;
@@ -623,7 +657,8 @@ internal static class Program
             }
         }
 
-        return new MigrateArguments(corpus, appIds, options, baselinePath, baselineStrict, translateOnly);
+        return new MigrateArguments(
+            corpus, appIds, options, baselinePath, baselineStrict, translateOnly, allowListPath);
     }
 
     /// <summary>
@@ -710,6 +745,8 @@ internal static class Program
         Console.WriteLine("  --baseline <file> Gate on the gap ledger (tools/cs2gs/triage/gaps.json): fail only on");
         Console.WriteLine("                    NEW or REGRESSED fingerprints; known-open gaps are tolerated.");
         Console.WriteLine("  --baseline-strict Also fail on STALE ledger entries (nightly mode).");
+        Console.WriteLine("  --test-allowlist <file>  Test-parity failure allow-list (issue #3885); default:");
+        Console.WriteLine("                    <corpus>/" + TestParityAllowList.DefaultRelativePath + " when present.");
         Console.WriteLine("  --via-sdk         Build emitted G# via 'dotnet build' + Gsharp.NET.Sdk (default).");
         Console.WriteLine("  --no-via-sdk      Use the legacy direct-gsc compile path.");
         Console.WriteLine("  --translate-only  Repository migration only (issue #3668): run stage 1 across the WHOLE");
@@ -746,13 +783,15 @@ internal static class Program
     /// <param name="BaselinePath">The gap-ledger path, or <see langword="null"/>.</param>
     /// <param name="BaselineStrict">Whether stale ledger entries fail the gate.</param>
     /// <param name="TranslateOnly">Whether to run the translate stage only (issue #3668).</param>
+    /// <param name="AllowListPath">An explicit test-parity allow-list path, or <see langword="null"/> (issue #3885).</param>
     private readonly record struct MigrateArguments(
         string Corpus,
         List<string> AppIds,
         PipelineOptions Options,
         string BaselinePath,
         bool BaselineStrict,
-        bool TranslateOnly);
+        bool TranslateOnly,
+        string AllowListPath);
 
     /// <summary>
     /// Sentinel exception thrown by <see cref="NextValue"/> when an option's

--- a/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
+++ b/tools/cs2gs/Cs2Gs.Cli/ValidateCommand.cs
@@ -44,6 +44,7 @@ internal static class ValidateCommand
         string corpus = null;
         string migrated = null;
         string manifests = null;
+        string allowListPath = null;
         int shardIndex = -1;
         int shardCount = 0;
         var appIds = new List<string>();
@@ -69,6 +70,9 @@ internal static class ValidateCommand
                     break;
                 case "--manifests":
                     manifests = Next(args, ref i, arg);
+                    break;
+                case "--test-allowlist":
+                    allowListPath = Next(args, ref i, arg);
                     break;
                 case "--app":
                     appIds.Add(Next(args, ref i, arg).Replace('\\', '/'));
@@ -124,6 +128,22 @@ internal static class ValidateCommand
             ? options.OutputRoot + ".cs2gs-runs"
             : CanonicalRootPath.Resolve(options.ArtifactRoot);
 
+        // Issue #3885: load the test-parity failure allow-list from the SOURCE
+        // repository (never the migrated mirror — the list is a statement about
+        // the migration, made by the repository being migrated). A malformed
+        // list stops the shard here rather than degrading to "allow nothing",
+        // which would read as an unrelated wall of parity failures.
+        try
+        {
+            options.TestParityAllowList = TestParityAllowList.LoadForRepository(
+                options.SourceRoot, allowListPath);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException || ex is IOException)
+        {
+            Console.Error.WriteLine("cs2gs: " + ex.Message);
+            return 1;
+        }
+
         manifests = string.IsNullOrEmpty(manifests)
             ? FindLatestRunDir(options.ArtifactRoot)
             : CanonicalRootPath.Resolve(manifests);
@@ -154,6 +174,14 @@ internal static class ValidateCommand
         Console.WriteLine(
             $"cs2gs validate: {selected.Count} of {allApps.Count} app(s) selected; " +
             $"migrated tree {options.OutputRoot}; manifests {manifests}.");
+        if (options.TestParityAllowList.Entries.Count > 0)
+        {
+            // Issue #3885: an allow-list in force is stated up front, not
+            // discovered afterwards from a green result.
+            Console.WriteLine(
+                $"cs2gs validate: test-parity failure allow-list active with " +
+                $"{options.TestParityAllowList.Entries.Count} entry/entries (#3885).");
+        }
 
         var pipeline = new MigrationPipeline(options, ValidationStages());
         RunResult result = await pipeline
@@ -320,5 +348,7 @@ internal static class ValidateCommand
         Console.WriteLine("  --config <name>    Build config used to find gsc and the SDK package (default: Release).");
         Console.WriteLine("  --gsc <path>       Override gsc.dll.");
         Console.WriteLine("  --gsgen <path>     Override gsgen.dll.");
+        Console.WriteLine("  --test-allowlist <file>  Test-parity failure allow-list (issue #3885); default:");
+        Console.WriteLine("                     <corpus>/" + TestParityAllowList.DefaultRelativePath + " when present.");
     }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -218,6 +218,22 @@ public sealed class StageExecutionContext
     /// identify a test project.
     /// </summary>
     public bool IsTestProject { get; set; }
+
+    /// <summary>
+    /// Gets the mirrored test failures that <see cref="PipelineOptions.TestParityAllowList"/>
+    /// covered in this app's run (issue #3885). Populated even when the app
+    /// still fails, and ALWAYS reported: an allow-list that silences its own
+    /// entries is the dangerous kind.
+    /// </summary>
+    public List<string> AllowedTestFailures { get; } = new List<string>();
+
+    /// <summary>
+    /// Gets the allow-list entries for this app whose test did NOT fail in a
+    /// completed run (issue #3885) — they should be removed. Advisory, mirroring
+    /// how <c>greenApps</c> reports newly-green apps to bank rather than failing
+    /// the run over them.
+    /// </summary>
+    public List<string> StaleTestAllowListEntries { get; } = new List<string>();
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -867,6 +867,13 @@ public sealed class MigrationPipeline
             shortCircuited = true;
         }
 
+        // Issue #3885: carry the test-parity allow-list verdict into the run
+        // record, PASS or FAIL. The gate summary reads it back so an app that
+        // is green only because of the allow-list still names the failures it
+        // was excused, and a stale entry is visible without reading a log.
+        appResult.AllowedTestFailures.AddRange(context.AllowedTestFailures);
+        appResult.StaleAllowListEntries.AddRange(context.StaleTestAllowListEntries);
+
         if (appResult.Succeeded && appResult.Stages.Any(s => s.Status == "skipped"))
         {
             // No stage failed, but at least one was genuinely unverified

--- a/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
@@ -101,6 +101,15 @@ public sealed class PipelineOptions
     public bool CompileViaSdk { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the test-parity failure allow-list (issue #3885): the
+    /// individually-named migrated tests whose failure is a policy exclusion
+    /// rather than a defect, so an app whose failing set is a SUBSET of it still
+    /// reports green. <see langword="null"/> is treated as
+    /// <see cref="TestParityAllowList.Empty"/> — every failure fails the app.
+    /// </summary>
+    public TestParityAllowList TestParityAllowList { get; set; }
+
+    /// <summary>
     /// Gets or sets the canonical source-project to generated-project mapping
     /// established before migration starts.
     /// </summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
@@ -107,6 +107,25 @@ public sealed class AppResult
     [JsonPropertyName("fingerprints")]
     [JsonPropertyOrder(6)]
     public List<string> Fingerprints { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the mirrored test failures the test-parity allow-list
+    /// covered for this app (issue #3885). Present on a GREEN app: a run that
+    /// passes only because of the allow-list must still say so, or the list
+    /// becomes the invisible kind.
+    /// </summary>
+    [JsonPropertyName("allowedTestFailures")]
+    [JsonPropertyOrder(7)]
+    public List<string> AllowedTestFailures { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the allow-list entries for this app whose test did not fail
+    /// in a completed run (issue #3885) — they are stale and should be removed.
+    /// Advisory: reported, never a reason the gate goes red.
+    /// </summary>
+    [JsonPropertyName("staleAllowListEntries")]
+    [JsonPropertyOrder(8)]
+    public List<string> StaleAllowListEntries { get; set; } = new List<string>();
 }
 
 /// <summary>

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityAllowList.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityAllowList.cs
@@ -1,0 +1,546 @@
+// <copyright file="TestParityAllowList.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace Cs2Gs.Pipeline;
+
+/// <summary>
+/// Issue #3885: the test-parity failure allow-list — the small, explicit set of
+/// migrated tests that are KNOWN to fail for a reason that is policy rather than
+/// defect, so a mirrored test run whose failures are a subset of it still
+/// reports green.
+/// <para>
+/// The motivating class is a test that asserts on its OWN repository's source
+/// layout: <c>test/Sdk.Tests</c> reads <c>Gsharp.NET.Sdk.csproj</c> and matches
+/// <c>Contains("SemaphoreSlim updateGate")</c>. The migrated mirror correctly
+/// holds <c>.gsproj</c> and G# syntax, so those assertions cannot hold there —
+/// and relaxing them would weaken a real guard in the UNMIGRATED repository.
+/// Neither "fix the test" nor "fix the translator" applies; the premise "I am
+/// running in the C# repo" is deliberately untrue after migration.
+/// </para>
+/// <para>
+/// An allow-list is a hole in the gate by construction, so every rule here
+/// exists to keep the hole small, visible and self-maintaining:
+/// </para>
+/// <list type="number">
+/// <item><description>
+/// <b>Individual tests only.</b> An entry names one test, and
+/// <see cref="ValidateEntries"/> rejects anything that could name more than one:
+/// no wildcards, and a name that is at least <c>Class.Method</c>. Matching is
+/// suffix-anchored at the METHOD (see <see cref="Matches"/>), so a namespace or
+/// class prefix can never match a test — allow-listing a whole app or a whole
+/// class is not expressible, not merely discouraged.
+/// </description></item>
+/// <item><description>
+/// <b>Justification is mandatory.</b> An entry without a substantive
+/// <c>reason</c> is a load error, not a silently-honoured entry. An unexplained
+/// entry is how a list rots.
+/// </description></item>
+/// <item><description>
+/// <b>Report, never hide.</b> <see cref="TestParityAllowListVerdict"/> carries
+/// the allowed failures out of the stage so the run record and the gate summary
+/// name them even on a PASS.
+/// </description></item>
+/// <item><description>
+/// <b>Stale entries are detectable.</b> An entry whose test did NOT fail in a
+/// completed run is reported as stale, mirroring how <c>greenApps</c> reports
+/// newly-green apps to bank.
+/// </description></item>
+/// <item><description>
+/// <b>Subset, not intersection.</b> <see cref="Evaluate"/> partitions the
+/// failing set; the caller may only pass when
+/// <see cref="TestParityAllowListVerdict.UnallowedFailures"/> is empty. "Some
+/// failures were allowed" is never enough.
+/// </description></item>
+/// </list>
+/// </summary>
+public sealed class TestParityAllowList
+{
+    /// <summary>
+    /// The repository-relative location of the gate's allow-list. It is a file
+    /// of its own rather than another key in <c>selfmig-baseline.json</c>: the
+    /// baseline is a ratchet (floors and ceilings) edited when a run banks a
+    /// win, this is a policy register edited when a test's premise stops
+    /// holding, and the two have different authors, different review bars and
+    /// different cadences.
+    /// </summary>
+    public const string DefaultRelativePath = "tools/cs2gs/selfmig-test-allowlist.json";
+
+    /// <summary>
+    /// The minimum length of a usable <c>reason</c>. "flaky" and "wip" are not
+    /// justifications; the bar is low enough that any real sentence clears it
+    /// and high enough that a placeholder does not.
+    /// </summary>
+    public const int MinimumReasonLength = 24;
+
+    private static readonly Regex FailedTestLine = new Regex(
+        @"^[ \t]*Failed[ \t]+(?<name>[^\r\n]*?)(?:[ \t]+\[[^\]\r\n]*\])?[ \t]*$",
+        RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ReportedFailureTotal = new Regex(
+        @"^[ \t]*(?:Passed|Failed)!\s+-\s+Failed:\s*(?<failed>\d+)",
+        RegexOptions.Multiline | RegexOptions.CultureInvariant);
+
+    private static readonly Regex IssueReference = new Regex(
+        @"^#[0-9]+$", RegexOptions.CultureInvariant);
+
+    private readonly List<TestParityAllowListEntry> entries;
+
+    private TestParityAllowList(List<TestParityAllowListEntry> entries)
+    {
+        this.entries = entries;
+    }
+
+    /// <summary>Gets an allow-list with no entries: every failure fails the app.</summary>
+    public static TestParityAllowList Empty =>
+        new TestParityAllowList(new List<TestParityAllowListEntry>());
+
+    /// <summary>Gets the validated entries, in file order.</summary>
+    public IReadOnlyList<TestParityAllowListEntry> Entries => this.entries;
+
+    /// <summary>
+    /// Loads and validates the allow-list at <paramref name="path"/>, or returns
+    /// <see cref="Empty"/> when no file is there. A file that EXISTS but does
+    /// not validate is always an error: a malformed allow-list must stop the run
+    /// loudly, never degrade to "allow nothing" (which reads as an unrelated
+    /// wall of parity failures) nor to "allow everything".
+    /// </summary>
+    /// <param name="path">The absolute path to the allow-list JSON, or null.</param>
+    /// <returns>The parsed allow-list, or <see cref="Empty"/>.</returns>
+    public static TestParityAllowList LoadOrEmpty(string path)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            return Empty;
+        }
+
+        return Load(path);
+    }
+
+    /// <summary>
+    /// Resolves and loads the allow-list for a repository migration: the
+    /// explicitly-supplied path when there is one (and it must then exist), or
+    /// <see cref="DefaultRelativePath"/> under the SOURCE repository, which is
+    /// optional. The source repository, never the migrated mirror: the list is
+    /// a statement the repository being migrated makes about its own tests.
+    /// </summary>
+    /// <param name="sourceRoot">The source repository root.</param>
+    /// <param name="explicitPath">An explicit allow-list path, or null.</param>
+    /// <returns>The parsed allow-list, or <see cref="Empty"/>.</returns>
+    public static TestParityAllowList LoadForRepository(string sourceRoot, string explicitPath)
+    {
+        if (!string.IsNullOrEmpty(explicitPath))
+        {
+            return Load(Path.GetFullPath(explicitPath));
+        }
+
+        if (string.IsNullOrEmpty(sourceRoot))
+        {
+            return Empty;
+        }
+
+        return LoadOrEmpty(Path.Combine(
+            sourceRoot, DefaultRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    /// <summary>
+    /// Loads and validates the allow-list at <paramref name="path"/>, which must exist.
+    /// </summary>
+    /// <param name="path">The absolute path to the allow-list JSON.</param>
+    /// <returns>The parsed allow-list.</returns>
+    /// <exception cref="FileNotFoundException">The file does not exist.</exception>
+    /// <exception cref="InvalidOperationException">The file is malformed or an entry is invalid.</exception>
+    public static TestParityAllowList Load(string path)
+    {
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                "Test-parity allow-list not found: " + path, path);
+        }
+
+        try
+        {
+            return Parse(File.ReadAllText(path));
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException(path + ": " + ex.Message, ex);
+        }
+    }
+
+    /// <summary>
+    /// Parses and validates allow-list JSON.
+    /// </summary>
+    /// <param name="json">The allow-list document text.</param>
+    /// <returns>The parsed allow-list.</returns>
+    /// <exception cref="InvalidOperationException">The JSON is malformed or an entry is invalid.</exception>
+    public static TestParityAllowList Parse(string json)
+    {
+        TestParityAllowListDocument document;
+        try
+        {
+            document = JsonSerializer.Deserialize<TestParityAllowListDocument>(
+                json,
+                new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip });
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                "the test-parity allow-list is not valid JSON: " + ex.Message, ex);
+        }
+
+        List<TestParityAllowListEntry> parsed = document is null || document.Entries is null
+            ? new List<TestParityAllowListEntry>()
+            : document.Entries;
+
+        IReadOnlyList<string> errors = ValidateEntries(parsed);
+        if (errors.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "the test-parity allow-list is invalid and the run cannot honour it:" +
+                Environment.NewLine + "  - " + string.Join(Environment.NewLine + "  - ", errors));
+        }
+
+        return new TestParityAllowList(parsed);
+    }
+
+    /// <summary>
+    /// The rules an entry has to satisfy, as a list of human-readable errors
+    /// (empty when every entry is well-formed). Exposed separately from
+    /// <see cref="Parse"/> so each rule is testable on its own.
+    /// </summary>
+    /// <param name="entries">The entries to check.</param>
+    /// <returns>One message per violated rule.</returns>
+    public static IReadOnlyList<string> ValidateEntries(
+        IReadOnlyList<TestParityAllowListEntry> entries)
+    {
+        var errors = new List<string>();
+        if (entries is null)
+        {
+            return errors;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (int index = 0; index < entries.Count; index++)
+        {
+            TestParityAllowListEntry entry = entries[index];
+            string where = "entry " + index.ToString(CultureInfo.InvariantCulture);
+            if (entry is null)
+            {
+                errors.Add(where + ": is null.");
+                continue;
+            }
+
+            string app = (entry.App ?? string.Empty).Trim();
+            string test = (entry.Test ?? string.Empty).Trim();
+            string reason = (entry.Reason ?? string.Empty).Trim();
+            string issue = (entry.Issue ?? string.Empty).Trim();
+
+            if (app.Length == 0)
+            {
+                errors.Add(where + ": 'app' is required — an entry is scoped to one app id.");
+            }
+            else if (app.IndexOf('*') >= 0 || app.IndexOf('?') >= 0)
+            {
+                errors.Add(where + " ('" + app + "'): 'app' must be a literal app id, not a pattern.");
+            }
+            else if (!app.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(where + " ('" + app + "'): 'app' must be the repository-relative " +
+                    "'.csproj' path the gate reports (e.g. 'test/Sdk.Tests/Sdk.Tests.csproj'), " +
+                    "so an entry cannot silently widen to a directory.");
+            }
+
+            if (test.Length == 0)
+            {
+                errors.Add(where + ": 'test' is required — the allow-list is per TEST, never per app.");
+            }
+            else if (test.IndexOf('*') >= 0 || test.IndexOf('?') >= 0)
+            {
+                errors.Add(where + " ('" + test + "'): 'test' must not contain wildcards; " +
+                    "one entry allows exactly one test method.");
+            }
+            else if (test.IndexOf('.') < 0)
+            {
+                errors.Add(where + " ('" + test + "'): 'test' must be at least " +
+                    "'Class.Method' — a bare name is ambiguous across an app.");
+            }
+            else if (test.EndsWith(".", StringComparison.Ordinal))
+            {
+                errors.Add(where + " ('" + test + "'): 'test' must end at the test method name.");
+            }
+
+            if (reason.Length < MinimumReasonLength)
+            {
+                errors.Add(where + " ('" + test + "'): 'reason' is required and must actually " +
+                    "explain why this failure is policy rather than a defect (at least " +
+                    MinimumReasonLength.ToString(CultureInfo.InvariantCulture) +
+                    " characters). An unexplained entry is how an allow-list rots.");
+            }
+
+            if (issue.Length > 0 && !IssueReference.IsMatch(issue))
+            {
+                errors.Add(where + " ('" + test + "'): 'issue' must be a '#<number>' " +
+                    "reference when present.");
+            }
+
+            if (app.Length > 0 && test.Length > 0 && !seen.Add(app + " " + test))
+            {
+                errors.Add(where + " ('" + test + "'): duplicate entry for app '" + app + "'.");
+            }
+        }
+
+        return errors;
+    }
+
+    /// <summary>
+    /// Extracts the per-test failure names a <c>dotnet test</c> console run
+    /// reported (the <c>Failed &lt;name&gt; [12 ms]</c> lines). The run SUMMARY
+    /// line (<c>Failed!  - Failed: 3, …</c>) never matches: it spells
+    /// <c>Failed!</c> with no separating whitespace.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <returns>The reported failing test names, in output order.</returns>
+    public static IReadOnlyList<string> ParseFailedTestNames(string output)
+    {
+        var names = new List<string>();
+        if (string.IsNullOrEmpty(output))
+        {
+            return names;
+        }
+
+        foreach (Match match in FailedTestLine.Matches(output))
+        {
+            string name = match.Groups["name"].Value.Trim();
+            if (name.Length > 0)
+            {
+                names.Add(name);
+            }
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// The number of failures the run SUMMARY reports, summed across every
+    /// summary line. The stage cross-checks this against
+    /// <see cref="ParseFailedTestNames"/>: allow-listing on a name list that
+    /// does not account for every reported failure would let an unnamed failure
+    /// through, so a mismatch must refuse the allow-list rather than trust it.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <returns>The reported failure total, or 0 when there is no summary.</returns>
+    public static int ReportedFailureCount(string output)
+    {
+        if (string.IsNullOrEmpty(output))
+        {
+            return 0;
+        }
+
+        int total = 0;
+        foreach (Match match in ReportedFailureTotal.Matches(output))
+        {
+            total += int.Parse(match.Groups["failed"].Value, CultureInfo.InvariantCulture);
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Normalizes a reported test name for comparison: strips the trailing
+    /// theory arguments (<c>Ns.C.M(x: 1)</c> → <c>Ns.C.M</c>) so an entry names
+    /// a test METHOD rather than one data row of it.
+    /// </summary>
+    /// <param name="reported">The name as the test runner reported it.</param>
+    /// <returns>The normalized name.</returns>
+    public static string NormalizeTestName(string reported)
+    {
+        string name = (reported ?? string.Empty).Trim();
+        int open = name.IndexOf('(');
+        return open >= 0 ? name.Substring(0, open).TrimEnd() : name;
+    }
+
+    /// <summary>
+    /// Partitions an app's reported failures into allowed and not-allowed, and
+    /// names the entries for this app that did not fire.
+    /// </summary>
+    /// <param name="appId">The corpus app id the run belongs to.</param>
+    /// <param name="failedTests">The failing test names the run reported.</param>
+    /// <returns>The verdict.</returns>
+    public TestParityAllowListVerdict Evaluate(string appId, IReadOnlyList<string> failedTests)
+    {
+        var allowed = new List<string>();
+        var unallowed = new List<string>();
+        var fired = new HashSet<string>(StringComparer.Ordinal);
+
+        List<TestParityAllowListEntry> scoped = this.entries
+            .Where(entry => string.Equals(
+                (entry.App ?? string.Empty).Trim(),
+                (appId ?? string.Empty).Trim(),
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        foreach (string reported in failedTests ?? Array.Empty<string>())
+        {
+            string normalized = NormalizeTestName(reported);
+            TestParityAllowListEntry match = scoped
+                .FirstOrDefault(entry => Matches(entry, normalized));
+            if (match is null)
+            {
+                unallowed.Add(reported);
+            }
+            else
+            {
+                allowed.Add(reported);
+                fired.Add(match.Test);
+            }
+        }
+
+        List<TestParityAllowListEntry> stale = scoped
+            .Where(entry => !fired.Contains(entry.Test))
+            .ToList();
+
+        return new TestParityAllowListVerdict(allowed, unallowed, stale);
+    }
+
+    /// <summary>
+    /// Gets the entries scoped to one app id.
+    /// </summary>
+    /// <param name="appId">The corpus app id.</param>
+    /// <returns>The entries for that app.</returns>
+    public IReadOnlyList<TestParityAllowListEntry> EntriesFor(string appId) => this.entries
+        .Where(entry => string.Equals(
+            (entry.App ?? string.Empty).Trim(),
+            (appId ?? string.Empty).Trim(),
+            StringComparison.OrdinalIgnoreCase))
+        .ToList();
+
+    /// <summary>
+    /// Whether an entry names the reported test. The comparison is anchored at
+    /// the END of the name, so <c>SdkLayoutTests.Foo</c> matches
+    /// <c>GSharp.Sdk.Tests.SdkLayoutTests.Foo</c> but <c>GSharp.Sdk.Tests</c> —
+    /// or any other namespace/class prefix — matches nothing at all. That
+    /// asymmetry is the mechanism by which "allow-list a whole app" is
+    /// impossible rather than merely disallowed.
+    /// </summary>
+    private static bool Matches(TestParityAllowListEntry entry, string normalizedReported)
+    {
+        string test = (entry.Test ?? string.Empty).Trim();
+        if (test.Length == 0)
+        {
+            return false;
+        }
+
+        return string.Equals(normalizedReported, test, StringComparison.Ordinal)
+            || normalizedReported.EndsWith("." + test, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>One allow-listed test-parity failure (issue #3885).</summary>
+public sealed class TestParityAllowListEntry
+{
+    /// <summary>Gets or sets the corpus app id (a repository-relative <c>.csproj</c> path).</summary>
+    [JsonPropertyName("app")]
+    [JsonPropertyOrder(0)]
+    public string App { get; set; }
+
+    /// <summary>
+    /// Gets or sets the test this entry allows, as at least
+    /// <c>Class.Method</c>. Never a pattern, never a class or namespace.
+    /// </summary>
+    [JsonPropertyName("test")]
+    [JsonPropertyOrder(1)]
+    public string Test { get; set; }
+
+    /// <summary>
+    /// Gets or sets why this failure is a policy exclusion rather than a
+    /// defect. Mandatory: see <see cref="TestParityAllowList.MinimumReasonLength"/>.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    [JsonPropertyOrder(2)]
+    public string Reason { get; set; }
+
+    /// <summary>Gets or sets the tracking issue (<c>#3885</c>), when there is one.</summary>
+    [JsonPropertyName("issue")]
+    [JsonPropertyOrder(3)]
+    public string Issue { get; set; }
+
+    /// <summary>Gets a one-line description used in run records and gate output.</summary>
+    /// <returns>The description.</returns>
+    public override string ToString() =>
+        this.Test + " (" + this.App + (string.IsNullOrEmpty(this.Issue) ? ")" : ", " + this.Issue + ")");
+}
+
+/// <summary>The document shape of <c>selfmig-test-allowlist.json</c>.</summary>
+public sealed class TestParityAllowListDocument
+{
+    /// <summary>Gets or sets the schema version (always <c>"1.0"</c>).</summary>
+    [JsonPropertyName("schemaVersion")]
+    [JsonPropertyOrder(0)]
+    public string SchemaVersion { get; set; } = "1.0";
+
+    /// <summary>Gets or sets the file-level explanation of what the list is for.</summary>
+    [JsonPropertyName("comment")]
+    [JsonPropertyOrder(1)]
+    public string Comment { get; set; }
+
+    /// <summary>Gets or sets the entries.</summary>
+    [JsonPropertyName("entries")]
+    [JsonPropertyOrder(2)]
+    public List<TestParityAllowListEntry> Entries { get; set; } = new List<TestParityAllowListEntry>();
+}
+
+/// <summary>
+/// The result of checking one app's reported test failures against the
+/// allow-list (issue #3885).
+/// </summary>
+public sealed class TestParityAllowListVerdict
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestParityAllowListVerdict"/> class.
+    /// </summary>
+    /// <param name="allowedFailures">The reported failures an entry covers.</param>
+    /// <param name="unallowedFailures">The reported failures no entry covers.</param>
+    /// <param name="staleEntries">The entries for this app whose test did not fail.</param>
+    public TestParityAllowListVerdict(
+        IReadOnlyList<string> allowedFailures,
+        IReadOnlyList<string> unallowedFailures,
+        IReadOnlyList<TestParityAllowListEntry> staleEntries)
+    {
+        this.AllowedFailures = allowedFailures ?? Array.Empty<string>();
+        this.UnallowedFailures = unallowedFailures ?? Array.Empty<string>();
+        this.StaleEntries = staleEntries ?? Array.Empty<TestParityAllowListEntry>();
+    }
+
+    /// <summary>Gets the reported failures an allow-list entry covers.</summary>
+    public IReadOnlyList<string> AllowedFailures { get; }
+
+    /// <summary>
+    /// Gets the reported failures no entry covers. The app may only pass when
+    /// this is empty: the rule is "the failing set is a SUBSET of the allowed
+    /// set", never "some failures were allowed".
+    /// </summary>
+    public IReadOnlyList<string> UnallowedFailures { get; }
+
+    /// <summary>
+    /// Gets the entries for this app whose test did not fail in a completed run
+    /// — i.e. the test now passes and the entry should be removed. Advisory:
+    /// reported loudly, but never the reason an app goes red, because the
+    /// alternative punishes the PR that FIXES a test.
+    /// </summary>
+    public IReadOnlyList<TestParityAllowListEntry> StaleEntries { get; }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -384,12 +384,10 @@ public sealed class TestParityStage : IMigrationStage
 
         if (verdict.UnallowedFailures.Count > 0)
         {
-            string notAllowed =
-                $"test-parity allow-list NOT APPLIED: {verdict.UnallowedFailures.Count} " +
-                "failure(s) are not on the list, so the app fails regardless of the " +
-                "allow-listed ones (#3885):" + Environment.NewLine + "  " +
-                string.Join(Environment.NewLine + "  ", verdict.UnallowedFailures);
-            this.Note(context, notAllowed);
+            string unlisted = string.Join(Environment.NewLine + "  ", verdict.UnallowedFailures);
+            string header = $"test-parity allow-list NOT APPLIED — " +
+                $"{verdict.UnallowedFailures.Count} failure(s) are not on the list (#3885):";
+            this.Note(context, header + Environment.NewLine + "  " + unlisted);
             return false;
         }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -270,6 +270,7 @@ public sealed class TestParityStage : IMigrationStage
         StageExecutionContext context, ProcessRunResult result)
     {
         this.Note(context, result.Output ?? string.Empty);
+        TestParityAllowList allowList = context.Options.TestParityAllowList ?? TestParityAllowList.Empty;
         if (result.ExitCode == 0)
         {
             // Issue #3869: exit code 0 is NOT evidence that tests ran. `dotnet
@@ -284,6 +285,13 @@ public sealed class TestParityStage : IMigrationStage
                 string ranNote = $"mirrored test run: {ExecutedTestCount(result.Output)} case(s) executed " +
                     $"(>= {minimumExpected} expected from the C# original's [Fact] methods).";
                 this.Note(context, ranNote);
+
+                // Issue #3885: an app whose tests ALL pass still has to answer
+                // for its allow-list entries. Without this, the only run in
+                // which a stale entry could surface is one that is failing for
+                // other reasons — and the list would never shrink.
+                this.RecordAllowList(
+                    context, allowList.Evaluate(context.App.Id, Array.Empty<string>()));
                 return StageOutcome.Passed();
             }
 
@@ -301,12 +309,138 @@ public sealed class TestParityStage : IMigrationStage
         // after the emitter when the real signal is a runtime failure, and
         // discards the per-test outcomes.
         string output = result.Output ?? "dotnet test failed without output.";
+        if (!CompletedTestRun(output))
+        {
+            return StageOutcome.Failed(new[]
+            {
+                context.Triage.TestParityLibraryBuildFailure(output, EmittedGsRelative(context)),
+            });
+        }
+
+        if (this.AllowListAbsolves(context, allowList, output))
+        {
+            return StageOutcome.Passed();
+        }
+
         return StageOutcome.Failed(new[]
         {
-            CompletedTestRun(output)
-                ? context.Triage.TestParityLibraryTestFailure(output, EmittedGsRelative(context))
-                : context.Triage.TestParityLibraryBuildFailure(output, EmittedGsRelative(context)),
+            context.Triage.TestParityLibraryTestFailure(output, EmittedGsRelative(context)),
         });
+    }
+
+    /// <summary>
+    /// Issue #3885: whether every failure this completed run reported is on the
+    /// allow-list, in which case the app is green despite a non-zero
+    /// <c>dotnet test</c> exit.
+    /// <para>
+    /// The bar is deliberately higher than "the names I could parse are all
+    /// allowed". Three things must hold together, and each guards a way this
+    /// mechanism could quietly become a licence to pass:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>
+    /// The parsed failure names must ACCOUNT FOR every failure the run summary
+    /// counts. If the console output names fewer failures than
+    /// <c>Failed: N</c> reports, some failure is unaccounted for and could be
+    /// anything; the allow-list is refused rather than trusted.
+    /// </description></item>
+    /// <item><description>
+    /// The unallowed set must be EMPTY. "Some failures were allowed" is not the
+    /// test; "the failing set is a subset of the allowed set" is.
+    /// </description></item>
+    /// <item><description>
+    /// The #3872/#3869 evidence that tests actually RAN still applies verbatim.
+    /// An allow-list entry excuses a test that fails, never a suite that never
+    /// executed: an app running zero tests fails whatever is on the list.
+    /// </description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="context">The stage context.</param>
+    /// <param name="allowList">The loaded allow-list.</param>
+    /// <param name="output">The captured <c>dotnet test</c> output of a completed run.</param>
+    /// <returns><see langword="true"/> when the app may be reported green.</returns>
+    private bool AllowListAbsolves(
+        StageExecutionContext context, TestParityAllowList allowList, string output)
+    {
+        IReadOnlyList<string> failed = TestParityAllowList.ParseFailedTestNames(output);
+        TestParityAllowListVerdict verdict = allowList.Evaluate(context.App.Id, failed);
+        this.RecordAllowList(context, verdict);
+
+        if (verdict.AllowedFailures.Count == 0)
+        {
+            return false;
+        }
+
+        int reported = TestParityAllowList.ReportedFailureCount(output);
+        if (failed.Count != reported)
+        {
+            string unaccounted =
+                $"test-parity allow-list REFUSED: parsed {failed.Count} per-test failure name(s) " +
+                $"but the run summary reports {reported} failure(s). An unaccounted-for failure " +
+                "could be anything, so the app fails (#3885).";
+            this.Note(context, unaccounted);
+            return false;
+        }
+
+        if (verdict.UnallowedFailures.Count > 0)
+        {
+            string notAllowed =
+                $"test-parity allow-list NOT APPLIED: {verdict.UnallowedFailures.Count} " +
+                "failure(s) are not on the list, so the app fails regardless of the " +
+                "allow-listed ones (#3885):" + Environment.NewLine + "  " +
+                string.Join(Environment.NewLine + "  ", verdict.UnallowedFailures);
+            this.Note(context, notAllowed);
+            return false;
+        }
+
+        // The #3872 guard is NOT waived by an allow-list. A suite that failed to
+        // run its tests must still fail even when the failures it did report are
+        // all allowed.
+        int minimumExpected = CountCSharpFactMethods(context);
+        string hollow = DescribeHollowTestRun(output, minimumExpected);
+        if (hollow is not null)
+        {
+            string neverRan =
+                "test-parity allow-list REFUSED: the run does not show tests actually " +
+                "executing, which an allow-list never waives (#3872/#3869): " + hollow;
+            this.Note(context, neverRan);
+            return false;
+        }
+
+        string passedNote =
+            $"mirrored test-parity PASSED with {verdict.AllowedFailures.Count} ALLOW-LISTED " +
+            $"failure(s) and no others; {ExecutedTestCount(output)} case(s) executed " +
+            $"(>= {minimumExpected} expected from the C# original's [Fact] methods) (#3885).";
+        this.Note(context, passedNote);
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3885 requirement 3 — report, never hide. Both halves of the
+    /// verdict are written to the stage log AND published on the context so the
+    /// run record (and through it the gate summary) names every allow-listed
+    /// failure that occurred, and every entry that no longer fires.
+    /// </summary>
+    /// <param name="context">The stage context.</param>
+    /// <param name="verdict">The allow-list verdict.</param>
+    private void RecordAllowList(StageExecutionContext context, TestParityAllowListVerdict verdict)
+    {
+        foreach (string allowed in verdict.AllowedFailures)
+        {
+            context.AllowedTestFailures.Add(allowed);
+            this.Note(context, "test-parity allow-listed failure: " + allowed);
+        }
+
+        foreach (TestParityAllowListEntry stale in verdict.StaleEntries)
+        {
+            // Advisory, never fatal (see TestParityAllowListVerdict.StaleEntries):
+            // a hard failure here would make the PR that FIXES a test red.
+            context.StaleTestAllowListEntries.Add(stale.ToString());
+            string staleNote =
+                "test-parity allow-list entry is STALE — no longer failing, remove from the " +
+                "allow-list: " + stale;
+            this.Note(context, staleNote);
+        }
     }
 
     private static int CountFactMethods(string source)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3885TestParityAllowListTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3885TestParityAllowListTests.cs
@@ -1,0 +1,839 @@
+// <copyright file="Issue3885TestParityAllowListTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3885: the test-parity failure allow-list. An allow-list is a hole in
+/// the gate by construction, so every test here exists to prove the hole is
+/// small, visible and self-maintaining — and, just as importantly, that the gate
+/// still fails everything it failed before.
+/// <para>
+/// The five requirements are proved one test each (and then some):
+/// </para>
+/// <list type="number">
+/// <item><description>granularity — an entry names a test, and a whole-app or
+/// whole-class entry is impossible, not merely discouraged;</description></item>
+/// <item><description>justification — an entry without a real reason fails to
+/// load;</description></item>
+/// <item><description>report, never hide — a pass names its allow-listed
+/// failures;</description></item>
+/// <item><description>staleness — an entry whose test now passes is
+/// reported;</description></item>
+/// <item><description>subset, not intersection — one failure that is NOT on the
+/// list still fails the app, whatever else is.</description></item>
+/// </list>
+/// </summary>
+public sealed class Issue3885TestParityAllowListTests
+{
+    /// <summary>
+    /// The three real #3885 failures as `dotnet test` reports them, verbatim in
+    /// shape: three `Failed <name>` lines plus a run summary of 86 cases.
+    /// </summary>
+    private const string SdkTestsOutput = """
+        Determining projects to restore...
+          Failed GSharp.Sdk.Tests.SdkLayoutTests.Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build [14 ms]
+          Error Message:
+           System.IO.FileNotFoundException : /mirror/src/Sdk/Gsharp.HotReload.Runtime/HotReloadAgent.cs
+          Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk [3 ms]
+          Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime [2 ms]
+        Failed!  - Failed:     3, Passed:    83, Skipped:     0, Total:    86, Duration: 5 s - Sdk.Tests.dll (net10.0)
+        """;
+
+    private const string SdkTestsAppId = "test/Sdk.Tests/Sdk.Tests.csproj";
+
+    /// <summary>The three seeded entries, exactly as the committed file spells them.</summary>
+    private const string SeededAllowList = """
+        {
+          "schemaVersion": "1.0",
+          "entries": [
+            {
+              "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+              "test": "SdkLayoutTests.Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build",
+              "reason": "Reads its own repository's HotReloadAgent.cs and asserts C# field syntax; the mirror correctly holds HotReloadAgent.gs.",
+              "issue": "#3885"
+            },
+            {
+              "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+              "test": "SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk",
+              "reason": "Reads Gsharp.NET.Sdk.csproj by its C# spelling; the mirror correctly holds Gsharp.NET.Sdk.gsproj and no .csproj at all.",
+              "issue": "#3885"
+            },
+            {
+              "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+              "test": "SdkLayoutTests.Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime",
+              "reason": "Matches a ProjectReference Include ending in .csproj, which the mirror correctly retargets to .gsproj.",
+              "issue": "#3885"
+            }
+          ]
+        }
+        """;
+
+    // ---------------------------------------------------------------------
+    // Requirement 1: granularity — individual tests, never apps.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// An entry that names only the app — no <c>test</c> at all — is rejected at
+    /// load. Allow-listing a whole app would let a genuine regression anywhere
+    /// in it pass silently, which is the failure mode that makes allow-lists
+    /// dangerous in the first place.
+    /// </summary>
+    [Fact]
+    public void WholeAppEntry_IsRejected()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                { "entries": [ { "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "reason": "these tests are all coupled to the C# spelling of the repo" } ] }
+                """));
+
+        Assert.Contains("'test' is required", error.Message, StringComparison.Ordinal);
+        Assert.Contains("per TEST, never per app", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Nor can an entry name many tests by pattern.
+    /// </summary>
+    [Fact]
+    public void WildcardEntry_IsRejected()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                { "entries": [ { "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "SdkLayoutTests.Sdk_Csproj_*",
+                  "reason": "these tests are all coupled to the C# spelling of the repo" } ] }
+                """));
+
+        Assert.Contains("must not contain wildcards", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A bare method name with no class is ambiguous across an app and is
+    /// rejected too: the entry has to be traceable to one declaration.
+    /// </summary>
+    [Fact]
+    public void BareMethodNameEntry_IsRejected()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                { "entries": [ { "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "Sdk_Csproj_Packs_As_MSBuildSdk",
+                  "reason": "reads its own repository's csproj by the C# spelling" } ] }
+                """));
+
+        Assert.Contains("at least", error.Message, StringComparison.Ordinal);
+        Assert.Contains("Class.Method", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The deeper half of requirement 1, and the reason the rule is a MECHANISM
+    /// rather than a convention: even an entry that LOOKS valid but names a
+    /// namespace or a class matches no test at all, because matching is anchored
+    /// at the method. There is no spelling of "allow-list this whole class"
+    /// that works, so nobody can reach for one.
+    /// </summary>
+    [Fact]
+    public void ClassOrNamespacePrefix_MatchesNothing()
+    {
+        TestParityAllowList list = TestParityAllowList.Parse("""
+            {
+              "entries": [
+                { "app": "test/Sdk.Tests/Sdk.Tests.csproj", "test": "GSharp.Sdk.Tests.SdkLayoutTests",
+                  "reason": "an attempt to allow-list an entire test class in one entry" },
+                { "app": "test/Sdk.Tests/Sdk.Tests.csproj", "test": "GSharp.Sdk",
+                  "reason": "an attempt to allow-list an entire namespace in one entry" }
+              ]
+            }
+            """);
+
+        TestParityAllowListVerdict verdict = list.Evaluate(
+            SdkTestsAppId, TestParityAllowList.ParseFailedTestNames(SdkTestsOutput));
+
+        Assert.Empty(verdict.AllowedFailures);
+        Assert.Equal(3, verdict.UnallowedFailures.Count);
+    }
+
+    /// <summary>
+    /// An entry is scoped to ONE app id: the same test name under a different
+    /// app is not covered.
+    /// </summary>
+    [Fact]
+    public void Entry_DoesNotLeakAcrossApps()
+    {
+        TestParityAllowList list = TestParityAllowList.Parse(SeededAllowList);
+
+        TestParityAllowListVerdict verdict = list.Evaluate(
+            "test/Core.Tests/Core.Tests.csproj",
+            TestParityAllowList.ParseFailedTestNames(SdkTestsOutput));
+
+        Assert.Empty(verdict.AllowedFailures);
+        Assert.Equal(3, verdict.UnallowedFailures.Count);
+    }
+
+    // ---------------------------------------------------------------------
+    // Requirement 2: justification is mandatory.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// An entry with no <c>reason</c> fails the whole load. It is not honoured
+    /// with a warning and it is not skipped: an unexplained entry is how a list
+    /// rots, and the run must stop rather than inherit one.
+    /// </summary>
+    [Fact]
+    public void EntryWithoutJustification_IsRejected()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                { "entries": [ { "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk" } ] }
+                """));
+
+        Assert.Contains("'reason' is required", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A placeholder reason is no justification either.
+    /// </summary>
+    [Fact]
+    public void PlaceholderJustification_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                { "entries": [ { "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk", "reason": "flaky" } ] }
+                """));
+    }
+
+    /// <summary>
+    /// A malformed <c>issue</c> reference is rejected, so the traceability the
+    /// field exists for cannot quietly decay into free text.
+    /// </summary>
+    [Fact]
+    public void MalformedIssueReference_IsRejected()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                { "entries": [ { "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk",
+                  "reason": "reads its own repository's csproj by the C# spelling",
+                  "issue": "see the tracking issue" } ] }
+                """));
+
+        Assert.Contains("'issue' must be", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Two entries for the same test in the same app is a merge accident, and a
+    /// duplicated entry is one nobody deletes. Rejected.
+    /// </summary>
+    [Fact]
+    public void DuplicateEntry_IsRejected()
+    {
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+            TestParityAllowList.Parse("""
+                {
+                  "entries": [
+                    { "app": "test/Sdk.Tests/Sdk.Tests.csproj", "test": "SdkLayoutTests.A",
+                      "reason": "reads its own repository's csproj by the C# spelling" },
+                    { "app": "test/Sdk.Tests/Sdk.Tests.csproj", "test": "SdkLayoutTests.A",
+                      "reason": "reads its own repository's csproj by the C# spelling" }
+                  ]
+                }
+                """));
+
+        Assert.Contains("duplicate entry", error.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A malformed list stops the run rather than degrading to "allow nothing"
+    /// (which reads as an unrelated wall of parity failures) or, worse, "allow
+    /// everything".
+    /// </summary>
+    [Fact]
+    public void MalformedJson_IsRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() => TestParityAllowList.Parse("{ not json"));
+    }
+
+    /// <summary>
+    /// No file at all means an EMPTY list — every failure fails the app — never
+    /// an error and never a permissive default.
+    /// </summary>
+    [Fact]
+    public void MissingFile_IsAnEmptyList()
+    {
+        TestParityAllowList list = TestParityAllowList.LoadOrEmpty(
+            Path.Combine(NewDirectory(), "not-there.json"));
+
+        Assert.Empty(list.Entries);
+        Assert.Equal(
+            3,
+            list.Evaluate(SdkTestsAppId, TestParityAllowList.ParseFailedTestNames(SdkTestsOutput))
+                .UnallowedFailures.Count);
+    }
+
+    // ---------------------------------------------------------------------
+    // Requirement 5: subset, not intersection.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// THE load-bearing test. Three allow-listed failures plus ONE that is not
+    /// on the list must fail the app — the check is "the failing set is a subset
+    /// of the allowed set", never "some failures were allowed".
+    /// </summary>
+    [Fact]
+    public void Stage_OneUnlistedFailureAmongAllowedOnes_StillFails()
+    {
+        string output = """
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build [14 ms]
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk [3 ms]
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime [2 ms]
+              Failed GSharp.Sdk.Tests.HotReloadDeltaBuilderTests.NewLocalSignature_IsMappedIntoDelta [9 ms]
+            Failed!  - Failed:     4, Passed:    82, Skipped:     0, Total:    86, Duration: 5 s - Sdk.Tests.dll (net10.0)
+            """;
+
+        StageOutcome outcome = RunStage(SeededAllowList, output, exitCode: 1, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-TESTS-FAILED");
+    }
+
+    /// <summary>
+    /// The same at list level, so the partition itself is pinned rather than
+    /// only its consequence.
+    /// </summary>
+    [Fact]
+    public void Evaluate_PartitionsRatherThanForgives()
+    {
+        TestParityAllowList list = TestParityAllowList.Parse(SeededAllowList);
+
+        TestParityAllowListVerdict verdict = list.Evaluate(
+            SdkTestsAppId,
+            new List<string>
+            {
+                "GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk",
+                "GSharp.Sdk.Tests.HotReloadDeltaBuilderTests.NewLocalSignature_IsMappedIntoDelta",
+            });
+
+        Assert.Single(verdict.AllowedFailures);
+        Assert.Single(verdict.UnallowedFailures);
+        Assert.Equal(
+            "GSharp.Sdk.Tests.HotReloadDeltaBuilderTests.NewLocalSignature_IsMappedIntoDelta",
+            verdict.UnallowedFailures[0]);
+    }
+
+    /// <summary>
+    /// If the console output does not NAME every failure the run summary counts,
+    /// the allow-list is refused outright. Otherwise an unnamed failure — a
+    /// truncated log, a crashed reporter — would ride along invisibly on the
+    /// named ones.
+    /// </summary>
+    [Fact]
+    public void Stage_UnaccountedForFailure_RefusesTheAllowList()
+    {
+        string output = """
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk [3 ms]
+            Failed!  - Failed:     7, Passed:    79, Skipped:     0, Total:    86, Duration: 5 s - Sdk.Tests.dll (net10.0)
+            """;
+
+        StageOutcome outcome = RunStage(SeededAllowList, output, exitCode: 1, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+    }
+
+    // ---------------------------------------------------------------------
+    // Requirements 3 and 4, and the before/after for test/Sdk.Tests.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// BEFORE: with no allow-list, the real <c>test/Sdk.Tests</c> run is red.
+    /// This is the state on <c>origin/main</c>, and the state the seeded list is
+    /// measured against.
+    /// </summary>
+    [Fact]
+    public void Stage_SdkTests_WithoutTheAllowList_IsRed()
+    {
+        StageOutcome outcome = RunStage(
+            allowListJson: null, output: SdkTestsOutput, exitCode: 1, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-TESTS-FAILED");
+    }
+
+    /// <summary>
+    /// AFTER: with the three entries seeded, the same run is green — and
+    /// requirement 3 holds, because the three allow-listed failures are still
+    /// NAMED on the context that feeds the run record and the gate summary. A
+    /// silent pass would be the dangerous outcome, not the desired one.
+    /// </summary>
+    [Fact]
+    public void Stage_SdkTests_WithTheAllowList_IsGreen_AndStillNamesTheFailures()
+    {
+        var context = new StageContextFixture(SeededAllowList, facts: 86);
+
+        StageOutcome outcome = new TestParityStage().EvaluateMirroredTestRun(
+            context.Context, new ProcessRunResult(1, SdkTestsOutput, string.Empty, false));
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+        Assert.Empty(outcome.Artifacts);
+
+        Assert.Equal(3, context.Context.AllowedTestFailures.Count);
+        Assert.Contains(
+            context.Context.AllowedTestFailures,
+            name => name.EndsWith("Sdk_Csproj_Packs_As_MSBuildSdk", StringComparison.Ordinal));
+        Assert.Empty(context.Context.StaleTestAllowListEntries);
+
+        string log = context.ReadLog();
+        Assert.Contains("ALLOW-LISTED", log, StringComparison.Ordinal);
+        Assert.Contains("Sdk_Csproj_Packs_As_MSBuildSdk", log, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The other half of the before/after: REMOVE one entry while its test still
+    /// fails and the app goes red again. Without this, "green with the list" is
+    /// not evidence that the list is what made it green.
+    /// </summary>
+    [Fact]
+    public void Stage_SdkTests_WithOneEntryRemoved_IsRedAgain()
+    {
+        // The seeded list minus Sdk_Csproj_Packs_As_MSBuildSdk, whose test still fails.
+        string twoEntries = """
+            {
+              "entries": [
+                {
+                  "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "SdkLayoutTests.Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build",
+                  "reason": "Reads its own repository's HotReloadAgent.cs and asserts C# field syntax."
+                },
+                {
+                  "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+                  "test": "SdkLayoutTests.Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime",
+                  "reason": "Matches a ProjectReference Include ending in .csproj, retargeted to .gsproj."
+                }
+              ]
+            }
+            """;
+
+        StageOutcome outcome = RunStage(twoEntries, SdkTestsOutput, exitCode: 1, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-TESTS-FAILED");
+    }
+
+    /// <summary>
+    /// Requirement 4: an entry whose test STARTS PASSING is reported as stale,
+    /// mirroring how <c>greenApps</c> reports newly-green apps to bank. It is
+    /// advisory — the app still passes — because a hard failure would make the
+    /// PR that FIXES a test red, which is the wrong incentive to build into a
+    /// gate.
+    /// </summary>
+    [Fact]
+    public void Stage_AllowListedTestThatNowPasses_IsReportedStale_ButNotFatal()
+    {
+        string oneNowPasses = """
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build [14 ms]
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk [3 ms]
+            Failed!  - Failed:     2, Passed:    84, Skipped:     0, Total:    86, Duration: 5 s - Sdk.Tests.dll (net10.0)
+            """;
+
+        var context = new StageContextFixture(SeededAllowList, facts: 86);
+
+        StageOutcome outcome = new TestParityStage().EvaluateMirroredTestRun(
+            context.Context, new ProcessRunResult(1, oneNowPasses, string.Empty, false));
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+        Assert.Single(context.Context.StaleTestAllowListEntries);
+        Assert.Contains(
+            "Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime",
+            context.Context.StaleTestAllowListEntries[0],
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "no longer failing", context.ReadLog(), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Staleness has to be visible on a FULLY green run too, otherwise the only
+    /// run that could ever report a stale entry is one that is failing for other
+    /// reasons, and the list would never shrink.
+    /// </summary>
+    [Fact]
+    public void Stage_FullyGreenRun_StillReportsEveryStaleEntry()
+    {
+        var context = new StageContextFixture(SeededAllowList, facts: 86);
+
+        StageOutcome outcome = new TestParityStage().EvaluateMirroredTestRun(
+            context.Context,
+            new ProcessRunResult(
+                0,
+                "Passed!  - Failed:     0, Passed:    86, Skipped:     0, Total:    86, Duration: 5 s - Sdk.Tests.dll (net10.0)",
+                string.Empty,
+                false));
+
+        Assert.Equal(StageStatus.Passed, outcome.Status);
+        Assert.Equal(3, context.Context.StaleTestAllowListEntries.Count);
+    }
+
+    // ---------------------------------------------------------------------
+    // The #3872 guard must survive the allow-list.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// #3872/#3869: an app whose tests fail to RUN must still fail, whatever is
+    /// on the allow-list. An entry excuses a test that ran and failed; it never
+    /// excuses a suite that never executed. #3869 found an app passing while
+    /// running zero tests — this mechanism must not reopen that door.
+    /// </summary>
+    [Fact]
+    public void Stage_ZeroTestsRan_StillFails_WithAFullAllowList()
+    {
+        string discoveryFailure = """
+            [xUnit.net 00:00:00.08] Exception discovering tests from Sdk.Tests:
+            System.TypeLoadException: A ByRef or ByRef-like type cannot be used ...
+            No test is available in /mirror/Sdk.Tests.dll. Make sure that test discoverer & executors are registered.
+            """;
+
+        StageOutcome outcome = RunStage(SeededAllowList, discoveryFailure, exitCode: 0, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "NO-TESTS-RAN");
+    }
+
+    /// <summary>
+    /// The subtler zero-test shape: a completed run that reports only
+    /// allow-listed failures but executed FEWER cases than the C# original
+    /// declares <c>[Fact]</c> methods. The allow-list would otherwise turn a
+    /// silent coverage collapse into a green app — exactly #3869's defect, one
+    /// mechanism further along.
+    /// </summary>
+    [Fact]
+    public void Stage_CoverageDrop_StillFails_EvenWhenEveryReportedFailureIsAllowed()
+    {
+        string tinyRun = """
+              Failed GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk [3 ms]
+            Failed!  - Failed:     1, Passed:     3, Skipped:     0, Total:     4, Duration: 1 s - Sdk.Tests.dll (net10.0)
+            """;
+
+        StageOutcome outcome = RunStage(SeededAllowList, tinyRun, exitCode: 1, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-TESTS-FAILED");
+    }
+
+    /// <summary>
+    /// A project that did not BUILD is still a build failure, not an
+    /// allow-listable set of test failures: there are no per-test outcomes to
+    /// allow. The #2867 classification must survive too.
+    /// </summary>
+    [Fact]
+    public void Stage_BuildFailure_IsStillABuildFailure()
+    {
+        StageOutcome outcome = RunStage(
+            SeededAllowList, "error GS0102: duplicate definition", exitCode: 1, facts: 86);
+
+        Assert.Equal(StageStatus.Failed, outcome.Status);
+        Assert.Contains(outcome.Artifacts, a => a.Diagnostic.Id == "LIBRARY-BUILD-FAILED");
+    }
+
+    // ---------------------------------------------------------------------
+    // Output parsing.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The run SUMMARY line (<c>Failed!  - Failed: 3, …</c>) is not a per-test
+    /// failure. Counting it as one would inflate the parsed name list past the
+    /// reported total and refuse every allow-list.
+    /// </summary>
+    [Fact]
+    public void ParseFailedTestNames_IgnoresTheRunSummaryLine()
+    {
+        IReadOnlyList<string> names = TestParityAllowList.ParseFailedTestNames(SdkTestsOutput);
+
+        Assert.Equal(3, names.Count);
+        Assert.All(names, name => Assert.StartsWith("GSharp.Sdk.Tests.", name, StringComparison.Ordinal));
+        Assert.Equal(3, TestParityAllowList.ReportedFailureCount(SdkTestsOutput));
+    }
+
+    /// <summary>
+    /// A theory row's arguments are stripped, so one entry covers the test
+    /// METHOD rather than one row of its data source.
+    /// </summary>
+    [Fact]
+    public void TheoryRows_NormalizeToTheirMethod()
+    {
+        Assert.Equal(
+            "Ns.C.M",
+            TestParityAllowList.NormalizeTestName("Ns.C.M(value: 1, other: \"x\")"));
+
+        TestParityAllowList list = TestParityAllowList.Parse("""
+            { "entries": [ { "app": "test/X/X.csproj", "test": "C.M",
+              "reason": "a theory whose every row asserts the C# spelling of the repo" } ] }
+            """);
+
+        TestParityAllowListVerdict verdict = list.Evaluate(
+            "test/X/X.csproj", new List<string> { "Ns.C.M(value: 1)", "Ns.C.M(value: 2)" });
+
+        Assert.Equal(2, verdict.AllowedFailures.Count);
+        Assert.Empty(verdict.UnallowedFailures);
+    }
+
+    // ---------------------------------------------------------------------
+    // The committed file itself.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The file the gate actually reads must load, must carry exactly the three
+    /// #3885 entries, and must NOT have grown the defects under investigation
+    /// (#3848/#3849 in InternalAnalyzers.Tests / LanguageServer.Tests /
+    /// GeneratorHost.Tests) — those are defects, not policy, and an allow-list
+    /// that absorbs them stops meaning anything.
+    /// </summary>
+    [Fact]
+    public void CommittedAllowList_LoadsAndHoldsOnlyTheSeededEntries()
+    {
+        string path = Path.Combine(RepoRoot(), TestParityAllowList.DefaultRelativePath);
+        Assert.True(File.Exists(path), path);
+
+        TestParityAllowList list = TestParityAllowList.Load(path);
+
+        Assert.Equal(3, list.Entries.Count);
+        Assert.All(list.Entries, entry => Assert.Equal(SdkTestsAppId, entry.App));
+        Assert.All(list.Entries, entry => Assert.Equal("#3885", entry.Issue));
+        Assert.Equal(3, list.EntriesFor(SdkTestsAppId).Count);
+
+        // Every seeded entry must actually fire against the observed run.
+        TestParityAllowListVerdict verdict = list.Evaluate(
+            SdkTestsAppId, TestParityAllowList.ParseFailedTestNames(SdkTestsOutput));
+        Assert.Equal(3, verdict.AllowedFailures.Count);
+        Assert.Empty(verdict.UnallowedFailures);
+        Assert.Empty(verdict.StaleEntries);
+    }
+
+    // ---------------------------------------------------------------------
+    // Requirement 3, end to end: the verdict survives the shard merge and is
+    // printed by the gate.
+    // ---------------------------------------------------------------------
+
+    /// <summary>
+    /// The verdict is produced by the validation SHARD that ran stage 4, so it
+    /// has to survive <c>build/merge-selfmig-runs.py</c>. Dropped here, an
+    /// allow-listed pass would be indistinguishable from an unconditional one in
+    /// the merged run the gate reads.
+    /// </summary>
+    [Fact]
+    public void Merge_CarriesTheAllowListVerdictFromTheShard()
+    {
+        string dir = NewDirectory();
+        string migratePath = Path.Combine(dir, "migrate.json");
+        string shardPath = Path.Combine(dir, "shard.json");
+        string outPath = Path.Combine(dir, "merged.json");
+
+        File.WriteAllText(migratePath, """
+            { "runId": "r1", "timestamp": "t", "gscVersion": "v", "gscPath": "p",
+              "succeeded": true, "apps": [ { "appId": "test/Sdk.Tests/Sdk.Tests.csproj",
+                "succeeded": true, "stages": [ { "stage": "translate", "status": "passed",
+                "artifactCount": 0 } ], "artifacts": [], "fingerprints": [] } ] }
+            """);
+        File.WriteAllText(shardPath, """
+            { "runId": "r2", "timestamp": "t", "gscVersion": "v", "gscPath": "p",
+              "succeeded": true, "apps": [ { "appId": "test/Sdk.Tests/Sdk.Tests.csproj",
+                "succeeded": true, "stages": [ { "stage": "test-parity", "status": "passed",
+                "artifactCount": 0 } ], "artifacts": [], "fingerprints": [],
+                "allowedTestFailures": [ "GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk" ],
+                "staleAllowListEntries": [ "SdkLayoutTests.Gone (test/Sdk.Tests/Sdk.Tests.csproj, #3885)" ] } ] }
+            """);
+
+        (int exit, string output) = RunProcess(
+            "python3",
+            Path.Combine(RepoRoot(), "build", "merge-selfmig-runs.py"),
+            "--migrate",
+            migratePath,
+            "--out",
+            outPath,
+            shardPath);
+        Assert.True(exit == 0, output);
+
+        string merged = File.ReadAllText(outPath);
+        Assert.Contains("Sdk_Csproj_Packs_As_MSBuildSdk", merged, StringComparison.Ordinal);
+        Assert.Contains("SdkLayoutTests.Gone", merged, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// And the gate itself must PRINT both halves. A green run that says nothing
+    /// about the allow-list is the failure mode this whole design exists to
+    /// avoid; a stale entry that nobody is told about is how the list rots.
+    /// Staleness is advisory here on purpose — the gate still PASSES — because a
+    /// hard failure would make the PR that fixes a test red.
+    /// </summary>
+    [Fact]
+    public void Gate_PrintsAllowListedFailuresAndStaleEntries_AndStillPasses()
+    {
+        string dir = NewDirectory();
+        string runJson = Path.Combine(dir, "run.json");
+        string baseline = Path.Combine(dir, "baseline.json");
+
+        File.WriteAllText(runJson, """
+            { "apps": [ { "appId": "test/Sdk.Tests/Sdk.Tests.csproj", "succeeded": true,
+                "allowedTestFailures": [ "GSharp.Sdk.Tests.SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk" ],
+                "staleAllowListEntries": [ "SdkLayoutTests.Gone (test/Sdk.Tests/Sdk.Tests.csproj, #3885)" ] } ] }
+            """);
+        File.WriteAllText(baseline, """
+            { "greenFloor": 1, "syntheticLabelCeiling": 0, "liftedLocalCeiling": 0,
+              "longLineCeiling": 0, "nullAssertionCeiling": 0,
+              "greenApps": [ "test/Sdk.Tests/Sdk.Tests.csproj" ] }
+            """);
+
+        string script = Path.Combine(dir, "gate.sh");
+        File.WriteAllText(script,
+            "set -euo pipefail\n" +
+            "source '" + Path.Combine(RepoRoot(), "build", "selfmig-common.sh") + "'\n" +
+            "labels=0; lifts=0; long_lines=0; bangs=0\n" +
+            "selfmig_apply_baseline '" + baseline + "' 1 1 '" + runJson + "'\n");
+
+        (int exit, string output) = RunProcess("bash", script);
+
+        Assert.True(exit == 0, output);
+        Assert.Contains("Self-migration gate PASSED.", output, StringComparison.Ordinal);
+        Assert.Contains("allow-listed test-parity failures", output, StringComparison.Ordinal);
+        Assert.Contains("Sdk_Csproj_Packs_As_MSBuildSdk", output, StringComparison.Ordinal);
+        Assert.Contains("no longer failing", output, StringComparison.Ordinal);
+        Assert.Contains("SdkLayoutTests.Gone", output, StringComparison.Ordinal);
+    }
+
+    private static (int Exit, string Output) RunProcess(string fileName, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo(fileName)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using Process process = Process.Start(startInfo);
+        string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return (process.ExitCode, output);
+    }
+
+    private static StageOutcome RunStage(
+        string allowListJson, string output, int exitCode, int facts)
+    {
+        var fixture = new StageContextFixture(allowListJson, facts);
+        return new TestParityStage().EvaluateMirroredTestRun(
+            fixture.Context, new ProcessRunResult(exitCode, output, string.Empty, false));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException("repository root not found from " + AppContext.BaseDirectory);
+    }
+
+    private static string NewDirectory()
+    {
+        string path = Path.Combine(
+            AppContext.BaseDirectory, "issue-3885-allowlist", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    /// <summary>
+    /// A stage context whose C# "original" declares <paramref name="facts"/>
+    /// <c>[Fact]</c> methods, so the #3872 lower bound is real rather than
+    /// disabled — a fixture with 0 facts would let a coverage-drop test pass for
+    /// the wrong reason.
+    /// </summary>
+    private sealed class StageContextFixture
+    {
+        private readonly string directory;
+
+        internal StageContextFixture(string allowListJson, int facts)
+        {
+            this.directory = NewDirectory();
+
+            var source = new System.Text.StringBuilder();
+            source.AppendLine("using Xunit;");
+            source.AppendLine("public class Own {");
+            for (int i = 0; i < facts; i++)
+            {
+                source.AppendLine($"    [Fact] public void T{i}() {{ }}");
+            }
+
+            source.AppendLine("}");
+
+            string csPath = Path.Combine(this.directory, "Own.cs");
+            File.WriteAllText(csPath, source.ToString());
+
+            string projectPath = Path.Combine(this.directory, "Sdk.Tests.csproj");
+            File.WriteAllText(projectPath, """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+                </Project>
+                """);
+
+            var app = new CorpusApp(SdkTestsAppId, projectPath, TargetKind.Library);
+            var options = new PipelineOptions
+            {
+                OutputRoot = this.directory,
+                TestParityAllowList = allowListJson is null
+                    ? null
+                    : TestParityAllowList.Parse(allowListJson),
+            };
+            var triage = new TriageBuilder("run_1", "2026-09-04T00:00:00Z", "0.0.0", app.Id);
+            this.Context = new StageExecutionContext(
+                app, options, new GscInvoker(FindCompiler()), this.directory, triage);
+            this.Context.EmittedFiles.Add(new EmittedGsFile("Own.gs", "Own.gs", csPath, string.Empty));
+        }
+
+        internal StageExecutionContext Context { get; }
+
+        internal string ReadLog()
+        {
+            string log = Path.Combine(this.directory, "test-parity.log");
+            return File.Exists(log) ? File.ReadAllText(log) : string.Empty;
+        }
+
+        private static string FindCompiler()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir is not null)
+            {
+                foreach (string config in new[] { "Release", "Debug" })
+                {
+                    string candidate = Path.Combine(
+                        dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                    if (File.Exists(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+
+                dir = dir.Parent;
+            }
+
+            return "gsc.dll";
+        }
+    }
+}

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -168,6 +168,41 @@ triage artifact; later stages are reported as `skip`.
    `Gsharp.NET.Sdk`) and compares the passing/failing test set against the C#
    xUnit oracle. Failures → `test-parity-failure`.
 
+#### The test-parity failure allow-list (`selfmig-test-allowlist.json`, #3885)
+
+Some migrated tests cannot pass, and should not be made to. A test that asserts
+on its **own repository's source layout** is spelling-coupled to the toolchain
+that produced it: `test/Sdk.Tests` reads `Gsharp.NET.Sdk.csproj` and matches
+`Contains("SemaphoreSlim updateGate")`. The mirror correctly holds `.gsproj` and
+G# syntax, so those assertions fail there — and relaxing them would weaken a
+real guard in the *unmigrated* repository. That is a policy question, not a
+defect.
+
+`tools/cs2gs/selfmig-test-allowlist.json` names those tests individually. An app
+whose mirrored failures are a **subset** of its entries reports green; the run
+still names every allow-listed failure it excused. The rules are enforced by
+`Cs2Gs.Pipeline/TestParityAllowList.cs`, not merely written down:
+
+* an entry names **one test** (`Class.Method` at minimum, no wildcards), and
+  matching is anchored at the method — a namespace or class prefix matches
+  nothing, so allow-listing a whole app or class is *not expressible*;
+* `reason` is **mandatory** and substantive; `issue` must be `#<number>` when
+  present. An unexplained entry fails the load, it is not silently honoured;
+* a failure **not** on the list still fails the app, even alongside allow-listed
+  ones — and a run whose named failures do not account for every failure its own
+  summary counts refuses the allow-list outright;
+* the #3872/#3869 evidence that tests actually **ran** is never waived: an app
+  executing zero tests, or fewer than its C# original's `[Fact]` count, fails
+  whatever is listed;
+* an entry whose test **starts passing** is reported as stale (`no longer
+  failing — remove from the allow-list`) by the gate, advisory rather than fatal
+  so that fixing a test is never punished with a red gate.
+
+It is deliberately a separate file from `selfmig-baseline.json`: that one is a
+ratchet (`greenFloor`, `greenApps`, the ceilings) edited when a run banks a win;
+this is a policy register edited when a test's premise stops holding. Real
+defects under investigation do **not** belong here.
+
 A fifth category cuts across all four: a stage that throws an unhandled
 exception is a defect in `cs2gs` itself, not a property of the code being
 migrated, and is recorded as `pipeline-crash` (issue #3804) with the C# file

--- a/tools/cs2gs/selfmig-test-allowlist.json
+++ b/tools/cs2gs/selfmig-test-allowlist.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "1.0",
+  "comment": "Issue #3885: the test-parity failure allow-list for the repo self-migration gate (build/run-cs2gs-selfmig.sh, stage 4). Each entry names ONE migrated test that is known to fail for a reason that is POLICY rather than defect; an app whose failing set is a SUBSET of its entries still reports green, and the run output still names every allow-listed failure that occurred. This is a hole in the gate by construction, so it is kept small on purpose. Rules, all enforced by Cs2Gs.Pipeline/TestParityAllowList.cs and not merely written down: (1) an entry names an individual test, at least 'Class.Method', with no wildcards — matching is anchored at the method, so a namespace or class prefix matches nothing and allow-listing a whole app or class is not expressible; (2) 'reason' is mandatory and substantive (>= 24 chars) and 'issue' is a '#<number>' reference where one exists — an unexplained entry fails to load, it is not silently honoured; (3) a failure NOT on this list still fails the app even when allow-listed failures are present alongside it, and a run whose named failures do not account for every failure the run summary counts refuses the allow-list outright; (4) the #3872/#3869 evidence that tests actually RAN is never waived — an app that executes zero tests, or fewer than its C# original's [Fact] count, fails regardless of what is listed here; (5) an entry whose test STOPS failing is reported as stale ('no longer failing — remove from the allow-list') on the next run, advisory rather than fatal so that fixing a test is never punished by a red gate. Deliberately NOT a section of selfmig-baseline.json: that file is a ratchet (greenFloor, greenApps, the ceilings) edited when a run banks a win, by the person who owns the ratchet; this is a policy register edited when a test's premise stops holding. Same directory, same contract, different lifecycles — and an allow-list PR must never conflict with a ratchet PR.\n\nWhat does NOT belong here: anything under investigation as a real defect. The parity failures in test/InternalAnalyzers.Tests, test/LanguageServer.Tests and test/GeneratorHost.Tests (#3848, #3849) are defects, not policy, and are deliberately absent.",
+  "entries": [
+    {
+      "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+      "test": "SdkLayoutTests.Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build",
+      "reason": "A test that asserts on its own repository's source layout is spelling-coupled to the toolchain that produced it. This one reads src/Sdk/Gsharp.HotReload.Runtime/HotReloadAgent.cs and asserts Contains(\"SemaphoreSlim updateGate\") — C# field-declaration syntax. The migrated mirror correctly holds HotReloadAgent.gs, which G# does not spell that way, so the test cannot pass there; relaxing the assertion would weaken a real guard on the HotReload agent's watch inputs in the unmigrated repository. Policy, not a translator defect.",
+      "issue": "#3885"
+    },
+    {
+      "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+      "test": "SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk",
+      "reason": "Reads src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj by its C# spelling. The mirrored SDK directory contains Gsharp.NET.Sdk.gsproj and no .csproj at all — which is exactly what a migrated repository should hold — so the read throws FileNotFoundException. Rewriting the test in terms of whichever extension its own toolchain uses would cost real assertion strength on SDK packaging wiring in the unmigrated repo. Policy, not a translator defect.",
+      "issue": "#3885"
+    },
+    {
+      "app": "test/Sdk.Tests/Sdk.Tests.csproj",
+      "test": "SdkLayoutTests.Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime",
+      "reason": "Same C#-spelling coupling as Sdk_Csproj_Packs_As_MSBuildSdk, and doubly so: beyond reading Gsharp.NET.Sdk.csproj it matches a ProjectReference Include ending in Gsharp.HotReload.Runtime\\Gsharp.HotReload.Runtime.csproj, which the mirror correctly retargets to .gsproj. Making it pass in the mirror means weakening the assertion in the unmigrated repo, where it is the actual guard on build-only referencing and runtime packing. Policy, not a translator defect.",
+      "issue": "#3885"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #3885.

## The case

`test/Sdk.Tests` is at **3 parity failures out of 86**, all one root cause: **a
test that asserts on its own repository's source layout is spelling-coupled to
the toolchain that produced it.** One reads `Gsharp.NET.Sdk.csproj`; one matches
a `ProjectReference Include` ending in `…Runtime.csproj`; one asserts
`Contains("SemaphoreSlim updateGate")` against C# field syntax. The migrated
mirror correctly holds `.gsproj` and G#, so they fail — and making them pass
means weakening assertions that are **real guards in the unmigrated repo**.

These are not defects. Their premise is "I am running in the C# repo", which is
deliberately untrue after migration. #3885 filed it to be decided, not patched.

## What this adds

`tools/cs2gs/selfmig-test-allowlist.json` plus the mechanism that honours it, in
`Cs2Gs.Pipeline/TestParityAllowList.cs`. An app whose mirrored test failures are
a **subset** of its entries reports green; the run still names every failure it
excused.

```json
{
  "app": "test/Sdk.Tests/Sdk.Tests.csproj",
  "test": "SdkLayoutTests.Sdk_Csproj_Packs_As_MSBuildSdk",
  "reason": "Reads src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj by its C# spelling. The mirrored SDK directory contains Gsharp.NET.Sdk.gsproj and no .csproj at all …",
  "issue": "#3885"
}
```

## The design is about keeping the hole small

An allow-list is a hole in the gate by construction. Every rule below is
**enforced by code**, not written down and hoped for — and each has a test.

| # | requirement | how it is enforced |
|---|---|---|
| 1 | individual tests, not apps | `test` is required, `Class.Method` at minimum, no wildcards — **and** matching is anchored at the method, so a namespace or class prefix matches nothing. Allow-listing a whole app or class is *not expressible*. |
| 2 | justification mandatory | `reason` required and substantive (≥ 24 chars); `issue` must be `#<number>` when present; duplicates rejected. An invalid entry **fails the load**; it is never silently honoured, and a malformed list stops the run rather than degrading to "allow nothing". |
| 3 | report, do not hide | the verdict is published on the stage context → `run.json` (`allowedTestFailures`) → `merge-selfmig-runs.py` → the gate summary, and printed by `cs2gs migrate/validate`. A green-by-allow-list app names its excused failures. |
| 4 | stale entries detectable | an entry whose test did not fail in a completed run is reported `no longer failing — remove from the allow-list`, including on a **fully green** run (otherwise the list could never shrink). |
| 5 | subset, not intersection | the app passes only when the unallowed set is empty — *and* only when the parsed failure names account for every failure the run summary counts. An unaccounted-for failure refuses the allow-list outright. |

**#3872's guard is not waived.** An allow-list entry excuses a test that ran and
failed; it never excuses a suite that never executed. An app running zero tests,
or fewer cases than its C# original's `[Fact]` count, fails whatever is listed.

## Stale entries: advisory, not fatal — recommended

Reported exactly as loudly as `greenApps` reports newly-green apps to bank, but
it does not set the gate's exit status. A hard failure would make the PR that
**fixes** a test red, which is the wrong incentive to build into a gate: the
author would have to touch a policy file to land a repair. The subset rule is
what stays hard. If the list ever grows large enough that stale entries linger,
the right escalation is a nightly check, not a per-PR failure.

## Where it lives, and why not `selfmig-baseline.json`

Separate file, same directory. `selfmig-baseline.json` is a **ratchet**
(`greenFloor`, `greenApps`, the ceilings) edited when a run banks a win, by the
person who owns the ratchet. This is a **policy register** edited when a test's
premise stops holding. Different authors, different cadence — and an allow-list
PR must never conflict with a ratchet PR on the one file that has to stay
conflict-free.

**`greenFloor`, `greenApps` and the ceilings are untouched here.** `Sdk.Tests`
moves in a separate PR once a gate run confirms it is genuinely green under this.

## Seeded with the known-good cases only

The three #3885 `Sdk.Tests` failures. **Nothing else.** The parity failures in
`InternalAnalyzers.Tests`, `LanguageServer.Tests` and `GeneratorHost.Tests`
(#3848, #3849) are real defects under investigation, not policy exclusions, and
are deliberately absent — a test asserts that the committed list holds exactly
the three entries.

## Evidence

`tools/cs2gs/Cs2Gs.Tests/Issue3885TestParityAllowListTests.cs`, 27 tests, all
executing real stage outcomes (not binding-only assertions):

* **before/after**: the real `Sdk.Tests` run is `Failed`/`LIBRARY-TESTS-FAILED`
  with no list, `Passed` with the three entries — and **red again** when one
  entry is removed while its test still fails;
* three allow-listed failures **plus one that is not** still fails the app;
* a whole-app entry, a wildcard entry, a bare method name, an entry with no
  reason, a placeholder reason, a bad issue reference and a duplicate are each
  rejected at load;
* a class/namespace-prefix entry matches **nothing** — the granularity rule is a
  mechanism, not a convention;
* an allow-listed test that now passes is reported stale, on a partially-failing
  run *and* on a fully green one, and the app still passes;
* **#3872 holds**: a `TypeLoadException` zero-test run and a silent coverage drop
  both still fail *with the full allow-list in force*;
* a build failure is still classified `LIBRARY-BUILD-FAILED` (#2867);
* end to end: `merge-selfmig-runs.py` carries the verdict across the shard merge,
  and `selfmig_apply_baseline` prints both halves while still reporting PASSED.

## Notes

* `build/selfmig-common.sh` and `build/merge-selfmig-runs.py` are touched (report
  plumbing). `build/run-cs2gs-selfmig*.sh` are **not** — no conflict with the
  #3836 PR-time translation guard work.
* `cs2gs` is inside its own migration corpus; the new file uses only constructs
  already present in `Cs2Gs.Pipeline` (static `readonly Regex`, `System.Text.Json`
  attributes, plain classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
