### PR TITLE
perf: four of the #3902 improvements — rendezvous −82%, select-park −73%, chunk1k −58%

### DIFF
--- a/src/Sdk/Gsharp.Runtime.Channels/ArmDescriptor.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ArmDescriptor.cs
@@ -20,8 +20,8 @@ internal abstract class ArmDescriptor : IDisposable
         Arm = arm;
     }
 
-    /// <summary>Gets the arm index.</summary>
-    internal int Arm { get; }
+    /// <summary>Gets the arm index; reset when a cached descriptor is retargeted (issue #3902 S4).</summary>
+    internal int Arm { get; private protected set; }
 
     /// <summary>Gets a value indicating whether the arm probes and registers under a shared gate (G# channels) rather than privately (timers) or lock-free (foreign channels, tasks).</summary>
     internal abstract bool RequiresGate { get; }
@@ -48,14 +48,25 @@ internal abstract class ArmDescriptor : IDisposable
 
     /// <summary>Removes the registration. Idempotent; takes whatever lock it needs.</summary>
     internal abstract void Deregister();
+
+    /// <summary>
+    /// Drops references to the select's participants so a thread-cached waiter
+    /// does not pin them (issue #3902 S4). Called after <see cref="Deregister"/>
+    /// when the select completes; the descriptor object itself is kept for the
+    /// next select in that slot.
+    /// </summary>
+    internal virtual void Release()
+    {
+    }
 }
 
 /// <summary>A receive arm over a runtime-owned selectable (a <see cref="Chan{T}"/> or a timer).</summary>
 /// <typeparam name="T">The element type.</typeparam>
-internal sealed class CoreReceiveArm<T> : ArmDescriptor
+internal sealed class CoreReceiveArm<T> : ArmDescriptor, IArmValue<T>
 {
-    private readonly ISelectableCore<T> selectable;
+    private ISelectableCore<T>? selectable;
     private SelectNode<T>? node;
+    private T? pending;
 
     /// <summary>Initializes a new instance of the <see cref="CoreReceiveArm{T}"/> class.</summary>
     /// <param name="selectable">The selectable.</param>
@@ -67,31 +78,65 @@ internal sealed class CoreReceiveArm<T> : ArmDescriptor
     }
 
     /// <inheritdoc/>
-    internal override bool RequiresGate => selectable.SelectGate is not null;
+    internal override bool RequiresGate => Selectable.SelectGate is not null;
 
     /// <inheritdoc/>
-    internal override object? Gate => selectable.SelectGate;
+    internal override object? Gate => Selectable.SelectGate;
 
     /// <inheritdoc/>
-    internal override long Order => selectable.SelectOrder;
+    internal override long Order => Selectable.SelectOrder;
+
+    // Read only between Retarget and Release, both driven by the waiter; a null
+    // here would mean the waiter walked a slot it had already released.
+    private ISelectableCore<T> Selectable => selectable!;
+
+    /// <inheritdoc/>
+    public T TakeArmValue()
+    {
+        var taken = pending;
+        pending = default;
+        return taken!;
+    }
+
+    /// <summary>Points a cached descriptor at a new select's participants (issue #3902 S4).</summary>
+    /// <param name="target">The selectable.</param>
+    /// <param name="arm">The arm index.</param>
+    internal void Retarget(ISelectableCore<T> target, int arm)
+    {
+        selectable = target;
+        Arm = arm;
+        node = null;
+        pending = default;
+    }
+
+    /// <inheritdoc/>
+    internal override void Release()
+    {
+        selectable = null;
+        node = null;
+        pending = default;
+    }
 
     /// <inheritdoc/>
     internal override bool TryProbe(SelectWaiter waiter, ref Completions completions)
     {
-        if (!selectable.TryReceiveLocked(out var value, out var ok, ref completions))
+        if (!Selectable.TryReceiveLocked(out var value, out var ok, ref completions))
         {
             return false;
         }
 
-        waiter.Deposit(value, ok, needsReprobe: false);
+        // The value stays here, typed (issue #3902 S4): the waiter records who
+        // holds it rather than taking it as object and boxing.
+        pending = value;
+        waiter.DepositFrom(this, ok);
         return true;
     }
 
     /// <inheritdoc/>
     internal override void Register(SelectWaiter waiter, long generation)
     {
-        node = new SelectNode<T>(waiter, generation, Arm, selectable, isSend: false, default);
-        selectable.RegisterReceiveLocked(node);
+        node = new SelectNode<T>(waiter, generation, Arm, Selectable, isSend: false, default!);
+        Selectable.RegisterReceiveLocked(node);
     }
 
     /// <inheritdoc/>
@@ -100,7 +145,7 @@ internal sealed class CoreReceiveArm<T> : ArmDescriptor
         if (node is { } registered)
         {
             node = null;
-            selectable.Deregister(registered);
+            Selectable.Deregister(registered);
         }
     }
 }
