### PR TITLE
gsc + cs2gs: three root causes take migrated Gsharp.Runtime.Channels from 304 diagnostics to 34 (#3907)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -3450,6 +3450,17 @@ public sealed class Conversion
             return true;
         }
 
+        // Issue #3907: a tuple is always `ValueTuple<...>`, a struct — but
+        // TupleTypeSymbol.BuildClrType returns null as soon as ONE element is a
+        // same-compilation type, so the ClrType test below could not see it.
+        // `cast[(A, B)](o)` therefore bound for BCL element types and failed for
+        // the user's own, which is the same "symbols carry no ClrType" hole the
+        // two cases above exist to close.
+        if (type is TupleTypeSymbol)
+        {
+            return true;
+        }
+
         return type?.ClrType != null && type.ClrType.IsValueType;
     }
 

--- a/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
+++ b/src/Core/CodeAnalysis/Binding/PartialTypeMerger.cs
@@ -29,8 +29,9 @@ internal static class PartialTypeMerger
 {
     /// <summary>
     /// Merges the <c>partial</c> struct/class declarations of
-    /// <paramref name="declarations"/> that share a <c>(package, name)</c> key,
-    /// leaving lone declarations (and non-partial duplicate groups) untouched.
+    /// <paramref name="declarations"/> that share a
+    /// <c>(package, name, arity)</c> key, leaving lone declarations (and
+    /// non-partial duplicate groups) untouched.
     /// </summary>
     /// <param name="declarations">The top-level struct/class declarations across every tree.</param>
     /// <param name="packageByTree">Maps each syntax tree to its owning package (for the grouping key).</param>
@@ -71,8 +72,9 @@ internal static class PartialTypeMerger
 
     /// <summary>
     /// Merges the <c>partial</c> interface declarations of
-    /// <paramref name="declarations"/> that share a <c>(package, name)</c> key,
-    /// leaving lone declarations (and non-partial duplicate groups) untouched.
+    /// <paramref name="declarations"/> that share a
+    /// <c>(package, name, arity)</c> key, leaving lone declarations (and
+    /// non-partial duplicate groups) untouched.
     /// </summary>
     /// <param name="declarations">The top-level interface declarations across every tree.</param>
     /// <param name="packageByTree">Maps each syntax tree to its owning package (for the grouping key).</param>
@@ -116,14 +118,23 @@ internal static class PartialTypeMerger
     {
         // Preserve first-appearance order of the groups for determinism of the
         // returned list.
-        var order = new List<(string Package, string Name)>();
-        var groups = new Dictionary<(string Package, string Name), List<T>>();
+        //
+        // Issue #3907: arity is part of the key. A type is identified by name
+        // AND type-parameter count, so `Chan` and `Chan[T]` are two types, not
+        // two parts of one — which is what ADR-0174 D12 declares (a non-generic
+        // factory host beside the generic channel). Grouping on the name alone
+        // merged them, then reported GS0475/GS0480 against a mismatch it had
+        // manufactured, and the poisoned type parameter list turned into 172
+        // "Type 'T' doesn't exist" downstream. The non-partial path already
+        // distinguished the two, so this only brings the partial path in line.
+        var order = new List<(string Package, string Name, int Arity)>();
+        var groups = new Dictionary<(string Package, string Name, int Arity), List<T>>();
 
         foreach (var decl in declarations)
         {
             var packageName = packageByTree.TryGetValue(decl.SyntaxTree, out var pkg) ? pkg.Name : string.Empty;
             var name = GetIdentifier(decl)?.Text ?? string.Empty;
-            var key = (packageName, name);
+            var key = (packageName, name, GetArity(decl));
             if (!groups.TryGetValue(key, out var list))
             {
                 list = new List<T>();
@@ -164,6 +175,19 @@ internal static class PartialTypeMerger
         StructDeclarationSyntax s => s.Identifier,
         InterfaceDeclarationSyntax i => i.Identifier,
         _ => null,
+    };
+
+    /// <summary>
+    /// The declaration's type-parameter count, which together with the name
+    /// identifies the type (issue #3907). A missing list is arity zero.
+    /// </summary>
+    /// <param name="decl">The declaration.</param>
+    /// <returns>The type-parameter count.</returns>
+    private static int GetArity(MemberSyntax decl) => decl switch
+    {
+        StructDeclarationSyntax s => s.TypeParameterList?.Parameters.Count ?? 0,
+        InterfaceDeclarationSyntax i => i.TypeParameterList?.Parameters.Count ?? 0,
+        _ => 0,
     };
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -654,20 +678,24 @@ internal static class PartialTypeMerger
             return nested;
         }
 
-        // Group the nested structs and interfaces by name (order-preserving).
+        // Group the nested structs and interfaces by name and arity (order-preserving).
         var structGroups = GroupByKey(nested.OfType<StructDeclarationSyntax>(), EmptyPackages);
         var interfaceGroups = GroupByKey(nested.OfType<InterfaceDeclarationSyntax>(), EmptyPackages);
 
-        var mergedStructByName = new Dictionary<string, StructDeclarationSyntax>(System.StringComparer.Ordinal);
-        var mergedInterfaceByName = new Dictionary<string, InterfaceDeclarationSyntax>(System.StringComparer.Ordinal);
+        // Issue #3907: keyed by (name, arity), matching GroupByKey. On the name
+        // alone a nested `Box` and `Box[T]` would collide here — the second
+        // merge would overwrite the first and the rebuild below would drop one
+        // of the two types outright.
+        var mergedStructByName = new Dictionary<(string Name, int Arity), StructDeclarationSyntax>();
+        var mergedInterfaceByName = new Dictionary<(string Name, int Arity), InterfaceDeclarationSyntax>();
         foreach (var g in structGroups.Where(g => g.Count > 1 && g.Any(d => d.IsPartial)))
         {
-            mergedStructByName[g[0].Identifier?.Text ?? string.Empty] = MergeStructGroup(g, diagnostics);
+            mergedStructByName[(g[0].Identifier?.Text ?? string.Empty, GetArity(g[0]))] = MergeStructGroup(g, diagnostics);
         }
 
         foreach (var g in interfaceGroups.Where(g => g.Count > 1 && g.Any(d => d.IsPartial)))
         {
-            mergedInterfaceByName[g[0].Identifier?.Text ?? string.Empty] = MergeInterfaceGroup(g, diagnostics);
+            mergedInterfaceByName[(g[0].Identifier?.Text ?? string.Empty, GetArity(g[0]))] = MergeInterfaceGroup(g, diagnostics);
         }
 
         // No nested partial group to merge at this level — but a lone nested
@@ -684,15 +712,15 @@ internal static class PartialTypeMerger
             return nested;
         }
 
-        var emittedStruct = new HashSet<string>(System.StringComparer.Ordinal);
-        var emittedInterface = new HashSet<string>(System.StringComparer.Ordinal);
+        var emittedStruct = new HashSet<(string Name, int Arity)>();
+        var emittedInterface = new HashSet<(string Name, int Arity)>();
         var result = ImmutableArray.CreateBuilder<MemberSyntax>();
         foreach (var member in nested)
         {
             switch (member)
             {
                 case StructDeclarationSyntax s:
-                    var sName = s.Identifier?.Text ?? string.Empty;
+                    var sName = (s.Identifier?.Text ?? string.Empty, GetArity(s));
                     if (mergedStructByName.TryGetValue(sName, out var mergedStruct))
                     {
                         if (emittedStruct.Add(sName))
@@ -710,7 +738,7 @@ internal static class PartialTypeMerger
                     break;
 
                 case InterfaceDeclarationSyntax iface:
-                    var iName = iface.Identifier?.Text ?? string.Empty;
+                    var iName = (iface.Identifier?.Text ?? string.Empty, GetArity(iface));
                     if (mergedInterfaceByName.TryGetValue(iName, out var mergedIface))
                     {
                         if (emittedInterface.Add(iName))

--- a/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0144PartialTypesBinderTests.cs
@@ -24,6 +24,15 @@ namespace GSharp.Core.Tests.CodeAnalysis;
 /// before the two-phase shell/body binder runs — covering successful merges
 /// (single-file and cross-file), <c>shared { }</c>/init merging, and each new
 /// consistency diagnostic (GS0475-GS0483).
+/// </para>
+/// <para>
+/// Issue #3907 discrimination witness: the mutant is
+/// <c>PartialTypeMerger.GroupByKey</c> keying on <c>(package, name)</c> without
+/// arity, which merged a non-generic type with a same-named generic one and
+/// then reported GS0475/GS0480 against the mismatch it had manufactured.
+/// <c>NonGenericAndGenericPartsOfTheSameName_AreDistinctTypes</c> kills it;
+/// <c>PartialParts_SameArityDifferentParameterNames_StillReportGS0480</c>
+/// proves the check was narrowed rather than removed.
 /// </summary>
 public class Adr0144PartialTypesBinderTests
 {
@@ -971,6 +980,130 @@ partial class Foo {
         Assert.Contains(
             result.Diagnostics,
             d => d.Id == expectedId);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #3907: a type is (name, arity), so `Chan` and `Chan[T]` are two
+    // types rather than two parts of one.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("partial class Box {")]
+    [InlineData("class Box {")]
+    public void NonGenericAndGenericPartsOfTheSameName_AreDistinctTypes(string nonGenericHeader)
+    {
+        // ADR-0174 D12's shape: a generic `Chan[T]` split across parts beside a
+        // non-generic `Chan` factory host. Both spellings of the non-generic
+        // part are legal — it is a different type, so `partial` is its own
+        // business.
+        var source = @"package App
+import System
+
+partial class Box[T] {
+    var value T
+}
+
+partial class Box[T] {
+    func Get() T {
+        return value
+    }
+}
+
+" + nonGenericHeader + @"
+    shared {
+        func Make[T](v T) Box[T] {
+            var b = Box[T]()
+            b.value = v
+            return b
+        }
+    }
+}
+
+let made = Box.Make[int32](42)
+Console.WriteLine(made.Get())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Issue3907-Arity-" + nonGenericHeader.GetHashCode().ToString("X"));
+        Assert.Contains("42", output);
+    }
+
+    [Fact]
+    public void NonGenericAndGenericInterfacesOfTheSameName_AreDistinctTypes()
+    {
+        // MergeInterfaces shares GroupByKey, so it shared the defect.
+        var source = @"package App
+import System
+
+partial interface IBox[T] {
+    func Get() T;
+}
+
+partial interface IBox {
+    func Describe() string;
+}
+
+class Holder : IBox[int32], IBox {
+    func Get() int32 {
+        return 7
+    }
+
+    func Describe() string {
+        return ""holder""
+    }
+}
+
+let h = Holder()
+Console.WriteLine(h.Get())
+Console.WriteLine(h.Describe())
+";
+        var output = CompileLoadInvokeCaptureStdout(source, "Issue3907-ArityInterface");
+        Assert.Contains("7", output);
+        Assert.Contains("holder", output);
+    }
+
+    [Fact]
+    public void PartialParts_SameArityDifferentParameterNames_StillReportGS0480()
+    {
+        // The narrowing must not have removed the check: same arity, different
+        // type-parameter names, is still a genuine mismatch.
+        var source = @"package App
+
+partial class Box[T] {
+    var value T
+}
+
+partial class Box[U] {
+    var other int32
+}
+";
+        var diagnostics = Compile(source);
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == "GS0480");
+    }
+
+    [Fact]
+    public void PartialParts_DifferentArity_ReportNeitherGS0475NorGS0480()
+    {
+        var source = @"package App
+
+partial class Box[T] {
+    var value T
+}
+
+class Box {
+    var marker int32
+}
+";
+        var diagnostics = Compile(source);
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0475");
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == "GS0480");
+    }
+
+    private static IReadOnlyList<GSharp.Core.CodeAnalysis.Diagnostic> Compile(string source)
+    {
+        using var peStream = new MemoryStream();
+        return new Compilation(SyntaxTree.Parse(SourceText.From(source, "Test.gs")))
+        {
+            IsLibrary = true,
+        }.Emit(peStream).Diagnostics.ToArray();
     }
 
     private static string CompileLoadInvokeCaptureStdout(string source, string contextName)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3748SymbolicTupleBoxingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3748SymbolicTupleBoxingTests.cs
@@ -23,6 +23,17 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// (<c>(A int32, B string)</c>) boxed fine, an <em>unnamed</em> tuple with a
 /// nullable element failed identically, and the lambda position was incidental.
 /// The trigger is a null <c>ClrType</c> on the tuple, not its element names.
+///
+/// <para>
+/// Issue #3907 is the UNBOXING direction of the same hole:
+/// <c>cast[(A, B)](o)</c> was rejected as soon as one element was a
+/// same-compilation type, because the value-type test in
+/// <c>Conversion.IsValueTypeLikeFrom</c> also ended at a null
+/// <c>ClrType</c>. Witness of discrimination:
+/// <c>cast[(StringBuilder, string)]</c> — every element BCL-backed, so the
+/// tuple reifies — bound and ran before the fix, and the user's own class as an
+/// element is the only difference.
+/// </para>
 /// </remarks>
 public class Issue3748SymbolicTupleBoxingTests
 {
@@ -99,5 +110,77 @@ Describe(t)
 ");
         Assert.Empty(result.Diagnostics);
         Assert.Equal("(4, q)", result.Value);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #3907: the unboxing direction. `ArmDescriptor.cs` casts a
+    // `ContinueWith` state object back to `((TaskArm, SelectWaiter))state!`.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SymbolicTuple_UnboxesFromObject()
+    {
+        var result = EmittedOracle.Evaluate(@"
+class A { var x int32 }
+class B { var y int32 }
+
+let a = A()
+a.x = 41
+let b = B()
+b.y = 1
+let boxed object = (a, b)
+let t = cast[(A, B)](boxed)
+t.Item1.x + t.Item2.y
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SymbolicTuple_UnboxesFromObject_AndDeconstructs()
+    {
+        // The shape the migrated channels runtime actually uses: the cast feeds
+        // a deconstruction, so a failure here reads as "variable doesn't exist"
+        // for every name the pattern binds.
+        var result = EmittedOracle.Evaluate(@"
+class A { var x int32 }
+class B { var y int32 }
+
+let a = A()
+a.x = 40
+let b = B()
+b.y = 2
+let boxed object = (a, b)
+let (p, q) = cast[(A, B)](boxed)
+p.x + q.y
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(42, result.Value);
+    }
+
+    [Fact]
+    public void SymbolicTuple_UnboxingWrongShape_StillThrowsAtRuntime()
+    {
+        // Widening the conversion classification must not turn a bad cast into
+        // a silent default: `cast[T]` keeps C# `(T)x` semantics.
+        var result = EmittedOracle.Evaluate(@"
+import System
+
+class A { var x int32 }
+class B { var y int32 }
+
+let boxed object = ""not a tuple""
+var caught = false
+try {
+    let t = cast[(A, B)](boxed)
+    let _ = t.Item1
+} catch (e InvalidCastException) {
+    caught = true
+}
+
+caught
+");
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal(true, result.Value);
     }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3676GeneratedCodeNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3676GeneratedCodeNullabilityTests.cs
@@ -37,6 +37,11 @@ namespace Cs2Gs.Tests;
 /// </para>
 ///
 /// <para>
+/// Issue #3907 extends the fifth to assignment and argument position; the
+/// discrimination witness is the pair of "keeps nullable" tests, which fail if
+/// the rewrite ever stops consulting the DECLARED type and simply strips every
+/// <c>?</c> off a <c>default</c>.
+///
 /// The fifth is unrelated to generated code: a bare <c>default</c> literal
 /// target-typed to an unconstrained type parameter picks up Roslyn's
 /// FLOW-derived <c>T?</c> ("maybe default") rather than the declared bare
@@ -419,6 +424,107 @@ namespace Demo
 
         Assert.Contains("func Missing[T class]() T?", printed[0]);
         Assert.Contains("return default(T?)", printed[0]);
+    }
+
+    /// <summary>
+    /// Issue #3907: the same flow-vs-declared confusion in ASSIGNMENT position.
+    /// <c>Gsharp.Runtime.Channels</c> is built on
+    /// <c>[MaybeNullWhen(false)] out T value</c> parameters whose bodies say
+    /// <c>value = default;</c> — the attribute makes Roslyn's flow state
+    /// maybe-null while the DECLARED parameter type stays a bare <c>T</c>, so
+    /// the return-only rewrite left <c>default(T?)</c> in a <c>T</c> slot.
+    /// </summary>
+    [Fact]
+    public void BareDefault_AssignedToMaybeNullWhenOutParameter_EmitsDefaultOfBareT()
+    {
+        string[] printed = TranslateEnabled(
+            ("Node.cs", @"
+using System.Diagnostics.CodeAnalysis;
+
+namespace Demo
+{
+    public class Node<T>
+    {
+        public bool TryTake([MaybeNullWhen(false)] out T value)
+        {
+            value = default;
+            return false;
+        }
+    }
+}"));
+
+        Assert.Contains("value = default(T)", printed[0]);
+        Assert.DoesNotContain("default(T?)", printed[0]);
+    }
+
+    /// <summary>
+    /// Issue #3907: a field the author DECLARED <c>T?</c> keeps its <c>?</c>.
+    /// The rewrite reads the declaration, so it must not follow the assignment
+    /// blindly — this is the assignment-position counterpart of the
+    /// <c>T?</c>-return test above.
+    /// </summary>
+    [Fact]
+    public void BareDefault_AssignedToDeclaredNullableField_KeepsNullable()
+    {
+        string[] printed = TranslateEnabled(
+            ("Node.cs", @"
+namespace Demo
+{
+    public class Node<T>
+    {
+        private T? slot;
+
+        public void Clear()
+        {
+            slot = default;
+        }
+    }
+}"));
+
+        Assert.Contains("slot = default(T?)", printed[0]);
+    }
+
+    /// <summary>
+    /// Issue #3907: ARGUMENT position, read off the SUBSTITUTED parameter type.
+    /// <c>ReceiveResult[T](default, false)</c> passes a bare <c>T</c> slot and
+    /// must drop the flow <c>?</c>; issue #2500's <c>Same&lt;T?&gt;(default)</c>
+    /// resolves to a parameter of type <c>T?</c> and must keep it. Both are
+    /// asserted here so neither can regress without the other noticing.
+    /// </summary>
+    [Fact]
+    public void BareDefault_AsArgument_FollowsTheSubstitutedParameterType()
+    {
+        string[] printed = TranslateEnabled(
+            ("Result.cs", @"
+namespace Demo
+{
+    public readonly struct Result<T>
+    {
+        public Result(T value, bool ok)
+        {
+            this.Value = value;
+            this.Ok = ok;
+        }
+
+        public T Value { get; }
+
+        public bool Ok { get; }
+
+        public static Result<T> Empty => new Result<T>(default, false);
+    }
+
+    public static class Same
+    {
+        public static T Of<T>(T value) => value;
+
+        public static T? Nullable<T>()
+            where T : class
+            => Of<T?>(default);
+    }
+}"));
+
+        Assert.Contains("Result[T](default(T), false)", printed[0]);
+        Assert.Contains("Of[T?](default(T?))", printed[0]);
     }
 
     private static string[] TranslateEnabled(params (string Path, string Source)[] sources)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -370,9 +370,19 @@ public sealed partial class CSharpToGSharpTranslator
         // still converts into a `T?` slot, so dropping a FLOW `?` can only
         // widen what binds.
         //
-        // The rewrite is scoped to the RETURN position, where the enclosing
-        // method's DECLARED return type settles the question and no flow state
-        // can reach it. Everywhere else an annotated type parameter on a
+        // The rewrite is scoped to positions where a DECLARED type settles the
+        // question and no flow state can reach it: the RETURN value, the
+        // right-hand side of a simple ASSIGNMENT, and an ARGUMENT. Issue #3907
+        // added the last two — `Gsharp.Runtime.Channels` is full of
+        // `[MaybeNullWhen(false)] out T value` parameters whose bodies say
+        // `value = default;`, which the return-only rewrite left as
+        // `default(T?)` in a `T` slot.
+        //
+        // Argument position reads the SUBSTITUTED parameter type, which is what
+        // keeps issue #2500 intact: `Same<T?>(default)` resolves to a parameter
+        // of type `T?` (annotated) and keeps its `?`, while
+        // `ReceiveResult[T](default, false)` resolves to one of type `T` and
+        // drops it. Everywhere else an annotated type parameter on a
         // `default` may be a genuinely AUTHORED `T?` that issue #2500 exists to
         // preserve — `Same<T?>(default)` / `Task.FromResult<T?>(default)` write
         // the nullable type argument explicitly and must keep emitting
@@ -383,9 +393,79 @@ public sealed partial class CSharpToGSharpTranslator
             TypeInfo info = this.context.GetTypeInfo(literal);
             return (info.ConvertedType ?? info.Type) is ITypeParameterSymbol
                 && resolved is NamedTypeReference { IsNullable: true } named
-                && this.ReturnsBareTypeParameter(literal)
+                && this.TargetIsBareTypeParameter(literal)
                     ? new NamedTypeReference(named.Name, named.TypeArguments, named.ContainingType)
                     : resolved;
+        }
+
+        // Whether the slot `literal` flows into is DECLARED as an unannotated
+        // type parameter, in any of the three positions where a declaration
+        // settles it (issue #3676 for returns, #3907 for the other two).
+        private bool TargetIsBareTypeParameter(LiteralExpressionSyntax literal)
+        {
+            return this.ReturnsBareTypeParameter(literal)
+                || this.AssignedToBareTypeParameter(literal)
+                || this.PassedToBareTypeParameter(literal);
+        }
+
+        // `value = default;` where `value` is declared `T` — most often an
+        // `[MaybeNullWhen(false)] out T`, whose attribute makes Roslyn's flow
+        // state maybe-null while the declared type stays a bare `T`.
+        private bool AssignedToBareTypeParameter(LiteralExpressionSyntax literal)
+        {
+            if (literal.Parent is not AssignmentExpressionSyntax assignment
+                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || assignment.Right != literal)
+            {
+                return false;
+            }
+
+            ISymbol target = this.context.GetSymbolInfo(assignment.Left).Symbol;
+            ITypeSymbol declared = target switch
+            {
+                IParameterSymbol parameter => parameter.Type,
+                ILocalSymbol local => local.Type,
+                IFieldSymbol field => field.Type,
+                IPropertySymbol property => property.Type,
+                _ => null,
+            };
+
+            return IsBareTypeParameter(declared);
+        }
+
+        // `M(default)` where the parameter is declared `T`. The parameter type
+        // is read off the RESOLVED (substituted) symbol, so an explicitly
+        // nullable type argument — `Same<T?>(default)`, issue #2500 — presents
+        // as annotated and keeps its `?`.
+        private bool PassedToBareTypeParameter(LiteralExpressionSyntax literal)
+        {
+            if (literal.Parent is not ArgumentSyntax argument
+                || argument.Parent is not BaseArgumentListSyntax argumentList
+                || argument.NameColon != null)
+            {
+                return false;
+            }
+
+            if (this.context.GetSymbolInfo(argumentList.Parent).Symbol is not IMethodSymbol method)
+            {
+                return false;
+            }
+
+            int index = argumentList.Arguments.IndexOf(argument);
+            if (index < 0 || index >= method.Parameters.Length)
+            {
+                // A `params` tail, or an argument list this overload does not
+                // line up with positionally; not a slot a declaration settles.
+                return false;
+            }
+
+            return IsBareTypeParameter(method.Parameters[index].Type);
+        }
+
+        private static bool IsBareTypeParameter(ITypeSymbol type)
+        {
+            return type is ITypeParameterSymbol
+                && type.NullableAnnotation != NullableAnnotation.Annotated;
         }
 
         // Whether `literal` is the value of a `return` in a method or local

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -3691,10 +3691,20 @@ public sealed partial class CSharpToGSharpTranslator
                 && !targetType.IsNullable
                     ? MakeNullable(targetType)
                     : targetType;
+
+            // Issue #3907: a TUPLE target has no `T(expr)` spelling. That form
+            // renders as `(TaskArm, SelectWaiter)(state)`, which G# reads as a
+            // call on a parenthesized expression rather than a conversion —
+            // `((TaskArm, SelectWaiter))state!` in ArmDescriptor.cs came out as
+            // eight "variable doesn't exist" errors. `cast[(A, B)](expr)` is the
+            // only form that binds, and it is what the unambiguous flag emits.
+            bool unambiguous = this.CastUsesCheckedReferenceConversion(cast)
+                || targetSymbol is INamedTypeSymbol { IsTupleType: true };
+
             return new ConversionExpression(
                 conversionTargetType,
                 operand,
-                this.CastUsesCheckedReferenceConversion(cast));
+                unambiguous);
         }
 
         private bool CastUsesCheckedReferenceConversion(CastExpressionSyntax cast)


### PR DESCRIPTION
Closes the substantive part of #3907. **304 real error sites → 34**, from three root causes.

## Sizing first

The 327 in the issue are **fingerprints**. The true unique site count is **304** — the SDK build log
has 614 error lines because MSBuild prints each one twice. Every number below is unique sites from the
real `cs2gs migrate` pipeline, isolated to this app with `--exclude` for the other 61 projects.

| after | sites | root removed |
|---|---:|---|
| baseline | 304 | |
| fix 1 | 52 | partial grouping ignored generic arity |
| fix 2 | 43 | bare `default` followed the flow type, not the declared slot |
| fix 3 | 34 | tuple cast spelling + symbolic tuple unboxing |

The issue predicted the "cannot find X" family would collapse. It was 229 of 327 fingerprints; it is
now **3 sites**.

## Root 1 — gsc: `PartialTypeMerger` grouped by name, not (name, arity) — 252 sites

`GroupByKey` keyed on `(package, name)`. ADR-0174 D12 puts a non-generic `Chan` factory host beside the
generic `Chan[T]`, which is why #3882 is where this surfaced — it is the first time the repo's own
corpus has carried that shape. The merger treated them as two parts of one type, reported `GS0475` +
4×`GS0480` against a mismatch it had *manufactured*, and the poisoned type-parameter list became 172
`Type 'T' doesn't exist` plus the entire `GS0125`/`GS0157`/`GS0158`/`GS0159` cascade.

gsc's **non-partial** path already got this right — `class Box[T]` beside `class Box` compiles clean on
`main` today — so this only brings the partial path in line with the rest of the type system, with C#,
and with the CLR.

The nested-type rebuild indexed merged groups by name alone as well. On the grouping fix alone that
would have silently **dropped** one of a nested `Box`/`Box[T]` pair, so it is keyed by `(name, arity)`
too. That one is worth a reviewer's eye — it is the only part of this PR not exercised by the corpus.

## Root 2 — cs2gs: `default` followed the flow type, not the declared slot — 9 sites

The #3676 rewrite that emits `default(T)` when Roslyn's `?` is flow-derived was deliberately scoped to
**return** position. The channels runtime is built on `[MaybeNullWhen(false)] out T value` parameters
whose bodies say `value = default;` — the attribute makes the flow state maybe-null while the declared
parameter type stays a bare `T`, so `default(T?)` landed in a `T` slot.

Extended to assignment and argument position, both of which have a declaration that settles the
question. **Argument position reads the substituted parameter type**, which is what keeps #2500 intact:
`Same[T?](default)` resolves to a parameter of type `T?` and keeps its `?`, while
`ReceiveResult[T](default, false)` resolves to one of type `T` and drops it. Confirmed on the corpus —
the three `default(T?)` sites that remain are assignments to fields the author genuinely declared `T?`.

## Root 3 — a tuple cast, one defect on each side — 9 sites

**cs2gs** emitted a tuple-target cast in the `T(expr)` form, so `((TaskArm, SelectWaiter))state!` became
`(TaskArm, SelectWaiter)(state!!)` — which G# reads as a call on a parenthesized expression, not a
conversion. `ArmDescriptor`'s `ContinueWith` continuation lost its whole deconstruction: eight
"variable doesn't exist" errors for names the pattern never got to bind.

With the spelling fixed the cast still failed, and **that half was real**:
`Conversion.IsValueTypeLikeFrom` ended at `ClrType != null && IsValueType`, while
`TupleTypeSymbol.BuildClrType` returns null as soon as one element is a same-compilation type. So
`cast[(A, B)](o)` bound when every element was BCL-backed and failed on the user's own classes. This is
the **unboxing direction of the hole #3748 fixed for boxing**, and the same hole the neighbouring
`StructSymbol`/`EnumSymbol` cases exist to close.

Verified by *running* the emitted `unbox.any` rather than by classification alone — directly and
through the deconstruction the channels runtime uses — and a wrong-shape cast still throws
`InvalidCastException` rather than yielding a silent default.

## Tests

Each fix has regression tests with the mutant actually run and killed:

| fix | tests | mutant |
|---|---|---|
| arity | `Adr0144PartialTypesBinderTests` ×4 | grouping without arity — 4 fail, and the same-arity/different-names `GS0480` test keeps passing, so the check was **narrowed, not removed** |
| `default` | `Issue3676GeneratedCodeNullabilityTests` ×3 | rewrite restricted back to returns — 2 fail, while both "keeps nullable" tests pass either way, which is what proves it consults the declaration rather than stripping every `?` |
| tuple | `Issue3748SymbolicTupleBoxingTests` ×3 | `IsValueTypeLikeFrom` false for tuples — 3 fail, while the five #3748 **boxing** tests keep passing, placing the fix on the unboxing side specifically |

## Regression, including one open question

| suite | result |
|---|---|
| Core.Tests | 8860 passed, 4 failed — environmental, confirmed `prerequisite missing: no NETStandard.Library.Ref targeting pack` |
| Compiler.Tests | 4707 passed, 3 failed — same family, same count as every prior run on this machine |
| Cs2Gs.Tests | 2752 passed, **1 failed** — `Issue3347RemainingSpillInventoryTests.TranslatorMigration_SpillFamilyStaysRetired` |

**I have not resolved that last one, and it is the reason this PR is up for review rather than
merge-ready.** It passes in isolation, but that is not sufficient evidence: the test loads and
translates `Cs2Gs.Translator.csproj` *itself* — one of the projects this PR edits — and asserts the
translated output carries no `let __spill` temps. My new code uses a switch expression and pattern
combinators, exactly the shapes that historically lower with spill temps. So there is a plausible
mechanism by which this is a **real** regression: C# written in a shape the translator cannot yet
migrate spill-free, which matters in a repo that self-migrates.

Against that reading: it passed in isolation against identical source, which points at process state or
a transient MSBuild design-time load rather than content. A full re-run is in flight to capture the
actual assertion (the first run kept only the tail). If it reproduces, the next step is a full run on a
`main` worktree to separate "pre-existing order-dependent failure" from "mine" — this session already
hit order-dependent cs2gs failures once and that is what settled them.

If review says the switch expression is the cause, the fix is to write those two helpers in a plainer
shape; I would rather that decision be made deliberately than have me pre-emptively de-idiomatise the
code.

## Not in this PR

The remaining **34 sites are roughly nine roots** — triage with grounded-vs-surface labelling is
[on the issue](https://github.com/DavidObando/gsharp/issues/3907#issuecomment-5541220476). Two worth
naming here:

- **7 sites**: a C# `static async` local function becomes an async *lambda* whose declared return is
  `ValueTask[T]` while its body returns `T`.
- **3 sites**: `DeferGraceExpired?.Invoke(null, args)` becomes `DeferGraceExpired?(nil, args)`. **This
  may not be a bug.** G# may simply not have first-class events, making it an ADR-level question about
  what `public static event EventHandler<T>?` should become — worth deciding before anyone writes a
  translator rule for it.

Two notes for whoever picks this up: `cs2gs migrate --app` only resolves corpus-layout ids, so
isolating one repository app means `--exclude` for every other `.csproj`; and the SDK build consumes a
**packed** gsc, so a compiler fix does not reach it until `src/Sdk/Gsharp.NET.Sdk` is rebuilt in
Release — that silently cost one full measurement round here.

Refs #3907, #3882, #3906, #3676, #3748, #2500, ADR-0174 D12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
