### PR TITLE
gsc + cs2gs: four root causes take migrated Gsharp.Runtime.Channels from 11 sites to 3 (#3907)

### DIFF
--- a/docs/adr/0052-event-declarations.md
+++ b/docs/adr/0052-event-declarations.md
@@ -162,4 +162,64 @@ This matches exactly what a C# `public event Action<object, EventArgs> Click;` p
 - `delegate MyHandler(…) ` syntax for named delegate types;
 - Thread-safe field-like event accessors (Interlocked.CompareExchange pattern)
 - `raise` accessor support (C#-style, rarely used)
-- Static events on user types
+- ~~Static events on user types~~ — **superseded, see the amendment below.**
+
+## Amendment (2026-09-04, issues #3911 / #3907): static events are supported
+
+**Static events on user types are no longer out of scope.** The entry above is
+struck; this section is now authoritative for them.
+
+A static event is declared in a `shared` block, with the same grammar,
+accessibility surface and accessor forms as an instance event:
+
+```gsharp
+class GsharpRuntime {
+    shared {
+        event DeferGraceExpired EventHandler[DeferGraceExpiredEventArgs]?
+
+        func RaiseDeferGraceExpired(budget TimeSpan) {
+            DeferGraceExpired?(nil, DeferGraceExpiredEventArgs(budget))
+        }
+    }
+}
+
+GsharpRuntime.DeferGraceExpired += func(sender object?, e DeferGraceExpiredEventArgs) { … }
+```
+
+### What is supported
+
+Everything the instance form supports, with identical semantics:
+
+- **Declaration** — field-like and explicit-accessor (`add` / `remove` / `raise`), in a `shared` block.
+- **Subscription** — `Type.Event += handler` / `-= handler` from outside, and the bare
+  `Event += handler` spelling inside the declaring type's own members.
+- **Reading and raising** — the event's name resolves inside the declaring type's members
+  to its backing delegate field, so `Event?(sender, args)`, `let h = Event`, and
+  `if Event != nil` all work. This mirrors C#, where a field-like event access
+  *within the program text of the declaring type* is an access to the backing field.
+- **Metadata** — an `EventDefinition` row, `add_`/`remove_`/`raise_` specialname
+  static methods and `MethodSemantics` rows, so C# consumers subscribe with
+  ordinary `+=` / `-=`.
+- **Thread safety** — the generated field-like `add`/`remove` accessors use the
+  same `Interlocked.CompareExchange` loop as the instance form (issue #256).
+- **Nil handlers** — `Event += nil` is a silent no-op, as in C#, because the
+  static path binds its handler through the same conversion the instance path
+  uses (issue #3775 / PR #3793). It is not a conversion error and not a throw.
+
+### History, and why the entry was stale
+
+Most of this shipped with issue #263 (`shared`-block static events: declaration,
+accessors, metadata emission, `Type.Event += handler`). What was never wired up
+was the *bare-name* half — reading, raising, and the bare `Event += handler`
+form inside the declaring type — because the binder's static bare-name exposure
+covered static fields, const fields and static properties but not static events'
+backing fields, and the bare `+=`/`-=` path walked instance events only. So a
+static event could be declared and subscribed to but never read or raised, which
+is what issue #3911 reported: `Static?(nil, args)` failed with `GS0130` while the
+identical instance event worked. Issue #3907 fixed both halves.
+
+### Still deferred
+
+Unchanged from the list above, and orthogonal to static-ness: the `delegate`
+keyword for named handler types, and custom (non-`Action`/`Func`/`EventHandler`)
+delegate declarations. Static events reach these exactly as instance events do.

--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -633,6 +633,52 @@ public sealed class Binder
                         }
                     }
                 }
+
+                // Issue #3907 / #3911: expose a field-like STATIC event of the
+                // enclosing type as a bare name, bound to its backing delegate
+                // field — the exact static counterpart of the instance
+                // exposure above (issues #1213 / #1221), and what makes the
+                // canonical raise pattern
+                //
+                //     shared { event Ticked EventHandler? }
+                //     shared func Raise() { Ticked?(nil, EventArgs.Empty) }
+                //
+                // resolve, precisely as C# compiles a field-like event access
+                // inside its declaring type to a read of the backing field.
+                //
+                // Static events were fully implemented by issue #263 —
+                // declaration, accessor emission with the #256
+                // Interlocked.CompareExchange loop, EventDef/MethodSemantics
+                // metadata, and `Type.Event += handler` subscription all work.
+                // This ONE lookup step was the omission, so a static event
+                // could be declared and subscribed to but never read or raised.
+                // ADR-0052's "Static events on user types" follow-up entry is
+                // amended accordingly.
+                //
+                // Scoped to the enclosing type with no base-class walk, which
+                // is what every other static path here does (see the note on
+                // the static-field block above). A bare `Ticked += handler`
+                // still routes to the event-subscription path, which
+                // BindBareEventOrCompoundAssignment checks before it consults
+                // this variable.
+                if (!ownerStruct.StaticEvents.IsDefaultOrEmpty)
+                {
+                    foreach (var evt in ownerStruct.StaticEvents)
+                    {
+                        if (!evt.IsFieldLike
+                            || evt.BackingField == null
+                            || paramNames.Contains(evt.Name)
+                            || seenMembers.Contains(evt.Name))
+                        {
+                            continue;
+                        }
+
+                        if (seenMembers.Add(evt.Name))
+                        {
+                            scope.TryDeclareVariable(new ImplicitStaticFieldVariableSymbol(ownerStruct, evt.BackingField));
+                        }
+                    }
+                }
             }
 
             // ADR-0089 / issue #1030: expose interface static *state* by bare