@@ -109,8 +154,8 @@ internal sealed class CoreReceiveArm<T> : ArmDescriptor
 /// <typeparam name="T">The element type.</typeparam>
 internal sealed class CoreSendArm<T> : ArmDescriptor
 {
-    private readonly ISendSelectableCore<T> selectable;
-    private readonly T value;
+    private ISendSelectableCore<T>? selectable;
+    private T value;
     private SelectNode<T>? node;
 
     /// <summary>Initializes a new instance of the <see cref="CoreSendArm{T}"/> class.</summary>
@@ -128,17 +173,40 @@ internal sealed class CoreSendArm<T> : ArmDescriptor
     internal override bool RequiresGate => true;
 
     /// <inheritdoc/>
-    internal override object? Gate => selectable.SelectGate;
+    internal override object? Gate => Selectable.SelectGate;
 
     /// <inheritdoc/>
-    internal override long Order => selectable.SelectOrder;
+    internal override long Order => Selectable.SelectOrder;
+
+    // See CoreReceiveArm.
+    private ISendSelectableCore<T> Selectable => selectable!;
+
+    /// <summary>Points a cached descriptor at a new select's participants (issue #3902 S4).</summary>
+    /// <param name="target">The selectable.</param>
+    /// <param name="offered">The value the arm offers.</param>
+    /// <param name="arm">The arm index.</param>
+    internal void Retarget(ISendSelectableCore<T> target, T offered, int arm)
+    {
+        selectable = target;
+        value = offered;
+        Arm = arm;
+        node = null;
+    }
+
+    /// <inheritdoc/>
+    internal override void Release()
+    {
+        selectable = null;
+        value = default!;
+        node = null;
+    }
 
     /// <inheritdoc/>
     internal override bool TryProbe(SelectWaiter waiter, ref Completions completions)
     {
         try
         {
-            return selectable.TrySendLocked(value, ref completions);
+            return Selectable.TrySendLocked(value, ref completions);
         }
         catch (ChannelClosedException closed)
         {
@@ -151,8 +219,8 @@ internal sealed class CoreSendArm<T> : ArmDescriptor
     /// <inheritdoc/>
     internal override void Register(SelectWaiter waiter, long generation)
     {
-        node = new SelectNode<T>(waiter, generation, Arm, selectable, isSend: true, value);
-        selectable.RegisterSendLocked(node);
+        node = new SelectNode<T>(waiter, generation, Arm, Selectable, isSend: true, value);
+        Selectable.RegisterSendLocked(node);
     }
 
     /// <inheritdoc/>
@@ -161,7 +229,7 @@ internal sealed class CoreSendArm<T> : ArmDescriptor
         if (node is { } registered)
         {
             node = null;
-            selectable.Deregister(registered);
+            Selectable.Deregister(registered);
         }
     }
 }

--- a/src/Sdk/Gsharp.Runtime.Channels/ArmDescriptor.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ArmDescriptor.cs
@@ -155,7 +155,7 @@ internal sealed class CoreReceiveArm<T> : ArmDescriptor, IArmValue<T>
 internal sealed class CoreSendArm<T> : ArmDescriptor
 {
     private ISendSelectableCore<T>? selectable;
-    private T value;
+    private T? value;
     private SelectNode<T>? node;
 
     /// <summary>Initializes a new instance of the <see cref="CoreSendArm{T}"/> class.</summary>
@@ -197,7 +197,7 @@ internal sealed class CoreSendArm<T> : ArmDescriptor
     internal override void Release()
     {
         selectable = null;
-        value = default!;
+        value = default;
         node = null;
     }
 
@@ -206,7 +206,9 @@ internal sealed class CoreSendArm<T> : ArmDescriptor
     {
         try
         {
-            return Selectable.TrySendLocked(value, ref completions);
+            // Set by the constructor or by Retarget, both of which run before
+            // the waiter can probe this arm; Release only runs after it is done.
+            return Selectable.TrySendLocked(value!, ref completions);
         }
         catch (ChannelClosedException closed)
         {
@@ -219,7 +221,8 @@ internal sealed class CoreSendArm<T> : ArmDescriptor
     /// <inheritdoc/>
     internal override void Register(SelectWaiter waiter, long generation)
     {
-        node = new SelectNode<T>(waiter, generation, Arm, Selectable, isSend: true, value);
+        // As in TryProbe: live between Retarget and Release.
+        node = new SelectNode<T>(waiter, generation, Arm, Selectable, isSend: true, value!);
         Selectable.RegisterSendLocked(node);
     }
 

--- a/src/Sdk/Gsharp.Runtime.Channels/ChannelOps.Awaited.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ChannelOps.Awaited.cs
@@ -15,6 +15,15 @@ namespace Gsharp.Concurrency;
 /// <c>(T, bool)</c> of the two-value receive — so the compiler awaits one call
 /// and reads no member of <see cref="ReceiveResult{T}"/> in emitted IL. Both
 /// complete synchronously when a value is ready and allocate nothing then.
+///
+/// <para>
+/// Issue #3902 (S2): a G#-owned <see cref="Chan{T}"/> — the overwhelmingly
+/// common case — is shaped by the channel itself, so the parked path is backed
+/// by the waiter node and allocates nothing either. Only a genuinely foreign
+/// <see cref="ChannelReader{T}"/> still goes through the reshaping wrappers
+/// below, and those now use the pooling builder so their state machine is
+/// rented rather than allocated.
+/// </para>
 /// </summary>
 public static partial class ChannelOps
 {
@@ -24,7 +33,9 @@ public static partial class ChannelOps
     /// <param name="cancellationToken">The ambient cancellation.</param>
     /// <returns>The element, or the zero value when closed.</returns>
     public static ValueTask<T> ReceiveValueAsync<T>(Channel<T>? channel, CancellationToken cancellationToken)
-        => Unwrap(ReceiveAsync(channel, cancellationToken));
+        => channel is Chan<T> chan
+            ? chan.ReceiveValueAsync(cancellationToken)
+            : ReceiveValueAsync(channel?.Reader, cancellationToken);
 
     /// <summary>Receives one value from a reader, suspending while none is available.</summary>
     /// <typeparam name="T">The element type.</typeparam>
@@ -32,7 +43,9 @@ public static partial class ChannelOps
     /// <param name="cancellationToken">The ambient cancellation.</param>
     /// <returns>The element, or the zero value when closed.</returns>
     public static ValueTask<T> ReceiveValueAsync<T>(ChannelReader<T>? reader, CancellationToken cancellationToken)
-        => Unwrap(ReceiveAsync(reader, cancellationToken));
+        => reader is Chan<T>.ChanReader owned
+            ? owned.Owner.ReceiveValueAsync(cancellationToken)
+            : Unwrap(ReceiveAsync(reader, cancellationToken));
 
     /// <summary>The suspending two-value receive as a tuple.</summary>
     /// <typeparam name="T">The element type.</typeparam>
@@ -40,7 +53,9 @@ public static partial class ChannelOps
     /// <param name="cancellationToken">The ambient cancellation.</param>
     /// <returns>The element and whether the channel delivered it.</returns>
     public static ValueTask<(T Value, bool Ok)> ReceiveTupleAsync<T>(Channel<T>? channel, CancellationToken cancellationToken)
-        => ToTuple(ReceiveAsync(channel, cancellationToken));
+        => channel is Chan<T> chan
+            ? chan.ReceiveTupleAsync(cancellationToken)
+            : ReceiveTupleAsync(channel?.Reader, cancellationToken);
 
     /// <summary>The suspending two-value receive from a reader as a tuple.</summary>
     /// <typeparam name="T">The element type.</typeparam>
@@ -48,7 +63,9 @@ public static partial class ChannelOps
     /// <param name="cancellationToken">The ambient cancellation.</param>
     /// <returns>The element and whether the channel delivered it.</returns>
     public static ValueTask<(T Value, bool Ok)> ReceiveTupleAsync<T>(ChannelReader<T>? reader, CancellationToken cancellationToken)
-        => ToTuple(ReceiveAsync(reader, cancellationToken));
+        => reader is Chan<T>.ChanReader owned
+            ? owned.Owner.ReceiveTupleAsync(cancellationToken)
+            : ToTuple(ReceiveAsync(reader, cancellationToken));
 
     /// <summary>Receives one value under <paramref name="context"/>; see <see cref="ReceiveValueAsync{T}(Channel{T}, CancellationToken)"/>.</summary>
     /// <typeparam name="T">The element type.</typeparam>

--- a/src/Sdk/Gsharp.Runtime.Channels/ChannelOps.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ChannelOps.cs
@@ -56,6 +56,13 @@ public static partial class ChannelOps
     /// <returns>The value and whether one was delivered.</returns>
     public static (T Value, bool Ok) Receive2<T>(Channel<T>? channel, CancellationToken cancellationToken)
     {
+        // Issue #3902 H1: a blocking channel operation is what the body of a
+        // `lock { ch <- v }` compiles to (ADR-0174 errata 10). Monitor is
+        // reentrant, so an inline continuation would run INSIDE the caller's
+        // lock and observe mutual exclusion it does not hold. Publication on
+        // these paths always queues.
+        using var noInline = InlineBudget.Suppress();
+
         if (channel is Chan<T> chan)
         {
             if (chan.TryReceive(out var value, out var ok))
@@ -78,6 +85,13 @@ public static partial class ChannelOps
     /// <returns>The value and whether one was delivered.</returns>
     public static (T Value, bool Ok) Receive2<T>(ChannelReader<T>? reader, CancellationToken cancellationToken)
     {
+        // Issue #3902 H1: a blocking channel operation is what the body of a
+        // `lock { ch <- v }` compiles to (ADR-0174 errata 10). Monitor is
+        // reentrant, so an inline continuation would run INSIDE the caller's
+        // lock and observe mutual exclusion it does not hold. Publication on
+        // these paths always queues.
+        using var noInline = InlineBudget.Suppress();
+
         if (reader is Chan<T>.ChanReader owned)
         {
             return Receive2(owned.Owner, cancellationToken);
@@ -112,6 +126,13 @@ public static partial class ChannelOps
     /// <exception cref="ChannelClosedException">The channel is closed.</exception>
     public static void Send<T>(Channel<T>? channel, T value, CancellationToken cancellationToken)
     {
+        // Issue #3902 H1: a blocking channel operation is what the body of a
+        // `lock { ch <- v }` compiles to (ADR-0174 errata 10). Monitor is
+        // reentrant, so an inline continuation would run INSIDE the caller's
+        // lock and observe mutual exclusion it does not hold. Publication on
+        // these paths always queues.
+        using var noInline = InlineBudget.Suppress();
+
         if (channel is Chan<T> chan)
         {
             if (!chan.TrySend(value))
@@ -133,6 +154,13 @@ public static partial class ChannelOps
     /// <exception cref="ChannelClosedException">The channel is closed.</exception>
     public static void Send<T>(ChannelWriter<T>? writer, T value, CancellationToken cancellationToken)
     {
+        // Issue #3902 H1: a blocking channel operation is what the body of a
+        // `lock { ch <- v }` compiles to (ADR-0174 errata 10). Monitor is
+        // reentrant, so an inline continuation would run INSIDE the caller's
+        // lock and observe mutual exclusion it does not hold. Publication on
+        // these paths always queues.
+        using var noInline = InlineBudget.Suppress();
+
         if (writer is Chan<T>.ChanWriter owned)
         {
             Send(owned.Owner, value, cancellationToken);

--- a/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.Batch.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.Batch.cs
@@ -202,7 +202,17 @@ public sealed partial class Chan<T>
         var taken = 0;
         while (taken < buffer.Length && count > 0)
         {
-            buffer[taken++] = DequeueBuffer();
+            taken += DrainBufferInto(buffer[taken..]);
+
+            // Issue #3902 S3: only consult the sender queue when there is one.
+            // The old loop called RefillFromSenderLocked once per element, and
+            // on a buffered channel with no parked sender — the common case —
+            // every one of those calls was a queue probe that found nothing.
+            if (senders.Count == 0)
+            {
+                break;
+            }
+
             RefillFromSenderLocked(ref completions);
         }
 

--- a/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.cs
@@ -511,6 +511,49 @@ public sealed partial class Chan<T> : Channel<T>, ISelectable<T>, ISendSelectabl
         return closed;
     }
 
+    /// <summary>
+    /// Copies as much of the ring as fits into <paramref name="destination"/>,
+    /// in at most two contiguous spans (issue #3902 S3).
+    /// </summary>
+    /// <remarks>
+    /// The batch receive used to walk <c>DequeueBuffer</c> per element, paying a
+    /// modulo and an <c>Array.Clear</c> of one slot each time. The clear only
+    /// matters when <typeparamref name="T"/> can hold a reference — leaving a
+    /// dead reference in the ring keeps an object alive — so for a blittable
+    /// element it is skipped entirely.
+    /// </remarks>
+    /// <param name="destination">Where to copy.</param>
+    /// <returns>The number of elements copied.</returns>
+    private int DrainBufferInto(Span<T> destination)
+    {
+        var ring = buffer;
+        if (ring is null || count == 0 || destination.IsEmpty)
+        {
+            return 0;
+        }
+
+        var take = Math.Min(destination.Length, count);
+        var first = Math.Min(take, ring.Length - head);
+        ring.AsSpan(head, first).CopyTo(destination);
+        if (take > first)
+        {
+            ring.AsSpan(0, take - first).CopyTo(destination[first..]);
+        }
+
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        {
+            Array.Clear(ring, head, first);
+            if (take > first)
+            {
+                Array.Clear(ring, 0, take - first);
+            }
+        }
+
+        head = (head + take) % ring.Length;
+        count -= take;
+        return take;
+    }
+
     private void RefillFromSenderLocked(ref Completions completions)
     {
         while (senders.TryDequeue(out var node))

--- a/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.cs
@@ -184,37 +184,58 @@ public sealed partial class Chan<T> : Channel<T>, ISelectable<T>, ISendSelectabl
     /// <returns>The value and whether one was delivered (false: closed and drained).</returns>
     public ValueTask<ReceiveResult<T>> ReceiveAsync(CancellationToken cancellationToken = default)
     {
-        if (IsClosedAndDrained)
+        var outcome = ReceiveOrPark(cancellationToken, out var value, out var ok, out var node);
+        return outcome switch
         {
-            return new ValueTask<ReceiveResult<T>>(ReceiveResult<T>.Closed);
-        }
+            ReceiveStart.Closed => new ValueTask<ReceiveResult<T>>(ReceiveResult<T>.Closed),
+            ReceiveStart.Cancelled => ValueTask.FromCanceled<ReceiveResult<T>>(cancellationToken),
+            ReceiveStart.Ready => new ValueTask<ReceiveResult<T>>(new ReceiveResult<T>(value, ok)),
+            _ => new ValueTask<ReceiveResult<T>>(node!, node!.Version),
+        };
+    }
 
-        var completions = default(Completions);
-        OpReceiveNode<T>? node = null;
-        T? value;
-        bool ok;
-        bool done;
-        lock (gate)
+    /// <summary>
+    /// Receives one value as the element alone — the zero value once the
+    /// channel is closed and drained (ADR-0174 D3).
+    /// </summary>
+    /// <remarks>
+    /// Issue #3902 (S2): the parked path returns a <see cref="ValueTask{T}"/>
+    /// backed by the node ITSELF, so a suspending receive through the language
+    /// no longer routes through an <c>async</c> wrapper that reshapes the
+    /// result. That wrapper ran on the default builder and boxed an
+    /// <c>AsyncStateMachineBox</c> — about 144 bytes on every park — and put a
+    /// Task continuation between the node and the caller's state machine. This
+    /// allocates nothing, ready or parked.
+    /// </remarks>
+    /// <param name="cancellationToken">The ambient cancellation.</param>
+    /// <returns>The element, or the zero value when closed.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<T> ReceiveValueAsync(CancellationToken cancellationToken = default)
+    {
+        var outcome = ReceiveOrPark(cancellationToken, out var value, out _, out var node);
+        return outcome switch
         {
-            done = TryReceiveLocked(out value, out ok, ref completions);
-            if (!done)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    completions.Publish();
-                    return ValueTask.FromCanceled<ReceiveResult<T>>(cancellationToken);
-                }
+            ReceiveStart.Closed => new ValueTask<T>(default(T)!),
+            ReceiveStart.Cancelled => ValueTask.FromCanceled<T>(cancellationToken),
+            ReceiveStart.Ready => new ValueTask<T>(value!),
+            _ => new ValueTask<T>(node!, node!.Version),
+        };
+    }
 
-                node = RentReceiveNode();
-                receivers.Enqueue(node);
-                node.RegisterCancellation(cancellationToken);
-            }
-        }
-
-        completions.Publish();
-        return done
-            ? new ValueTask<ReceiveResult<T>>(new ReceiveResult<T>(value, ok))
-            : new ValueTask<ReceiveResult<T>>(node!, node!.Version); // `done` false only where a node was parked above.
+    /// <summary>The suspending two-value receive as a tuple; see <see cref="ReceiveValueAsync"/> for why it is shaped here rather than wrapped.</summary>
+    /// <param name="cancellationToken">The ambient cancellation.</param>
+    /// <returns>The element and whether the channel delivered it.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<(T Value, bool Ok)> ReceiveTupleAsync(CancellationToken cancellationToken = default)
+    {
+        var outcome = ReceiveOrPark(cancellationToken, out var value, out var ok, out var node);
+        return outcome switch
+        {
+            ReceiveStart.Closed => new ValueTask<(T Value, bool Ok)>((default(T)!, false)),
+            ReceiveStart.Cancelled => ValueTask.FromCanceled<(T Value, bool Ok)>(cancellationToken),
+            ReceiveStart.Ready => new ValueTask<(T Value, bool Ok)>((value!, ok)),
+            _ => new ValueTask<(T Value, bool Ok)>(node!, node!.Version),
+        };
     }
 
     /// <summary>
@@ -565,6 +586,55 @@ public sealed partial class Chan<T> : Channel<T>, ISelectable<T>, ISendSelectabl
 
         buffer = grown;
         head = 0;
+    }
+
+    /// <summary>
+    /// The shared start of every suspending receive: take a ready value, or
+    /// park a node. Factored so the three result shapes (issue #3902 S2) differ
+    /// only in how they wrap the outcome — the lock body, the cancellation
+    /// check and the completion publication have one copy between them.
+    /// </summary>
+    /// <param name="cancellationToken">The ambient cancellation.</param>
+    /// <param name="value">The value taken, when the outcome is <see cref="ReceiveStart.Ready"/>.</param>
+    /// <param name="ok">Whether a value was delivered, when ready.</param>
+    /// <param name="node">The parked node, when the outcome is <see cref="ReceiveStart.Parked"/>.</param>
+    /// <returns>How the receive started.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ReceiveStart ReceiveOrPark(
+        CancellationToken cancellationToken,
+        out T? value,
+        out bool ok,
+        out OpReceiveNode<T>? node)
+    {
+        value = default;
+        ok = false;
+        node = null;
+        if (IsClosedAndDrained)
+        {
+            return ReceiveStart.Closed;
+        }
+
+        var completions = default(Completions);
+        bool done;
+        lock (gate)
+        {
+            done = TryReceiveLocked(out value, out ok, ref completions);
+            if (!done)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    completions.Publish();
+                    return ReceiveStart.Cancelled;
+                }
+
+                node = RentReceiveNode();
+                receivers.Enqueue(node);
+                node.RegisterCancellation(cancellationToken);
+            }
+        }
+
+        completions.Publish();
+        return done ? ReceiveStart.Ready : ReceiveStart.Parked;
     }
 
     private OpReceiveNode<T> RentReceiveNode()

--- a/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/Chan{T}.cs
@@ -190,6 +190,9 @@ public sealed partial class Chan<T> : Channel<T>, ISelectable<T>, ISendSelectabl
             ReceiveStart.Closed => new ValueTask<ReceiveResult<T>>(ReceiveResult<T>.Closed),
             ReceiveStart.Cancelled => ValueTask.FromCanceled<ReceiveResult<T>>(cancellationToken),
             ReceiveStart.Ready => new ValueTask<ReceiveResult<T>>(new ReceiveResult<T>(value, ok)),
+
+            // Parked is the only remaining outcome, and ReceiveOrPark assigns
+            // `node` on exactly that path.
             _ => new ValueTask<ReceiveResult<T>>(node!, node!.Version),
         };
     }
@@ -215,9 +218,17 @@ public sealed partial class Chan<T> : Channel<T>, ISelectable<T>, ISendSelectabl
         var outcome = ReceiveOrPark(cancellationToken, out var value, out _, out var node);
         return outcome switch
         {
+            // The zero value is the documented closed-channel result (D3), so a
+            // null here is the answer rather than a missing one.
             ReceiveStart.Closed => new ValueTask<T>(default(T)!),
             ReceiveStart.Cancelled => ValueTask.FromCanceled<T>(cancellationToken),
+
+            // Ready means ReceiveOrPark took a value; `ok` reports whether the
+            // channel delivered one, and this shape deliberately discards it.
             ReceiveStart.Ready => new ValueTask<T>(value!),
+
+            // Parked is the only remaining outcome, and ReceiveOrPark assigns
+            // `node` on exactly that path.
             _ => new ValueTask<T>(node!, node!.Version),
         };
     }
@@ -231,9 +242,15 @@ public sealed partial class Chan<T> : Channel<T>, ISelectable<T>, ISendSelectabl
         var outcome = ReceiveOrPark(cancellationToken, out var value, out var ok, out var node);
         return outcome switch
         {
+            // The `false` IS the report that the value is meaningless (D3).
             ReceiveStart.Closed => new ValueTask<(T Value, bool Ok)>((default(T)!, false)),
             ReceiveStart.Cancelled => ValueTask.FromCanceled<(T Value, bool Ok)>(cancellationToken),
+
+            // Ready means ReceiveOrPark took a value; `ok` travels beside it.
             ReceiveStart.Ready => new ValueTask<(T Value, bool Ok)>((value!, ok)),
+
+            // Parked is the only remaining outcome, and ReceiveOrPark assigns
+            // `node` on exactly that path.
             _ => new ValueTask<(T Value, bool Ok)>(node!, node!.Version),
         };
     }

--- a/src/Sdk/Gsharp.Runtime.Channels/ChunkReader{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ChunkReader{T}.cs
@@ -54,10 +54,36 @@ public sealed class ChunkReader<T> : ChannelReader<ReadOnlyMemory<T>>
     /// <inheritdoc/>
     public override Task Completion => source.Completion;
 
+    /// <summary>
+    /// Gets how many elements are known to be waiting, or <c>size</c> when the
+    /// source cannot say (issue #3902 S3). A G#-owned channel can answer
+    /// exactly; a foreign reader is asked for a lower bound, and the
+    /// conservative answer keeps the old behaviour rather than skipping a read.
+    /// </summary>
+    private int Available => source switch
+    {
+        Chan<T>.ChanReader owned => owned.Owner.Length(),
+        _ => source.CanCount ? source.Count : size,
+    };
+
     /// <inheritdoc/>
+    /// <remarks>
+    /// Issue #3902 (S3): the array is sized to what is actually there, and is
+    /// not allocated at all when nothing is. This path is probed by the
+    /// readiness/re-probe loop a foreign reader goes through, so an empty
+    /// channel used to throw away one <c>T[size]</c> per probe — at a chunk
+    /// size of 1024 that dominated everything else the scenario did.
+    /// </remarks>
     public override bool TryRead(out ReadOnlyMemory<T> item)
     {
-        var buffer = new T[size];
+        var available = Available;
+        if (available == 0)
+        {
+            item = default;
+            return false;
+        }
+
+        var buffer = new T[Math.Min(size, available)];
         var taken = source.TryReceiveBatch(buffer.AsSpan());
         if (taken == 0)
         {

--- a/src/Sdk/Gsharp.Runtime.Channels/IArmValue{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/IArmValue{T}.cs
@@ -1,0 +1,25 @@
+// <copyright file="IArmValue{T}.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace Gsharp.Concurrency;
+
+/// <summary>
+/// A select participant that holds the winning value in its own typed field
+/// (issue #3902 S4).
+/// </summary>
+/// <remarks>
+/// <see cref="SelectWaiter"/> is not generic, so it used to take the winning
+/// value as <c>object?</c> — which boxed every value-typed element on both the
+/// ready and the parked path. The value now stays with whichever participant
+/// produced it (the arm descriptor when the probe succeeded, the parked node
+/// when the transfer did), and <c>TakeValue&lt;T&gt;</c> reaches it through
+/// this interface: a cast, not a box.
+/// </remarks>
+/// <typeparam name="T">The element type.</typeparam>
+internal interface IArmValue<out T>
+{
+    /// <summary>Takes the deposited value, clearing it. Called once, by the winner.</summary>
+    /// <returns>The value.</returns>
+    T TakeArmValue();
+}

--- a/src/Sdk/Gsharp.Runtime.Channels/InlineBudget.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/InlineBudget.cs
@@ -1,0 +1,94 @@
+// <copyright file="InlineBudget.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Runtime.CompilerServices;
+
+namespace Gsharp.Concurrency;
+
+/// <summary>
+/// Decides whether a hand-off may complete its waiter's continuation INLINE, on
+/// the publishing thread, instead of queueing it to the thread pool
+/// (ADR-0174 gate G6, issue #3902 H1).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A parked receive costs one thread-pool work item per hand-off: the publisher
+/// queues, another pool thread steals. That hop is most of what separates a G#
+/// rendezvous from Go's, where <c>goready</c> hands the receiver straight to the
+/// scheduler. Completing inline removes it — at the price of running the
+/// receiver's continuation on the sender's stack, which is why this is a
+/// budget rather than a switch.
+/// </para>
+/// <para>
+/// Two things bound it. <b>Depth</b>: a chain of rendezvous hand-offs would
+/// otherwise nest one frame per link, so past <see cref="Limit"/> the hop comes
+/// back and the stack unwinds. <b>Stack</b>:
+/// <see cref="RuntimeHelpers.TryEnsureSufficientExecutionStack"/> is consulted
+/// every time, so a deep user stack declines before it overflows rather than
+/// after.
+/// </para>
+/// <para>
+/// <b>Suppression is the correctness half.</b> Inline publication is only safe
+/// where the publisher holds no lock the continuation could re-enter. G#'s
+/// blocking channel forms are what <c>lock { ch &lt;- v }</c> compiles to, and
+/// Monitor is reentrant: an inline receiver would run INSIDE the sender's
+/// monitor and observe mutual exclusion it does not have. Those paths, and
+/// cancellation callbacks, publish under <see cref="Suppress"/>.
+/// </para>
+/// </remarks>
+internal static class InlineBudget
+{
+    /// <summary>
+    /// The default nesting limit. Sixteen is deep enough that a hand-off chain
+    /// almost never pays the hop and shallow enough to be irrelevant against
+    /// any real stack; the environment variable exists to measure the ends.
+    /// </summary>
+    private const int DefaultLimit = 16;
+
+    [ThreadStatic]
+    private static int depth;
+
+    [ThreadStatic]
+    private static int suppressions;
+
+    /// <summary>Gets the nesting limit; <c>GS_INLINE_DEPTH=0</c> restores the always-queue behaviour.</summary>
+    internal static int Limit { get; } =
+        int.TryParse(Environment.GetEnvironmentVariable("GS_INLINE_DEPTH"), out var configured) && configured >= 0
+            ? configured
+            : DefaultLimit;
+
+    /// <summary>Takes an inline slot when one is available.</summary>
+    /// <returns>True when the caller may publish inline, and must then call <see cref="Exit"/>.</returns>
+    internal static bool TryEnter()
+    {
+        if (suppressions > 0 || depth >= Limit || !RuntimeHelpers.TryEnsureSufficientExecutionStack())
+        {
+            return false;
+        }
+
+        depth++;
+        return true;
+    }
+
+    /// <summary>Releases a slot taken by <see cref="TryEnter"/>.</summary>
+    internal static void Exit() => depth--;
+
+    /// <summary>
+    /// Forbids inline publication for the duration of the returned scope. Used
+    /// where the publisher holds a lock, or is running inside a cancellation
+    /// callback, and must not run a continuation on its own stack.
+    /// </summary>
+    /// <returns>A scope that restores the previous state.</returns>
+    internal static Scope Suppress() => new Scope();
+
+    /// <summary>The suppression scope; see <see cref="Suppress"/>.</summary>
+    internal readonly struct Scope : IDisposable
+    {
+        /// <summary>Initializes a new instance of the <see cref="Scope"/> struct.</summary>
+        public Scope() => suppressions++;
+
+        /// <inheritdoc/>
+        public void Dispose() => suppressions--;
+    }
+}

--- a/src/Sdk/Gsharp.Runtime.Channels/ParkedNode{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ParkedNode{T}.cs
@@ -54,6 +54,15 @@ internal abstract class ParkedNode<T> : WaiterNode<T>
     /// <summary>Gets a value indicating whether a transfer committed to this node.</summary>
     protected bool IsCommitted => Volatile.Read(ref state) == Committed;
 
+    /// <summary>
+    /// Gets a value indicating whether this node's continuation may run on the
+    /// publishing thread (issue #3902 H1). False for notifiers: their
+    /// continuation is a BCL <c>WaitToReadAsync</c> consumer, which
+    /// <see cref="System.Threading.Channels.Channel{T}"/> itself completes
+    /// asynchronously for the same reason.
+    /// </summary>
+    protected virtual bool AllowsInlineCompletion => true;
+
     /// <inheritdoc/>
     internal sealed override bool TryCancel(OperationCanceledException exception) => TryFault(exception);
 
@@ -73,13 +82,30 @@ internal abstract class ParkedNode<T> : WaiterNode<T>
             CanPool = registration.Unregister();
         }
 
-        if (Volatile.Read(ref state) == Committed)
+        // Issue #3902 H1 / ADR-0174 gate G6: complete the awaiter's
+        // continuation on this thread when the budget allows, instead of
+        // queueing a thread-pool work item and waiting for another thread to
+        // steal it. Publication already happens outside every channel lock,
+        // which is what makes this admissible at all.
+        var inline = AllowsInlineCompletion && InlineBudget.TryEnter();
+        try
         {
-            PublishResult();
+            SetRunContinuationsAsynchronously(!inline);
+            if (Volatile.Read(ref state) == Committed)
+            {
+                PublishResult();
+            }
+            else
+            {
+                PublishException(fault!);
+            }
         }
-        else
+        finally
         {
-            PublishException(fault!);
+            if (inline)
+            {
+                InlineBudget.Exit();
+            }
         }
     }
 
@@ -125,6 +151,10 @@ internal abstract class ParkedNode<T> : WaiterNode<T>
         fault = exception;
         return true;
     }
+
+    /// <summary>Points the node's value-task source at inline or queued completion.</summary>
+    /// <param name="value">Whether continuations must be queued.</param>
+    protected abstract void SetRunContinuationsAsynchronously(bool value);
 
     /// <summary>Publishes the committed result to the awaiter.</summary>
     protected abstract void PublishResult();
@@ -246,6 +276,9 @@ internal sealed class OpReceiveNode<T>
     }
 
     /// <inheritdoc/>
+    protected override void SetRunContinuationsAsynchronously(bool value) => core.RunContinuationsAsynchronously = value;
+
+    /// <inheritdoc/>
     protected override void PublishResult() => core.SetResult(result);
 
     /// <inheritdoc/>
@@ -358,6 +391,9 @@ internal sealed class OpSendNode<T> : ParkedNode<T>, IValueTaskSource
     }
 
     /// <inheritdoc/>
+    protected override void SetRunContinuationsAsynchronously(bool value) => core.RunContinuationsAsynchronously = value;
+
+    /// <inheritdoc/>
     protected override void PublishResult() => core.SetResult(true);
 
     /// <inheritdoc/>
@@ -389,6 +425,15 @@ internal sealed class NotifyNode<T> : ParkedNode<T>, IValueTaskSource<bool>
 
     /// <inheritdoc/>
     internal override bool IsNotify => true;
+
+    /// <summary>
+    /// Gets a value indicating whether the continuation may run inline: never,
+    /// for a notifier. Its continuation is a BCL <c>WaitToReadAsync</c>
+    /// consumer, and running arbitrary consumer code on a sender's stack is
+    /// exactly what <c>Channel&lt;T&gt;</c> avoids by defaulting that path to
+    /// asynchronous.
+    /// </summary>
+    protected override bool AllowsInlineCompletion => false;
 
     /// <inheritdoc/>
     bool IValueTaskSource<bool>.GetResult(short token) => core.GetResult(token);
@@ -431,6 +476,9 @@ internal sealed class NotifyNode<T> : ParkedNode<T>, IValueTaskSource<bool>
             result = false;
         }
     }
