### PR TITLE
gsc + cs2gs: four more root causes take migrated Gsharp.Runtime.Channels from 27 sites to 11 (#3907)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -315,6 +315,26 @@ internal sealed class LambdaBinder
         var isAsync = syntax.IsAsync
             || (isAsyncIteratorReturnType(returnType) && IteratorDetection.ContainsYield(syntax.Body));
 
+        // Issue #1918 / #3907: an `async func` may spell its return-type clause
+        // as the explicit `Task` / `Task[T]` / `ValueTask` / `ValueTask[T]`
+        // wrapper instead of the bare awaited result. DeclarationBinder has
+        // normalized that form for named functions since #1918
+        // (NormalizeAsyncDeclaredReturnType); a function LITERAL took the
+        // clause literally, so `async func (p ValueTask[T]) ValueTask[T] { …
+        // return t }` rejected its own body (GS0155 `T` -> `ValueTask[T]`) and
+        // then handed callers a doubly-wrapped `Task[ValueTask[T]]`. Unwrap
+        // here so FunctionSymbol.Type holds the awaited result for a lambda
+        // exactly as it does for a named function, and remember which wrapper
+        // was asked for so the observable type below rebuilds the same one.
+        var asyncReturnsValueTask = false;
+        if (syntax.IsAsync
+            && !isAsyncIteratorReturnType(returnType)
+            && AsyncReturnTypeNormalizer.TryUnwrapTaskReturnType(returnType, out var awaitedReturnType, out var declaredValueTask))
+        {
+            returnType = awaitedReturnType;
+            asyncReturnsValueTask = declaredValueTask;
+        }
+
         if (isAsync && isAsyncIteratorReturnType(returnType))
         {
             Diagnostics.ReportAsyncIteratorFunctionLiteralNotSupported(syntax.Location, returnType);
@@ -338,7 +358,7 @@ internal sealed class LambdaBinder
         var observableReturnType = returnType;
         if (isAsync && !isAsyncIteratorReturnType(returnType))
         {
-            observableReturnType = WrapAsTask(returnType);
+            observableReturnType = WrapAsTask(returnType, asyncReturnsValueTask);
         }
 
         var fnType = FunctionTypeSymbol.Get(parameterTypes.MoveToImmutable(), BuildVariadicFlagsIfAny(parameterSymbols), observableReturnType);
@@ -347,6 +367,7 @@ internal sealed class LambdaBinder
             parameterSymbols.ToImmutable(),
             returnType);
         synthetic.IsAsync = isAsync;
+        synthetic.AsyncReturnsValueTask = asyncReturnsValueTask;
 
         // Issue #3501 A2: give a named-binding caller the chance to declare
         // the literal's own name into the (still-current) enclosing scope

--- a/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
+++ b/src/Core/CodeAnalysis/Symbols/TypeMemberModel.cs
@@ -1105,12 +1105,27 @@ public static class TypeMemberModel
                 continue;
             }
 