@@ -4511,6 +4557,74 @@ public sealed class Binder
         if (syntax.HasOuterSegmentTypeArguments)
         {
             return BindPerSegmentClrQualifiedTypeName(syntax, segmentTexts);
+        }
+
+        // Issue #3907: a SOURCE declaration outranks an imported one carrying
+        // the same fully-qualified name. The greedy reflection walk below only
+        // sees types with a CLR representation, and a same-compilation type has
+        // none while binding — so whenever the reference set happens to contain
+        // `Pkg.Name` too, the walk bound the METADATA type and the source
+        // declaration was never consulted. That is backwards from C#, which
+        // resolves the collision in favour of source (Roslyn reports CS0436 and
+        // uses the source type).
+        //
+        // It bites hardest when an assembly is compiled against a build of
+        // ITSELF, which is the normal state for `Gsharp.Runtime.Channels`: gsc
+        // appends the bundled channel runtime to every reference set
+        // (ReferenceResolver.FindBundledChannelsRuntimePath), so while compiling
+        // the runtime's own sources every `Gsharp.Concurrency.X` in a base
+        // clause resolved to the PREVIOUS build's `X`. `class TaskArm[T] :
+        // Gsharp.Concurrency.TaskArm` therefore linked its base to another
+        // assembly's `TaskArm`, and the three diagnostics that followed —
+        // GS0214 (no accessible 2-arg base constructor), GS0185 (override does
+        // not match the base), GS0155 (`TaskArm[T]` is not an `ArmDescriptor`)
+        // — were all one wrong base link. The bare-name spelling was already
+        // correct, which is why only the QUALIFIED spelling failed.
+        //
+        // Scoped tightly on purpose, in TWO ways.
+        //
+        // First (see TryLookupSourceTypeInPackage): the qualifier must exactly
+        // name a package this compilation declares, and that package must
+        // declare this name at this arity.
+        //
+        // Second, and just as important: there must ACTUALLY BE an imported
+        // homonym to beat. This rule is only about a source-vs-metadata
+        // collision — C#'s CS0436 — so it must not reorder a source-vs-SOURCE
+        // question, which is governed by ordinary scope shadowing and not by
+        // this probe. Issue #3466 is the case that pins it down: inside
+        // `Holder`, which declares a nested `Target`, the name
+        // `Demo.Target` has no CLR type at all, so the walk below and the
+        // simple-name fallback under it keep resolving it exactly as they did.
+        // Without this second condition the type clause started disagreeing
+        // with the construction expression beside it — the type resolved to the
+        // top-level `Demo.Target` while `Demo.Target()` still resolved to
+        // `Holder.Target`, giving `GS0155 Cannot convert 'Holder.Target' to
+        // 'Target'`. (That disagreement is a real pre-existing gap in the
+        // QUALIFIED-construction path, which resolves a package-qualified name
+        // by inner-scope simple name; it is reported separately rather than
+        // widened into here.)
+        if (scope.TryLookupSourceTypeInPackage(
+                string.Join(".", segmentTexts, 0, totalSegments - 1),
+                segmentTexts[totalSegments - 1],
+                targetArity,
+                out var packageQualifiedSourceType)
+            && TryResolveOuterPrefix(segmentTexts, totalSegments, targetArity) != null)
+        {
+            if (targetArity == 0)
+            {
+                return packageQualifiedSourceType;
+            }
+
+            var constructedSourceType = BindAndConstructUserGenericSegment(
+                syntax,
+                packageQualifiedSourceType,
+                Invariant.Required(qualifiedTypeArguments, "targetArity != 0 implies HasTypeArguments was true, so TypeArguments is non-null"),
+                qualifiedIdentifier.Location,
+                syntax.DottedName);
+            if (constructedSourceType != null)
+            {
+                return constructedSourceType;
+            }
         }
 
         // Greedy: prefer the longest outer prefix that resolves to a real type,

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -919,6 +919,86 @@ public sealed class BoundScope
     }
 
     /// <summary>