+
+    /// <inheritdoc/>
+    protected override void SetRunContinuationsAsynchronously(bool value) => core.RunContinuationsAsynchronously = value;
 
     /// <inheritdoc/>
     protected override void PublishResult() => core.SetResult(result);

--- a/src/Sdk/Gsharp.Runtime.Channels/ParkedNode{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ParkedNode{T}.cs
@@ -147,7 +147,11 @@ internal abstract class ParkedNode<T> : WaiterNode<T>
 
 /// <summary>A parked receiver: the awaitable behind <see cref="Chan{T}.ReceiveAsync"/>.</summary>
 /// <typeparam name="T">The channel element type.</typeparam>
-internal sealed class OpReceiveNode<T> : ParkedNode<T>, IValueTaskSource<ReceiveResult<T>>
+internal sealed class OpReceiveNode<T>
+    : ParkedNode<T>,
+      IValueTaskSource<ReceiveResult<T>>,
+      IValueTaskSource<T>,
+      IValueTaskSource<(T Value, bool Ok)>
 {
     private ManualResetValueTaskSourceCore<ReceiveResult<T>> core;
     private ReceiveResult<T> result;
@@ -167,27 +171,42 @@ internal sealed class OpReceiveNode<T> : ParkedNode<T>, IValueTaskSource<Receive
     internal override bool IsNotify => false;
 
     /// <inheritdoc/>
-    ReceiveResult<T> IValueTaskSource<ReceiveResult<T>>.GetResult(short token)
-    {
-        var pool = CanPool && token == core.Version && core.GetStatus(token) != ValueTaskSourceStatus.Pending;
-        try
-        {
-            return core.GetResult(token);
-        }
-        finally
-        {
-            if (pool)
-            {
-                Owner.ReturnReceiveNode(this);
-            }
-        }
-    }
+    ReceiveResult<T> IValueTaskSource<ReceiveResult<T>>.GetResult(short token) => TakeResult(token);
 
     /// <inheritdoc/>
     ValueTaskSourceStatus IValueTaskSource<ReceiveResult<T>>.GetStatus(short token) => core.GetStatus(token);
 
     /// <inheritdoc/>
     void IValueTaskSource<ReceiveResult<T>>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        => core.OnCompleted(continuation, state, token, flags);
+
+    // The single-value shape. A closed, drained channel yields the zero value
+    // by design (ADR-0174 D3), so there is no null to guard.
+
+    /// <inheritdoc/>
+    T IValueTaskSource<T>.GetResult(short token) => TakeResult(token).Value!;
+
+    /// <inheritdoc/>
+    ValueTaskSourceStatus IValueTaskSource<T>.GetStatus(short token) => core.GetStatus(token);
+
+    /// <inheritdoc/>
+    void IValueTaskSource<T>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
+        => core.OnCompleted(continuation, state, token, flags);
+
+    // The two-value shape: the tuple IS the three-state encoding (D3).
+
+    /// <inheritdoc/>
+    (T Value, bool Ok) IValueTaskSource<(T Value, bool Ok)>.GetResult(short token)
+    {
+        var taken = TakeResult(token);
+        return (taken.Value!, taken.Ok);
+    }
+
+    /// <inheritdoc/>
+    ValueTaskSourceStatus IValueTaskSource<(T Value, bool Ok)>.GetStatus(short token) => core.GetStatus(token);
+
+    /// <inheritdoc/>
+    void IValueTaskSource<(T Value, bool Ok)>.OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags)
         => core.OnCompleted(continuation, state, token, flags);
 
     /// <inheritdoc/>
@@ -231,6 +250,32 @@ internal sealed class OpReceiveNode<T> : ParkedNode<T>, IValueTaskSource<Receive
 
     /// <inheritdoc/>
     protected override void PublishException(Exception exception) => core.SetException(exception);
+
+    /// <summary>
+    /// Consumes the result exactly once and returns the node to its channel's
+    /// pool. Issue #3902 (S2): the node backs three <see cref="ValueTask{T}"/>
+    /// shapes over one result, and only the shape the awaiter chose calls its
+    /// <c>GetResult</c> — so this is still one consumption per rental. It is
+    /// factored rather than repeated because the pooling predicate has to stay
+    /// identical across all three; a drifted copy would return a node twice.
+    /// </summary>
+    /// <param name="token">The version token the awaiter holds.</param>
+    /// <returns>The receive result.</returns>
+    private ReceiveResult<T> TakeResult(short token)
+    {
+        var pool = CanPool && token == core.Version && core.GetStatus(token) != ValueTaskSourceStatus.Pending;
+        try
+        {
+            return core.GetResult(token);
+        }
+        finally
+        {
+            if (pool)
+            {
+                Owner.ReturnReceiveNode(this);
+            }
+        }
+    }
 }
 
 /// <summary>A parked sender: the awaitable behind <see cref="Chan{T}.SendAsync"/>.</summary>

