### PR TITLE
cs2gs: a PR-time translation guard for the hot core (#3836)

### DIFF
--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -1,0 +1,127 @@
+name: cs2gs-pr-guard
+
+# Issue #3836: the PR-time translation guard for the self-migration effort
+# (#3501).
+#
+# WHY THIS EXISTS
+#
+# build.yml COMPILES the repository's C# sources. The nightly
+# cs2gs-selfmig-nightly gate TRANSLATES them to G# and then compiles the
+# result. Those are different questions, so a fully CI-green PR can take the
+# gate down purely by existing — and the damage lands hours later, attributed
+# to whatever else merged nearby. Three times so far:
+#
+#   #3831  a new tools/cs2gs/Cs2Gs.Translator file did not translate;
+#          7 banked apps red, gate 43 -> 35.
+#   #3896  three untranslatable errors in #3882's new src/Core files;
+#          16 apps red, gate 44 -> 28.
+#   #3905  #3882's src/Sdk/Gsharp.Runtime.Channels crashed gsc with a stack
+#          overflow, blinding 11 apps.
+#
+# Each was found the slow way. All three are the same shape: a project most of
+# the corpus transitively references stopped surviving its own migration. This
+# job migrates exactly that hot core, on the PR, in minutes.
+#
+# WHAT IT IS NOT
+#
+# It is not the gate. It checks four projects, not fifty-three; it says
+# nothing about the readability ceilings or corpus-wide test parity. The job's
+# own output repeats that on every run, pass or fail, because a partial check
+# mistaken for a full one is worse than no check at all.
+#
+# It also does not currently cover src/Sdk/Gsharp.Runtime.Channels, so it
+# would NOT have caught #3905 as it stands. That project is red on main today
+# (#3907) and a guard that is red from day one gets disabled; the guarded set
+# is one line away from including it. See build/run-cs2gs-selfmig-pr-guard.sh.
+#
+# THE paths FILTER
+#
+# Scoped to exactly what the job can actually judge: the sources of the
+# guarded projects, plus the compiler and translator machinery that decides
+# how they translate, plus this job's own definition. #3836 suggested
+# `tools/cs2gs/**` alone — but #3896, the most expensive of the three
+# incidents, was a src/Core change, and src/Core is already inside the guarded
+# closure, so including it costs nothing extra to run and catches strictly
+# more.
+#
+# Note: `tools/cs2gs/**` is included in full even though only Cs2Gs.CodeModel
+# and Cs2Gs.Translator are guarded — a change to any part of cs2gs changes how
+# the guarded sources translate, which is the thing being measured.
+
+on:
+  pull_request:
+    paths:
+      # The guarded projects' own sources: a new file here is the #3831 /
+      # #3896 / #3905 hazard directly.
+      - 'src/Core/**'
+      - 'src/Analyzers/InternalAnalyzers/**'
+      # The translator: it decides what the guarded sources become.
+      - 'tools/cs2gs/**'
+      # The compiler and the SDK: they decide whether what it produces
+      # compiles. #3905 was a gsc crash, not a translation defect.
+      - 'src/Compiler/**'
+      - 'src/Sdk/Gsharp.NET.Sdk/**'
+      # The guard itself, so changes to it are exercised by it.
+      - 'build/run-cs2gs-selfmig-pr-guard.sh'
+      - '.github/workflows/cs2gs-pr-guard.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: cs2gs-pr-guard-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # See build.yml: parallel MSBuild nodes corrupt $GITHUB_ENV via
+  # Nerdbank.GitVersioning's GitBuildVersion* emission.
+  NBGV_SetCloudBuildVersionVars: false
+  SELFMIG_PR_GUARD_ROOT: /tmp/gsharp-cs2gs-pr-guard
+
+jobs:
+  guard:
+    name: hot-core translation guard
+    runs-on: ubuntu-latest
+    # The measured run is well under this; the headroom is for a gsc hang,
+    # which is a failure mode this job specifically exists to catch (#3905).
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Nerdbank.GitVersioning needs history to compute a version, and the
+          # migrated tree is restored as NuGet packages that carry it.
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore
+        run: dotnet restore GSharp.sln --locked-mode
+
+      - name: Restore .NET local tools
+        run: dotnet tool restore
+
+      # The script builds the solution itself (which repacks the
+      # Gsharp.NET.Sdk nupkg the compile stage consumes) and then migrates.
+      # That ordering is load-bearing: a freshly built gsc.dll alone is
+      # silently ignored by the packed-SDK compile path, and interleaving
+      # another `dotnet build` between the pack and the migrate is how MSB4236
+      # appears here. Do not add build steps above this one.
+      - name: Migrate and compile the hot core
+        run: ./build/run-cs2gs-selfmig-pr-guard.sh
+
+      - name: Upload guard artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: cs2gs-pr-guard
+          retention-days: 7
+          path: |
+            /tmp/gsharp-cs2gs-pr-guard/guard.log
+            /tmp/gsharp-cs2gs-pr-guard/runs/**/*.json
+            /tmp/gsharp-cs2gs-pr-guard/runs/**/report.html
+            /tmp/gsharp-cs2gs-pr-guard/runs/**/sdk.build.log
+            # The migrated .gs of the guarded projects, so a failure can be
+            # read at the source rather than reproduced locally.
+            /tmp/gsharp-cs2gs-pr-guard/migrated/**/*.gs

--- a/build/run-cs2gs-selfmig-pr-guard.sh
+++ b/build/run-cs2gs-selfmig-pr-guard.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# Issue #3836: the PR-time translation guard for the self-migration effort
+# (#3501).
+#
+# THE HAZARD THIS EXISTS FOR
+#
+# CI *compiles* the repository's C# sources. The self-migration gate
+# *translates* them to G# and then compiles the result. Those are different
+# questions, and a source file can answer the first perfectly while failing
+# the second — so a fully CI-green PR can take the nightly gate down purely by
+# existing, and the damage surfaces hours later attributed to whatever else
+# landed nearby. It has happened three times:
+#
+#   #3831  a new tools/cs2gs/Cs2Gs.Translator file did not translate;
+#          7 banked apps red, gate 43 -> 35.
+#   #3896  three untranslatable errors in #3882's new src/Core files;
+#          16 apps red, gate 44 -> 28.
+#   #3905  #3882's src/Sdk/Gsharp.Runtime.Channels crashed gsc with a stack
+#          overflow, blinding 11 apps behind "no parseable diagnostics".
+#
+# All three are the same shape: a *hot-core* project — one that most of the
+# corpus transitively references — stopped surviving its own migration, and
+# the cost was paid by everything downstream. This script migrates exactly
+# that hot core and nothing else, so the same failures are minutes of PR time
+# instead of a night of gate time.
+#
+# WHAT IT COVERS, AND WHAT IT DOES NOT
+#
+# It migrates the apps in $guard_apps below — Cs2Gs.Translator's reference
+# closure, which is #3836's recommendation — and runs translate -> compile ->
+# ilverify -> test-parity for those apps only.
+#
+# It is NOT the gate. It says nothing about the other ~49 apps, about the
+# readability ceilings, or about test parity across the corpus. A green run
+# here means "the hot core still migrates", never "this PR migrates fine".
+# The banner printed at the end says so out loud on purpose.
+#
+# In particular it does NOT cover src/Sdk/Gsharp.Runtime.Channels, i.e. it
+# would NOT have caught #3905 — see the note under guard_apps.
+#
+# Usage: run-cs2gs-selfmig-pr-guard.sh
+# Environment:
+#   SELFMIG_PR_GUARD_ROOT  work root (default ${TMPDIR:-/tmp}/gsharp-cs2gs-pr-guard)
+#   SELFMIG_PR_GUARD_APPS  space-separated override for the app list, so the
+#                          set can be widened (e.g. to tools/cs2gs/Cs2Gs.Tests
+#                          once #3836's ~9 known failures clear) without
+#                          editing this file.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# The guarded hot core, as repository-relative .csproj paths (which is exactly
+# what cs2gs uses as an app id).
+#
+# INVARIANT: this list must be CLOSED under ProjectReference. `--exclude` on a
+# project that a KEPT app references breaks reference resolution in the
+# migrated tree and manufactures phantom cascades — dropping src/Core from a
+# LanguageServer run once produced ~794 bogus errors. verify_closure() below
+# fails the run rather than let that happen silently.
+#
+#   src/Core                      the dependency root of most of the corpus,
+#                                 and #3896's blast radius.
+#   src/Analyzers/InternalAnalyzers  Core's analyzer ProjectReference.
+#   tools/cs2gs/Cs2Gs.CodeModel   Core -> CodeModel -> Translator, the chain
+#                                 #3836 names.
+#   tools/cs2gs/Cs2Gs.Translator  cs2gs is inside its own corpus (#3831).
+#
+# DELIBERATELY ABSENT, and the first thing to add back:
+#
+#   src/Sdk/Gsharp.Runtime.Channels — #3905's root, referenced by eight
+#   projects, and a ProjectReference leaf, so it would cost this job about
+#   four minutes and would make the guard cover all three incidents instead
+#   of two. It is left out only because it is RED ON MAIN TODAY (#3907: the
+#   #3905 crash fix un-blinded 327 diagnostics), and a guard that is red from
+#   day one gets ignored or disabled. Measured on 03b6e1e8d, adding it gives
+#   4/5 rather than 5/5 — a real failure, not a harness artifact, which is
+#   itself evidence this job detects the thing it is for. Add the line back
+#   the moment #3907 closes; nothing else needs to change.
+#
+# The same reasoning governs tools/cs2gs/Cs2Gs.Tests, which #3836 names as the
+# natural second step: it has ~9 known migration failures and would be red by
+# construction until those clear.
+guard_apps=(
+  src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj
+  src/Core/Core.csproj
+  tools/cs2gs/Cs2Gs.CodeModel/Cs2Gs.CodeModel.csproj
+  tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj
+)
+
+if [[ -n "${SELFMIG_PR_GUARD_APPS:-}" ]]; then
+  # shellcheck disable=SC2206
+  guard_apps=(${SELFMIG_PR_GUARD_APPS})
+fi
+
+work_root=${SELFMIG_PR_GUARD_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-pr-guard"}
+case "$work_root" in
+  ""|"/"|"$repo_root")
+    echo "Refusing unsafe PR-guard root: '$work_root'" >&2
+    exit 2
+    ;;
+esac
+
+# Fails the run when a guarded app project-references something outside the
+# guarded set, i.e. when the set stopped being closed under ProjectReference.
+# The check is textual on purpose: it needs no MSBuild evaluation, so it runs
+# before anything expensive.
+verify_closure() {
+  local app dir ref resolved missing=0
+  for app in "${guard_apps[@]}"; do
+    dir=$(dirname "$repo_root/$app")
+    while IFS= read -r ref; do
+      # Windows-style separators in the .csproj, POSIX path on disk.
+      ref=${ref//\\//}
+      resolved=$(cd "$dir" && cd "$(dirname "$ref")" 2>/dev/null && pwd -P)/$(basename "$ref")
+      resolved=${resolved#"$repo_root/"}
+      if [[ ! " ${guard_apps[*]} " == *" $resolved "* ]]; then
+        echo "PR guard: '$app' references '$resolved', which is not in the guarded set." >&2
+        missing=1
+      fi
+    done < <(grep -o 'ProjectReference Include="[^"]*"' "$repo_root/$app" 2>/dev/null \
+      | sed 's/.*Include="//; s/"$//')
+  done
+  if (( missing )); then
+    echo "PR guard: the guarded app set is no longer closed under ProjectReference." >&2
+    echo "Add the referenced project(s) to guard_apps — excluding them would" >&2
+    echo "manufacture phantom cascades rather than report real ones." >&2
+    exit 2
+  fi
+}
+
+verify_closure
+
+# Everything that is not guarded is excluded. Because the guarded set is
+# closed under ProjectReference (verified above), no kept app references an
+# excluded one, so this narrowing cannot manufacture the phantom cascades the
+# gate's --exclude invariant warns about.
+excludes=()
+while IFS= read -r project; do
+  if [[ ! " ${guard_apps[*]} " == *" $project "* ]]; then
+    excludes+=(--exclude "$project")
+  fi
+done < <(cd "$repo_root" && git ls-files '*.csproj' | sort)
+
+# A short list would mean the enumeration silently failed, and a migrate with
+# too few --excludes would quietly migrate the whole repository instead of the
+# hot core — a 30-minute job pretending to be a 20-minute one.
+if (( ${#excludes[@]} < 80 )); then
+  echo "PR guard: enumerated only $(( ${#excludes[@]} / 2 )) project(s) to exclude; the" >&2
+  echo "repository has ~60. Is this a git checkout?" >&2
+  exit 2
+fi
+
+rm -rf "$work_root"
+mkdir -p "$work_root"
+work_root=$(cd "$work_root" && pwd -P)
+
+# ORDER MATTERS, and this is the one part of the script that is fragile.
+#
+# The compile stage builds the migrated tree through the PACKED
+# Gsharp.NET.Sdk nupkg under out/bin/Release/nupkgs. A freshly built gsc.dll
+# alone is therefore silently ignored, and the run measures the OLD compiler —
+# which for a guard would be worse than useless. The Release Gsharp.NET.Sdk
+# build below repacks it, and it is the LAST thing built before migrate on
+# purpose: repack strictly before migrate with nothing built in between is the
+# ordering that avoids MSB4236 ("SDK not found") here.
+#
+# The three builds, in order:
+#   1. the migration tool itself, in Release;
+#   2. the Debug prerequisites — MSBuildWorkspace evaluates project loads in
+#      Debug regardless of --config Release, and Gsharp.Extensions.csproj's
+#      Bootstrap SDK import hard-errors when the Debug compiler/SDK outputs are
+#      missing, which fails ProjectLoad for the whole run;
+#   3. the Release SDK pack, immediately before migrate.
+#
+# Building GSharp.sln instead of these three also works and is what a local
+# proof usually does, but it compiles every test project for nothing and adds
+# roughly ten minutes to a job whose whole value is being fast.
+dotnet build "$repo_root/tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj" -c Release -graph
+dotnet build "$repo_root/src/Compiler/Compiler.csproj" -c Debug -graph
+dotnet build "$repo_root/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj" -c Debug -graph
+echo "PR guard: repacking the Release Gsharp.NET.Sdk nupkg (the compile stage consumes it)."
+dotnet build "$repo_root/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj" -c Release -graph
+
+started=$(date +%s)
+
+set +e
+dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
+  --corpus "$repo_root" \
+  --out "$work_root/migrated" \
+  --artifacts "$work_root/runs" \
+  --config Release \
+  "${excludes[@]}" \
+  | tee "$work_root/guard.log"
+migrate_exit=${PIPESTATUS[0]}
+set -e
+
+elapsed=$(( $(date +%s) - started ))
+
+run_json=$(find "$work_root/runs" -maxdepth 2 -name run.json | sort | tail -1)
+if [[ -z "$run_json" ]]; then
+  echo "PR guard: no run.json produced (migrate exit $migrate_exit)." >&2
+  exit 1
+fi
+
+green=$(jq '[.apps[] | select(.succeeded)] | length' "$run_json")
+total=$(jq '.apps | length' "$run_json")
+failed=$(jq -r '.apps[] | select(.succeeded | not) | .appId' "$run_json")
+
+echo
+echo "PR guard: $green/$total guarded app(s) migrated and compiled in ${elapsed}s (migrate exit $migrate_exit)."
+
+# The scope disclaimer is emitted on EVERY run, pass or fail. A partial check
+# that reads as a full one is worse than no check: the failure mode of #3831,
+# #3896 and #3905 was precisely someone concluding "CI is green, so this is
+# fine".
+guard_app_lines=$(printf '    - %s\n' "${guard_apps[@]}")
+scope_note="SCOPE — what a green run here does and does not mean.
+
+  It means: the ${#guard_apps[@]} hot-core project(s) below still translate to G# and
+  compile. Those are the projects whose migration failures have cascaded
+  widest (#3831, #3896, #3905).
+
+$guard_app_lines
+
+  It does NOT mean this PR migrates cleanly. The self-migration gate covers
+  ~53 apps, four readability ceilings and corpus-wide test parity; this job
+  covers none of that. Only the nightly cs2gs-selfmig gate is the gate."
+echo
+echo "$scope_note"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "### cs2gs PR translation guard (#3836)"
+    echo
+    echo "\`$green/$total\` guarded app(s) migrated + compiled in ${elapsed}s."
+    echo
+    if [[ -n "$failed" ]]; then
+      echo "**Failed:**"
+      echo "$failed" | sed 's/^/- `/; s/$/`/'
+      echo
+    fi
+    echo '```'
+    echo "$scope_note"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [[ -n "$failed" ]]; then
+  echo >&2
+  echo "PR guard FAILED: the following guarded app(s) did not survive migration:" >&2
+  echo "$failed" | sed 's/^/  - /' >&2
+  echo >&2
+  echo "This is the #3831/#3896/#3905 hazard: the C# compiles, the migrated G#" >&2
+  echo "does not. See $work_root/guard.log and the uploaded run artifacts for the" >&2
+  echo "diagnostics, and fix the source shape rather than the baseline." >&2
+  exit 1
+fi
+
+echo "PR guard PASSED."

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -143,6 +143,42 @@ See `build/run-cs2gs-selfmig-{migrate,validate,gate}.sh` and
 `.github/workflows/cs2gs-selfmig-nightly.yml`; `build/run-cs2gs-selfmig.sh`
 remains the equivalent single-job reference path for local proofs.
 
+### The PR-time translation guard (issue #3836)
+
+CI **compiles** the repository's C# sources. The gate **translates** them and
+then compiles the result. Those are different questions, so a fully CI-green
+PR can take the gate down purely by existing — and the damage lands hours
+later, attributed to whatever else merged nearby. It happened three times in
+five days: #3831 (a `Cs2Gs.Translator` file, 7 banked apps), #3896 (three
+errors in new `src/Core` files, 16 apps), #3905 (a gsc stack overflow on
+`Gsharp.Runtime.Channels`, 11 apps blinded).
+
+`build/run-cs2gs-selfmig-pr-guard.sh` (workflow
+`.github/workflows/cs2gs-pr-guard.yml`) migrates and compiles just the **hot
+core** — the projects whose migration failures cascade widest:
+
+```
+src/Analyzers/InternalAnalyzers  src/Core
+tools/cs2gs/Cs2Gs.CodeModel      tools/cs2gs/Cs2Gs.Translator
+```
+
+That is `Cs2Gs.Translator`'s reference closure, so it covers #3831 and #3896
+but **not** #3905: `src/Sdk/Gsharp.Runtime.Channels` is outside the closure and
+is red on `main` today (#3907), and a guard that is red from day one gets
+disabled. Adding it back is one line, and worth doing the moment #3907 closes.
+
+Everything else is `--exclude`d. That is safe here — and only here — because
+the set is **closed under `ProjectReference`**, so no kept app references an
+excluded one; the script verifies that closure before it builds anything and
+refuses to run otherwise. Widening the set means adding whole reference
+closures, never a single project. `SELFMIG_PR_GUARD_APPS` overrides the list
+(e.g. to add `tools/cs2gs/Cs2Gs.Tests` once #3836's known failures clear).
+
+**It is not the gate.** Four apps, no readability ceilings, no corpus-wide
+test parity. The script prints that disclaimer on every run, pass or fail,
+because a partial check mistaken for a full one is how #3831/#3896/#3905
+reached `main` in the first place.
+
 ### `report` — regenerate a report from an existing run
 
 ```sh


### PR DESCRIPTION
Closes #3836. Part of #3501. Recommended in PR #3835.

## The hazard

CI **compiles** the repository's C# sources. The self-migration gate
**translates** them to G# and then compiles the result. Those are different
questions, so a fully CI-green PR can take the gate down purely by existing —
and the damage lands hours later, attributed to whatever else merged nearby.
Three times in five days, at escalating cost: #3831 (a `Cs2Gs.Translator`
file, 7 banked apps, gate 43 → 35), #3896 (three errors in new `src/Core`
files, 16 apps, gate 44 → 28), #3905 (a gsc stack overflow on
`Gsharp.Runtime.Channels`, 11 apps blinded).

## What this adds

`build/run-cs2gs-selfmig-pr-guard.sh`, run by
`.github/workflows/cs2gs-pr-guard.yml`, migrates and compiles
`Cs2Gs.Translator`'s **reference closure** and nothing else:

```
src/Analyzers/InternalAnalyzers  src/Core
tools/cs2gs/Cs2Gs.CodeModel      tools/cs2gs/Cs2Gs.Translator
```

Everything outside the closure is `--exclude`d. That is safe **only** because
the set is closed under `ProjectReference` — no kept app references an
excluded one — which is exactly the condition whose violation manufactures
phantom cascades. The script verifies the closure textually before it builds
anything and refuses to run otherwise, so the set cannot silently rot into a
cascade generator when a guarded project grows a new reference.

Widening is a one-line edit to `guard_apps`, or the `SELFMIG_PR_GUARD_APPS`
environment override.

## Evidence

**Green on `main`** (`03b6e1e8d`), all four stages:

```
src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj  PASS  PASS  PASS  PASS
src/Core/Core.csproj                                      PASS  PASS  PASS  PASS
tools/cs2gs/Cs2Gs.CodeModel/Cs2Gs.CodeModel.csproj        PASS  PASS  PASS  PASS
tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj      PASS  PASS  PASS  PASS

4/4 apps green; run PASSED.
PR guard: 4/4 guarded app(s) migrated and compiled in 1225s (migrate exit 0).
```

**Red on #3896.** `main` with #3900's four production files reverted to their
pre-fix state (the three `src/Core` binder files and the one
`Cs2Gs.Translator` file) — i.e. the tree as it was when #3896 was live:

```
src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj  PASS  PASS     PASS  PASS
src/Core/Core.csproj                                      PASS  FAIL(3)  skip  skip
tools/cs2gs/Cs2Gs.CodeModel/Cs2Gs.CodeModel.csproj        PASS  FAIL(3)  skip  skip
tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj      PASS  FAIL(3)  skip  skip

1/4 apps green; run FAILED.
```

The three diagnostics are #3896's three, verbatim:

```
error GS0376: The initializer for const field 'ChanTypeName' must be a compile-time constant expression.
error GS0154: Parameter 'arguments' requires a value of type 'System.Collections.Immutable.ImmutableArray<…>'
error GS0155: Cannot convert type 'SyntaxNode?' to 'SyntaxNode'.
```

The cascade into `Cs2Gs.CodeModel` and `Cs2Gs.Translator` is the real one, not
an exclusion artifact — which is what keeping the closure whole buys.

**Runtime**: 1244 s wall (20.7 min) for the green run, of which 1225 s is the
migrate itself; on this machine the four builds were warm and cost 19 s. A
cold CI runner adds the restore plus those builds, so budget ~30 min. The
migrate cost is dominated by `src/Core` (≈10 min compile) and
`Cs2Gs.Translator` (≈6 min); there is no cheap way to cut it without cutting
coverage.

The build step is deliberately **not** `dotnet build GSharp.sln`: it builds
`Cs2Gs.Cli` (Release), the two Debug project-load prerequisites, and then
repacks the Release `Gsharp.NET.Sdk` nupkg immediately before migrating. The
repack is load-bearing — the compile stage consumes the packed SDK, so a
freshly built `gsc.dll` alone is silently ignored and the run would measure
the *old* compiler — and it goes last so nothing is built between the pack and
the migrate (`MSB4236`).

## The `paths:` filter, and why it is wider than #3836 proposed

#3836 proposed `paths: tools/cs2gs/**`. That would have caught only #3831.
The two expensive incidents were **not** cs2gs changes: #3896 was `src/Core`,
#3905 was `src/Sdk/Gsharp.Runtime.Channels`. Since `src/Core` is *already*
inside the guarded closure, adding it to the filter costs nothing at runtime
and catches strictly more. The filter is:

```
src/Core/**                     the guarded sources themselves (#3896)
src/Analyzers/InternalAnalyzers/**
tools/cs2gs/**                  the translator decides what they become (#3831)
src/Compiler/**                 gsc decides whether the result compiles (#3905's class)
src/Sdk/Gsharp.NET.Sdk/**       the SDK the compile stage builds through
build/run-cs2gs-selfmig-pr-guard.sh, .github/workflows/cs2gs-pr-guard.yml
```

At ~30 min this is not free enough to run on *every* PR, which is why it stays
path-filtered rather than unconditional.

## Correcting the framing in #3836 — this does NOT cover #3905

The premise that "a PR-time check would have caught all three" is **wrong for
#3905**, and I could not make it right without shipping a red job.

`src/Sdk/Gsharp.Runtime.Channels` is not in `Cs2Gs.Translator`'s reference
closure — nothing in the closure references it. I did include it at first:
it is a `ProjectReference` leaf, eight projects reference it, and it costs
about four minutes, so on cost/benefit it belongs. **Measured on `main`
(`03b6e1e8d`) it comes back red**: 4/5, `Gsharp.Runtime.Channels` failing
compile with a long list of diagnostics. That is #3907 — #3905's crash fix
un-blinded 327 diagnostics — not a harness artifact.

A guard that is red on `main` from day one gets ignored or disabled, so it is
out, documented as the first thing to add back, and the guarded set is one
line away from including it. (Incidentally, that run is itself evidence the
job detects what it is for: it independently reproduced an open regression in
under 20 minutes.)

`tools/cs2gs/Cs2Gs.Tests` — #3836's "natural second step" — is out for the
same reason and remains so until its ~9 known failures clear.

## What a green run does not mean

The job prints this on **every** run, pass or fail, because a partial check
mistaken for a full one is precisely how all three incidents reached `main`:

```
SCOPE — what a green run here does and does not mean.

  It means: the 4 hot-core project(s) below still translate to G# and
  compile. Those are the projects whose migration failures have cascaded
  widest (#3831, #3896, #3905).

    - src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj
    - src/Core/Core.csproj
    - tools/cs2gs/Cs2Gs.CodeModel/Cs2Gs.CodeModel.csproj
    - tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj

  It does NOT mean this PR migrates cleanly. The self-migration gate covers
  ~53 apps, four readability ceilings and corpus-wide test parity; this job
  covers none of that. Only the nightly cs2gs-selfmig gate is the gate.
```

`tools/cs2gs/selfmig-baseline.json` is untouched, and no gate script is
modified — only the new script, the new workflow and a README section.

Refs #3831, #3896, #3905, #3907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