+    /// Issue #3907: resolves a package-qualified name — <c>Pkg.Sub.Name</c> —
+    /// to a type <em>declared in this compilation</em>, in the package the
+    /// qualifier segments spell, at the requested generic arity.
+    /// </summary>
+    /// <remarks>
+    /// <para>This exists so a source declaration can be preferred over an
+    /// imported one carrying the same fully-qualified name. C# resolves such a
+    /// collision in favour of source (Roslyn reports <c>CS0436</c> and uses the
+    /// source type); gsc's dotted-name binder used to reach the reflection
+    /// prefix walk first and therefore chose the metadata type, silently
+    /// re-pointing a base clause at another assembly's same-named type.</para>
+    /// <para>Deliberately strict: the qualifier must match the candidate's
+    /// declaring package EXACTLY, the simple name must match the candidate's
+    /// containing-type-qualified name, and the arity must match. Two source
+    /// candidates for the same qualified name yield no match rather than a
+    /// guess, leaving the caller's existing resolution and diagnostics
+    /// untouched.</para>
+    /// </remarks>
+    /// <param name="packageName">The qualifier segments, dot-joined.</param>
+    /// <param name="name">The final segment.</param>
+    /// <param name="preferredArity">The requested generic arity, or -1/0 for none.</param>
+    /// <param name="type">The matching source type, when unambiguous.</param>
+    /// <returns>Whether exactly one source type matches.</returns>
+    public bool TryLookupSourceTypeInPackage(
+        string packageName,
+        string name,
+        int preferredArity,
+        [NotNullWhen(true)] out TypeSymbol? type)
+    {
+        type = null;
+        if (string.IsNullOrEmpty(packageName) || string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        var wantedArity = preferredArity > 0 ? preferredArity : 0;
+        TypeSymbol? match = null;
+        var seen = new HashSet<TypeSymbol>();
+        foreach (var pair in EnumerateTypeAliasesInChain())
+        {
+            var candidate = TypeDefinition(pair.Value);
+            if (!seen.Add(candidate))
+            {
+                continue;
+            }
+
+            if (GetTypeAliasArity(candidate) != wantedArity)
+            {
+                continue;
+            }
+
+            // A type declared in a file with no `package` declaration lands in
+            // the implicit package; it is not addressable by a qualified name,
+            // so it must not answer one.
+            if (IsDeclaredInImplicitPackage(candidate))
+            {
+                continue;
+            }
+
+            var candidatePackage = TypePackageName(candidate);
+            if (string.IsNullOrEmpty(candidatePackage)
+                || !string.Equals(candidatePackage, packageName, System.StringComparison.Ordinal)
+                || !string.Equals(QualifiedTypeName(candidate), name, System.StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (match != null && !ReferenceEquals(match, candidate))
+            {
+                return false;
+            }
+
+            match = candidate;
+        }
+
+        type = match;
+        return match != null;
+    }
+
+    /// <summary>
     /// Resolves an explicit import alias whose target is a same-compilation
     /// source type rather than a CLR type.
     /// </summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1282,6 +1282,32 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #3907 / #3911: the STATIC counterpart of the walk above — a
+        // bare `Ticked += handler` inside the declaring type's own members,
+        // where `Ticked` is declared in a `shared` block. This must be checked
+        // BEFORE the compound-assignment fallback below, because Binder.cs now
+        // also exposes a field-like static event's backing field as a bare
+        // name (so the event can be READ and raised). Without this branch that
+        // exposure would capture `+=` and turn a subscription into a delegate
+        // compound assignment on the backing field, which is a different
+        // operation: it bypasses the add/remove accessors and their
+        // Interlocked.CompareExchange loop (issue #256), so a concurrent
+        // subscribe could be lost.
+        //
+        // The handler goes through the same BindEventSubscriptionHandler the
+        // instance and `Type.Event += handler` paths use, which is what keeps
+        // issue #3775's nil-tolerance (`e += nil` is a silent no-op in C#, not
+        // a conversion error) identical on the static path.
+        if (isEventOperator
+            && (function?.StaticOwnerType as StructSymbol ?? function?.ReceiverType as StructSymbol) is StructSymbol staticOwner
+            && TypeMemberModel.TryGetStaticEventIncludingInherited(staticOwner, name, out var staticEv, out var staticEventOwner))
+        {
+            var staticEventType = staticEventOwner.SubstituteMemberType(staticEv.Type);
+            var staticHandler = BindEventSubscriptionHandler(syntax.Value, staticEventType);
+            return new BoundEventSubscriptionExpression(
+                null, receiver: null, staticEventOwner, staticEv, staticHandler, isAdd, staticEventType);
+        }
+
         // Not an event: fall back to compound assignment semantics.
         // Reconstruct `name = name +/- rhs` as the parser used to do.
         var variable = BindVariableReference(name, bareName.IdentifierToken.Location, suppressNotAVariable: false, suppressUndefinedVariable: true);

--- a/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Members.cs
@@ -992,6 +992,39 @@ public partial class Parser
     // arrow's source position so diagnostics and spans stay anchored at the
     // member. G# spells this arrow `->` (RightArrowToken); the C# fat arrow `=>`
     // is never accepted.
+
+    /// <summary>
+    /// Issue #3907: whether an <c>async</c> function's return-type clause names
+    /// the void-result await envelope — a bare <c>Task</c> or <c>ValueTask</c>
+    /// with no type arguments — so an arrow body is an expression statement
+    /// rather than a return.
+    /// </summary>
+    /// <remarks>
+    /// The test is deliberately syntactic and deliberately narrow: only
+    /// <c>async</c> declarations are considered, only the two envelope names
+    /// issue #1918 recognises, and only the unqualified, non-generic,
+    /// non-nullable spelling. <c>Task[T]</c> / <c>ValueTask[T]</c> carry a
+    /// result and keep their return; a nullable or qualified spelling is left
+    /// alone rather than guessed at. A non-async function named the same way
+    /// really does return a task value, so it is untouched.
+    /// </remarks>
+    /// <param name="asyncModifier">The <c>async</c> modifier token, if present.</param>
+    /// <param name="type">The return-type clause.</param>
+    /// <returns>Whether the arrow body should lower to an expression statement.</returns>
+    private static bool IsAsyncVoidResultEnvelope(SyntaxToken? asyncModifier, TypeClauseSyntax type)
+    {
+        if (asyncModifier == null
+            || type.HasTypeArguments
+            || type.HasQualifier
+            || type.IsNullable
+            || type.Identifier is not { } identifier)
+        {
+            return false;
+        }
+
+        return identifier.Text is "Task" or "ValueTask";
+    }
+
     private BlockStatementSyntax ParseArrowExpressionBody(bool asReturn)
     {
         var arrowToken = MatchToken(SyntaxKind.RightArrowToken);
@@ -1211,7 +1244,23 @@ public partial class Parser
             // binder infers the return type from the literal, narrowing it at a
             // public/protected boundary per ADR-0146's "Kotlin visibility narrowing" section.
             // Every other omitted-type arrow body keeps the existing void behavior.
-            body = ParseArrowExpressionBody(asReturn: type != null || IsAnonymousClassLiteralStartAfterArrow());
+            // Issue #3907: an `async` function whose return-type clause spells
+            // the VOID-RESULT envelope — `async func F() ValueTask -> Deposit(…)`
+            // — is a void function that happens to have a type clause, so its
+            // arrow body is an expression STATEMENT like every other void
+            // arrow. Issue #1918 lets an async function name its envelope
+            // (`Task` / `ValueTask` / `Task[T]` / `ValueTask[T]`) instead of the
+            // bare awaited result, and DeclarationBinder unwraps it — but the
+            // `type != null` test here runs before any of that and lowered the
+            // body to `{ return <void expr> }`, which the binder then rejected
+            // with GS0122 + GS0124. Both neighbouring spellings were already
+            // right: `func F() -> voidExpr` and `async func F() -> voidExpr`
+            // (no clause) both produce a statement. This is the C# shape
+            // `public async ValueTask M<T>(…) => VoidCall();`, which is what
+            // `AsyncLetCell.Run` is written as.
+            body = ParseArrowExpressionBody(
+                asReturn: (type != null && !IsAsyncVoidResultEnvelope(asyncModifier, type))
+                    || IsAnonymousClassLiteralStartAfterArrow());
         }
         else
         {

--- a/test/Compiler.Tests/Issue3907SourceTypePrecedenceTests.cs
+++ b/test/Compiler.Tests/Issue3907SourceTypePrecedenceTests.cs
@@ -1,0 +1,268 @@
+// <copyright file="Issue3907SourceTypePrecedenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3907: a SOURCE type declaration outranks an imported one carrying the
+/// same fully-qualified name, and an <c>async</c> function whose return clause
+/// spells the void-result envelope may use an arrow body over a void call.
+/// </summary>
+/// <remarks>
+/// <para><b>Source beats metadata for a package-qualified name.</b> The
+/// dotted-name binder resolved <c>Pkg.Name</c> through a reflection prefix walk
+/// BEFORE consulting same-compilation declarations, so whenever the reference
+/// set also contained <c>Pkg.Name</c> the metadata type won and the source one
+/// was never considered. C# resolves that collision the other way (Roslyn
+/// reports <c>CS0436</c> and uses the source type).</para>
+/// <para>It bites hardest when an assembly is compiled against a build of
+/// ITSELF, which is the normal state for <c>Gsharp.Runtime.Channels</c>: gsc
+/// appends the bundled channel runtime to every reference set, so while
+/// compiling that runtime's own sources every <c>Gsharp.Concurrency.X</c> in a
+/// base clause bound to the PREVIOUS build's <c>X</c>. The single wrong base
+/// link on <c>class TaskArm[T] : Gsharp.Concurrency.TaskArm</c> produced three
+/// diagnostics at once — <c>GS0214</c> (no accessible two-argument base
+/// constructor), <c>GS0185</c> (override does not match the base) and
+/// <c>GS0155</c> (<c>TaskArm[T]</c> is not an <c>ArmDescriptor</c>). The BARE
+/// spelling was always correct, which is why only the qualified one failed and
+/// why the shape did not reproduce until the declaring assembly's name was part
+/// of the repro.</para>
+/// <para>Both cases RUN. The base-link case is specifically about WHICH type a
+/// name denotes: a binding-only assertion cannot tell a correct base link from
+/// one that resolves to a different assembly's same-named type and happens to
+/// type-check, and a wrong link changes the emitted base-constructor call and
+/// vtable slot — so ILVerify runs too.</para>
+/// </remarks>
+public class Issue3907SourceTypePrecedenceTests
+{
+    [Fact]
+    public void PackageQualifiedBaseName_BindsToTheSourceTypeNotTheImportedHomonym()
+    {
+        // `Gsharp.Concurrency` + assembly name `Gsharp.Runtime.Channels` is the
+        // self-compilation shape: gsc auto-references the bundled channel
+        // runtime, which already declares Gsharp.Concurrency.TaskArm and
+        // Gsharp.Concurrency.TaskArm`1.
+        const string source = @"
+package Gsharp.Concurrency
+
+import System
+
+internal open class ArmDescriptor {
+    protected init(arm int32) {
+        Arm = arm
+    }
+
+    internal prop Arm int32 {
+        get;
+        private set;
+    }
+}
+
+internal open class TaskArm : ArmDescriptor {
+    internal init(tag string, arm int32) : base(arm) {
+        Tag = tag
+    }
+
+    internal prop Tag string {
+        get;
+        private set;
+    }
+
+    protected open func Describe() string -> ""base:"" + Tag
+}
+
+internal open class TaskArm[T] : Gsharp.Concurrency.TaskArm {
+    internal init(tag string, arm int32) : base(tag, arm) {
+    }
+
+    protected open override func Describe() string -> ""derived:"" + Tag + "":"" + Arm.ToString()
+
+    internal func Show() string -> Describe()
+}
+
+let arms = System.Collections.Generic.List[ArmDescriptor]()
+let derived = TaskArm[int32](""t"", 7)
+arms.Add(derived)
+Console.WriteLine(derived.Show())
+Console.WriteLine(""count="" + arms.Count.ToString())
+Console.WriteLine(""isArmDescriptor="" + (arms[0] is ArmDescriptor).ToString())
+";
+
+        var lines = CompileVerifyAndRunAs(source, "Gsharp.Runtime.Channels");
+
+        // The base constructor ran (Tag/Arm came through it), the override won
+        // over the base's Describe, and the derived type really is an
+        // ArmDescriptor — the three things the wrong base link broke.
+        Assert.Contains("derived:t:7", lines);
+        Assert.Contains("count=1", lines);
+        Assert.Contains("isArmDescriptor=True", lines);
+    }
+
+    [Fact]
+    public void PackageQualifiedName_StillReachesAnImportedTypeWhenSourceDeclaresNoSuchName()
+    {
+        // Anti-over-reach guard: the new source-first probe must not shadow
+        // ordinary qualified CLR names. `System.Text.StringBuilder` has no
+        // same-compilation homonym and must keep resolving through the
+        // reflection walk.
+        const string source = @"
+package Demo
+
+import System
+
+class Holder {
+    var builder System.Text.StringBuilder = System.Text.StringBuilder()
+}
+
+let h = Holder()
+h.builder.Append(""ok"")
+Console.WriteLine(h.builder.ToString())
+Console.WriteLine(""type="" + h.builder.GetType().Name)
+";
+
+        var lines = CompileVerifyAndRunAs(source, "Demo");
+
+        Assert.Contains("ok", lines);
+        Assert.Contains("type=StringBuilder", lines);
+    }
+
+    [Fact]
+    public void AsyncFunctionWithVoidResultEnvelope_MayUseAnArrowBodyOverAVoidCall()
+    {
+        // `public async ValueTask Run<T>(ValueTask<T> body) => Deposit(await …);`
+        // — AsyncLetCell.Run's shape. Issue #1918 lets an async function spell
+        // its envelope instead of the awaited result; the parser's
+        // return-vs-statement choice for an arrow body ran before that
+        // normalization and lowered this to `{ return <void expr> }`, which the
+        // binder rejected with GS0122 + GS0124. Both neighbouring spellings
+        // (`func F() -> voidExpr` and `async func F() -> voidExpr`) were already
+        // right.
+        const string source = @"
+package Demo
+
+import System
+import System.Threading.Tasks
+
+class Cell {
+    var log string = """"
+
+    async func RunValueTask[T](body ValueTask[T]) ValueTask -> Deposit(""v:"" + (await body).ToString())
+
+    async func RunTask[T](body Task[T]) Task -> Deposit(""t:"" + (await body).ToString())
+
+    async func RunBare() -> Deposit(""bare"")
+
+    func RunSync() -> Deposit(""sync"")
+
+    private func Deposit(entry string) {
+        log = log + entry + "";""
+    }
+}
+
+async func Main() {
+    let c = Cell()
+    await c.RunValueTask[int32](ValueTask[int32](1))
+    await c.RunTask[int32](Task.FromResult(2))
+    await c.RunBare()
+    c.RunSync()
+    Console.WriteLine(""log="" + c.log)
+}
+
+Main().GetAwaiter().GetResult()
+";
+
+        var lines = CompileVerifyAndRunAs(source, "Demo");
+
+        // Every arrow body ran its void call exactly once, in order — the
+        // observable difference between an expression STATEMENT (correct) and a
+        // dropped or doubled body.
+        Assert.Contains("log=v:1;t:2;bare;sync;", lines);
+    }
+
+    private static string[] CompileVerifyAndRunAs(string source, string assemblyName)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_precedence_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Program.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/assemblyname:" + assemblyName,
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout
+                .ReplaceLineEndings("\n")
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/test/Compiler.Tests/Issue3907StaticEventTests.cs
+++ b/test/Compiler.Tests/Issue3907StaticEventTests.cs
@@ -1,0 +1,346 @@
+// <copyright file="Issue3907StaticEventTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issues #3911 / #3907, ADR-0052 (amended): a <c>shared</c>-block static event
+/// can be READ and RAISED by its bare name inside the declaring type, and
+/// subscribed to by its bare name, exactly as an instance event can.
+/// </summary>
+/// <remarks>
+/// <para>Issue #263 shipped static events' declaration, accessors, metadata and
+/// the qualified <c>Type.Event += handler</c> subscription. The bare-name half
+/// was never wired up: the binder's static bare-name exposure covered static
+/// fields, const fields and static properties but not a field-like static
+/// event's BACKING FIELD, and the bare <c>+=</c>/<c>-=</c> path walked instance
+/// events only. So <c>Static?(nil, args)</c> failed with <c>GS0130 Function
+/// 'Static' doesn't exist</c> while the identical instance event worked — which
+/// is what the migrated <c>Gsharp.Runtime.Channels</c> hit on
+/// <c>GsharpRuntime.RaiseDeferGraceExpired</c>, <c>RaiseScopeStalled</c> and
+/// <c>GoroutineRuntime.TryHandle</c>.</para>
+/// <para>Every case RUNS the emitted program. Binding-only assertions cannot
+/// tell a correct subscription from one that binds and then never fires, cannot
+/// see that <c>-=</c> actually detaches, and cannot see that <c>+= nil</c> is
+/// the silent no-op C# specifies rather than a throw. ILVerify runs too,
+/// because the fix changes which member a bare name binds to and therefore the
+/// emitted field/accessor references.</para>
+/// </remarks>
+public class Issue3907StaticEventTests
+{
+    [Fact]
+    public void StaticEvent_IsRaisedAndReadByBareNameInsideItsDeclaringType()
+    {
+        // The shape of GsharpRuntime.RaiseDeferGraceExpired: a process-wide
+        // diagnostic hook raised through the canonical null-conditional form.
+        const string source = @"
+package Demo
+
+import System
+
+class Bus {
+    shared {
+        event Ticked EventHandler[EventArgs]?
+
+        func Raise() {
+            Ticked?(nil, EventArgs.Empty)
+        }
+
+        func HasSubscribers() bool {
+            // The READ half — GoroutineRuntime.TryHandle's `var handlers = E`.
+            let handlers = Ticked
+            return handlers != nil
+        }
+    }
+}
+
+Console.WriteLine(""before="" + Bus.HasSubscribers().ToString())
+Bus.Ticked += func(sender object?, e EventArgs) { Console.WriteLine(""fired"") }
+Console.WriteLine(""after="" + Bus.HasSubscribers().ToString())
+Bus.Raise()
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        Assert.Contains("before=False", lines);
+        Assert.Contains("after=True", lines);
+
+        // The subscriber actually ran. A fix that merely made the raise BIND
+        // would pass a binding-only assertion and fail here.
+        Assert.Contains("fired", lines);
+    }
+
+    [Fact]
+    public void StaticEvent_UnsubscribeDetaches_AndSubscribeIsCumulative()
+    {
+        const string source = @"
+package Demo
+
+import System
+
+class Bus {
+    shared {
+        event Ticked EventHandler[EventArgs]?
+
+        func Raise() {
+            Ticked?(nil, EventArgs.Empty)
+        }
+    }
+}
+
+let first = func(sender object?, e EventArgs) { Console.WriteLine(""first"") }
+let second = func(sender object?, e EventArgs) { Console.WriteLine(""second"") }
+
+Bus.Ticked += first
+Bus.Ticked += second
+Console.WriteLine(""--- both ---"")
+Bus.Raise()
+
+Bus.Ticked -= first
+Console.WriteLine(""--- second only ---"")
+Bus.Raise()
+
+Bus.Ticked -= second
+Console.WriteLine(""--- none ---"")
+Bus.Raise()
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+        var text = string.Join("\n", lines);
+
+        // Both handlers ran while both were attached, in subscription order.
+        Assert.Contains("--- both ---\nfirst\nsecond\n--- second only ---", text);
+
+        // `-=` genuinely detached the first and left the second.
+        Assert.Contains("--- second only ---\nsecond\n--- none ---", text);
+
+        // Removing the last handler leaves the backing field nil and the
+        // null-conditional raise is a no-op rather than a NullReferenceException.
+        Assert.Contains("--- none ---\ndone", text);
+    }
+
+    [Fact]
+    public void StaticEvent_BareNameSubscriptionInsideTheDeclaringType_RoutesThroughTheAccessors()
+    {
+        // Exercises the bare `Ticked += handler` spelling from inside the type.
+        // This must reach the add/remove ACCESSORS, not a compound assignment on
+        // the backing field the read half now also exposes: the accessors carry
+        // the issue-#256 Interlocked.CompareExchange loop, so a compound-assign
+        // lowering would silently drop the concurrency guarantee.
+        const string source = @"
+package Demo
+
+import System
+
+class Bus {
+    shared {
+        event Ticked EventHandler[EventArgs]?
+
+        func Attach(h EventHandler[EventArgs]) {
+            Ticked += h
+        }
+
+        func Detach(h EventHandler[EventArgs]) {
+            Ticked -= h
+        }
+
+        func Raise() {
+            Ticked?(nil, EventArgs.Empty)
+        }
+    }
+}
+
+let h = func(sender object?, e EventArgs) { Console.WriteLine(""bare-fired"") }
+Bus.Attach(h)
+Bus.Raise()
+Bus.Detach(h)
+Console.WriteLine(""--- detached ---"")
+Bus.Raise()
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+        var text = string.Join("\n", lines);
+
+        Assert.Contains("bare-fired", lines);
+        Assert.Contains("--- detached ---\ndone", text);
+    }
+
+    [Fact]
+    public void StaticEvent_NilHandlerSubscriptionIsASilentNoOp()
+    {
+        // Issue #3775 / PR #3793 established that C#'s `e += null` is a silent
+        // no-op (add_E forwards to Delegate.Combine, which returns the other
+        // operand unchanged) and fixed the divergence for INSTANCE events. The
+        // static path must not reintroduce it: this must neither fail to
+        // compile (GS0155) nor throw at run time.
+        const string source = @"
+package Demo
+
+import System
+
+class Bus {
+    shared {
+        event Ticked EventHandler[EventArgs]?
+
+        func Raise() {
+            Ticked?(nil, EventArgs.Empty)
+        }
+    }
+}
+
+let absent EventHandler[EventArgs]? = nil
+
+Bus.Ticked += absent
+Console.WriteLine(""added-nil"")
+Bus.Raise()
+
+Bus.Ticked += func(sender object?, e EventArgs) { Console.WriteLine(""real"") }
+Bus.Ticked += absent
+Bus.Raise()
+
+Bus.Ticked -= absent
+Bus.Raise()
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+        var text = string.Join("\n", lines);
+
+        Assert.Contains("added-nil", lines);
+
+        // The nil subscription left the invocation list untouched: the real
+        // handler still fires exactly once per raise, both after a nil `+=`
+        // and after a nil `-=`.
+        Assert.Contains("added-nil\nreal\nreal\ndone", text);
+    }
+
+    [Fact]
+    public void StaticAndInstanceEventsOfTheSameNameCoexist()
+    {
+        // Guards the shadowing precedence the bare-name exposure must preserve:
+        // the instance member is exposed first, so a same-named static event
+        // must not displace it, and each must still raise its own subscribers.
+        const string source = @"
+package Demo
+
+import System
+
+class Bus {
+    event Ticked EventHandler[EventArgs]?
+
+    func RaiseInstance() {
+        Ticked?(nil, EventArgs.Empty)
+    }
+
+    shared {
+        event Shared EventHandler[EventArgs]?
+
+        func RaiseShared() {
+            Shared?(nil, EventArgs.Empty)
+        }
+    }
+}
+
+let b = Bus()
+b.Ticked += func(sender object?, e EventArgs) { Console.WriteLine(""instance"") }
+Bus.Shared += func(sender object?, e EventArgs) { Console.WriteLine(""static"") }
+
+b.RaiseInstance()
+Bus.RaiseShared()
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+        var text = string.Join("\n", lines);
+
+        Assert.Contains("instance\nstatic\ndone", text);
+    }
+
+    private static string[] CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_staticevent_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Program.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout
+                .ReplaceLineEndings("\n")
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3907NullForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3907NullForgivenessTranslationTests.cs
@@ -1,0 +1,134 @@
+// <copyright file="Issue3907NullForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3907: two translation faithfulness defects found by the migrated
+/// <c>src/Sdk/Gsharp.Runtime.Channels</c>.
+/// </summary>
+/// <remarks>
+/// <para><b>A deconstruction-assignment TARGET skipped the null-forgiveness
+/// lift.</b> <c>SelectRandom.Shuffle</c>'s Fisher–Yates swap
+/// <c>(order[i], order[j]) = (order[j], order[i]);</c> sits two lines below
+/// <c>order[i] = i;</c>, on the same <c>int[]?</c> local, flow-proved non-null
+/// by the same preceding guard. The single-target write got its <c>!!</c>; the
+/// deconstruction targets did not, because
+/// <c>TryLowerNativeMultiAssignment</c> translated each target with the plain
+/// expression translator rather than the assignment-target translator every
+/// other write goes through. gsc then rejected the indexing of a <c>[]?int32</c>
+/// with <c>GS0116</c>.</para>
+/// <para><b>An inferred local's delegate type was erased to its arrow
+/// type.</b> <c>GoroutineRuntime.TryHandle</c>'s <c>var handlers =
+/// UnhandledGoroutineException;</c> is a plain <c>var</c>; the type clause
+/// exists only to carry the issue-#1072 nullable widening. Mapping it through
+/// the structural type mapper turned <c>EventHandler&lt;T&gt;</c> into
+/// <c>(object?, T) -&gt; void</c>, and in G# the conversion between a nominal
+/// delegate and a structurally equal function type is EXPLICIT — so the emitted
+/// declaration failed with <c>GS0156</c>.</para>
+/// </remarks>
+public class Issue3907NullForgivenessTranslationTests
+{
+    [Fact]
+    public void DeconstructionAssignmentTargets_GetTheSameNullForgivenessAsASingleTarget()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    private static int[]? buffer;
+
+    public static int M(int n)
+    {
+        var order = buffer;
+        if (order is null || order.Length < n)
+        {
+            order = buffer = new int[System.Math.Max(n, 8)];
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            order[i] = i;
+        }
+
+        for (int i = n - 1; i > 0; i--)
+        {
+            int j = i / 2;
+            (order[i], order[j]) = (order[j], order[i]);
+        }
+
+        return order[0];
+    }
+}");
+
+        // The anti-vacuity anchor: the single-target write on the SAME local
+        // already lifted before this fix, so a test that only asserted the
+        // swap line's presence would pass on a broken build.
+        Assert.Contains("order!![i] = i", printed, StringComparison.Ordinal);
+
+        // The regression itself: every indexing in the swap is lifted too.
+        Assert.Contains(
+            "order!![i], order!![j] = order!![j], order!![i]",
+            printed,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InferredNullableLocal_KeepsADelegatesNominalType()
+    {
+        string printed = Translate(@"
+public sealed class C
+{
+    public static event EventHandler<EventArgs>? Ticked;
+
+    public static bool M()
+    {
+        var handlers = Ticked;
+        if (handlers is null)
+        {
+            return false;
+        }
+
+        handlers(null, EventArgs.Empty);
+        return true;
+    }
+}");
+
+        // The nominal delegate name survives; the structural arrow spelling
+        // (which gsc will not implicitly convert to) must not appear.
+        Assert.Contains("EventHandler[EventArgs]?", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("(object?, EventArgs) -> void", printed, StringComparison.Ordinal);
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Snippet.cs", "using System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: "
+                + string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        string printed = GSharpPrinter.Print(unit);
+
+        RoundTripResult roundTrip = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            roundTrip.Success,
+            "Translated G# must round-trip. Errors:\n" + string.Join("\n", roundTrip.Errors)
+                + "\n\nPrinted:\n" + printed);
+
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -206,7 +206,21 @@ public sealed partial class CSharpToGSharpTranslator
                     // whose uses prove it nullable needs an explicit `T?`.
                     // Otherwise G# may re-infer a non-null type from `e`, making a
                     // later nil check fail GS0129.
-                    type = MakeNullable(this.typeMapper.Map(
+                    //
+                    // Issue #3907: map through MapEventType, not Map. The C#
+                    // author wrote no type here at all — the clause exists only
+                    // to carry the `?` — so the spelling must be one G# accepts
+                    // for the initializer's own type. `Map` erases a DELEGATE to
+                    // its structural arrow type (`EventHandler<T>` becomes
+                    // `(object?, T) -> void`), and in G# those are different
+                    // types: the conversion between them exists but is
+                    // EXPLICIT, so the emitted `let h ((object?, T) -> void)? =
+                    // <delegate>` failed with GS0156. MapEventType keeps the
+                    // nominal delegate name for exactly the reason it already
+                    // documents — structurally equivalent delegates are not
+                    // interchangeable — and falls through to Map unchanged for
+                    // every non-delegate type, so only this shape moves.
+                    type = MakeNullable(this.typeMapper.MapEventType(
                         inferredLocal.Type, this.context, declaration.Type.GetLocation()));
                 }
 


### PR DESCRIPTION
**Picks up where #3914 left off.** Based on current `origin/main` (`d75d6c4fc`).

## Re-measured first, as the issue asks

Scale: **deduplicated compile-error artifacts**, the same one #3914 used for its 27/11. Measured end to end on the real pipeline (translate → compile through the repacked Release `Gsharp.NET.Sdk` nupkg), isolated to this one app with `--exclude` for the other 61 projects.

| stage | artifacts |
|---|---:|
| `origin/main` (`d75d6c4fc`) | **11** |
| + this PR | **3** |

**#3912 moved the count neither way** — it is still exactly the 11 the issue triaged, same ids, same locations. The cascade-suppression worry was unfounded here.

## The four root causes

**1. gsc — a SOURCE declaration now outranks an imported homonym for a package-qualified name.**
`Binder`'s dotted-name resolution ran its greedy reflection prefix walk *before* consulting same-compilation declarations, and a source type has no CLR representation while binding — so whenever the reference set also contained `Pkg.Name`, the **metadata** type won and the source one was never considered. C# resolves that collision the other way round (Roslyn reports `CS0436` and uses the source type).

It bites hardest when an assembly is compiled against a build of **itself**, which is the normal state for `Gsharp.Runtime.Channels`: `ReferenceResolver.FindBundledChannelsRuntimePath` appends the bundled channel runtime to *every* reference set, so while compiling that runtime's own sources every `Gsharp.Concurrency.X` in a base clause bound to the previous build's `X`. One wrong base link on `class TaskArm[T] : Gsharp.Concurrency.TaskArm` produced all three of the issue's `TaskArm` diagnostics at once — `GS0214` (no accessible 2-arg base ctor), `GS0185` (override does not match the base), `GS0155` (`TaskArm[T]` is not an `ArmDescriptor`).

This also explains the issue's "**does not reproduce** in a 30-line file with the same shape, dotted package included". It does not, and cannot: the missing ingredient was not in the code at all. `/assemblyname:Gsharp.Runtime.Channels` + `package Gsharp.Concurrency` + the qualified spelling is the whole repro, and it reproduces in 14 lines. The **bare** spelling was always correct, which is why only the qualified one failed.

The new probe is deliberately strict — the qualifier must exactly name a package this compilation declares, the simple name and arity must match, and two candidates yield no match rather than a guess — so `System.Console` and every other purely-imported qualified name reach the existing walk unchanged. There is a test for that.

**2. gsc — static events can be read, raised and subscribed to by bare name (#3911, ADR-0052 amended).**
The issue flagged this as the item most likely to need a language decision. **It did not, and the premise on #3911 was wrong**: static events are not an unimplemented feature. Issue #263 shipped declaration in a `shared` block, `add`/`remove`/`raise` accessors with the #256 `Interlocked.CompareExchange` loop, `EventDef`/`MethodSemantics` metadata, and `Type.Event += handler` subscription. Exactly one lookup step was missing — `Binder`'s static bare-name exposure covered static fields, const fields and static properties but not a field-like static event's **backing field**, and `BindBareEventOrCompoundAssignment` walked instance events only. So a static event could be declared and subscribed to but never read or raised: `Static?(nil, args)` gave `GS0130` while the identical instance event worked.

The fix is the exact static counterpart of the instance exposure (#1213/#1221), plus a static branch in the bare `+=`/`-=` path placed *before* the compound-assignment fallback — without it the new backing-field exposure would capture `+=` and turn a subscription into a delegate compound assignment on the field, silently bypassing the accessors' CAS loop. ADR-0052's "Static events on user types" follow-up entry is struck and replaced with an amendment saying what is supported and what is still deferred.

Both things the coordinator asked me to check while I was in there are covered by tests: `+= nil` is a silent no-op (the static path routes its handler through the same `BindEventSubscriptionHandler` that carries #3775/#3793's nil tolerance), and the generated accessors are the thread-safe #256 ones.

**3. gsc — an `async` function whose return clause spells the void-result envelope may use an arrow body over a void call.**
#1918 lets an `async func` name `Task` / `ValueTask` instead of the bare awaited result, and `DeclarationBinder` unwraps it. The parser's return-vs-statement choice for an arrow body (`asReturn: type != null`) runs long before that, so `async func Run[T](body ValueTask[T]) ValueTask -> Deposit(await …)` lowered to `{ return <void expr> }` and the binder rejected its own body with `GS0122` + `GS0124`. Both neighbouring spellings were already right: `func F() -> voidExpr` and `async func F() -> voidExpr` (no clause) both produce an expression statement. This is the C# shape `public async ValueTask M<T>(…) => VoidCall();`, which is what `AsyncLetCell.Run` is written as. The new test pins all four spellings, including the two that already worked.

**4. cs2gs — an inferred local keeps a delegate's nominal type.**
`var handlers = UnhandledGoroutineException;` is a plain `var`; the emitted type clause exists only to carry the #1072 nullable widening. Mapping it through the structural mapper erased `EventHandler<T>` to `(object?, T) -> void`, and in G# the conversion between a nominal delegate and a structurally equal function type is **explicit** — so the emitted declaration failed with `GS0156`. `CSharpTypeMapper.MapEventType` already exists for precisely this reason ("structurally equivalent delegates are not interchangeable in the CLR"); this routes the inferred-local branch through it. It falls through to `Map` unchanged for every non-delegate type, so only this shape moves.

## Layer judgement

**gsc (1, 2, 3).** The C# is ordinary and legal, and in each case gsc's own neighbouring path already got it right: bare-name base clauses resolve to source; instance events are exposed by bare name; a named async function's envelope is normalized. These are wrong for *every* G# program, not just this app — #1 in particular silently mis-resolves any project compiled against an older build of itself.

**cs2gs (4).** The C# is fine and the emitted G# is not what the author wrote.

**No source edits.** I did not touch #3882's C#, and in particular did not turn the process-wide diagnostic hooks into instance events — which the owner's decision made moot anyway, but which was also unnecessary once the actual hole turned out to be one missing lookup step.

## Evidence

- `Issue3907StaticEventTests` (5 cases) and `Issue3907SourceTypePrecedenceTests` (3 cases) **compile, ILVerify and RUN** the emitted program and assert on observable behaviour: a subscriber actually fires, `-=` actually detaches, a nil handler leaves the invocation list untouched, the base constructor actually ran, the override actually won, each arrow body ran its void call exactly once and in order.
- **Failing on the base branch, honestly labelled.** Re-run with the four gsc files reverted: **7 of 8 fail**, with exactly `GS0130`/`GS0125` (static events), `GS0214` (base link) and `GS0122`+`GS0124` (arrow body). The 8th — `PackageQualifiedName_StillReachesAnImportedTypeWhenSourceDeclaresNoSuchName` — is the deliberate anti-over-reach guard and must pass both ways.
- **Full suites:** `Core.Tests` **8874 passed / 0 failed**; `Compiler.Tests` **4722 passed / 0 failed**. Both matter: #1 changes type resolution and #2 changes bare-name lookup, whose blast radius is the whole binder. Plus **509 targeted `Cs2Gs.Tests`** (golden, nullability, deconstruction, event) — the full Cs2Gs suite has a known non-deterministic host crash, so it is verified by subset as usual.
- **PR guard:** `build/run-cs2gs-selfmig-pr-guard.sh` — result in a comment below.

## What this does NOT do, and the corrected remainder

**`Channels` does not reach zero, so the ten dependents do not clear and the gate stays at 38/53.** The all-or-nothing property is unchanged, and I did not beat it. `Channels` therefore stays **out** of `run-cs2gs-selfmig-pr-guard.sh`'s `guard_apps`.

Three artifacts remain, but only **two** are defects — and this corrects the issue's triage:

**A. `GS0154` at `Chan{T}.gs:173` — gsc ignores `@AllowNull`.** The issue called this "a `T?` in a `T` slot", implying a cs2gs neighbour of root 2. It is not. `ReceiveResult<T>`'s C# ctor is `public ReceiveResult([AllowNull] T value, bool ok)` and cs2gs translates it faithfully to `init(@AllowNull value T, ok bool)`. **gsc has no `AllowNull` support at all** — grep finds it only as a consumer in `Compilation.cs`. `[AllowNull]` is the .NET-standard "this *input* accepts null though its type is not nullable" annotation and is exactly what makes the C# legal. Verified in 30 lines: a `@AllowNull T` parameter and a plain `T` parameter reject a `T?` argument identically. cs2gs is already right on its side — `ObliviousNullabilityAnalyzer.HasAllowNullWriteContract` correctly declines to add a `!!` because the target accepts null. **Fix belongs in gsc**: carry the annotation on `ParameterSymbol` and relax the *argument* conversion only (never the parameter's own type, so reads inside the body still require the author's `!!` — the asymmetry the attribute exists to express). I scaffolded this and backed it out rather than ship it half-done: the conversion must be annotation-only, and getting it wrong on a value-type `T` would emit `Nullable<T>` where `T` is expected — a wrong-IL bug an ILVerify-passing test would not catch.

**B. `GS0156` at `Chan{T}.gs:451`/`452` — a by-ref argument over a same-compilation user class erases to `object&`.** Root-caused precisely. `Interlocked` declares both `Exchange<T>(ref T, T) where T : class` and the non-generic `Exchange(ref object?, object?)`. Issue #658 erases a user class argument to `System.Object` because its CLR type is a surrogate while binding; for a by-value argument that ride-through is harmless and load-bearing, but for a **by-ref** one it makes the non-generic overload an exact *identity* match, so gsc picks it and the call's type becomes `object`. csc never considers that overload at all, because a `ref` argument requires exact type identity. Confirmed by three controls: the same call over a BCL element type resolves correctly; `Exchange[Node?](&slot, nil)` with an explicit type argument resolves correctly; and the defect is independent of the reference set. Note the neighbouring `Volatile.Write(&receiveNodePool, node)` almost certainly binds the wrong overload too and is simply *silent*, because its result is discarded — so this is a latent correctness bug, not only a diagnostic. `ImportedClassSymbol.TryLookupFunction` already has the exact analogue for user **value** types (#1599/#1601, feeding the "matches any by-ref parameter" sentinel); the reference-type case needs the *symbolic* type-argument vector to reach inference (`deferredInferenceArgs` + `recoverTypeArgSymbols`), which that path does not thread today. I attempted both the sentinel widening and a `ref`-identity rule in `ClrOverloadResolution.ClassifyImplicit`, verified neither is sufficient, and reverted both.

**C. `GS0116` at `SelectRandom.gs:59` is not a defect at all — it is a pipeline artifact, and the issue's diagnosis of it is wrong.** The issue calls it "the `!!` lift skips a tuple-deconstruction assignment TARGET". cs2gs's lift is present and correct: translating `SelectRandom.cs` emits `order!![i], order!![j] = order!![j], order!![i]`, verified three ways — standalone, standalone with `#nullable enable`, and with all 41 project files loaded together. The assertions are removed afterwards by `NullAssertionPolishPass`, whose log for this app reads `assertions stripped: 24`. The keep-rule is the bug:

```csharp
if (polished.IsAvailable && (polished.Succeeded || !result.Succeeded))
{
    result = polished;   // kept even if stripping INTRODUCED an error
```

The rollback below it only fires when a strip "regressed a previously passing" build. On an app that is already red for unrelated reasons, `!result.Succeeded` is true, so a strip that introduces a *new* error is kept permanently and invisibly. That is exactly what happens here. **It self-heals the moment A and B land**: with the app otherwise green, the same strip would regress a passing build and the backups would be restored. So `Channels` has **two** remaining root causes, not three — but the polish keep-rule is worth fixing on its own, because while it does not block anything it actively manufactures phantom sites and misdirects triage, which is precisely what it did here.

Refs #3907, #3911, #3910, #3914, #3501, #1918, #263, #658, #1599, #3775, ADR-0052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