--- a/src/Sdk/Gsharp.Runtime.Channels/ReceiveStart.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/ReceiveStart.cs
@@ -1,0 +1,24 @@
+// <copyright file="ReceiveStart.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace Gsharp.Concurrency;
+
+/// <summary>
+/// How a suspending receive began, so the three result shapes of
+/// <see cref="Chan{T}"/> can share one start (issue #3902 S2).
+/// </summary>
+internal enum ReceiveStart
+{
+    /// <summary>A value was available and taken without parking.</summary>
+    Ready,
+
+    /// <summary>The channel is closed and drained; no value will ever arrive.</summary>
+    Closed,
+
+    /// <summary>Cancellation was already requested when the receive would have parked.</summary>
+    Cancelled,
+
+    /// <summary>A node was parked; the result arrives through it.</summary>
+    Parked,
+}

--- a/src/Sdk/Gsharp.Runtime.Channels/SelectNode{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/SelectNode{T}.cs
@@ -17,7 +17,7 @@ namespace Gsharp.Concurrency;
 /// what protects a pooled waiter from ABA.
 /// </summary>
 /// <typeparam name="T">The element type of the arm's selectable.</typeparam>
-internal sealed class SelectNode<T> : WaiterNode<T>, ISelectArm
+internal sealed class SelectNode<T> : WaiterNode<T>, IArmValue<T>, ISelectArm
 {
     private readonly SelectWaiter waiter;
     private readonly long generation;
@@ -26,6 +26,7 @@ internal sealed class SelectNode<T> : WaiterNode<T>, ISelectArm
     private readonly bool isSend;
     private T? sendValue;
     private bool won;
+    private T? received;
 
     /// <summary>Initializes a new instance of the <see cref="SelectNode{T}"/> class.</summary>
     /// <param name="waiter">The shared waiter.</param>
@@ -51,6 +52,14 @@ internal sealed class SelectNode<T> : WaiterNode<T>, ISelectArm
     public void Deregister() => selectable.Deregister(this);
 
     /// <inheritdoc/>
+    public T TakeArmValue()
+    {
+        var taken = received;
+        received = default;
+        return taken!;
+    }
+
+    /// <inheritdoc/>
     internal override bool TryCommitReceive(T value)
     {
         if (isSend || !waiter.TryClaim(generation, arm))
@@ -58,7 +67,10 @@ internal sealed class SelectNode<T> : WaiterNode<T>, ISelectArm
             return false;
         }
 
-        waiter.Deposit(value, ok: true, needsReprobe: false);
+        // Issue #3902 S4: the value stays typed on the node; the waiter only
+        // records who holds it, so a value-typed element never boxes.
+        received = value;
+        waiter.DepositFrom(this, ok: true);
         won = true;
         return true;
     }
@@ -97,7 +109,8 @@ internal sealed class SelectNode<T> : WaiterNode<T>, ISelectArm
         else
         {
             // Go: a receive arm on a closed channel proceeds with the zero value.
-            waiter.Deposit(default(T)!, ok: false, needsReprobe: false);
+            received = default;
+            waiter.DepositFrom(this, ok: false);
         }
     }
 

--- a/src/Sdk/Gsharp.Runtime.Channels/SelectNode{T}.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/SelectNode{T}.cs
@@ -56,6 +56,9 @@ internal sealed class SelectNode<T> : WaiterNode<T>, IArmValue<T>, ISelectArm
     {
         var taken = received;
         received = default;
+
+        // Only the winning arm takes the value, and the winner deposited it
+        // first; a closed arm deposits the zero value on purpose (D3).
         return taken!;
     }
 

--- a/src/Sdk/Gsharp.Runtime.Channels/SelectWaiter.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/SelectWaiter.cs
@@ -44,6 +44,8 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     private ManualResetValueTaskSourceCore<int> core;
     private long word = StateIdle;
     private int winnerArm = -1;
+    private int armCount;
+    private object? valueOwner;
     private object? value;
     private bool ok;
     private bool needsReprobe;
@@ -69,7 +71,7 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     internal long Generation => Volatile.Read(ref word) >> StateBits;
 
     /// <summary>Gets the number of registered arms. Diagnostic.</summary>
-    internal int ArmCount => arms.Count;
+    internal int ArmCount => armCount;
 
     /// <summary>
     /// Rents a waiter for <paramref name="arms"/> arms, cancelled by
@@ -102,7 +104,7 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     {
         if (channel is not null)
         {
-            arms.Add(new CoreReceiveArm<T>(channel, arm));
+            PlaceReceive(channel, arm);
         }
     }
 
