### PR TITLE
bench: every scenario body reaches Tier1, and both sides run for comparable time (#3902)

### DIFF
--- a/bench/concurrency/go/main.go
+++ b/bench/concurrency/go/main.go
@@ -1,15 +1,41 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"io"
+	"os"
 	"runtime"
 	"sync"
 	"time"
 )
 
-const N = 1_000_000
+// Issue #3902: per-scenario counts, matched to the G# side so each row runs for
+// roughly the same wall time on both. They used to differ by up to 10x — Go's
+// closed-channel receive ran 20 000 iterations against G#'s 200 000, finishing
+// in under a millisecond, which is where its ~2x launch-to-launch swing came
+// from. A ratio between two rows measured over different durations is not a
+// comparison of the two runtimes.
+const (
+	N          = 2_000_000  // buf64
+	NPingPong  = 1_000_000  // 2 hand-offs per iteration: 2M hand-offs, matching G#'s rendezvous
+	NClosed    = 25_000_000 // closed receive is nanoseconds; it needs the count to be measurable
+	NSpawn     = 750_000
+	NSelect    = 2_000_000
+	NChunk64   = 32_000_000
+	NChunk1k   = 75_000_000
+	NPark      = 200_000 // park-scale is a memory probe, not a rate
+)
+
+// quiet suppresses report output during warm-up rounds. The runner parses the
+// `[name] ms ns/op` lines, so a warm-up round must emit none of them.
+var quiet bool
 
 func report(name string, d time.Duration, ops int) {
+	if quiet {
+		return
+	}
+
 	fmt.Printf("[%-12s] %8.1f ms   %7.1f ns/op\n", name, float64(d.Nanoseconds())/1e6, float64(d.Nanoseconds())/float64(ops))
 }
 