+            // Issue #3907: an ADR-0149 explicit-interface implementation
+            // (`func (IFoo) Bar(…)`) is NOT a member of the implementing type's
+            // own lookup surface — C# and the CLR reach it only through the
+            // interface. It keeps its plain Name in the symbol table (only the
+            // METADATA name is mangled), so leaving it here put it in the
+            // overload set for `Bar(…)` written inside the type, where it beat
+            // or tied the ordinary method it was meant to delegate to. In the
+            // migrated Gsharp.Runtime.Channels that turned
+            // `Chan<T>.TrySendLocked`'s `SendOutcome` helper into the `bool`
+            // explicit implementation calling itself.
+            if (m.HasExplicitInterfaceClause || m.ExplicitInterfaceClauseTarget != null)
+            {
+                continue;
+            }
+
             if (builder != null)
             {
                 var hidden = false;
                 foreach (var existing in builder)
                 {
-                    if (BoundScope.FunctionSignaturesEqual(existing, m))
+                    if (BoundScope.FunctionSignaturesEqual(existing, m) || Overrides(existing, m))
                     {
                         hidden = true;
                         break;
@@ -1126,5 +1141,39 @@ public static class TypeMemberModel
             builder ??= ImmutableArray.CreateBuilder<FunctionSymbol>();
             builder.Add(m);
         }
+    }
+
+    /// <summary>
+    /// Issue #3907: reports whether <paramref name="derived"/> (already in the
+    /// overload set, found first by the this-first hierarchy walk) overrides
+    /// <paramref name="baseCandidate"/>, so the base declaration must not be
+    /// added a second time.
+    /// </summary>
+    /// <remarks>
+    /// The signature comparison above cannot see this on a GENERIC hierarchy.
+    /// <c>class Derived[T] : Base[T]</c> gives each level its own
+    /// <c>TypeParameterSymbol</c> named <c>T</c>, so
+    /// <c>Commit(value T)</c> on the base and on the override are not
+    /// signature-equal by symbol identity, both entered the set, and every call
+    /// became <c>GS0266 ambiguous between multiple overloads</c>. The override
+    /// LINK the binder already recorded says what the type comparison cannot.
+    /// </remarks>
+    /// <param name="derived">The candidate already in the overload set.</param>
+    /// <param name="baseCandidate">The base-class candidate being considered.</param>
+    /// <returns><see langword="true"/> when the base candidate is already represented.</returns>
+    private static bool Overrides(FunctionSymbol derived, FunctionSymbol baseCandidate)
+    {
+        // Bounded by the depth of the override chain, which the binder builds
+        // acyclically; the guard is belt-and-braces against a malformed chain.
+        var depth = 0;
+        for (var current = derived.OverriddenMethod; current != null && depth < 64; current = current.OverriddenMethod, depth++)
+        {
+            if (ReferenceEquals(current, baseCandidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/test/Compiler.Tests/Issue3907AsyncLambdaTaskEnvelopeTests.cs
+++ b/test/Compiler.Tests/Issue3907AsyncLambdaTaskEnvelopeTests.cs
@@ -1,0 +1,212 @@
+// <copyright file="Issue3907AsyncLambdaTaskEnvelopeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3907 (issue #1918 parity for function literals): an <c>async func</c>
+/// may spell its return-type clause as the explicit <c>Task</c> /
+/// <c>Task[T]</c> / <c>ValueTask</c> / <c>ValueTask[T]</c> wrapper rather than
+/// the bare awaited result. <c>DeclarationBinder</c> has normalized that form
+/// for NAMED functions since #1918; a function LITERAL took the clause
+/// literally, so an <c>async func (…) ValueTask[T] { … return t }</c> rejected
+/// its own body with <c>GS0155 Cannot convert 'T' to 'ValueTask[T]'</c> and
+/// then handed callers a doubly-wrapped <c>Task[ValueTask[T]]</c>.
+/// </summary>
+/// <remarks>
+/// <para>The migrated <c>src/Sdk/Gsharp.Runtime.Channels</c> is where this
+/// surfaced: C# <c>static async ValueTask&lt;T&gt; Awaited(…)</c> LOCAL
+/// functions (<c>ChannelOps.Awaited.cs</c>) translate to exactly this shape,
+/// and three of the app's remaining error sites were this one defect.</para>
+/// <para>Witness of discrimination (ADR-0154): the two <c>Bare</c> cases below
+/// declare the awaited result directly and passed BEFORE the fix, so a mutant
+/// that unwraps unconditionally — or one that never unwraps — is caught by the
+/// envelope cases alone. The assertions RUN the emitted program and ILVerify
+/// it, because the failure mode this guards is a wrong observable delegate
+/// return type, which a binding-only assertion cannot see.</para>
+/// </remarks>
+public class Issue3907AsyncLambdaTaskEnvelopeTests
+{
+    [Fact]
+    public void AsyncLambda_DeclaringTheTaskEnvelope_BindsRunsAndVerifies()
+    {
+        // Each `Envelope*` local declares the wrapper explicitly and returns the
+        // awaited result from its body — the C# `async ValueTask<T>` shape.
+        // Each `Bare*` local declares the awaited result, the form that already
+        // worked, so a mutant cannot pass by treating every clause the same way.
+        const string source = @"
+package Demo
+
+import System
+import System.Threading.Tasks
+
+async func Main() {
+    let EnvelopeValueTask = async func (x int32) ValueTask[int32] {
+        await Task.Yield()
+        return x * 2
+    }
+
+    let EnvelopeTask = async func (x int32) Task[int32] {
+        await Task.Yield()
+        return x + 5
+    }
+
+    let BareResult = async func (x int32) int32 {
+        await Task.Yield()
+        return x * 10
+    }
+
+    let EnvelopeVoid = async func (x int32) ValueTask {
+        await Task.Yield()
+        Console.WriteLine(""void=$x"")
+    }
+
+    let vt = await EnvelopeValueTask(21)
+    Console.WriteLine(""vt=$vt"")
+    let t = await EnvelopeTask(21)
+    Console.WriteLine(""t=$t"")
+    let bare = await BareResult(21)
+    Console.WriteLine(""bare=$bare"")
+    await EnvelopeVoid(7)
+}
+
+await Main()
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        Assert.Contains("vt=42", lines);
+        Assert.Contains("t=26", lines);
+        Assert.Contains("bare=210", lines);
+        Assert.Contains("void=7", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    [Fact]
+    public void AsyncLambda_DeclaringTheEnvelope_IsCallableThroughItsDeclaredType()
+    {
+        // The observable delegate return type must be the wrapper the clause
+        // asked for, not `Task[ValueTask[T]]`: binding `let v ValueTask[int32] =`
+        // against the call is what pins that down, and it is exactly the shape
+        // the migrated channels runtime uses (`return Awaited(pending)` from a
+        // non-async caller declared `ValueTask[T]`).
+        const string source = @"
+package Demo
+
+import System
+import System.Threading.Tasks
+
+func Outer(seed int32) ValueTask[int32] {
+    let Awaited = async func (x int32) ValueTask[int32] {
+        await Task.Yield()
+        return x * 3
+    }
+
+    return Awaited(seed)
+}
+
+async func Main() {
+    let outer = await Outer(14)
+    Console.WriteLine(""outer=$outer"")
+}
+
+await Main()
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        Assert.Contains("outer=42", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    private static string[] CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_async_lambda_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Program.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            // Both checks are load-bearing on this effort: an executing test has
+            // passed a broken build that only ILVerify caught, and an
+            // ILVerify-clean build has produced a wrong runtime answer.
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout
+                .ReplaceLineEndings(Environment.NewLine)
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Issue3907MemberLookupTests.cs
+++ b/test/Compiler.Tests/Issue3907MemberLookupTests.cs
@@ -1,0 +1,190 @@
+// <copyright file="Issue3907MemberLookupTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3907: two defects in <c>TypeMemberModel.GetMethods</c>'s overload-set
+/// construction, both found by the migrated
+/// <c>src/Sdk/Gsharp.Runtime.Channels</c>.
+/// </summary>
+/// <remarks>
+/// <para><b>Explicit-interface implementations leaked into simple-name
+/// lookup.</b> An ADR-0149 <c>func (IFoo) Bar(…)</c> keeps its plain
+/// <c>Name</c> in the symbol table — only the METADATA name is mangled — so it
+/// joined the overload set for <c>Bar(…)</c> written inside the type. C# and
+/// the CLR reach such a member only through the interface. In the channels
+/// runtime, <c>Chan&lt;T&gt;</c>'s <c>bool ISendSelectableCore&lt;T&gt;.TrySendLocked</c>
+/// therefore resolved its own <c>TrySendLocked(value, ref completions)</c> call
+/// to ITSELF instead of the private <c>SendOutcome</c>-returning helper, and
+/// the enum comparisons below it failed with
+/// <c>GS0129 '==' is not defined for 'bool' and 'SendOutcome'</c>.</para>
+/// <para><b>An override did not hide its base on a generic hierarchy.</b>
+/// <c>class Derived[T] : Base[T]</c> gives each level its own
+/// <c>TypeParameterSymbol</c> named <c>T</c>, so <c>Commit(value T)</c> on the
+/// base and on the override were not signature-equal by symbol identity. Both
+/// entered the overload set and every call became <c>GS0266 ambiguous between
+/// multiple overloads</c> — which is what <c>SelectNode[DateTime].TryCommitReceive</c>
+/// hit in <c>Timers</c>. The dedup now also consults the override link the
+/// binder already recorded.</para>
+/// <para>Both assertions RUN the emitted program: the explicit-interface case
+/// is specifically about WHICH overload is selected, and a binding-only
+/// assertion cannot tell a right selection from a wrong one that also
+/// type-checks. ILVerify runs too, because the fix changes overload selection
+/// and therefore the emitted call targets.</para>
+/// </remarks>
+public class Issue3907MemberLookupTests
+{
+    [Fact]
+    public void ExplicitInterfaceImplementation_DoesNotJoinTheTypesOwnOverloadSet()
+    {
+        // `Box[T]`'s explicit implementation calls the SAME NAME expecting the
+        // private `Outcome`-returning helper — the exact shape of
+        // `Chan<T>.TrySendLocked`. Before the fix it bound to itself.
+        const string source = @"
+package Demo
+
+import System
+
+internal enum Outcome { Sent, Full }
+
+interface ISend[T] {
+    func TrySendLocked(value T) bool;
+}
+
+class Box[T] : ISend[T] {
+    internal func (ISend[T]) TrySendLocked(value T) bool {
+        let outcome = TrySendLocked(value)
+        return outcome == Outcome.Sent
+    }
+
+    private func TrySendLocked(value T) Outcome -> Outcome.Sent
+}
+
+let asInterface ISend[string] = Box[string]()
+let sent = asInterface.TrySendLocked(""x"")
+Console.WriteLine(""sent=$sent"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        // The private helper answers `Sent`, so the explicit implementation's
+        // `outcome == Outcome.Sent` is true. Before the fix this did not
+        // compile at all; a variant of the defect that merely picked a
+        // different overload would print `False`.
+        Assert.Contains("sent=True", lines);
+    }
+
+    [Fact]
+    public void OverrideOnAGenericHierarchy_HidesItsBaseDeclaration()
+    {
+        const string source = @"
+package Demo
+
+import System
+
+open class Base[T] {
+    internal open func Commit(value T) bool;
+}
+
+class Derived[T] : Base[T] {
+    internal override func Commit(value T) bool -> true
+}
+
+func Go(n Derived[int32]) bool -> n.Commit(1)
+
+let commit = Go(Derived[int32]())
+Console.WriteLine(""commit=$commit"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        Assert.Contains("commit=True", lines);
+    }
+
+    private static string[] CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_lookup_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Program.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout
+                .ReplaceLineEndings(Environment.NewLine)
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0174SuspendFuncTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0174SuspendFuncTranslationTests.cs
@@ -118,6 +118,61 @@ public static class Plain
         Assert.DoesNotContain("suspend", rendered, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AsyncValueTask_DeclaredInsideTheRuntime_KeepsTheExplicitEnvelope()
+    {
+        // Issue #3907: inside Gsharp.Concurrency itself the runtime-usage probe
+        // is trivially true for every method, so it labelled the runtime's own
+        // private helpers `suspend`. Those return their ValueTask to a
+        // fast-path caller un-awaited, which a suspend func cannot express
+        // (ADR-0174 D4 makes every call an implicit await).
+        string rendered = Render(@"
+using System.Threading.Tasks;
+
+namespace Gsharp.Concurrency;
+
+public static class Inside
+{
+    public static ValueTask<int> Fast(Chan<int> ch) => Slow(ch);
+
+    private static async ValueTask<int> Slow(Chan<int> ch)
+    {
+        await Task.CompletedTask;
+        return 1;
+    }
+}
+");
+
+        Assert.Contains("async func Slow(ch Chan[int32]) ValueTask[int32] {", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("suspend", rendered, StringComparison.Ordinal);
+        AssertRoundTripBinds(rendered);
+    }
+
+    [Fact]
+    public void AsyncValueTask_InsideTheRuntime_MarkedSuspending_StillRendersSuspendFunc()
+    {
+        // The attribute stays authoritative inside the runtime: #3882 marks
+        // exactly the ChannelBatchExtensions methods that really are the
+        // suspend ABI, and the #3907 narrowing must not reach them.
+        string rendered = Render(@"
+using System.Threading.Tasks;
+
+namespace Gsharp.Concurrency;
+
+public static class InsideMarked
+{
+    [Suspending]
+    public static async ValueTask<int> Ready()
+    {
+        await Task.CompletedTask;
+        return 7;
+    }
+}
+");
+
+        Assert.Contains("suspend func Ready() int32 {", rendered, StringComparison.Ordinal);
+    }
+
     private static void AssertRoundTripBinds(string rendered)
     {
         RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Suspension.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Suspension.cs
@@ -46,6 +46,26 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #3907: the runtime-usage probe below is a heuristic for
+            // C# authored AGAINST the concurrency runtime. Inside the runtime
+            // assembly itself it carries no signal at all — every method there
+            // names a Gsharp.Concurrency type — so it fired on
+            // Gsharp.Runtime.Channels' own private helpers
+            // (`Chan<T>.ReceiveBatchSlowAsync`, `ChannelOps.ForeignReceiveSlowAsync`,
+            // `ScopeFrame.JoinAsync`, …). Those are ordinary async methods whose
+            // ValueTask is RETURNED un-awaited by their fast-path callers, and a
+            // `suspend func` cannot express that: ADR-0174 D4 makes every call to
+            // one an implicit await, so `return SlowAsync(…)` from a
+            // `ValueTask[int32]`-returning caller stopped type-checking. The
+            // attribute stays authoritative there (checked above) — #3882 marks
+            // exactly the four ChannelBatchExtensions methods that really are the
+            // suspend ABI — which is why this narrowing is a tightening, not a
+            // removal.
+            if (IsConcurrencyRuntimeNamespace(symbol.ContainingType?.ContainingNamespace))
+            {
+                return false;
+            }
+
             SemanticModel model = this.context.SemanticModel.SyntaxTree == node.SyntaxTree
                 ? this.context.SemanticModel
                 : this.context.Compilation.GetSemanticModel(node.SyntaxTree);


### PR DESCRIPTION
**Picks up where #3910 (now merged) left off.** Based on current `origin/main` (`914ce5989`), so this diff is only what #3910 does not cover.

## Where this picks up

#3910 takes the migrated `src/Sdk/Gsharp.Runtime.Channels` from 304 error sites to 34 with three root causes. Re-measuring on its head, in isolation through the packed SDK, I get **27 deduplicated compile-error artifacts**. This PR fixes **four more root causes worth 16 of them, leaving 11**.

Measured end to end on the real pipeline (translate → compile via the repacked Release `Gsharp.NET.Sdk` nupkg), not classified:

| stage | artifacts |
|---|---:|
| `origin/main` (`4832a4c5f`) | **194** |
| + #3910 | 27 |
| + this PR | **11** |

## The four roots

**1. gsc — an `async func` LITERAL took its declared Task envelope literally.** Issue #1918 lets an `async func` spell its return-type clause as `Task` / `Task[T]` / `ValueTask` / `ValueTask[T]` instead of the bare awaited result, and `DeclarationBinder.NormalizeAsyncDeclaredReturnType` has unwrapped that for *named* functions ever since. A function literal never got the same treatment, so `async func (p ValueTask[T]) ValueTask[T] { … return t }` rejected its own body with `GS0155 'T' -> 'ValueTask[T]'`, and callers then saw a doubly-wrapped `Task[ValueTask[T]]`. cs2gs emits exactly that shape for a C# `static async ValueTask<T>` **local function**, which `ChannelOps.Awaited` is built from. `LambdaBinder` now applies the same unwrap and rebuilds the observable return type with the wrapper that was asked for.

**2. cs2gs — the runtime's own async helpers are not `suspend func`s.** `IsSuspendingCandidate` treats "names a `Gsharp.Concurrency` type anywhere in the signature or body" as evidence that an `async ValueTask` method is the G# suspend ABI. Inside the runtime assembly that probe is **trivially true for every method**, so it labelled `Gsharp.Runtime.Channels`' own private helpers (`Chan<T>.ReceiveBatchSlowAsync`, `ChannelOps.ForeignReceiveSlowAsync`, `ScopeFrame.JoinAsync`, `AsyncLetCell.CancelIfUnreadAsync`, `ChunkReader<T>.ReadAsync`) `suspend func`. Those are ordinary async methods whose `ValueTask` is **returned un-awaited** by their fast-path callers — and a suspend func cannot express that, because ADR-0174 D4 makes every call to one an implicit await. The probe is now skipped for methods declared *in* the runtime namespace. `[Suspending]` stays authoritative there, which is how #3882's four genuine `ChannelBatchExtensions` suspend methods keep their ABI. **A tightening, not a removal** — the existing test where a `Chan`-using method *outside* the namespace still renders `suspend func` is what pins that down.

**3. gsc — explicit-interface implementations leaked into simple-name lookup.** An ADR-0149 `func (IFoo) Bar(…)` keeps its plain `Name` in the symbol table (only the *metadata* name is mangled), so it joined the overload set for `Bar(…)` written inside the type. C# and the CLR reach such a member only through the interface. In `Chan[T]`, `bool ISendSelectableCore[T].TrySendLocked` therefore resolved its own call **to itself** instead of the private `SendOutcome`-returning helper it exists to wrap, and the enum comparisons below failed with `GS0129 '==' is not defined for 'bool' and 'SendOutcome'`.

**4. gsc — an override did not hide its base on a generic hierarchy.** `class Derived[T] : Base[T]` gives each level its own `TypeParameterSymbol` named `T`, so `Commit(value T)` on the base and on the override are not signature-equal by symbol identity. Both entered the overload set and every call became `GS0266 ambiguous between multiple overloads` — which is what `SelectNode[DateTime].TryCommitReceive` hit in `Timers`. The dedup now also consults the override link the binder already recorded.

Roots 1, 3 and 4 are wrong for **every** G# program, not just this app: gsc's own neighbouring paths already got each of them right (named functions normalize the envelope; the CLR does not expose explicit implementations by simple name; an override hides its base everywhere else).

## Evidence

- Both gsc test classes **compile, ILVerify and RUN** the emitted program. That is deliberate: root 1's second half is a wrong *observable delegate return type* and root 3 is about *which overload is selected* — neither is visible to a binding-only assertion, and on this effort binding-only assertions have passed a wrong fix six times.
- **Failing on the base branch**, honestly labelled: `Issue3907AsyncLambdaTaskEnvelopeTests` was re-run with `LambdaBinder.cs` alone reverted — **2 failed, 0 passed**. Its `Bare*` cases declare the awaited result directly and pass either way, so a mutant that unwraps *unconditionally* is caught too. Roots 3 and 4 were each first reproduced on the unfixed compiler from a 30-line file (`GS0129` and `GS0266` respectively).
- cs2gs: two new cases in `Adr0174SuspendFuncTranslationTests`; the existing four keep passing, including `AsyncValueTask_UsingChan_RendersSuspendFunc`, which consumes the runtime from *outside* it — that is what places the narrowing on the containing namespace rather than on the probe.
- **Full suites, no regressions:** `Core.Tests` **8864 passed / 0 failed**; `Compiler.Tests` **4714 passed / 0 failed**. Both matter here — roots 3 and 4 change member lookup, whose blast radius is the whole binder.

## What this does NOT do

`Channels` is **not green** (11 sites left), so the gate stays at 38/53 and the app stays **out** of `run-cs2gs-selfmig-pr-guard.sh`'s `guard_apps` — the script already records why a day-one-red guard is worse than none. That line goes back when the last of the remaining roots lands.

The remaining 11, triaged on #3907: **static events cannot be read or raised** (3 sites — a language gap, ADR-0052 lists it under out-of-scope follow-up work, filed as **#3911**); a `TaskArm[T] : TaskArm` half-formed base link (3); `Interlocked.Exchange(&field, nil)` picking the non-generic overload (1); a `!!` lift missed on a tuple-deconstruction assignment target (1); a `T?` argument in a `T` slot (1); and an `async func … ValueTask -> voidExpr` arrow body (2) that root 2's fix **surfaced**, so it is on this PR's ledger rather than #3882's.

## The cascade, now proved

`src/Compiler`, `test/Core.Tests` and `src/Repl` each carry a **byte-identical** 19-artifact set on the nightly gate, and every entry names a `Gsharp.Runtime.Channels` symbol — they recompile the migrated runtime's sources and re-report its errors verbatim. So the ten dependents clear **if and only if `Channels` reaches zero**: 194 errors and 1 error cost the same eleven apps. Details on #3907.

Refs #3907, #3910, #3911, #3882, #3501, #1918, ADR-0149, ADR-0174 D4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