@@ -115,12 +117,12 @@ public sealed class SelectWaiter : IValueTaskSource<int>
         switch (channel)
         {
             case Chan<T> chan:
-                arms.Add(new CoreReceiveArm<T>(chan, arm));
+                PlaceReceive(chan, arm);
                 break;
             case null:
                 break;
             default:
-                arms.Add(new ForeignReceiveArm<T>(channel.Reader, arm));
+                Place(new ForeignReceiveArm<T>(channel.Reader, arm));
                 break;
         }
     }
@@ -134,12 +136,12 @@ public sealed class SelectWaiter : IValueTaskSource<int>
         switch (reader)
         {
             case Chan<T>.ChanReader owned:
-                arms.Add(new CoreReceiveArm<T>(owned.Owner, arm));
+                PlaceReceive(owned.Owner, arm);
                 break;
             case null:
                 break;
             default:
-                arms.Add(new ForeignReceiveArm<T>(reader, arm));
+                Place(new ForeignReceiveArm<T>(reader, arm));
                 break;
         }
     }
@@ -153,7 +155,7 @@ public sealed class SelectWaiter : IValueTaskSource<int>
         switch (selectable)
         {
             case ISelectableCore<T> core:
-                arms.Add(new CoreReceiveArm<T>(core, arm));
+                PlaceReceive(core, arm);
                 break;
             case null:
                 break;
@@ -171,7 +173,7 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     {
         if (channel is not null)
         {
-            arms.Add(new CoreSendArm<T>(channel, value, arm));
+            PlaceSend(channel, value, arm);
         }
     }
 
@@ -185,12 +187,12 @@ public sealed class SelectWaiter : IValueTaskSource<int>
         switch (channel)
         {
             case Chan<T> chan:
-                arms.Add(new CoreSendArm<T>(chan, value, arm));
+                PlaceSend(chan, value, arm);
                 break;
             case null:
                 break;
             default:
-                arms.Add(new ForeignSendArm<T>(channel.Writer, value, arm));
+                Place(new ForeignSendArm<T>(channel.Writer, value, arm));
                 break;
         }
     }
@@ -205,12 +207,12 @@ public sealed class SelectWaiter : IValueTaskSource<int>
         switch (writer)
         {
             case Chan<T>.ChanWriter owned:
-                arms.Add(new CoreSendArm<T>(owned.Owner, value, arm));
+                PlaceSend(owned.Owner, value, arm);
                 break;
             case null:
                 break;
             default:
-                arms.Add(new ForeignSendArm<T>(writer, value, arm));
+                Place(new ForeignSendArm<T>(writer, value, arm));
                 break;
         }
     }
@@ -218,13 +220,13 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     /// <summary>Adds a <c>case await task</c> arm.</summary>
     /// <param name="task">The task.</param>
     /// <param name="arm">The arm index.</param>
-    public void AddTask(Task task, int arm) => arms.Add(new TaskArm(task, arm));
+    public void AddTask(Task task, int arm) => Place(new TaskArm(task, arm));
 
     /// <summary>Adds a <c>case let v = await task</c> arm.</summary>
     /// <typeparam name="T">The task result type.</typeparam>
     /// <param name="task">The task.</param>
     /// <param name="arm">The arm index.</param>
-    public void AddTask<T>(Task<T> task, int arm) => arms.Add(new TaskArm<T>(task, arm));
+    public void AddTask<T>(Task<T> task, int arm) => Place(new TaskArm<T>(task, arm));
 
     /// <summary>
     /// Adds a <c>case cancelled</c> arm. With it, cancellation of the ambient
@@ -263,7 +265,7 @@ public sealed class SelectWaiter : IValueTaskSource<int>
                 Monitor.Enter(gates[taken].Gate);
             }
 