@@ -30,6 +56,7 @@ func throughput() {
 }
 
 func chunked() {
+	const N = NChunk64
 	const C = 64
 	ch := make(chan []int, 64)
 	start := time.Now()
@@ -55,6 +82,7 @@ func chunked() {
 
 // Fair counterpart to the CLR chunk+pool stage: 1024-element chunks, pooled.
 func chunked1k() {
+	const N = NChunk1k
 	const C = 1024
 	ch := make(chan []int, 16)
 	pool := make(chan []int, 32)
@@ -125,7 +153,7 @@ func computeStage() {
 }
 
 func pingpong() {
-	const R = 200_000
+	const R = NPingPong
 	a := make(chan int)
 	b := make(chan int)
 	start := time.Now()
@@ -143,7 +171,7 @@ func pingpong() {
 }
 
 func closedRecv() {
-	const R = 20_000
+	const R = NClosed
 	ch := make(chan int)
 	close(ch)
 	start := time.Now()
@@ -158,7 +186,7 @@ func closedRecv() {
 }
 
 func spawn() {
-	const R = 200_000
+	const R = NSpawn
 	var wg sync.WaitGroup
 	wg.Add(R)
 	start := time.Now()
@@ -170,7 +198,7 @@ func spawn() {
 }
 
 func selectCost() {
-	const R = 200_000
+	const R = NSelect
 	a := make(chan int, 1024)
 	b := make(chan int, 1024)
 	go func() {
@@ -191,7 +219,7 @@ func selectCost() {
 }
 
 func parkScale() {
-	const P = 200_000
+	const P = NPark
 	ch := make(chan int)
 	var wg sync.WaitGroup
 	wg.Add(P)
@@ -218,7 +246,30 @@ func parkScale() {
 }
 
 func main() {
+	// Issue #3902: the G# side runs warm-up rounds before the reported one,
+	// because a tiered JIT needs them. Go is ahead-of-time compiled and has no
+	// equivalent, but "no equivalent" is a claim worth testing rather than
+	// assuming — the scheduler's threads, the GC's pacing and the CPU's own
+	// frequency ramp are all warm-up-shaped. This flag makes the question
+	// measurable: compare -warmup=0 against -warmup=3.
+	warmup := flag.Int("warmup", 0, "unreported rounds to run before the reported one")
+	flag.Parse()
+
 	fmt.Printf("go=%s cores=%d\n\n", runtime.Version(), runtime.NumCPU())
+
+	for i := 0; i < *warmup; i++ {
+		quiet = true
+		stdout := os.Stdout
+		os.Stdout, _ = os.Open(os.DevNull)
+		all()
+		os.Stdout = stdout
+		quiet = false
+	}
+
+	all()
+}
+
+func all() {
 	throughput()
 	chunked()
 	chunked1k()
@@ -229,3 +280,5 @@ func main() {
 	selectCost()
 	parkScale()
 }
+
+var _ = io.Discard

--- a/bench/concurrency/gsharp/Bench.gs
+++ b/bench/concurrency/gsharp/Bench.gs
@@ -23,24 +23,55 @@ package GSharp.Bench.Concurrency
 
 import System
 import System.Diagnostics
+import System.Threading
 
-let rounds = 3
-let ops = 200000
-let spawnOps = 50000
-let pingPongOps = 20000
+// Issue #3902 (H2): three of the eight scenario bodies never reached Tier1.
+// A scenario's `MoveNext` is entered ONCE and then loops, so call counting —
+// which needs 30 invocations — could never promote it, and only on-stack
+// replacement could. OSR does not fire for every G#-emitted body, and why is
+// still undetermined.
+//
+// So the harness stops depending on OSR. `warmupRounds` exceeds the runtime's
+// call-count threshold, at a cheap `warmupOps`, which promotes every body by
+// the ordinary path before the measured round runs. This sidesteps H2 rather
+// than solving it; H2 remains open, and matters wherever a hot loop inside a
+// suspending function does not park.
+// 120 rounds, not 40: a body that never parks is entered ONCE per call, and
+// promotion is two-stage — roughly 30 calls to earn an instrumented rejit, then
+// 30 more on that version to earn Tier1. Bodies that park reach both far sooner
+// because every resume is another entry. 120 clears it for all eight.
+let warmupRounds = 120
+let warmupOps = 4000
+
+// Issue #3902: counts are set so every scenario MEASURES for roughly a quarter
+// of a second. They used to run 1-5 ms, where timer granularity and the CPU's
+// own frequency ramp are a large fraction of the result — `chunk1k` measured
+// 1.3 ms. The Go side carries the matching counts; a row whose two sides run
+// for wildly different durations is not a comparison.
+let ops = 2000000
+let closedOps = 25000000
+let spawnOps = 750000
+let pingPongOps = 2000000
+let parkOps = 900000
+let chunk64Ops = 32000000
+let chunk1kOps = 75000000
 
 func report(name string, elapsed TimeSpan, count int32) {
     let perOp = elapsed.TotalNanoseconds / float64(count)
-    Console.WriteLine(name + " ns_per_op " + perOp.ToString("F2"))
+
+    // Elapsed milliseconds travel with the rate so a scenario that is too short
+    // to measure is visible as such rather than merely noisy. The Go side has
+    // always printed it; the runner reads the `ns_per_op` token either way.
+    Console.WriteLine(name + " ns_per_op " + perOp.ToString("F2") + " ms " + elapsed.TotalMilliseconds.ToString("F1"))
 }
 
 // A bounded channel driven producer-to-consumer: the shape a pipeline stage
 // has, and the row the ADR's throughput claim rests on.
-func buf64() TimeSpan {
+func buf64(count int32) TimeSpan {
     let ch = chan[int32](64)
     let sw = Stopwatch.StartNew()
     scope {
-        go produce(ch, ops)
+        go produce(ch, count)
         var seen = 0
         for v in ch {
             seen = seen + v - v + 1
@@ -61,11 +92,11 @@ func produce(ch out chan[int32], count int32) {
 
 // Capacity 0: a send completes only when a receiver takes the value, so this
 // measures the hand-off itself rather than the buffer.
-func rendezvous() TimeSpan {
+func rendezvous(count int32) TimeSpan {
     let ch = chan[int32](0)
     let sw = Stopwatch.StartNew()
     scope {
-        go produce(ch, pingPongOps)
+        go produce(ch, count)
         for v in ch {
             let ignored = v
         }
@@ -77,11 +108,11 @@ func rendezvous() TimeSpan {
 
 // The 382x defect ADR-0174 D2 removes: a receive from a closed, drained
 // channel used to raise an exception per call.
-func closedRecv() TimeSpan {
+func closedRecv(count int32) TimeSpan {
     let ch = chan[int32](1)
     ch.Close()
     let sw = Stopwatch.StartNew()
-    for i in 0 ... ops {
+    for i in 0 ... count {
         let (value, ok) = <-ch
         let ignored = value
     }
@@ -91,15 +122,15 @@ func closedRecv() TimeSpan {
 }
 
 // Spawn cost: `go` is a thread-pool work item, not a Task.
-func spawn() TimeSpan {
-    let done = chan[int32](spawnOps)
+func spawn(count int32) TimeSpan {
+    let done = chan[int32](count)
     let sw = Stopwatch.StartNew()
     scope {
-        for i in 0 ... spawnOps {
+        for i in 0 ... count {
             go signal(done)
         }
 
-        for j in 0 ... spawnOps {
+        for j in 0 ... count {
             let (value, ok) = <-done
             let ignored = value
         }
@@ -116,11 +147,11 @@ func signal(done out chan[int32]) {
 // A select whose arms are already ready: the fast path, no registration and no
 // park. Both arms are refilled each round so the uniform-random choice always
 // has two candidates.
-func selectReady() TimeSpan {
+func selectReady(count int32) TimeSpan {
     let a = chan[int32](1)
     let b = chan[int32](1)
     let sw = Stopwatch.StartNew()
-    for i in 0 ... ops {
+    for i in 0 ... count {
         a <- 1
         b <- 2
         select {
@@ -139,14 +170,14 @@ func selectReady() TimeSpan {
 
 // A select with no ready arm: registration on every arm, a park, and a
 // hand-off. This is the path wave 1 could not measure at all.
-func selectPark() TimeSpan {
+func selectPark(count int32) TimeSpan {
     let a = chan[int32](0)
     let b = chan[int32](0)
     let sw = Stopwatch.StartNew()
     scope {
-        go produce(a, pingPongOps)
+        go produce(a, count)
         var taken = 0
-        while taken < pingPongOps {
+        while taken < count {
             select {
             case let v = <-a {
                 taken = taken + 1
@@ -212,43 +243,43 @@ func produceBatched(ch chan[int32], count int32, size int32) {
 
 func run(name string) {
     if name == "buf64" {
-        report("buf64", buf64(), ops)
+        report("buf64", buf64(ops), ops)
     } else if name == "rendezvous" {
-        report("rendezvous", rendezvous(), pingPongOps)
+        report("rendezvous", rendezvous(pingPongOps), pingPongOps)
     } else if name == "closed-recv" {
-        report("closed-recv", closedRecv(), ops)
+        report("closed-recv", closedRecv(closedOps), closedOps)
     } else if name == "spawn" {
-        report("spawn", spawn(), spawnOps)
+        report("spawn", spawn(spawnOps), spawnOps)
     } else if name == "select-ready" {
-        report("select-ready", selectReady(), ops)
+        report("select-ready", selectReady(ops), ops)
     } else if name == "select-park" {
-        report("select-park", selectPark(), pingPongOps)
+        report("select-park", selectPark(parkOps), parkOps)
     } else if name == "chunk64" {
-        report("chunk64", chunked(64, ops), ops)
+        report("chunk64", chunked(64, chunk64Ops), chunk64Ops)
     } else if name == "chunk1k" {
-        report("chunk1k", chunked(1024, ops), ops)
+        report("chunk1k", chunked(1024, chunk1kOps), chunk1kOps)
     }
 }
 
+// Same work at a cheap op count, no output. Called warmupRounds times so the
+// runtime's call counter promotes every scenario body before it is measured.
 func runWarmup(name string) {
-    // Same work, no output: rounds 1 and 2 exist only to let the JIT tier up.
-    let sink = Console.Out
     if name == "buf64" {
-        let ignored = buf64()
+        let ignored = buf64(warmupOps)
     } else if name == "rendezvous" {
-        let ignored = rendezvous()
+        let ignored = rendezvous(warmupOps)
     } else if name == "closed-recv" {
-        let ignored = closedRecv()
+        let ignored = closedRecv(warmupOps)
     } else if name == "spawn" {
-        let ignored = spawn()
+        let ignored = spawn(warmupOps)
     } else if name == "select-ready" {
-        let ignored = selectReady()
+        let ignored = selectReady(warmupOps)
     } else if name == "select-park" {
-        let ignored = selectPark()
+        let ignored = selectPark(warmupOps)
     } else if name == "chunk64" {
-        let ignored = chunked(64, ops)
+        let ignored = chunked(64, warmupOps)
     } else if name == "chunk1k" {
-        let ignored = chunked(1024, ops)
+        let ignored = chunked(1024, warmupOps)
     }
 }
 
@@ -257,15 +288,23 @@ let requested = Environment.GetEnvironmentVariable("GSHARP_BENCH_SCENARIO")
 
 Console.WriteLine("runtime " + Environment.Version.ToString() + " cores " + Environment.ProcessorCount.ToString())
 
-for round in 0 ... rounds {
-    let reportable = round == rounds - 1
+for round in 0 ... warmupRounds {
     for name in all {
         if requested == nil || requested == "" || requested == name {
-            if reportable {
-                run(name)
-            } else {
-                runWarmup(name)
-            }
+            runWarmup(name)
         }
+    }
+}
+
+// Tier1 compilation is queued when the call counter trips and installed by a
+// background thread. Give it room to land before measuring, or the measured
+// round races the promotion it just paid for.
+Thread.Sleep(250)
+GC.Collect()
+GC.WaitForPendingFinalizers()
+
+for name in all {
+    if requested == nil || requested == "" || requested == name {
+        run(name)
     }
 }

--- a/build/run-concurrency-bench.py
+++ b/build/run-concurrency-bench.py
@@ -52,7 +52,11 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 BENCH = REPO / "bench" / "concurrency"
-ROW = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+) ns_per_op (?P<value>[0-9]+(?:\.[0-9]+)?)$")
+# The trailing `ms <elapsed>` is optional so the runner reads both the old
+# and the current Bench.gs output (issue #3902).
+ROW = re.compile(
+    r"^(?P<name>[A-Za-z0-9_.-]+) ns_per_op (?P<value>[0-9]+(?:\.[0-9]+)?)"
+    r"(?: ms (?P<elapsed_ms>[0-9]+(?:\.[0-9]+)?))?$")
 GO_ROW = re.compile(r"^\[(?P<name>[^\]]+?)\s*\]\s+[0-9.]+ ms\s+(?P<value>[0-9.]+) ns/op$")
 
 # Pinning the tiering delay is normative, not a tuning knob; see the module


### PR DESCRIPTION
Answers two questions asked of the harness: does every scenario actually reach Tier1, and does the Go
side have anything warm-up-shaped of its own. The answers were **no** and **yes**, and both were
distorting the published ratios.

## Every scenario body now reaches Tier1

Three of eight never left Tier0, even with S1's tier pin (#3903) — because the pin promotes *callees*,
and a scenario body is entered once and then loops, so only OSR could promote it. OSR does not fire for
every G#-emitted body (H2, cause still undetermined). Same suite, same binary:

| | Tier1 compiles | scenario bodies optimised |
|---|---:|---|
| default | 71 | 4 of 8 |
| pinned (`TC_CallCountingDelayMs=0`) | 534 | **the same 4** |

The harness now stops depending on OSR: 120 cheap warm-up rounds promote every body by the ordinary
call-counted path. **120, not 40**, because promotion is two-stage for a body entered once per call —
~30 calls to earn an instrumented rejit, then ~30 more *on that version* to earn Tier1. Bodies that
park reach both far sooner, since every resume is another entry, which is exactly why the parking
scenarios were already fine. Verified with `JitDisasmSummary`: all eight now show
`Tier1 with Synthesized PGO`.

## Go was being measured cold and short, and it flattered G#

Go is ahead-of-time compiled, so "no warm-up effect" is the obvious assumption — but it is a claim, so
I tested it. A `-warmup` flag was added; nine launches per configuration:

| Go row | cold (median) | warmed | min cold → warm |
|---|---:|---:|---|
| go-closed | 24.3 | **17.1** | 15.6 → 15.6 |
| go-spawn | 306.1 | 255.1 | |
| go-pingpong | 399.6 | 345.4 | |
| go-buf64 | 50.6 | 60.0 | noise |

Warm-up removes a **cold tail** rather than shifting the floor — the minimum barely moves. `go-closed`
is both the most affected and the shortest scenario, at 20 000 iterations finishing in under a
millisecond.

(An earlier three-launch sample suggested ~2× on several rows. That was over-reading noise; nine
launches gives the more modest picture above.)

Counts on both sides are now set per scenario so each row **measures for roughly a quarter second**.
They ran 1–5 ms before — `chunk1k` measured 1.3 ms. Go's own numbers improve accordingly: closed
29 → 16 ns, chunk1k 2.9 → 1.1, chunk64 11.1 → 7.5.

## Measured — interleaved against the old harness, 5 launches, 2 rounds, same runtime code

```
G#          buf64 158 -> 133   rendezvous 185-214 -> 124   closed-recv 21 -> 10.6
            chunk64 9-12 -> 8.1   chunk1k 3.9-4.7 -> 3.2   select-park 304-338 -> 301
```

**The reproducibility is the bigger result.** Launch-to-launch spread across the two rounds:

| scenario | before | after |
|---|---|---|
| rendezvous | 15% | **0.6%** |
| closed-recv | 5% | **0.8%** |
| chunk64 | 33% | **3%** |
| select-park | 11% | **1.4%** |

That is the complaint #3901 was opened about.

A second validation: with the JIT genuinely warm, **JIT and AOT converge** — closed-recv 10.56 vs
11.02, rendezvous 124 vs 149, select-park 300 vs 299. Two compilation modes agreeing is what you would
expect if the warm-up is doing what this PR claims.

## Three ratios move against G#, and that is the point

`select-ready` 1.4–1.6× → 1.8×, `spawn` 1.6× → 1.9×, `chunk1k` 1.6× → 2.0–3.0×. Those rows were
flattered by a Go side measured over runs too short to be fair. Correcting a benchmark that was
favouring us is worth more than the numbers it costs.

## One thing not explained

G#'s `spawn` is consistently ~20% slower under the new harness (443–449 → 531–541). It is the same row
that regressed unexplainably under #3915's S2 and then recovered on its own. Recorded rather than
rationalised.

## Notes

- The runner's row regex was `$`-anchored; the added elapsed-ms column would have silently stopped it
  parsing. It now accepts both forms.
- No change to `baseline.json` — every median stays null.
- H2 remains **open**. This sidesteps it for the benchmark; it still matters wherever a hot loop inside
  a suspending function does not park, and still needs a Checked JIT to root-cause.
- Closes the loop on #3902's S1, which asked for time-based warm-up.
- ADR-0174 errata 34 says tier is "controlled" — true for callees only. Worth an errata 35 once this
  lands, or an amendment to 34.

Refs #3902, #3901, #3903, ADR-0174 D11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