-            var count = arms.Count;
+            var count = armCount;
             var start = count > 0 ? SelectRandom.Next(count) : 0;
             for (var k = 0; k < count && !won; k++)
             {
@@ -293,12 +295,12 @@ public sealed class SelectWaiter : IValueTaskSource<int>
         if (!won)
         {
             var hasCancelled = cancelledArm >= 0;
-            var count = arms.Count + (hasCancelled ? 1 : 0);
+            var count = armCount + (hasCancelled ? 1 : 0);
             var start = count > 0 ? SelectRandom.Next(count) : 0;
             for (var k = 0; k < count && !won; k++)
             {
                 var slot = (start + k) % count;
-                if (hasCancelled && slot == arms.Count)
+                if (hasCancelled && slot == armCount)
                 {
                     if (token.IsCancellationRequested)
                     {
@@ -359,7 +361,7 @@ public sealed class SelectWaiter : IValueTaskSource<int>
             }
 
             // Phase 2: re-probe the gated arms under the locks, from a random start.
-            var count = arms.Count;
+            var count = armCount;
             var start = count > 0 ? SelectRandom.Next(count) : 0;
             for (var k = 0; k < count && !wonSynchronously; k++)
             {
@@ -382,8 +384,9 @@ public sealed class SelectWaiter : IValueTaskSource<int>
             // so no arm can become ready-and-unobserved mid-registration.
             if (!wonSynchronously)
             {
-                foreach (var descriptor in arms)
+                for (var index = 0; index < armCount; index++)
                 {
+                    var descriptor = arms[index];
                     if (descriptor.RequiresGate)
                     {
                         descriptor.Register(this, generation);
@@ -407,8 +410,9 @@ public sealed class SelectWaiter : IValueTaskSource<int>
 
         // Phase 4: arms that lock privately or have no lock (timers, foreign
         // channels, tasks) — they may claim synchronously during registration.
-        foreach (var descriptor in arms)
+        for (var index = 0; index < armCount; index++)
         {
+            var descriptor = arms[index];
             if (!descriptor.RequiresGate)
             {
                 descriptor.Register(this, generation);
@@ -431,6 +435,17 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     /// <returns>The value, or the zero value when <see cref="Ok"/> is false.</returns>
     public T TakeValue<T>()
     {
+        // Issue #3902 S4: the winner keeps the value in its own typed field, so
+        // the common path is a cast. The object? slot survives for the arms
+        // that genuinely have nothing typed to hand over — a re-probe signal
+        // carries no value at all.
+        var owner = valueOwner;
+        valueOwner = null;
+        if (owner is IArmValue<T> typed)
+        {
+            return typed.TakeArmValue();
+        }
+
         var taken = value;
         value = null;
         return taken is null ? default! : (T)taken;
@@ -439,9 +454,14 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     /// <summary>Deregisters every losing arm, tears down callbacks, and pools the waiter. Call exactly once per <see cref="Rent(int, Context)"/>.</summary>
     public void Return()
     {
-        foreach (var descriptor in arms)
+        // Issue #3902 S4: the descriptors are NOT discarded — they are the
+        // per-slot cache the next select reuses. Their targets are released so
+        // a thread-cached waiter cannot pin the channels of a select that has
+        // finished.
+        for (var i = 0; i < armCount; i++)
         {
-            descriptor.Deregister();
+            arms[i].Deregister();
+            arms[i].Release();
         }
 
         if (hasTokenRegistration)
@@ -450,9 +470,10 @@ public sealed class SelectWaiter : IValueTaskSource<int>
             canPool &= tokenRegistration.Unregister();
         }
 
-        arms.Clear();
+        armCount = 0;
         gates.Clear();
         winnerArm = -1;
+        valueOwner = null;
         value = null;
         ok = false;
         needsReprobe = false;
@@ -509,8 +530,23 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     internal void Deposit(object? deposited, bool ok, bool needsReprobe)
     {
         value = deposited;
+        valueOwner = null;
         this.ok = ok;
         this.needsReprobe = needsReprobe;
+    }
+
+    /// <summary>
+    /// Deposits an outcome whose value stays in <paramref name="owner"/>'s typed
+    /// field (issue #3902 S4), so a value-typed element never boxes.
+    /// </summary>
+    /// <param name="owner">The arm or node holding the value.</param>
+    /// <param name="ok">Whether a value was delivered.</param>
+    internal void DepositFrom(object owner, bool ok)
+    {
+        valueOwner = owner;
+        value = null;
+        this.ok = ok;
+        needsReprobe = false;
     }
 
     /// <summary>Deposits a fault the winning arm surfaces from <see cref="WaitAsync"/>.</summary>
@@ -535,8 +571,9 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     internal IReadOnlyList<(long Order, object Gate)> CollectGates()
     {
         gates.Clear();
-        foreach (var descriptor in arms)
+        for (var index = 0; index < armCount; index++)
         {
+            var descriptor = arms[index];
             if (descriptor.Gate is not { } gate)
             {
                 continue;
@@ -560,6 +597,84 @@ public sealed class SelectWaiter : IValueTaskSource<int>
 
         gates.Sort(static (a, b) => a.Order.CompareTo(b.Order));
         return gates;
+    }
+
+    /// <summary>
+    /// Places a receive arm in the next slot, reusing the descriptor already
+    /// cached there when it is the same shape (issue #3902 S4).
+    /// </summary>
+    /// <remarks>
+    /// The waiter is thread-cached and shared by every select on the thread, so
+    /// slot 0 may be a <c>CoreReceiveArm&lt;int&gt;</c> in one select and a
+    /// send arm over another element type in the next. The type test is what
+    /// makes reuse safe: a hot loop over the same select allocates nothing after
+    /// its first pass, and a thread that alternates shapes pays one allocation
+    /// per change rather than one per arm per select.
+    /// </remarks>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="selectable">The selectable to receive from.</param>
+    /// <param name="arm">The arm index.</param>
+    private void PlaceReceive<T>(ISelectableCore<T> selectable, int arm)
+    {
+        if (armCount < arms.Count)
+        {
+            if (arms[armCount] is CoreReceiveArm<T> reusable)
+            {
+                reusable.Retarget(selectable, arm);
+            }
+            else
+            {
+                arms[armCount] = new CoreReceiveArm<T>(selectable, arm);
+            }
+        }
+        else
+        {
+            arms.Add(new CoreReceiveArm<T>(selectable, arm));
+        }
+
+        armCount++;
+    }
+
+    /// <summary>Places a send arm; see <see cref="PlaceReceive{T}"/> for the reuse rule.</summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    /// <param name="selectable">The selectable to send to.</param>
+    /// <param name="value">The value to send.</param>
+    /// <param name="arm">The arm index.</param>
+    private void PlaceSend<T>(ISendSelectableCore<T> selectable, T value, int arm)
+    {
+        if (armCount < arms.Count)
+        {
+            if (arms[armCount] is CoreSendArm<T> reusable)
+            {
+                reusable.Retarget(selectable, value, arm);
+            }
+            else
+            {
+                arms[armCount] = new CoreSendArm<T>(selectable, value, arm);
+            }
+        }
+        else
+        {
+            arms.Add(new CoreSendArm<T>(selectable, value, arm));
+        }
+
+        armCount++;
+    }
+
+    /// <summary>Places an arm shape that is not reused across selects (foreign channels, tasks).</summary>
+    /// <param name="descriptor">The descriptor.</param>
+    private void Place(ArmDescriptor descriptor)
+    {
+        if (armCount < arms.Count)
+        {
+            arms[armCount] = descriptor;
+        }
+        else
+        {
+            arms.Add(descriptor);
+        }
+
+        armCount++;
     }
 
     private void Begin(CancellationToken cancellationToken)

--- a/src/Sdk/Gsharp.Runtime.Channels/SelectWaiter.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/SelectWaiter.cs
@@ -556,13 +556,28 @@ public sealed class SelectWaiter : IValueTaskSource<int>
     /// <summary>Fires the select's continuation. Called exactly once, by the claimer, outside every channel lock.</summary>
     internal void PublishOutcome()
     {
-        if (fault is not null)
+        // Issue #3902 H1: the select's continuation may run on the claiming
+        // thread when the budget allows. Like a channel hand-off, the claim is
+        // published outside every gate.
+        var inline = InlineBudget.TryEnter();
+        try
         {
-            core.SetException(fault);
+            core.RunContinuationsAsynchronously = !inline;
+            if (fault is not null)
+            {
+                core.SetException(fault);
+            }
+            else
+            {
+                core.SetResult(winnerArm);
+            }
         }
-        else
+        finally
         {
-            core.SetResult(winnerArm);
+            if (inline)
+            {
+                InlineBudget.Exit();
+            }
         }
     }
 
@@ -695,6 +710,11 @@ public sealed class SelectWaiter : IValueTaskSource<int>
 
     private void OnCancelled()
     {
+        // Issue #3902 H1: this runs inside CancellationTokenSource.Cancel, so
+        // an inline continuation would execute the select's body — arbitrary
+        // user code — on whatever thread called Cancel, and inside the CTS's
+        // own callback machinery. Publication here always queues.
+        using var noInline = InlineBudget.Suppress();
         var generation = Generation;
         if (cancelledArm >= 0)
         {

--- a/test/Runtime.Channels.Tests/Issue3902BatchDrainTests.cs
+++ b/test/Runtime.Channels.Tests/Issue3902BatchDrainTests.cs
@@ -1,0 +1,198 @@
+// <copyright file="Issue3902BatchDrainTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Gsharp.Concurrency;
+using Xunit;
+
+namespace GSharp.Runtime.Channels.Tests;
+
+/// <summary>
+/// Issue #3902 (S3): a batch receive copies the ring in contiguous spans rather
+/// than element by element, and a chunked read sizes its array to what is
+/// actually there.
+/// </summary>
+/// <remarks>
+/// Discrimination witnesses (ADR-0154).
+/// <see cref="BatchReceive_OfReferenceElements_LeavesNoLiveReferenceInTheRing"/>
+/// is the one that matters: the element-wise loop cleared each slot as it went,
+/// and the bulk copy must keep doing so for reference elements or the ring
+/// keeps objects alive after they have been received. The mutant is dropping
+/// the <c>IsReferenceOrContainsReferences</c> clear in <c>DrainBufferInto</c> —
+/// invisible to every other test, because the VALUES are still correct.
+/// <para>
+/// <see cref="BatchReceive_WrappingTheRing_PreservesFifoOrder"/> covers the
+/// two-segment copy specifically; a single-span implementation passes every
+/// non-wrapping test and silently reorders here.
+/// </para>
+/// </remarks>
+public class Issue3902BatchDrainTests
+{
+    [Fact]
+    public void BatchReceive_WrappingTheRing_PreservesFifoOrder()
+    {
+        // Force head past zero so the next fill wraps, then take it all in one
+        // batch: the copy has to be two segments in the right order.
+        var ch = new Chan<int>(8);
+        for (var i = 0; i < 8; i++)
+        {
+            Assert.True(ch.TrySend(i));
+        }
+
+        var drain = new int[5];
+        Assert.Equal(5, ch.TryReceiveBatch(drain));
+
+        for (var i = 8; i < 13; i++)
+        {
+            Assert.True(ch.TrySend(i));
+        }
+
+        var wrapped = new int[8];
+        Assert.Equal(8, ch.TryReceiveBatch(wrapped));
+        Assert.Equal(new[] { 5, 6, 7, 8, 9, 10, 11, 12 }, wrapped);
+    }
+
+    [Fact]
+    public void BatchReceive_TakingLessThanIsBuffered_LeavesTheRestInOrder()
+    {
+        var ch = new Chan<int>(8);
+        for (var i = 0; i < 8; i++)
+        {
+            Assert.True(ch.TrySend(i));
+        }
+
+        var first = new int[3];
+        Assert.Equal(3, ch.TryReceiveBatch(first));
+        Assert.Equal(new[] { 0, 1, 2 }, first);
+
+        var rest = new int[8];
+        Assert.Equal(5, ch.TryReceiveBatch(rest));
+        Assert.Equal(new[] { 3, 4, 5, 6, 7 }, rest[..5]);
+    }
+
+    [Fact]
+    public void BatchReceive_OfReferenceElements_LeavesNoLiveReferenceInTheRing()
+    {
+        var ch = new Chan<object>(4);
+
+        // Fill and drain in frames of their own: an optimized build can keep a
+        // local alive to the end of ITS method, which would root the elements
+        // here and fail this test for a reason that has nothing to do with the
+        // ring.
+        var witnesses = Fill(ch);
+        Drain(ch);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        foreach (var witness in witnesses)
+        {
+            Assert.False(
+                witness.IsAlive,
+                "a received element is still reachable — the ring slot was not cleared, so the "
+                + "channel is keeping delivered objects alive (issue #3902 S3).");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static WeakReference[] Fill(Chan<object> ch)
+        {
+            var witnesses = new WeakReference[4];
+            for (var i = 0; i < 4; i++)
+            {
+                var element = new object();
+                witnesses[i] = new WeakReference(element);
+                Assert.True(ch.TrySend(element));
+            }
+
+            return witnesses;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Drain(Chan<object> ch)
+        {
+            var drained = new object[4];
+            Assert.Equal(4, ch.TryReceiveBatch(drained));
+            Array.Clear(drained);
+        }
+    }
+
+    [Fact]
+    public async Task BatchReceive_DrainingWhileSendersAreParked_TakesFromBoth()
+    {
+        // The bulk drain breaks out of its loop when no sender is parked; a
+        // buffered channel that IS full with senders behind it must still hand
+        // over from both sources.
+        var ch = new Chan<int>(2);
+        Assert.True(ch.TrySend(1));
+        Assert.True(ch.TrySend(2));
+
+        var parked = ch.SendAsync(3).AsTask();
+        var second = ch.SendAsync(4).AsTask();
+
+        var drain = new int[4];
+        var taken = 0;
+        while (taken < 4)
+        {
+            taken += ch.TryReceiveBatch(drain.AsSpan(taken));
+            if (taken < 4)
+            {
+                await Task.Yield();
+            }
+        }
+
+        await parked.WaitAsync(TimeSpan.FromSeconds(10));
+        await second.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.Equal(new[] { 1, 2, 3, 4 }, drain);
+    }
+
+    [Fact]
+    public void ChunkedRead_OnAnEmptyChannel_AllocatesNothing()
+    {
+        var ch = new Chan<int>(1024);
+        var reader = Chunks.Of(ch, 1024);
+
+        // Warm the paths before measuring.
+        for (var i = 0; i < 100; i++)
+        {
+            reader.TryRead(out _);
+        }
+
+        const int Probes = 5_000;
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        for (var i = 0; i < Probes; i++)
+        {
+            reader.TryRead(out _);
+        }
+
+        var perProbe = (GC.GetTotalAllocatedBytes(precise: true) - before) / (double)Probes;
+#if DEBUG
+        Assert.True(perProbe >= 0, "Debug builds do not carry a meaningful allocation number.");
+#else
+        Assert.True(
+            perProbe < 16,
+            $"expected an empty chunked probe to allocate nothing, measured {perProbe:F1} B/probe. "
+            + "About 4096 means the chunk array is allocated before the count is known "
+            + "(issue #3902 S3).");
+#endif
+    }
+
+    [Fact]
+    public void ChunkedRead_TakesEverythingBuffered()
+    {
+        var ch = new Chan<int>(64);
+        for (var i = 0; i < 40; i++)
+        {
+            Assert.True(ch.TrySend(i));
+        }
+
+        var reader = Chunks.Of(ch, 1024);
+        Assert.True(reader.TryRead(out var chunk));
+        Assert.Equal(40, chunk.Length);
+        Assert.Equal(0, chunk.Span[0]);
+        Assert.Equal(39, chunk.Span[39]);
+    }
+}

--- a/test/Runtime.Channels.Tests/Issue3902InlineCompletionTests.cs
+++ b/test/Runtime.Channels.Tests/Issue3902InlineCompletionTests.cs
@@ -1,0 +1,186 @@
+// <copyright file="Issue3902InlineCompletionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Gsharp.Concurrency;
+using Xunit;
+
+namespace GSharp.Runtime.Channels.Tests;
+
+/// <summary>
+/// Issue #3902 (H1) / ADR-0174 gate G6: a hand-off completes its waiter's
+/// continuation on the publishing thread when the inline budget allows,
+/// instead of queueing a thread-pool work item for another thread to steal.
+/// </summary>
+/// <remarks>
+/// The performance case is measured by the concurrency benchmark. These tests
+/// exist for the four ways inline completion can be WRONG, each of which is
+/// silent under every pre-existing test.
+/// <list type="number">
+/// <item>A blocking channel operation is what <c>lock { ch &lt;- v }</c>
+/// compiles to. Monitor is reentrant, so an inline continuation would run
+/// inside the caller's lock and observe mutual exclusion it does not hold —
+/// <see cref="BlockingSend_DoesNotRunAContinuationInsideTheCallersLock"/>.</item>
+/// <item>The continuation runs while <c>SetResult</c> is still on the stack, so
+/// a node returned to its pool from inside <c>GetResult</c> is re-rented within
+/// the publisher's own frame —
+/// <see cref="InlineContinuation_MayReRentTheSameNode"/>.</item>
+/// <item>Nesting is bounded, or a chain of hand-offs grows the stack per link —
+/// <see cref="DeepHandoffChain_CompletesWithoutExhaustingTheStack"/>.</item>
+/// <item>A cancellation callback must not run user code on the cancelling
+/// thread — <see cref="CancelledSelect_DoesNotRunItsContinuationOnTheCancellingThread"/>.</item>
+/// </list>
+/// </remarks>
+public class Issue3902InlineCompletionTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task BlockingSend_DoesNotRunAContinuationInsideTheCallersLock()
+    {
+        var gate = new object();
+        var ch = new Chan<int>(0);
+        var observedInsideLock = false;
+        var receiverReady = new SemaphoreSlim(0);
+
+        var receiver = Task.Run(async () =>
+        {
+            receiverReady.Release();
+            await ch.ReceiveValueAsync().AsTask().ConfigureAwait(false);
+
+            // If the sender published inline, this continuation is running on
+            // the sender's stack, inside its lock.
+            observedInsideLock = Monitor.IsEntered(gate);
+        });
+
+        await receiverReady.WaitAsync(Timeout);
+        await Task.Delay(50);
+
+        lock (gate)
+        {
+            ChannelOps.Send(ch, 1, default(CancellationToken));
+        }
+
+        await receiver.WaitAsync(Timeout);
+        Assert.False(
+            observedInsideLock,
+            "a receive continuation ran inside the sending thread's monitor. A blocking channel "
+            + "operation is a `lock { ch <- v }` body, and Monitor's reentrancy makes that silently "
+            + "wrong (issue #3902 H1).");
+    }
+
+    [Fact]
+    public async Task InlineContinuation_MayReRentTheSameNode()
+    {
+        // The continuation runs before SetResult has returned, and consuming the
+        // result returns the node to the channel's single-slot cache. Re-renting
+        // it from inside that frame is the sharpest version of the reuse, and it
+        // must produce a fresh version token rather than replay the old result.
+        var ch = new Chan<int>(0);
+        var results = new int[8];
+
+        var consumer = Task.Run(async () =>
+        {
+            for (var i = 0; i < results.Length; i++)
+            {
+                results[i] = await ch.ReceiveValueAsync().ConfigureAwait(false);
+            }
+        });
+
+        for (var i = 0; i < results.Length; i++)
+        {
+            await ch.SendAsync(i + 1).AsTask().WaitAsync(Timeout);
+        }
+
+        await consumer.WaitAsync(Timeout);
+        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6, 7, 8 }, results);
+    }
+
+    [Fact]
+    public async Task DeepHandoffChain_CompletesWithoutExhaustingTheStack()
+    {
+        // Each link's receive completes the previous link's send, so an
+        // unbounded inline budget would nest one frame per link. The gate's
+        // stack test: it must complete, not merely avoid crashing.
+        const int Links = 10_000;
+        var ch = new Chan<int>(0);
+        var total = 0L;
+
+        var consumer = Task.Run(async () =>
+        {
+            for (var i = 0; i < Links; i++)
+            {
+                total += await ch.ReceiveValueAsync().ConfigureAwait(false);
+            }
+        });
+
+        for (var i = 1; i <= Links; i++)
+        {
+            await ch.SendAsync(i).AsTask().WaitAsync(Timeout);
+        }
+
+        await consumer.WaitAsync(Timeout);
+        Assert.Equal(Links * (Links + 1L) / 2, total);
+    }
+
+    [Fact]
+    public async Task CancelledSelect_DoesNotRunItsContinuationOnTheCancellingThread()
+    {
+        using var cts = new CancellationTokenSource();
+        var ch = new Chan<int>(0);
+        var cancellingThread = 0;
+        var continuationThread = 0;
+
+        var w = SelectWaiter.Rent(1, cts.Token);
+        w.AddReceive(ch, 0);
+        var wait = w.WaitAsync().AsTask();
+        Assert.False(wait.IsCompleted);
+
+        var observer = wait.ContinueWith(
+            _ => continuationThread = Environment.CurrentManagedThreadId,
+            TaskContinuationOptions.ExecuteSynchronously);
+
+        cancellingThread = Environment.CurrentManagedThreadId;
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => wait.WaitAsync(Timeout));
+        await observer.WaitAsync(Timeout);
+        w.Return();
+
+        Assert.NotEqual(cancellingThread, continuationThread);
+    }
+
+    [Fact]
+    public async Task HandoffStillDelivers_WhenTheBudgetIsExhausted()
+    {
+        // Whatever the budget decides, the value must arrive. Drive far more
+        // hand-offs than the depth limit through one channel.
+        var ch = new Chan<int>(0);
+        var seen = 0;
+        var consumer = Task.Run(async () =>
+        {
+            while (true)
+            {
+                var (value, ok) = await ch.ReceiveTupleAsync().ConfigureAwait(false);
+                if (!ok)
+                {
+                    return;
+                }
+
+                seen += value;
+            }
+        });
+
+        for (var i = 0; i < 200; i++)
+        {
+            await ch.SendAsync(1).AsTask().WaitAsync(Timeout);
+        }
+
+        ch.Close();
+        await consumer.WaitAsync(Timeout);
+        Assert.Equal(200, seen);
+    }
+}

--- a/test/Runtime.Channels.Tests/Issue3902NodeBackedReceiveShapesTests.cs
+++ b/test/Runtime.Channels.Tests/Issue3902NodeBackedReceiveShapesTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue3902NodeBackedReceiveShapesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Gsharp.Concurrency;
+using Xunit;
+
+namespace GSharp.Runtime.Channels.Tests;
+
+/// <summary>
+/// Issue #3902 (S2): a suspending receive through the language is backed by the
+/// waiter node itself in all three result shapes, rather than by an
+/// <c>async</c> wrapper that reshapes <see cref="ReceiveResult{T}"/> after the
+/// fact. The wrapper ran on the default builder, so every park boxed an
+/// <c>AsyncStateMachineBox</c> — about 144 bytes — and inserted a Task
+/// continuation between the node and the caller's state machine.
+/// </summary>
+/// <remarks>
+/// Discrimination witnesses (ADR-0154). The product mutant for the allocation
+/// claim is reverting S2 <em>entirely</em> in <c>ChannelOps.Awaited.cs</c> —
+/// both the <c>is Chan&lt;T&gt;</c> dispatch and the pooling builder on the
+/// wrapper — which
+/// <see cref="ParkedReceive_ThroughTheLanguageSurface_AllocatesNothingPerOperation"/>
+/// catches at 71.8 B/op against a 32 B threshold.
+/// <para>
+/// Measured, so the claim is not overstated: reverting the dispatch <em>alone</em>
+/// does NOT fail that test. The allocation is removed by the pooling builder,
+/// and what the dispatch additionally removes is the Task continuation between
+/// the node and the caller's state machine — a latency effect this test cannot
+/// see. That half is evidenced by the concurrency benchmark, not here.
+/// </para>
+/// <para>
+/// A second mutant — dropping the pooling in <c>OpReceiveNode.TakeResult</c>,
+/// or letting two of the three shapes each return the node — is caught by
+/// <see cref="ParkedReceives_AcrossShapes_KeepReusingOneNode"/>. A node
+/// returned twice is the failure this factoring exists to prevent.
+/// </para>
+/// </remarks>
+public class Issue3902NodeBackedReceiveShapesTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task ParkedReceiveValue_DeliversTheValue()
+    {
+        var ch = new Chan<int>(0);
+        var receive = ch.ReceiveValueAsync().AsTask();
+        Assert.False(receive.IsCompleted);
+
+        await ch.SendAsync(7).AsTask().WaitAsync(Timeout);
+        Assert.Equal(7, await receive.WaitAsync(Timeout));
+    }
+
+    [Fact]
+    public async Task ParkedReceiveTuple_DeliversTheValueAndOk()
+    {
+        var ch = new Chan<int>(0);
+        var receive = ch.ReceiveTupleAsync().AsTask();
+
+        await ch.SendAsync(9).AsTask().WaitAsync(Timeout);
+        var (value, ok) = await receive.WaitAsync(Timeout);
+        Assert.Equal(9, value);
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public async Task ParkedShapes_OnClose_YieldTheDocumentedClosedResults()
+    {
+        // D3: the single-value shape yields the zero value, the two-value shape
+        // says so explicitly. Both must hold for a receive already PARKED when
+        // the close arrives, which is the path the node backs.
+        var single = new Chan<int>(0);
+        var pair = new Chan<int>(0);
+        var singleReceive = single.ReceiveValueAsync().AsTask();
+        var pairReceive = pair.ReceiveTupleAsync().AsTask();
+
+        single.Close();
+        pair.Close();
+
+        Assert.Equal(0, await singleReceive.WaitAsync(Timeout));
+        var (value, ok) = await pairReceive.WaitAsync(Timeout);
+        Assert.Equal(0, value);
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task ClosedAndDrained_ShapesCompleteSynchronously()
+    {
+        var ch = new Chan<int>(1);
+        ch.Close();
+
+        var single = ch.ReceiveValueAsync();
+        var pair = ch.ReceiveTupleAsync();
+        Assert.True(single.IsCompletedSuccessfully);
+        Assert.True(pair.IsCompletedSuccessfully);
+        Assert.Equal(0, await single);
+        Assert.Equal((0, false), await pair);
+    }
+
+    [Fact]
+    public async Task ParkedShapes_Cancelled_ThrowOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        var ch = new Chan<int>(0);
+        var single = ch.ReceiveValueAsync(cts.Token).AsTask();
+        var pair = ch.ReceiveTupleAsync(cts.Token).AsTask();
+
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => single.WaitAsync(Timeout));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pair.WaitAsync(Timeout));
+    }
+
+    [Fact]
+    public async Task ParkedReceives_AcrossShapes_KeepReusingOneNode()
+    {
+        // The node cache is a single slot, so a node consumed through any shape
+        // must come back to it. Interleaving the shapes is the point: if one of
+        // them failed to pool, or pooled twice, the reuse count collapses or the
+        // channel starts handing the same node to two waiters.
+        var ch = new Chan<int>(0);
+        for (var i = 0; i < 200; i++)
+        {
+            var single = ch.ReceiveValueAsync().AsTask();
+            await ch.SendAsync(i).AsTask().WaitAsync(Timeout);
+            Assert.Equal(i, await single.WaitAsync(Timeout));
+
+            var pair = ch.ReceiveTupleAsync().AsTask();
+            await ch.SendAsync(i).AsTask().WaitAsync(Timeout);
+            Assert.Equal((i, true), await pair.WaitAsync(Timeout));
+
+            var raw = ch.ReceiveAsync().AsTask();
+            await ch.SendAsync(i).AsTask().WaitAsync(Timeout);
+            Assert.True((await raw.WaitAsync(Timeout)).Ok);
+        }
+    }
+
+    [Fact]
+    public async Task ParkedReceive_ThroughTheLanguageSurface_AllocatesNothingPerOperation()
+    {
+        // The allocation witness for S2. Measures the surface the compiler
+        // actually emits (`ChannelOps.ReceiveValueAsync(Channel<T>, …)`, what
+        // `<-ch` lowers to) on a rendezvous channel, so iterations park.
+        //
+        // Process-wide, not per-thread: continuations publish with
+        // RunContinuationsAsynchronously, so the boxes this exists to detect are
+        // allocated on POOL threads. GC.GetAllocatedBytesForCurrentThread sees
+        // none of them and reports a clean ~0 even with the wrapper restored,
+        // which made an earlier version of this test pass against its own
+        // mutant.
+        //
+        // Thresholded, not exact: the drivers are async methods and the runtime
+        // rents and returns pooled objects around them. The mutant allocates
+        // ~144 B per park, so a few tens of bytes discriminates it. Release-only:
+        // a Debug build's state machines are shaped differently.
+        Channel<int> ch = new Chan<int>(0);
+
+        // Warm up the JIT, the node cache and the builder pools before measuring.
+        await DrainAsync(ch, 2_000);
+
+        const int Operations = 20_000;
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        await DrainAsync(ch, Operations);
+        var perOperation = (GC.GetTotalAllocatedBytes(precise: true) - before) / (double)Operations;
+
+#if DEBUG
+        Assert.True(perOperation >= 0, "Debug builds do not carry a meaningful allocation number.");
+#else
+        Assert.True(
+            perOperation < 32,
+            $"expected a node-backed park to allocate ~nothing, measured {perOperation:F1} B/op. "
+            + "A number in the tens means the reshaping wrapper in ChannelOps.Awaited.cs is boxing "
+            + "its state machine again — check both the Chan<T> dispatch and the pooling builder "
+            + "on Unwrap/ToTuple's local functions (issue #3902 S2).");
+#endif
+
+        static async Task DrainAsync(Channel<int> ch, int operations)
+        {
+            var producer = Task.Run(async () =>
+            {
+                for (var i = 0; i < operations; i++)
+                {
+                    await ChannelOps.SendAsync(ch, i, default(CancellationToken)).ConfigureAwait(false);
+                }
+            });
+
+            for (var i = 0; i < operations; i++)
+            {
+                await ChannelOps.ReceiveValueAsync(ch, default(CancellationToken)).ConfigureAwait(false);
+            }
+
+            await producer.WaitAsync(Timeout).ConfigureAwait(false);
+        }
+    }
+}

--- a/test/Runtime.Channels.Tests/Issue3902SelectAllocationTests.cs
+++ b/test/Runtime.Channels.Tests/Issue3902SelectAllocationTests.cs
@@ -1,0 +1,155 @@
+// <copyright file="Issue3902SelectAllocationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Gsharp.Concurrency;
+using Xunit;
+
+namespace GSharp.Runtime.Channels.Tests;
+
+/// <summary>
+/// Issue #3902 (S4): a <c>select</c> over G# channels allocates nothing in
+/// steady state. Two costs were measured and both are removed here — an arm
+/// descriptor per arm per select, and a box for every value-typed element the
+/// winning arm delivered.
+/// </summary>
+/// <remarks>
+/// Discrimination witnesses (ADR-0154). The mutants are, respectively,
+/// restoring <c>arms.Add(new CoreReceiveArm&lt;T&gt;(…))</c> in place of the
+/// slot reuse, and restoring <c>waiter.Deposit(value, …)</c> in place of
+/// <c>DepositFrom</c> — each caught by
+/// <see cref="ReadySelect_InSteadyState_AllocatesNothing"/>.
+/// <para>
+/// <see cref="ReusedSlot_OfADifferentShape_IsReplacedNotReinterpreted"/> is the
+/// one that matters for correctness rather than cost: the waiter is
+/// thread-cached and shared by every select on the thread, so a slot holding a
+/// <c>CoreReceiveArm&lt;int&gt;</c> must not be handed to a select whose arm is
+/// a different element type. The type test in <c>PlaceReceive</c> is what
+/// prevents it; without it this reads a value at the wrong type.
+/// </para>
+/// <para>
+/// Not covered here because it is covered better elsewhere: descriptor reuse is
+/// exactly where a generation/ABA defect would hide, and
+/// <c>SelectWaiterStressTests</c> is the suite that finds those.
+/// </para>
+/// </remarks>
+public class Issue3902SelectAllocationTests
+{
+    [Fact]
+    public void ReadySelect_InSteadyState_AllocatesNothing()
+    {
+        var a = new Chan<int>(1);
+        var b = new Chan<int>(1);
+
+        // Warm the thread-cached waiter, its arm slots and the JIT before
+        // measuring; the first select on a thread legitimately allocates.
+        var warm = Drain(a, b, 500);
+        Assert.True(warm > 0, "the warm-up loop should have taken values");
+
+        const int Selects = 20_000;
+        var before = GC.GetTotalAllocatedBytes(precise: true);
+        var taken = Drain(a, b, Selects);
+        var perSelect = (GC.GetTotalAllocatedBytes(precise: true) - before) / (double)Selects;
+
+        Assert.True(taken > 0, "the measured loop should have taken values");
+#if DEBUG
+        Assert.True(perSelect >= 0, "Debug builds do not carry a meaningful allocation number.");
+#else
+        Assert.True(
+            perSelect < 12,
+            $"expected a ready select to allocate ~nothing, measured {perSelect:F1} B/select. "
+            + "Roughly 104 B means the arm descriptors are being allocated per select again; "
+            + "a smaller excess means the winning value is boxing through SelectWaiter.Deposit "
+            + "instead of DepositFrom (issue #3902 S4).");
+#endif
+
+        // No xunit assertions inside the measured loop: Assert.Equal allocates,
+        // and an earlier version of this test measured 448 B/select of its own
+        // making. Correctness of the same path is asserted by the other tests
+        // in this class; here the loop only has to exercise it.
+        static long Drain(Chan<int> a, Chan<int> b, int selects)
+        {
+            long observed = 0;
+            for (var i = 0; i < selects; i++)
+            {
+                a.TrySend(i);
+                b.TrySend(i);
+                var w = SelectWaiter.Rent(2, CancellationToken.None);
+                w.AddReceive(a, 0);
+                w.AddReceive(b, 1);
+                var won = w.TryNow();
+                observed += w.TakeValue<int>() + won;
+                w.Return();
+
+                // The arm the select did not take keeps its buffered value, so
+                // drain it to keep both channels at the same depth.
+                var other = won == 0 ? b : a;
+                other.TryReceive(out _, out _);
+            }
+
+            return observed;
+        }
+    }
+
+    [Fact]
+    public void ReusedSlot_OfADifferentShape_IsReplacedNotReinterpreted()
+    {
+        // Same thread, same waiter cache, different element types in slot 0.
+        var ints = new Chan<int>(1);
+        var strings = new Chan<string>(1);
+
+        ints.TrySend(11);
+        var first = SelectWaiter.Rent(1, CancellationToken.None);
+        first.AddReceive(ints, 0);
+        Assert.Equal(0, first.TryNow());
+        Assert.Equal(11, first.TakeValue<int>());
+        first.Return();
+
+        strings.TrySend("eleven");
+        var second = SelectWaiter.Rent(1, CancellationToken.None);
+        second.AddReceive(strings, 0);
+        Assert.Equal(0, second.TryNow());
+        Assert.Equal("eleven", second.TakeValue<string>());
+        second.Return();
+    }
+
+    [Fact]
+    public async Task ParkedSelect_DeliversTheValueThroughTheTypedHandoff()
+    {
+        // The parked path deposits from SelectNode<T> rather than from the arm
+        // descriptor, so it needs its own coverage.
+        var a = new Chan<int>(0);
+        var b = new Chan<int>(0);
+        var w = SelectWaiter.Rent(2, CancellationToken.None);
+        w.AddReceive(a, 0);
+        w.AddReceive(b, 1);
+        var wait = w.WaitAsync().AsTask();
+        Assert.False(wait.IsCompleted);
+
+        await b.SendAsync(77).AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(1, await wait.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.True(w.Ok);
+        Assert.Equal(77, w.TakeValue<int>());
+        w.Return();
+    }
+
+    [Fact]
+    public async Task ParkedSelect_OnClose_TakesTheZeroValueWithOkFalse()
+    {
+        var a = new Chan<int>(0);
+        var w = SelectWaiter.Rent(1, CancellationToken.None);
+        w.AddReceive(a, 0);
+        var wait = w.WaitAsync().AsTask();
+
+        a.Close();
+
+        Assert.Equal(0, await wait.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.False(w.Ok);
+        Assert.Equal(0, w.TakeValue<int>());
+        w.Return();
+    }
+}


### PR DESCRIPTION
Four of the improvements ranked in #3902, one commit each so the final numbers can be bisected.
S1 (pin the JIT tier) landed separately in #3903.

## Measured: interleaved A/B against `main`, 5 launches per side, two rounds, tier pinned

| scenario | main | branch | | vs Go (main → branch) |
|---|---:|---:|---|---|
| rendezvous | 1003 / 965 | **173 / 178** | −82% | 3.21× → **0.57×** |
| select-park | 1147 / 1067 | **287 / 313** | −73% | — |
| chunk1k | 15.6 / 14.4 | **5.9 / 6.5** | −58% | 12.98× → **4.93×** |
| chunk64 | 24.0 / 22.6 | **12.8 / 13.0** | −44% | 4.07× → 2.68× |
| closed-recv | 25.8 / 21.7 | 19.1 / 18.9 | −20% | 1.60× → 1.18× |
| select-ready | 175 / 178 | 150 / 156 | −13% | 2.25× → 1.97× |
| buf64 | 157 / 165 | 150 / 141 | −10% | 3.18× → 3.24× |
| spawn | 376 / 365 | 378 / 393 | flat | 1.50× → 1.49× |

Read `rendezvous` against Go with care: G#'s row is **one** hand-off, `go-pingpong` is **two**
(#3902's pairing finding), so 173 ns against ~153 ns per Go hand-off is roughly parity, not a 2× win.
The honest headline is that the row went from 3.2× to about even.

## S2 — a suspending receive is backed by the waiter node (`878cf79e`)

`OpReceiveNode<T>` implements `IValueTaskSource<T>` and `IValueTaskSource<(T, bool)>` beside its
existing shape, and `ChannelOps` routes a G#-owned `Chan<T>` into them — so the `async` wrappers that
reshaped `ReceiveResult<T>` after the fact survive only for a genuinely foreign reader. Per park:
−144 B and one fewer continuation hop.

Worth knowing: the **pooling-builder one-liner removes the allocation on its own**. What the node
shapes additionally remove is the continuation hop, which is what the rendezvous row measures. The
issue conflated the two.

## S4 — a select allocates nothing in steady state (`ac591b15`)

Arm descriptors become the pooled waiter's per-slot cache instead of garbage (type-checked on reuse,
since the waiter is shared by every select on its thread), and the winning value stays in its
producer's typed field rather than passing through an `object?` slot. 104 B/select → 0.

**Correction to the issue:** S4 also lists `CollectGates`' `List + Sort`. That one is not real —
`gates` is a reused field cleared in place with a static comparator. Left alone.

## S3 — bulk ring copy and a right-sized chunk array (`cf9948d3`)

The batch receive copies the ring in at most two contiguous spans instead of walking `DequeueBuffer`
per element, clearing slots only for element types that can hold a reference. `RefillFromSenderLocked`
is consulted only when a sender is actually queued. `ChunkReader.TryRead` sizes to what is available
and allocates nothing when the channel is empty — at chunk size 1024 those discarded probe arrays
dominated the scenario.

The availability hint counts buffered elements **plus parked senders**: `Length()` alone is zero on a
rendezvous channel however many senders are parked, and a chunked read sized from it would decline
forever and spin its caller's re-probe loop.

## H1 — inline completion within a bounded budget (`17516bd6`), ADR-0174 gate G6

The largest lever. A waiter's continuation runs on the publishing thread when a budget allows, instead
of costing a thread-pool work item per hand-off. Bounded by depth (16) and by
`TryEnsureSufficientExecutionStack`. `GS_INLINE_DEPTH=0` restores the old behaviour, which is what
makes it A/B-able inside one binary.

**The prototype embedded in #3902 has a correctness bug, and it is the reason this commit is mostly
suppression rather than budget.** Inline publication is only safe where the publisher holds no lock the
continuation could re-enter. G#'s blocking channel forms are what `lock { ch <- v }` compiles to
(ADR-0174 errata 10), and Monitor is reentrant — an inline receiver would run **inside the sender's
monitor** and observe mutual exclusion it does not hold. Those paths publish under
`InlineBudget.Suppress`, as does `SelectWaiter.OnCancelled`, which runs inside
`CancellationTokenSource.Cancel`. `NotifyNode` never inlines: its continuation is a BCL
`WaitToReadAsync` consumer, which `Channel<T>` itself completes asynchronously for the same reason.
The issue's hazard list named this; the patch it shipped did not address it.

**The hazard the issue predicted did not occur.** It expected buffered channels to degrade under
inline completion until S2 landed. S2 landed first, and `buf64` improves 10%.

## Two items deferred, with reasons rather than silently

- **H3** (bypass the `ChannelOps` facade for a statically-known `Chan[T]`): S2 already put that dispatch
  *inside* the facade, so what remains is a single type test against a `buf64` that is now 141 ns. Its
  measured premise — ~15 ns of ~130 — has largely been captured already.
- **S5** (emit the `go` closure as a `GoroutineWorkItem` subclass): worth an estimated 30–60 ns of ~380
  on `spawn`, but it is a display-class synthesis and metadata-emit change in the area that produced
  GS9998 ICEs and invalid IL during ADR-0174, with blast radius across `async let`, `scope` and the
  debugger. `spawn` is already G#'s closest row to Go at 1.49×. Worth doing deliberately, not as the
  tail of a batch.

**H2** (G#-emitted `MoveNext` never gets OSR) needs a Checked JIT to root-cause and is not actionable
here. H4/H5 are the low-value tail.

## An open item I am not closing

S2 measured a consistent **+15% on `spawn`** when it stood alone, across six variants, which I could
not explain. Across the full branch `spawn` is flat. I have no explanation for either the regression or
its disappearance, and I would rather leave that recorded than invent one.

## Tests

Twenty new tests across four files, each with the product mutant actually applied and killed:

| commit | witness | mutant caught |
|---|---|---|
| S2 | allocation on the emitted receive surface | reverting S2 → 71.8 B/op |
| S4 | allocation on a ready select | no reuse → 80 B; boxing → 24 B |
| S3 | a received reference element must not stay reachable | dropping the ring clear |
| H1 | a continuation must not run inside the sender's monitor | removing the suppression |

Two of those witnesses were wrong first and are documented in place, because both mistakes are easy to
repeat: `GetAllocatedBytesForCurrentThread` is per-thread and misses boxes allocated on pool threads
(that version passed against its own mutant), and xunit's `Assert.Equal` allocates inside a measured
loop (448 B/select of the test's own making). The GC witness also needs its fill and drain in
`NoInlining` frames or an optimized build roots the elements itself.

## Regression

| suite | result |
|---|---|
| Runtime.Channels | 188 / 0 |
| Extensions | 180 / 0 |
| Sdk | 92 / 0 |
| Interpreter | 1516 / 0 |
| Core | 8860 / 4 — environmental (`no NETStandard.Library.Ref targeting pack`) |
| Compiler | 4707 / 3 — same family, same count as `main` |

No `baseline.json` change: nothing here was measured by a nightly.

Refs #3902, #3903, ADR-0174 D10/D11, gates G3/G5/G6/G7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
