### PR TITLE
cs2gs/gsc: analyzer-snippet package split, marker placement, and four ADR-0169 symbol-surface gaps (#3794, #3797)

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -278,13 +278,35 @@ shapes differ (its index node is narrower than C#'s element access). Containment
 in *both* directions keeps the assertion falsifiable — a marker narrower than
 the diagnostic, or on a neighbouring construct, still fails.
 
-**Known limitation: one package per unit.** A G# compilation unit declares a
-single `package`, so a C# snippet spanning several namespaces collapses into the
-first one and namespace-scoped rules (GSA0003, GSA0004) then judge the wrong
-declarations. Fixing it needs a multi-unit verifier (the harness takes one
-source string). Until then the collapse is reported as
-`CS2GS-ANALYZER-SNIPPET`, because a negative test that passes because its
-subject changed namespace is passing for the wrong reason.
+**One package per unit — several units per snippet (issue #3794).** A G#
+compilation unit declares a single `package`, so a C# snippet spanning several
+namespaces has no one-unit rendering: collapsing it into the first package moved
+every declaration, and the namespace-scoped rules then judged the wrong ones —
+GSA0004 found *nothing* in a snippet whose C# original reports four times, and
+GSA0003 reported a false positive on a cache the C# exempts only because of its
+namespace. `SnippetTranslator` therefore emits **one unit per declared package,
+in declaration order**, joined by the `// ---8<--- cs2gs:next-compilation-unit
+---` line, and `GSharpAnalyzerVerifier` splits on that line and compiles the
+units **together** in one compilation. The harness signature is unchanged — it
+still takes one source string, which is what a translated Roslyn harness has in
+hand.
+
+Markers and diagnostics are then compared **per unit**: a diagnostic belongs to
+the unit whose file name it carries, ordering is (unit, span start), and a
+diagnostic reported in the wrong unit fails with that named cause. A source
+containing no separator is one unit, so every hand-written G# analyzer test is
+untouched.
+
+**The one lexical rename (issue #3797).** C#'s predefined type keywords become
+G#'s width-bearing primitive names (ADR-0115 §B.12), which is the only rename
+translation applies *inside* expression text — so the marker
+`[|typeof(int) != type|]` could not be placed on the printed
+`typeof(int32) != type` and was dropped. Placement now retries against the
+marker re-spelled from its own `PredefinedTypeSyntax` nodes (never by text
+substitution, so an identifier that merely contains the letters is untouched),
+with the ordinal measured in the equally re-spelled source so a repeated marker
+still lands on the right occurrence. A marker that still cannot be placed stays
+loud.
 
 ## Project and consumer transform
 
@@ -388,6 +410,54 @@ Order: GSA0001 → GSA0003 → GSA0004 → GSA0002 → GSA0005; harness and pari
   (`Adr0169Gsa0005ParityTests`), which is what stops a rule that quietly stops
   firing from passing again: its negatives share one parameterised path with
   positives that demand a diagnostic.
+
+  **The last four (2026-09-04, issues #3794 / #3797).** Re-measured on the
+  whole-repository gate, `test/InternalAnalyzers.Tests` was **3 failing / 15
+  passing of 18**, not four: #3796 had already been cleared by #3847's field
+  source locations. The three that remained were two causes — and clearing
+  them exposed three more, every one of them a FRAMEWORK gap rather than a
+  translation one, in the same family as #3795:
+
+  1. **Package collapse (#3794, ×2).** Fixed by emitting one compilation unit
+     per declared package and teaching the verifier to compile them together
+     (see §Test-harness above).
+  2. **Marker rename (#3797, ×1).** Fixed by retrying placement against the
+     predefined-type re-spelling.
+  3. **`ImportedTypeSymbol.ConstructedTypeArguments` was CLR-derived**, and a
+     generic over a same-compilation user type is type-erased to
+     `Dictionary<object, object>` — so GSA0004 saw `System.Object` for every
+     cache key and matched nothing. It now prefers the symbolic arguments.
+  4. **`TupleTypeSymbol` did not implement `IsTupleType`/`TupleElements`**, so
+     a tuple key looked like a type with no components.
+  5. **`IArrayTypeSymbol` mapped to `ArrayTypeSymbol`** — G#'s fixed-length
+     `[N]T`, a shape cs2gs never emits. C# `T[]` translates to the slice `[]T`,
+     so the map now names `SliceTypeSymbol`.
+  6. **`PropertySymbol.Location` spanned the whole declaration**, swallowing
+     the marker; it now points at the identifier, as #3847 already did for
+     fields.
+
+  Note what (3)–(5) have in common: each made a structural walk return `false`
+  early, and each therefore presented as *silence*. That is why the regression
+  tests (`Issue3794AnalyzerSnippetPackageSplitTests`) put the positive and
+  negative snippets of GSA0003 **and** GSA0004 on one parameterised path that
+  translates the real analyzer, compiles it with the real G# compiler, loads it,
+  and runs it through the real verifier: a rule that stops reporting fails the
+  positives instead of passing the negatives.
+
+  Whole-repository gate on the same tree: `test/InternalAnalyzers.Tests`
+  test-parity **3 failing / 15 passing → 1 failing / 17 passing of 18**
+  (translate, compile and ILVerify stay PASS on both sides).
+
+  **The one that remains is #3920**, and clearing #3797 is what exposed it: with
+  the third marker finally placed, `ReflectionTypeComparisonAnalyzerTests.
+  ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces` gets past the
+  marker/id count check and GSA0002 then reports **nothing**. `OperationKindMap`
+  maps each Roslyn operation kind to ONE G# bound-node kind, but a `==` over
+  IMPORTED operands binds to `BoundClrBinaryOperatorExpression` and a call to an
+  imported method to `BoundImportedCallExpression` — so the registrations the
+  translation emits (`BinaryExpression`, `CallExpression`) are dispatched zero
+  times for exactly the reflection-`Type` code the rule exists to police. The map
+  has to become one-to-many, and the handler shape has to accept both nodes.
 - **M6 Parity + self-migration** — `AnalyzerParityStage`; extend the
   Issue3347-style self-migration ratchet to translate
   `InternalAnalyzers.csproj` live. Exit criterion: all five translated

--- a/src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/GSharpAnalyzerVerifier.cs
+++ b/src/Analyzers/GSharp.CodeAnalysis.Analyzers.Testing/GSharpAnalyzerVerifier.cs
@@ -2,6 +2,7 @@
 // Copyright (C) GSharp Authors. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -28,10 +29,39 @@ namespace GSharp.CodeAnalysis.Analyzers.Testing;
 public static class GSharpAnalyzerVerifier
 {
     /// <summary>
+    /// The line that separates one G# compilation unit from the next inside a
+    /// single <c>markedSource</c> string (issue #3794).
+    ///
+    /// <para>
+    /// A G# compilation unit declares exactly ONE <c>package</c>, so a C#
+    /// analyzer-test snippet spanning several namespaces has no single-unit
+    /// G# rendering: collapsing it into the first package silently moves every
+    /// declaration, and a namespace-scoped rule (GSA0003, GSA0004) then judges
+    /// the wrong ones — which is how the migrated
+    /// <c>ReportsSymbolKeyedReferenceCachesWithoutRemapScope</c> detected
+    /// nothing at all and the migrated
+    /// <c>IgnoresTypeSymbolsInstanceCachesTuplesAndNonMetadataNamespaces</c>
+    /// reported a false positive. The harness signature stays "one source
+    /// string" — it is what a translated Roslyn harness has in hand — and the
+    /// string carries the unit boundaries explicitly instead.
+    /// </para>
+    ///
+    /// <para>
+    /// Markers and diagnostics are compared per unit: a diagnostic belongs to
+    /// the unit whose file name it carries, and ordering is
+    /// (unit, span start), so a rule that fires in the wrong package fails
+    /// exactly as it should.
+    /// </para>
+    /// </summary>
+    public const string UnitSeparator = "// ---8<--- cs2gs:next-compilation-unit ---";
+
+    /// <summary>
     /// Compiles <paramref name="markedSource"/> (after stripping the
     /// <c>[|…|]</c> markers), runs <paramref name="analyzer"/> over it, and
     /// asserts the produced diagnostics match the markers and
-    /// <paramref name="diagnosticIds"/>.
+    /// <paramref name="diagnosticIds"/>. A source containing
+    /// <see cref="UnitSeparator"/> lines compiles as several compilation
+    /// units in one compilation.
     /// </summary>
     /// <param name="analyzer">The analyzer under test.</param>
     /// <param name="markedSource">G# source with expected-diagnostic markers.</param>
@@ -45,21 +75,29 @@ public static class GSharpAnalyzerVerifier
         string markedSource,
         params string[] diagnosticIds)
     {
+        IReadOnlyList<string> markedUnits = SplitUnits(markedSource);
         var expectedLocations = new List<MarkerSpan>();
-        var cleanSource = StripMarkers(markedSource, expectedLocations);
+        var trees = new List<SyntaxTree>(markedUnits.Count);
+        for (var unit = 0; unit < markedUnits.Count; unit++)
+        {
+            var unitMarkers = new List<MarkerSpan>();
+            var cleanSource = StripMarkers(markedUnits[unit], unitMarkers, unit);
 
-        // Markers are recorded when they CLOSE, so a nested pair would land out
-        // of order; produced diagnostics are compared in span order.
-        expectedLocations.Sort((left, right) => left.Start.CompareTo(right.Start));
+            // Markers are recorded when they CLOSE, so a nested pair would land
+            // out of order; produced diagnostics are compared in span order.
+            unitMarkers.Sort((left, right) => left.Start.CompareTo(right.Start));
+            expectedLocations.AddRange(unitMarkers);
+            trees.Add(SyntaxTree.Parse(SourceText.From(cleanSource, UnitFileName(unit))));
+        }
+
         if (expectedLocations.Count != diagnosticIds.Length)
         {
             throw new GSharpAnalyzerVerificationException(
                 $"The source contains {expectedLocations.Count} [|…|] marker(s) but {diagnosticIds.Length} diagnostic ID(s) were supplied.");
         }
 
-        var tree = SyntaxTree.Parse(SourceText.From(cleanSource, "test.gs"));
-        var compilation = new Core.CodeAnalysis.Compilation.Compilation(tree);
-        var compileErrors = tree.Diagnostics
+        var compilation = new Core.CodeAnalysis.Compilation.Compilation(trees.ToArray());
+        var compileErrors = trees.SelectMany(t => t.Diagnostics)
             .Concat(compilation.GlobalScope.Diagnostics)
             .Concat(compilation.BoundProgram.Diagnostics)
             .Where(d => d.IsError)
@@ -72,7 +110,8 @@ public static class GSharpAnalyzerVerifier
 
         var produced = GSharpAnalyzerDriver
             .Run(compilation, ImmutableArray.Create(analyzer))
-            .OrderBy(d => d.Location.Span.Start)
+            .OrderBy(d => UnitOf(d, markedUnits.Count))
+            .ThenBy(d => d.Location.Span.Start)
             .ToImmutableArray();
 
         if (!produced.Select(d => d.Id).SequenceEqual(diagnosticIds))
@@ -93,15 +132,19 @@ public static class GSharpAnalyzerVerifier
                     + "on a symbol must attribute the diagnostic to one of its declaring syntax nodes.");
             }
 
+            var actualUnit = UnitOf(produced[i], markedUnits.Count);
             var actualStart = produced[i].Location.Span.Start;
             var actualEnd = produced[i].Location.Span.End;
-            if (actualStart < expected.Start || actualEnd > expected.End)
+            if (actualUnit != expected.Unit || actualStart < expected.Start || actualEnd > expected.End)
             {
                 var actualLine = produced[i].Location.StartLine + 1;
                 var actualColumn = produced[i].Location.StartCharacter + 1;
+                var where = markedUnits.Count == 1
+                    ? string.Empty
+                    : $" in compilation unit {actualUnit} (expected unit {expected.Unit})";
                 throw new GSharpAnalyzerVerificationException(
                     $"Diagnostic {i} ({produced[i].Id}) spans [{actualStart}..{actualEnd}) — reported at "
-                    + $"({actualLine},{actualColumn}) — which is not inside the marked region "
+                    + $"({actualLine},{actualColumn}){where} — which is not inside the marked region "
                     + $"[{expected.Start}..{expected.End}) starting at ({expected.Line},{expected.Column}).");
             }
         }
@@ -110,9 +153,72 @@ public static class GSharpAnalyzerVerifier
     private static string Format(Diagnostic diagnostic)
         => diagnostic.Location.Text is null
             ? $"{diagnostic.Id}: {diagnostic.Message}"
-            : $"{diagnostic.Id} at ({diagnostic.Location.StartLine + 1},{diagnostic.Location.StartCharacter + 1}): {diagnostic.Message}";
+            : $"{diagnostic.Id} at {diagnostic.Location.FileName}({diagnostic.Location.StartLine + 1},{diagnostic.Location.StartCharacter + 1}): {diagnostic.Message}";
 
-    private static string StripMarkers(string source, List<MarkerSpan> expectedLocations)
+    /// <summary>The file name of the <paramref name="unit"/>-th compilation unit.</summary>
+    /// <param name="unit">The zero-based unit index.</param>
+    /// <returns>The synthetic file name.</returns>
+    private static string UnitFileName(int unit) => unit == 0 ? "test.gs" : $"test{unit}.gs";
+
+    /// <summary>
+    /// Which compilation unit <paramref name="diagnostic"/> was reported in.
+    /// A diagnostic with no location sorts last so the marker loop can name it
+    /// as location-less rather than mis-ordering the comparison.
+    /// </summary>
+    /// <param name="diagnostic">The produced diagnostic.</param>
+    /// <param name="unitCount">How many units the source declared.</param>
+    /// <returns>The zero-based unit index, or <paramref name="unitCount"/>.</returns>
+    private static int UnitOf(Diagnostic diagnostic, int unitCount)
+    {
+        if (diagnostic.Location.Text is null)
+        {
+            return unitCount;
+        }
+
+        for (var unit = 0; unit < unitCount; unit++)
+        {
+            if (string.Equals(diagnostic.Location.FileName, UnitFileName(unit), StringComparison.Ordinal))
+            {
+                return unit;
+            }
+        }
+
+        return unitCount;
+    }
+
+    /// <summary>
+    /// Splits <paramref name="markedSource"/> on <see cref="UnitSeparator"/>
+    /// lines. A source with no separator is one unit, which is every
+    /// hand-written G# analyzer test.
+    /// </summary>
+    /// <param name="markedSource">The marked source.</param>
+    /// <returns>One entry per compilation unit, in source order.</returns>
+    private static IReadOnlyList<string> SplitUnits(string markedSource)
+    {
+        if (markedSource is null || markedSource.IndexOf(UnitSeparator, StringComparison.Ordinal) < 0)
+        {
+            return new[] { markedSource ?? string.Empty };
+        }
+
+        var units = new List<string>();
+        var current = new StringBuilder();
+        foreach (var line in markedSource.Split('\n'))
+        {
+            if (line.Trim().Equals(UnitSeparator, StringComparison.Ordinal))
+            {
+                units.Add(current.ToString());
+                current.Clear();
+                continue;
+            }
+
+            current.Append(line).Append('\n');
+        }
+
+        units.Add(current.ToString());
+        return units;
+    }
+
+    private static string StripMarkers(string source, List<MarkerSpan> expectedLocations, int unit = 0)
     {
         var result = new StringBuilder(source.Length);
         var open = new Stack<(int Start, int Line, int Column)>();
@@ -133,7 +239,7 @@ public static class GSharpAnalyzerVerifier
                 {
                     (int start, int startLine, int startColumn) = open.Pop();
                     expectedLocations.Add(
-                        new MarkerSpan(start, result.Length, startLine, startColumn));
+                        new MarkerSpan(unit, start, result.Length, startLine, startColumn));
                 }
 
                 i++;
@@ -173,11 +279,12 @@ public static class GSharpAnalyzerVerifier
     /// construct, or on an enclosing one, still fails — while not asserting a
     /// span identity that does not survive translation.
     /// </remarks>
+    /// <param name="Unit">The zero-based compilation unit the marker is in.</param>
     /// <param name="Start">The marked region's start offset in the clean source.</param>
     /// <param name="End">The marked region's end offset in the clean source.</param>
     /// <param name="Line">The 1-based line of the region's first character.</param>
     /// <param name="Column">The 1-based column of the region's first character.</param>
-    private readonly record struct MarkerSpan(int Start, int End, int Line, int Column);
+    private readonly record struct MarkerSpan(int Unit, int Start, int End, int Line, int Column);
 }
 
 /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedTypeSymbol.cs
@@ -103,6 +103,28 @@ public sealed class ImportedTypeSymbol : TypeSymbol
             || a is TupleTypeSymbol { HasNames: true });
 
     /// <summary>
+    /// Gets the type arguments this instantiation was constructed with,
+    /// preferring the SYMBOLIC <see cref="TypeArguments"/> over the CLR ones
+    /// (ADR-0169, issue #3794).
+    ///
+    /// <para>
+    /// The base implementation reads <c>ClrType.GenericTypeArguments</c>, and
+    /// for a generic constructed over a same-compilation user type the CLR
+    /// form is type-ERASED — <c>Dictionary[StructSymbol, MemberReferenceHandle]</c>
+    /// is backed by <c>Dictionary&lt;object, object&gt;</c>. A migrated
+    /// analyzer walking a member's type structure (GSA0004's key/value
+    /// inspection is exactly this) therefore saw <c>System.Object</c> for
+    /// every argument and matched nothing at all — the silent under-reporting
+    /// failure mode #3795 warned about. The symbolic arguments are the ones
+    /// the source actually wrote, so they are what Roslyn's
+    /// <c>INamedTypeSymbol.TypeArguments</c> corresponds to; the erased CLR
+    /// list stays the fallback for a plain imported type that carries none.
+    /// </para>
+    /// </summary>
+    public override ImmutableArray<TypeSymbol> ConstructedTypeArguments =>
+        TypeArguments.IsDefaultOrEmpty ? base.ConstructedTypeArguments : TypeArguments;
+
+    /// <summary>
     /// Gets or creates the imported type symbol for the given CLR type.
     /// </summary>
     /// <param name="type">The CLR type.</param>

--- a/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PropertySymbol.cs
@@ -141,9 +141,23 @@ public sealed class PropertySymbol : Symbol
     /// <summary>Gets the declaring syntax node, or <see langword="null"/> for synthesized properties.</summary>
     public PropertyDeclarationSyntax? Declaration { get; private set; }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Gets the declaring syntax — the property's IDENTIFIER, matching what
+    /// #3847 already does for a field and what Roslyn's
+    /// <c>IPropertySymbol.Locations[0]</c> points at (ADR-0169, issue #3794).
+    ///
+    /// <para>
+    /// A migrated symbol-action analyzer reports at <c>Symbol.Location</c>, and
+    /// the whole declaration spans the accessors and the initializer, so the
+    /// reported span swallowed the marked name and the verifier rejected it as
+    /// not contained in the marker. The name is the construct the diagnostic is
+    /// about; the accessors are not.
+    /// </para>
+    /// </summary>
     public override ImmutableArray<SyntaxNode> DeclaringSyntaxNodes =>
-        Declaration is { } declaration ? ImmutableArray.Create<SyntaxNode>(declaration) : ImmutableArray<SyntaxNode>.Empty;
+        Declaration is { } declaration
+            ? ImmutableArray.Create<SyntaxNode>(declaration.Identifier)
+            : ImmutableArray<SyntaxNode>.Empty;
 
     /// <summary>Gets or sets the synthesized backing field symbol for auto-properties. Null for computed properties.</summary>
     public FieldSymbol? BackingField { get; set; }

--- a/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/TupleTypeSymbol.cs
@@ -53,6 +53,42 @@ public sealed class TupleTypeSymbol : TypeSymbol
     /// <summary>Gets the arity of the tuple.</summary>
     public int Arity => ElementTypes.Length;
 
+    /// <inheritdoc/>
+    public override bool IsTupleType => true;
+
+    /// <summary>
+    /// Gets the positional tuple elements as field symbols — the Roslyn
+    /// <c>INamedTypeSymbol.TupleElements</c> analogue (ADR-0169, issue #3794).
+    ///
+    /// <para>
+    /// Without this override the base returned EMPTY, so a migrated analyzer
+    /// that walks a tuple's elements (GSA0004's cache-key inspection is
+    /// exactly that) saw a tuple with no components and silently concluded
+    /// the key mentioned nothing — reporting nothing at all. Elements are
+    /// named after their declared name where ADR-0172 gives one, and
+    /// <c>Item1..ItemN</c> otherwise, which is what Roslyn does.
+    /// </para>
+    /// </summary>
+    public override ImmutableArray<FieldSymbol> TupleElements
+    {
+        get
+        {
+            var builder = ImmutableArray.CreateBuilder<FieldSymbol>(ElementTypes.Length);
+            for (var i = 0; i < ElementTypes.Length; i++)
+            {
+                string? declared = ElementNames.IsDefaultOrEmpty ? null : ElementNames[i];
+                string elementName = string.IsNullOrEmpty(declared) ? $"Item{i + 1}" : declared;
+                builder.Add(new FieldSymbol(
+                    elementName,
+                    ElementTypes[i],
+                    Accessibility.Public,
+                    isReadOnly: true));
+            }
+
+            return builder.MoveToImmutable();
+        }
+    }
+
     /// <summary>Returns the cached <see cref="TupleTypeSymbol"/> for the given element types.</summary>
     /// <param name="elementTypes">The element types in order.</param>
     /// <returns>The (cached) tuple type symbol.</returns>

--- a/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests.cs
@@ -269,6 +269,89 @@ class Cache([|entries|] int32) {
     }
 
     /// <summary>
+    /// Issue #3794: a marked source may declare several compilation units,
+    /// separated by <see cref="GSharpAnalyzerVerifier.UnitSeparator"/>, and
+    /// they compile TOGETHER — which is the only rendering of a multi-namespace
+    /// analyzer-test snippet that keeps a package-scoped rule judging the
+    /// declarations the C# original meant. Collapsed into one unit, the
+    /// <c>App.Emit</c> field below would sit in <c>App.Symbols</c> and this
+    /// analyzer would report nothing at all.
+    /// </summary>
+    [Fact]
+    public void MultipleUnits_ArePackageScopedIndependently()
+    {
+        GSharpAnalyzerVerifier<EmitPackageFieldAnalyzer>.VerifyAnalyzer(
+            @"package App.Symbols
+
+class SymbolCache {
+    shared {
+        var entries int32
+    }
+}
+" + GSharpAnalyzerVerifier.UnitSeparator + @"
+package App.Emit
+
+class EmitCache {
+    shared {
+        var [|entries|] int32
+    }
+}
+",
+            "TESTGSA0004");
+    }
+
+    /// <summary>
+    /// The companion falsifier: the SAME two units with the marker moved to the
+    /// unit the rule does not police must fail. Without this, a rule that fired
+    /// everywhere — or nowhere — could still satisfy the test above.
+    /// </summary>
+    [Fact]
+    public void MultipleUnits_AMarkerInTheWrongUnit_IsRejected()
+    {
+        var exception = Assert.Throws<GSharpAnalyzerVerificationException>(() =>
+            GSharpAnalyzerVerifier<EmitPackageFieldAnalyzer>.VerifyAnalyzer(
+                @"package App.Symbols
+
+class SymbolCache {
+    shared {
+        var [|entries|] int32
+    }
+}
+" + GSharpAnalyzerVerifier.UnitSeparator + @"
+package App.Emit
+
+class EmitCache {
+    shared {
+        var entries int32
+    }
+}
+",
+                "TESTGSA0004"));
+
+        Assert.Contains("compilation unit", exception.Message, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A source with no separator stays exactly one unit, so every
+    /// hand-written G# analyzer test is unaffected: the package-scoped rule
+    /// sees one package and reports once.
+    /// </summary>
+    [Fact]
+    public void SingleUnit_IsUnaffectedBySeparatorSupport()
+    {
+        GSharpAnalyzerVerifier<EmitPackageFieldAnalyzer>.VerifyAnalyzer(
+            @"package App.Emit
+
+class EmitCache {
+    shared {
+        var [|entries|] int32
+    }
+}
+",
+            "TESTGSA0004");
+    }
+
+    /// <summary>
     /// The G# analogue of GSA0001: direct index reads of a member named
     /// <c>structFieldDefs</c> outside <c>ResolveFieldToken</c> /
     /// <c>ResolveInterfaceFieldToken</c> are flagged. Uses
@@ -349,6 +432,41 @@ class Cache([|entries|] int32) {
         private static void Report(SyntaxNodeAnalysisContext context)
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, default(GSharp.Core.CodeAnalysis.Text.TextLocation)));
+        }
+    }
+
+    /// <summary>
+    /// A package-scoped analogue of GSA0003/GSA0004: reports every field
+    /// declared in package <c>App.Emit</c>, and only there. Issue #3794's
+    /// discrimination witness — its answer changes when a declaration's package
+    /// changes, which is exactly what collapsing several units into one did.
+    /// </summary>
+    [GSharpDiagnosticAnalyzer]
+    public sealed class EmitPackageFieldAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA0004",
+            "Field in the Emit package",
+            "Field is declared in the Emit package.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSymbolAction(
+                ctx =>
+                {
+                    if (ctx.Symbol.ContainingNamespace == "App.Emit")
+                    {
+                        ctx.ReportDiagnostic(Diagnostic.Create(Rule, ctx.Symbol.Location));
+                    }
+                },
+                GSharp.Core.CodeAnalysis.Symbols.SymbolKind.Field);
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
@@ -9,6 +9,9 @@ using System.Linq;
 using System.Text;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Cs2Gs.Translator.Analyzers;
 
@@ -31,6 +34,16 @@ public static class SnippetTranslator
 {
     /// <summary>The diagnostic id carried by unplaceable-marker warnings.</summary>
     public const string SnippetDiagnosticId = "CS2GS-ANALYZER-SNIPPET";
+
+    /// <summary>
+    /// The line separating one emitted G# compilation unit from the next
+    /// (issue #3794). MUST equal
+    /// <c>GSharpAnalyzerVerifier.UnitSeparator</c>, which is what splits it
+    /// back apart; <c>Issue3794AnalyzerSnippetPackageSplitTests</c> asserts the two
+    /// spellings agree, because cs2gs cannot reference the G# testing assembly
+    /// it emits calls into.
+    /// </summary>
+    public const string UnitSeparator = "// ---8<--- cs2gs:next-compilation-unit ---";
 
     /// <summary>
     /// Translates <paramref name="csharpWithMarkers"/> to a G# snippet with
@@ -58,14 +71,44 @@ public static class SnippetTranslator
                 markedTexts.Select(m => m.Text).ToList());
         }
 
-        var translator = new CSharpToGSharpTranslator();
         LoadedDocument document = project.Documents.Single(d => Path.GetFileName(d.FilePath) == "Snippet.cs");
-        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
-        string printed = GSharpPrinter.Print(translator.TranslateDocument(document, context));
-        diagnostics.AddRange(context.Diagnostics);
-        ReportNamespaceCollapse(document, diagnostics);
+
+        // Issue #3794: one G# compilation unit declares one `package`, so a
+        // snippet spanning several namespaces is emitted as several units
+        // joined by UnitSeparator instead of being collapsed into the first
+        // package. Collapsing silently moved every declaration, which made a
+        // namespace-scoped rule (GSA0003, GSA0004) judge the wrong ones — total
+        // detection loss in one migrated test and a false positive in another.
+        // Unit order is declaration order, which is what lets the ordinal
+        // marker placement below keep working over the concatenation.
+        IReadOnlyList<string> packages = CSharpToGSharpTranslator.GetDeclaredPackages(document);
+        int unitCount = Math.Max(1, packages.Count);
+        var printedUnits = new List<string>(unitCount);
+        for (var unitIndex = 0; unitIndex < unitCount; unitIndex++)
+        {
+            string package = packages.Count > 1 ? packages[unitIndex] : null;
+            var translator = new CSharpToGSharpTranslator(
+                packageFilter: package,
+                includeFileAttributes: unitIndex == 0);
+            var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+            printedUnits.Add(GSharpPrinter.Print(translator.TranslateDocument(document, context)));
+            foreach (TranslationDiagnostic reported in context.Diagnostics)
+            {
+                // The same document is translated once per package, so a
+                // diagnostic about a construct outside every filter is raised
+                // by every unit; report each distinct one once.
+                if (!diagnostics.Any(existing =>
+                        string.Equals(existing.Message, reported.Message, StringComparison.Ordinal)))
+                {
+                    diagnostics.Add(reported);
+                }
+            }
+        }
+
+        string printed = string.Join("\n" + UnitSeparator + "\n", printedUnits);
 
         var unplaced = new List<string>();
+        PredefinedRenaming renaming = PredefinedRenaming.For(document, cleanSource);
 
         // Occurrence-ORDINAL placement (issue #3778). The previous rule —
         // "search forward from the last marker" — silently mis-places a marker
@@ -82,7 +125,47 @@ public static class SnippetTranslator
         foreach (MarkedText marked in markedTexts)
         {
             int ordinal = OccurrenceOrdinal(cleanSource, marked.Text, marked.Start);
-            int index = NthOccurrence(printed, marked.Text, ordinal);
+            int length = marked.Text.Length;
+
+            // Issue #3794: a marker on a DECLARATION's name is placed on a
+            // declaration, never on a use. Plain ordinal placement breaks here
+            // because translation does not preserve occurrence counts: cs2gs
+            // hoists a property initializer into a synthesized constructor, so
+            // the migrated `NullableCtorRefs` occurs twice — assignment first,
+            // declaration second — and the C#'s single occurrence (ordinal 0)
+            // landed on the assignment, moving the expected span off the
+            // property the rule actually reports on. Being a declaration name
+            // is a fact about the C# node, and "is preceded by a declaration
+            // keyword" is the printed G# counterpart, so the two ordinals are
+            // counted over declarations only and agree again.
+            int index = DeclarationOrdinal(document, marked) is { } declarationOrdinal
+                ? NthDeclarationOccurrence(printed, marked.Text, declarationOrdinal)
+                : -1;
+            if (index < 0)
+            {
+                index = NthOccurrence(printed, marked.Text, ordinal);
+            }
+
+            if (index < 0)
+            {
+                // Issue #3797: retry against the ONE lexical rename translation
+                // applies inside expression text — C#'s predefined type
+                // keywords become G#'s width-bearing primitive names, so
+                // `typeof(int) != type` prints as `typeof(int32) != type`.
+                // The renamed candidate is computed from the marked region's
+                // own `PredefinedTypeSyntax` nodes, never by text substitution,
+                // so an identifier that merely contains `int` is untouched, and
+                // its ordinal is measured in the equally renamed source so a
+                // repeated marker still lands on the right occurrence.
+                MarkedText renamed = renaming.Rename(marked);
+                if (!string.Equals(renamed.Text, marked.Text, StringComparison.Ordinal))
+                {
+                    int renamedOrdinal = OccurrenceOrdinal(renaming.Source, renamed.Text, renamed.Start);
+                    index = NthOccurrence(printed, renamed.Text, renamedOrdinal);
+                    length = renamed.Text.Length;
+                }
+            }
+
             if (index < 0)
             {
                 unplaced.Add(marked.Text);
@@ -97,7 +180,7 @@ public static class SnippetTranslator
                 continue;
             }
 
-            placements.Add((index, marked.Text.Length));
+            placements.Add((index, length));
         }
 
         var result = new StringBuilder(printed);
@@ -111,46 +194,125 @@ public static class SnippetTranslator
     }
 
     /// <summary>
-    /// A G# compilation unit declares exactly ONE package, so a C# snippet
-    /// spanning several namespaces collapses into the first one — every type
-    /// silently changes namespace, and a namespace-scoped analyzer rule
-    /// (GSA0003, GSA0004) then fires, or fails to fire, on the wrong
-    /// declarations. cs2gs's normal pipeline splits such a file per package;
-    /// a snippet has nowhere to split to because the verifier takes ONE
-    /// source. Surface it as <c>CS2GS-ANALYZER-SNIPPET</c> so the migrated
-    /// test's disagreement has a stated cause rather than looking like an
-    /// analyzer regression.
+    /// When <paramref name="marked"/> covers exactly the identifier a C#
+    /// declaration is NAMED by, the number of same-named declarations earlier
+    /// in the snippet; otherwise <see langword="null"/> (issue #3794).
     /// </summary>
     /// <param name="document">The loaded snippet document.</param>
-    /// <param name="diagnostics">The diagnostic list to append to.</param>
-    private static void ReportNamespaceCollapse(
-        LoadedDocument document,
-        List<TranslationDiagnostic> diagnostics)
+    /// <param name="marked">The marker.</param>
+    /// <returns>The declaration ordinal, or <see langword="null"/>.</returns>
+    private static int? DeclarationOrdinal(LoadedDocument document, MarkedText marked)
     {
-        var names = document.SemanticModel.SyntaxTree.GetRoot()
-            .DescendantNodes()
-            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.BaseNamespaceDeclarationSyntax>()
-            .Select(declaration => declaration.Name.ToString())
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-        if (names.Count < 2)
+        var ordinal = 0;
+        var isDeclarationName = false;
+        foreach (SyntaxToken token in document.GetRoot().DescendantTokens())
         {
-            return;
+            if (!token.IsKind(SyntaxKind.IdentifierToken)
+                || !string.Equals(token.ValueText, marked.Text, StringComparison.Ordinal)
+                || !IsDeclarationName(token))
+            {
+                continue;
+            }
+
+            if (token.Span.Start == marked.Start && token.Span.Length == marked.Text.Length)
+            {
+                isDeclarationName = true;
+                break;
+            }
+
+            ordinal++;
         }
 
-        string message = "the snippet declares " + names.Count + " namespaces ("
-            + string.Join(", ", names)
-            + ") but a G# compilation unit declares one package, so they collapse into '"
-            + names[0] + "'. Namespace-scoped analyzer rules will disagree with the C# "
-            + "expectation; split the test or re-express the snippet in one namespace.";
-        diagnostics.Add(new TranslationDiagnostic(
-            "analyzer-snippet",
-            message,
-            location: null,
-            TranslationSeverity.Warning)
+        return isDeclarationName ? ordinal : null;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="token"/> is the identifier that names its
+    /// declaration — a field/local declarator, a property, a method, a type,
+    /// a parameter, or an enum member.
+    /// </summary>
+    /// <param name="token">The candidate identifier token.</param>
+    /// <returns>True when the token names a declaration.</returns>
+    private static bool IsDeclarationName(SyntaxToken token) =>
+        token.Parent switch
         {
-            DiagnosticId = SnippetDiagnosticId,
-        });
+            VariableDeclaratorSyntax declarator => declarator.Identifier == token,
+            PropertyDeclarationSyntax property => property.Identifier == token,
+            MethodDeclarationSyntax method => method.Identifier == token,
+            BaseTypeDeclarationSyntax type => type.Identifier == token,
+            ParameterSyntax parameter => parameter.Identifier == token,
+            EnumMemberDeclarationSyntax member => member.Identifier == token,
+            _ => false,
+        };
+
+    /// <summary>
+    /// The index of the <paramref name="ordinal"/>-th (zero-based) occurrence
+    /// of <paramref name="text"/> in <paramref name="source"/> that is spelled
+    /// as a G# DECLARATION name — a whole word immediately preceded, on the
+    /// same line, by a declaration keyword — or -1.
+    /// </summary>
+    /// <param name="source">The printed G#.</param>
+    /// <param name="text">The declaration name.</param>
+    /// <param name="ordinal">The zero-based declaration occurrence to find.</param>
+    /// <returns>The index, or -1.</returns>
+    private static int NthDeclarationOccurrence(string source, string text, int ordinal)
+    {
+        var seen = 0;
+        for (int i = source.IndexOf(text, StringComparison.Ordinal);
+             i >= 0;
+             i = source.IndexOf(text, i + text.Length, StringComparison.Ordinal))
+        {
+            if (!IsWholeWord(source, i, text.Length) || !FollowsDeclarationKeyword(source, i))
+            {
+                continue;
+            }
+
+            if (seen == ordinal)
+            {
+                return i;
+            }
+
+            seen++;
+        }
+
+        return -1;
+    }
+
+    private static bool IsWholeWord(string source, int index, int length)
+        => (index == 0 || !IsIdentifierChar(source[index - 1]))
+            && (index + length >= source.Length || !IsIdentifierChar(source[index + length]));
+
+    private static bool IsIdentifierChar(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '$';
+
+    // The G# keyword that introduces a declaration name, read backwards from
+    // the name over the spaces that separate them. Modifiers (`private`,
+    // `shared`) sit BEFORE the keyword, so only the immediately preceding word
+    // matters.
+    private static bool FollowsDeclarationKeyword(string source, int index)
+    {
+        int end = index;
+        while (end > 0 && source[end - 1] == ' ')
+        {
+            end--;
+        }
+
+        int start = end;
+        while (start > 0 && IsIdentifierChar(source[start - 1]))
+        {
+            start--;
+        }
+
+        if (start == end)
+        {
+            return false;
+        }
+
+        return source.Substring(start, end - start) switch
+        {
+            "let" or "var" or "const" or "prop" or "func" or "class" or "struct"
+                or "interface" or "enum" or "type" or "data" => true,
+            _ => false,
+        };
     }
 
     /// <summary>
@@ -230,4 +392,110 @@ public static class SnippetTranslator
     /// <param name="Text">The marked text.</param>
     /// <param name="Start">The offset of the marked text in the stripped source.</param>
     private readonly record struct MarkedText(string Text, int Start);
+
+    /// <summary>
+    /// Issue #3797: the C# snippet re-spelled with G#'s predefined type names
+    /// (<c>int</c> → <c>int32</c>, <c>float</c> → <c>float32</c>, …), plus the
+    /// offset map that carries a marker from the C# text to that re-spelling.
+    ///
+    /// <para>
+    /// This is the one lexical rename translation applies INSIDE expression
+    /// text, and it is the reason ordered exact-text marker placement drops an
+    /// otherwise perfectly survivable marker. Replacements come from the C#
+    /// tree's <c>PredefinedTypeSyntax</c> nodes, so nothing that merely
+    /// contains the keyword's letters is rewritten.
+    /// </para>
+    /// </summary>
+    private sealed class PredefinedRenaming
+    {
+        private readonly List<(int Start, int End, int Delta)> deltas = new();
+
+        private PredefinedRenaming(string source) => this.Source = source;
+
+        /// <summary>Gets the renamed source.</summary>
+        public string Source { get; }
+
+        /// <summary>
+        /// Builds the renaming for <paramref name="document"/>.
+        /// </summary>
+        /// <param name="document">The loaded snippet document.</param>
+        /// <param name="cleanSource">The marker-free C# source.</param>
+        /// <returns>The renaming.</returns>
+        public static PredefinedRenaming For(LoadedDocument document, string cleanSource)
+        {
+            var replacements = new List<(int Start, int Length, string Text)>();
+            foreach (PredefinedTypeSyntax predefined in document.GetRoot()
+                .DescendantNodes()
+                .OfType<PredefinedTypeSyntax>())
+            {
+                ITypeSymbol type = document.SemanticModel.GetTypeInfo(predefined).Type;
+                if (type is null
+                    || CSharpTypeMapper.GetPredefinedName(type.SpecialType) is not { } name
+                    || string.Equals(name, predefined.Keyword.ValueText, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                replacements.Add((predefined.Span.Start, predefined.Span.Length, name));
+            }
+
+            replacements.Sort((left, right) => left.Start.CompareTo(right.Start));
+
+            var builder = new StringBuilder(cleanSource.Length);
+            var pending = new List<(int Start, int End, int Delta)>();
+            var copied = 0;
+            var delta = 0;
+            foreach ((int start, int length, string text) in replacements)
+            {
+                if (start < copied)
+                {
+                    continue;
+                }
+
+                builder.Append(cleanSource, copied, start - copied);
+                builder.Append(text);
+                copied = start + length;
+                delta += text.Length - length;
+                pending.Add((start, copied, delta));
+            }
+
+            builder.Append(cleanSource, copied, cleanSource.Length - copied);
+            var renaming = new PredefinedRenaming(builder.ToString());
+            renaming.deltas.AddRange(pending);
+            return renaming;
+        }
+
+        /// <summary>
+        /// Carries <paramref name="marked"/> into the renamed source: its text
+        /// re-spelled, and its start offset shifted.
+        /// </summary>
+        /// <param name="marked">The marker as it appears in the C# source.</param>
+        /// <returns>The marker as it appears in the renamed source.</returns>
+        public MarkedText Rename(MarkedText marked)
+        {
+            int start = this.Shift(marked.Start);
+            int end = this.Shift(marked.Start + marked.Text.Length);
+            return new MarkedText(this.Source.Substring(start, end - start), start);
+        }
+
+        // The renamed offset of a C# offset: shifted by every replacement that
+        // ENDS at or before it, so an offset inside a replacement (which a
+        // marker boundary never is — a marker wraps whole nodes) maps to the
+        // replacement's own start.
+        private int Shift(int offset)
+        {
+            var delta = 0;
+            foreach ((int Start, int End, int Delta) entry in this.deltas)
+            {
+                if (entry.End > offset)
+                {
+                    break;
+                }
+
+                delta = entry.Delta;
+            }
+
+            return offset + delta;
+        }
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169TranslatedAnalyzerHarness.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169TranslatedAnalyzerHarness.cs
@@ -40,14 +40,41 @@ public static class DiagnosticDescriptors
     /// <param name="workDirectory">The directory receiving the emitted dll.</param>
     /// <returns>The analyzer assembly path.</returns>
     public static string CompileTranslatedGsa0001(string workDirectory)
+        => CompileTranslatedAnalyzer(
+            workDirectory,
+            "StructFieldDefsReadAnalyzer.cs",
+            "TranslatedGsa0001",
+            Gsa0001Descriptors);
+
+    /// <summary>
+    /// Translates and compiles one REAL analyzer from
+    /// <c>src/Analyzers/InternalAnalyzers</c> into an analyzer assembly, using
+    /// the repository's own <c>DiagnosticDescriptors.cs</c> unless a stand-in
+    /// is supplied. Generalized for issue #3794 so GSA0003 and GSA0004 — the
+    /// two namespace-scoped rules whose migrated tests the snippet
+    /// package-split fixes — can be executed here, not merely translated.
+    /// </summary>
+    /// <param name="workDirectory">The directory receiving the emitted dll.</param>
+    /// <param name="analyzerFileName">The analyzer source file name.</param>
+    /// <param name="assemblyName">The emitted assembly name.</param>
+    /// <param name="descriptorSource">A descriptor stand-in, or null for the real table.</param>
+    /// <returns>The analyzer assembly path.</returns>
+    public static string CompileTranslatedAnalyzer(
+        string workDirectory,
+        string analyzerFileName,
+        string assemblyName,
+        string descriptorSource = null)
     {
-        string analyzerSource = File.ReadAllText(Path.Combine(
-            FindRepoRoot(), "src", "Analyzers", "InternalAnalyzers", "StructFieldDefsReadAnalyzer.cs"));
+        string analyzerDirectory = Path.Combine(
+            FindRepoRoot(), "src", "Analyzers", "InternalAnalyzers");
+        string analyzerSource = File.ReadAllText(Path.Combine(analyzerDirectory, analyzerFileName));
+        string descriptors = descriptorSource
+            ?? File.ReadAllText(Path.Combine(analyzerDirectory, "DiagnosticDescriptors.cs"));
 
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
         {
-            ("StructFieldDefsReadAnalyzer.cs", analyzerSource),
-            ("DiagnosticDescriptors.cs", Gsa0001Descriptors),
+            (analyzerFileName, analyzerSource),
+            ("DiagnosticDescriptors.cs", descriptors),
         });
         Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
         Assert.True(AnalyzerProjectDetector.IsAnalyzerProject(project.Compilation));
@@ -70,16 +97,16 @@ public static class DiagnosticDescriptors
         var compilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(resolver, trees.ToArray())
         {
             IsLibrary = true,
-            AssemblyName = "TranslatedGsa0001",
+            AssemblyName = assemblyName,
         };
 
-        string dllPath = Path.Combine(workDirectory, "TranslatedGsa0001.dll");
+        string dllPath = Path.Combine(workDirectory, assemblyName + ".dll");
         using (var peStream = File.Create(dllPath))
         {
-            var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: "TranslatedGsa0001");
+            var result = compilation.Emit(peStream, pdbStream: null, refStream: null, assemblyName: assemblyName);
             Assert.True(
                 result.Success,
-                "Translated GSA0001 should compile:\n" + string.Join("\n", result.Diagnostics.Where(d => d.IsError).Select(d => d.Message)));
+                $"Translated {assemblyName} should compile:\n" + string.Join("\n", result.Diagnostics.Where(d => d.IsError).Select(d => d.Message)));
         }
 
         return dllPath;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3778AnalyzerSnippetDispatchTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3778AnalyzerSnippetDispatchTests.cs
@@ -235,14 +235,13 @@ class Holder
 
     /// <summary>
     /// A C# snippet spanning several namespaces cannot become one G# unit — G#
-    /// declares one package per compilation unit — so the declarations collapse
-    /// into the first namespace and a namespace-scoped rule then fires, or
-    /// fails to fire, on the wrong ones. Left unfixed (it needs a multi-unit
-    /// verifier), but it must be REPORTED: a negative test that passes because
-    /// its subject moved namespace is passing for the wrong reason.
+    /// declares one package per compilation unit. It used to collapse into the
+    /// first namespace, which made a namespace-scoped rule fire, or fail to
+    /// fire, on the wrong declarations; issue #3794 splits it into one unit per
+    /// package instead, and the verifier compiles the units together.
     /// </summary>
     [Fact]
-    public void MultiNamespaceSnippet_ReportsTheCollapse()
+    public void MultiNamespaceSnippet_SplitsIntoOneUnitPerPackage()
     {
         SnippetTranslationResult result = SnippetTranslator.Translate(@"
 namespace One
@@ -256,16 +255,25 @@ namespace Two
 }
 ");
 
+        // Issue #3794: the collapse is no longer REPORTED because it no longer
+        // HAPPENS. Each declared namespace becomes its own compilation unit,
+        // separated by SnippetTranslator.UnitSeparator, and the verifier
+        // compiles them together — so a namespace-scoped rule still judges the
+        // declarations the C# original meant.
         Assert.NotNull(result.GsWithMarkers);
-        Assert.Contains(
+        Assert.DoesNotContain(
             result.Diagnostics,
             d => d.DiagnosticId == SnippetTranslator.SnippetDiagnosticId
                 && d.Message.Contains("collapse", StringComparison.Ordinal));
 
-        // …and the collapse is real, so the report is not decorative.
         Assert.Equal(
-            1,
+            2,
             result.GsWithMarkers.Split("package ", StringSplitOptions.None).Length - 1);
+        Assert.Contains("package One", result.GsWithMarkers, StringComparison.Ordinal);
+        Assert.Contains("package Two", result.GsWithMarkers, StringComparison.Ordinal);
+        Assert.Equal(
+            2,
+            result.GsWithMarkers.Split(SnippetTranslator.UnitSeparator, StringSplitOptions.None).Length);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3794AnalyzerSnippetPackageSplitTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3794AnalyzerSnippetPackageSplitTests.cs
@@ -1,0 +1,405 @@
+// <copyright file="Issue3794AnalyzerSnippetPackageSplitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.Translator.Analyzers;
+using GSharp.CodeAnalysis.Analyzers.Testing;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Analyzers;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// ADR-0169 M5, issues #3794 and #3797: the two remaining ways a migrated
+/// <c>InternalAnalyzers.Tests</c> case disagreed with its C# original.
+///
+/// <para>
+/// <b>#3794 — package collapse.</b> A G# compilation unit declares exactly one
+/// <c>package</c>. Emitting a multi-namespace C# snippet as ONE unit moved
+/// every declaration into the first package, so the two namespace-scoped rules
+/// judged the wrong ones: GSA0004 found nothing at all in a snippet whose C#
+/// original reports four times, and GSA0003 reported a false positive on a
+/// declaration the C# exempts precisely because it lives in a different
+/// namespace. The snippet is now emitted as one unit per package and the
+/// verifier compiles them together.
+/// </para>
+///
+/// <para>
+/// <b>#3797 — the one lexical rename.</b> C#'s predefined type keywords become
+/// G#'s width-bearing primitive names, so a marker reading
+/// <c>typeof(int) != type</c> could not be re-placed on the printed
+/// <c>typeof(int32) != type</c> and was dropped, leaving the migrated test with
+/// two markers and three ids.
+/// </para>
+///
+/// <para>
+/// Every assertion here EXECUTES: the real analyzer is translated, compiled by
+/// the real G# compiler, loaded, and run through the real
+/// <see cref="GSharpAnalyzerVerifier"/> over the translated snippet — the exact
+/// path the migrated test takes. Positives and negatives share that one path,
+/// so an analyzer that quietly stopped reporting fails the positive cases
+/// instead of passing the negative ones (the #3795 failure mode).
+/// </para>
+/// </summary>
+public sealed class Issue3794AnalyzerSnippetPackageSplitTests : IDisposable
+{
+    // The real Prelude + positive snippet from
+    // EmitCacheKeyRemapScopeAnalyzerTests.ReportsSymbolKeyedReferenceCachesWithoutRemapScope:
+    // three namespaces, four expected GSA0004 diagnostics, all in the third.
+    private const string Gsa0004Prelude = """
+using System.Collections.Generic;
+
+namespace System.Reflection.Metadata
+{
+    public struct EntityHandle { }
+    public struct MemberReferenceHandle { }
+    public struct TypeSpecificationHandle { }
+    public struct MethodSpecificationHandle { }
+    public struct TypeDefinitionHandle { }
+    public struct MethodDefinitionHandle { }
+    public struct FieldDefinitionHandle { }
+}
+
+namespace GSharp.Core.CodeAnalysis.Symbols
+{
+    public class TypeSymbol { }
+    public class StructSymbol { }
+    public class TypeParameterSymbol { }
+    public class FunctionSymbol { }
+}
+
+
+""";
+
+    private const string Gsa0004Positive = Gsa0004Prelude + """
+namespace GSharp.Core.CodeAnalysis.Emit
+{
+    using System.Reflection.Metadata;
+    using GSharp.Core.CodeAnalysis.Symbols;
+
+    internal readonly struct RemapScope { }
+
+    internal readonly struct BadCompositeKey
+    {
+        private readonly TypeSymbol[] typeArgs;
+
+        public BadCompositeKey(TypeSymbol[] typeArgs) => this.typeArgs = typeArgs;
+    }
+
+    internal sealed class Caches
+    {
+        private readonly Dictionary<StructSymbol, MemberReferenceHandle> [|plainSymbolCache|] = new();
+        private readonly Dictionary<(StructSymbol Sym, object ClassRemap, object MethodRemap), EntityHandle> [|objectTupleCache|] = new();
+        private readonly Dictionary<BadCompositeKey, MethodSpecificationHandle> [|compositeKeyCache|] = new();
+
+        public Dictionary<TypeParameterSymbol, MemberReferenceHandle> [|NullableCtorRefs|] { get; } = new();
+    }
+}
+""";
+
+    // The real negative snippet from the same class. Under package collapse it
+    // passed VACUOUSLY — every declaration had left the Emit package, so
+    // silence proved nothing. Split, it is a real exemption test again.
+    private const string Gsa0004Negative = Gsa0004Prelude + """
+namespace GSharp.Core.CodeAnalysis.Emit
+{
+    using System.Reflection.Metadata;
+    using GSharp.Core.CodeAnalysis.Symbols;
+
+    internal readonly struct RemapScope { }
+
+    internal readonly struct ScopedCompositeKey
+    {
+        private readonly TypeSymbol[] typeArgs;
+        private readonly RemapScope scope;
+
+        public ScopedCompositeKey(TypeSymbol[] typeArgs, RemapScope scope)
+        {
+            this.typeArgs = typeArgs;
+            this.scope = scope;
+        }
+    }
+
+    internal sealed class Caches
+    {
+        // Key carries the remap scope: the invariant is satisfied.
+        private readonly Dictionary<(StructSymbol Sym, RemapScope Scope), EntityHandle> scopedTupleCache = new();
+        private readonly Dictionary<ScopedCompositeKey, MethodSpecificationHandle> scopedCompositeCache = new();
+
+        // Definition rows are scope-invariant: one row per symbol.
+        private readonly Dictionary<StructSymbol, TypeDefinitionHandle> typeDefCache = new();
+        private readonly Dictionary<FunctionSymbol, MethodDefinitionHandle> methodDefCache = new();
+
+        // Non-symbol keys carry no symbolic type parameters.
+        private readonly Dictionary<string, MemberReferenceHandle> stringKeyedCache = new();
+
+        // Non-handle values are not metadata rows.
+        private readonly Dictionary<FunctionSymbol, TypeParameterSymbol[]> symbolToSymbolsCache = new();
+
+        public Dictionary<(TypeParameterSymbol Tp, RemapScope Scope), MemberReferenceHandle> ScopedProperty { get; } = new();
+    }
+}
+
+namespace GSharp.Core.CodeAnalysis.Binding
+{
+    using System.Reflection.Metadata;
+    using GSharp.Core.CodeAnalysis.Symbols;
+
+    // Outside the Emit namespace: not this rule's concern.
+    internal sealed class OtherLayer
+    {
+        private readonly Dictionary<StructSymbol, MemberReferenceHandle> notEmit = new();
+    }
+}
+""";
+
+    // The real positive snippet from
+    // StrongStaticReflectionCacheAnalyzerTests.ReportsStaticTypeAssemblyAndModuleDictionaryKeys.
+    private const string Gsa0003Positive = """
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace GSharp.Core.CodeAnalysis.Symbols;
+
+class C
+{
+    private static readonly Dictionary<Type, string> [|TypeCache|] = new();
+    private static readonly ConcurrentDictionary<Assembly, string> [|AssemblyCache|] = new();
+    private static readonly Dictionary<Module, string> [|ModuleCache|] = new();
+}
+""";
+
+    // The real negative snippet from the same class: the last cache is exempt
+    // ONLY because it lives in a non-metadata namespace, which is exactly what
+    // package collapse destroyed.
+    private const string Gsa0003Negative = """
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace GSharp.Core.CodeAnalysis.Symbols
+{
+    class TypeSymbol { }
+    class C
+    {
+        private static readonly ConcurrentDictionary<TypeSymbol, string> SymbolCache = new();
+        private static readonly ConcurrentDictionary<(Type Source, Type Target), string> TupleCache = new();
+        private readonly Dictionary<Type, string> InstanceCache = new();
+    }
+}
+
+namespace GSharp.Core.CodeAnalysis.Syntax
+{
+    class SyntaxCache
+    {
+        private static readonly ConcurrentDictionary<Type, string> ChildAccessorsByType = new();
+    }
+}
+""";
+
+    // The real positive snippet from
+    // ReflectionTypeComparisonAnalyzerTests.ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces:
+    // the middle marker is the one #3797 dropped.
+    private const string Gsa0002Positive = """
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Binding
+{
+    class C
+    {
+        bool EqualsTypeof(Type type) => [|type == typeof(string)|];
+        bool NotEqualsTypeof(Type type) => [|typeof(int) != type|];
+        bool ReferenceEqualsTypeof(Type type) => [|ReferenceEquals(type, typeof(string))|];
+    }
+}
+""";
+
+    private readonly DirectoryInfo workDirectory =
+        Directory.CreateTempSubdirectory("cs2gs-snippet-package-split");
+
+    public void Dispose()
+    {
+        try
+        {
+            workDirectory.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The producer and the consumer of the unit boundary must spell it
+    /// identically; cs2gs cannot reference the G# testing assembly it emits
+    /// calls into, so the two constants are checked against each other here.
+    /// </summary>
+    [Fact]
+    public void UnitSeparator_IsSpelledIdenticallyOnBothSides()
+        => Assert.Equal(GSharpAnalyzerVerifier.UnitSeparator, SnippetTranslator.UnitSeparator);
+
+    /// <summary>
+    /// A multi-namespace snippet becomes one G# compilation unit per package,
+    /// in declaration order, each declaring its own package.
+    /// </summary>
+    [Fact]
+    public void MultiNamespaceSnippet_EmitsOneUnitPerPackage()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(Gsa0004Positive);
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+
+        string[] units = SplitUnits(result.GsWithMarkers);
+        Assert.Equal(3, units.Length);
+        Assert.Contains("package System.Reflection.Metadata", units[0], StringComparison.Ordinal);
+        Assert.Contains("package GSharp.Core.CodeAnalysis.Symbols", units[1], StringComparison.Ordinal);
+        Assert.Contains("package GSharp.Core.CodeAnalysis.Emit", units[2], StringComparison.Ordinal);
+
+        // All four markers belong to the Emit unit, which is the whole point:
+        // before the split they landed in a package the rule does not police.
+        Assert.Equal(4, CountMarkers(units[2]));
+        Assert.Equal(0, CountMarkers(units[0]) + CountMarkers(units[1]));
+    }
+
+    /// <summary>
+    /// A single-namespace snippet is still exactly one unit — the separator
+    /// never appears where it is not needed, so every hand-written G# analyzer
+    /// test and every already-passing migrated one is untouched.
+    /// </summary>
+    [Fact]
+    public void SingleNamespaceSnippet_EmitsNoSeparator()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(Gsa0003Positive);
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.DoesNotContain(SnippetTranslator.UnitSeparator, result.GsWithMarkers, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Issue #3797: the marker whose text carries a predefined type keyword is
+    /// placed on the renamed G# text instead of being dropped, and the other
+    /// two — whose text is unchanged — still place.
+    /// </summary>
+    [Fact]
+    public void PredefinedTypeMarker_IsPlacedAcrossThePrimitiveRename()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(Gsa0002Positive);
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+        Assert.Equal(3, CountMarkers(result.GsWithMarkers));
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            d => d.DiagnosticId == SnippetTranslator.SnippetDiagnosticId
+                && d.Message.Contains("does not survive translation verbatim", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// GSA0004, end to end, positive AND negative on one path: the real
+    /// analyzer, translated and compiled by the real G# compiler, reports
+    /// exactly four diagnostics at exactly the four re-placed markers of the
+    /// split positive snippet — the case that reported NOTHING before the
+    /// split — and stays silent over the split negative one, which before the
+    /// split was silent for the wrong reason.
+    /// </summary>
+    /// <param name="markedSnippet">The C# snippet with its markers.</param>
+    /// <param name="ids">The expected diagnostic ids.</param>
+    [Theory]
+    [MemberData(nameof(Gsa0004Cases))]
+    public void TranslatedGsa0004_AgreesWithTheCSharpExpectation(string markedSnippet, string[] ids)
+        => VerifyTranslated(
+            "EmitCacheKeyRemapScopeAnalyzer.cs",
+            "TranslatedGsa0004",
+            markedSnippet,
+            ids);
+
+    /// <summary>Gets the GSA0004 positive and negative cases.</summary>
+    /// <returns>The theory data.</returns>
+    public static IEnumerable<object[]> Gsa0004Cases()
+    {
+        yield return new object[]
+        {
+            Gsa0004Positive,
+            new[] { "GSA0004", "GSA0004", "GSA0004", "GSA0004" },
+        };
+        yield return new object[] { Gsa0004Negative, Array.Empty<string>() };
+    }
+
+    /// <summary>
+    /// GSA0003, positive AND negative on one path (theory data, one method):
+    /// the positive demands three diagnostics, so an analyzer that has stopped
+    /// reporting cannot pass the negative vacuously, and the negative — whose
+    /// last cache is exempt only because of its namespace — demands silence.
+    /// </summary>
+    /// <param name="markedSnippet">The C# snippet with its markers.</param>
+    /// <param name="ids">The expected diagnostic ids.</param>
+    [Theory]
+    [MemberData(nameof(Gsa0003Cases))]
+    public void TranslatedGsa0003_AgreesWithTheCSharpExpectation(string markedSnippet, string[] ids)
+        => VerifyTranslated(
+            "StrongStaticReflectionCacheAnalyzer.cs",
+            "TranslatedGsa0003",
+            markedSnippet,
+            ids);
+
+    /// <summary>Gets the GSA0003 positive and negative cases.</summary>
+    /// <returns>The theory data.</returns>
+    public static IEnumerable<object[]> Gsa0003Cases()
+    {
+        yield return new object[] { Gsa0003Positive, new[] { "GSA0003", "GSA0003", "GSA0003" } };
+        yield return new object[] { Gsa0003Negative, Array.Empty<string>() };
+    }
+
+    /// <summary>
+    /// Translates <paramref name="markedSnippet"/>, translates and compiles the
+    /// named analyzer, and runs the real verifier over both.
+    /// </summary>
+    /// <param name="analyzerFileName">The analyzer source file name.</param>
+    /// <param name="assemblyName">The emitted analyzer assembly name.</param>
+    /// <param name="markedSnippet">The marked C# snippet.</param>
+    /// <param name="ids">The expected diagnostic ids.</param>
+    private void VerifyTranslated(
+        string analyzerFileName,
+        string assemblyName,
+        string markedSnippet,
+        params string[] ids)
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(markedSnippet);
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+
+        string analyzerDll = Adr0169TranslatedAnalyzerHarness.CompileTranslatedAnalyzer(
+            workDirectory.FullName, analyzerFileName, assemblyName);
+        ImmutableArray<GSharpDiagnosticAnalyzer> analyzers =
+            GSharpAnalyzerHost.Load(new[] { analyzerDll }, out ImmutableArray<Diagnostic> hostDiagnostics);
+        Assert.Empty(hostDiagnostics);
+        GSharpDiagnosticAnalyzer analyzer = Assert.Single(analyzers);
+
+        GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, result.GsWithMarkers, ids);
+    }
+
+    private static string[] SplitUnits(string source)
+        => source.Split(SnippetTranslator.UnitSeparator, StringSplitOptions.None);
+
+    private static int CountMarkers(string source)
+    {
+        var count = 0;
+        for (var i = 0; i + 1 < source.Length; i++)
+        {
+            if (source[i] == '[' && source[i + 1] == '|')
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
@@ -138,7 +138,20 @@ internal static class RoslynAnalyzerApiMap
         ["Microsoft.CodeAnalysis.IParameterSymbol"] = new("GSharp.Core.CodeAnalysis.Symbols", "ParameterSymbol"),
         ["Microsoft.CodeAnalysis.SymbolKind"] = new("GSharp.Core.CodeAnalysis.Symbols", "SymbolKind"),
         ["Microsoft.CodeAnalysis.SymbolEqualityComparer"] = new("GSharp.Core.CodeAnalysis.Symbols", "SymbolEqualityComparer"),
-        ["Microsoft.CodeAnalysis.IArrayTypeSymbol"] = new("GSharp.Core.CodeAnalysis.Symbols", "ArrayTypeSymbol"),
+
+        // Issue #3794: the SLICE, not the fixed-length array. cs2gs translates
+        // C# `T[]` to G# `[]T`, which binds to `SliceTypeSymbol`;
+        // `ArrayTypeSymbol` is G#'s `[N]T`, a shape this translator never
+        // emits. Mapping to it made `type is IArrayTypeSymbol` false for every
+        // array the migration itself produced, so GSA0004's structural key
+        // walk stopped at a composite key's `TypeSymbol[]` field and reported
+        // nothing. Adapted fidelity: a migrated analyzer sees the shape
+        // migrated code has, and a hand-written G# `[N]T` is out of its reach —
+        // strictly better than the previous "matches nothing at all".
+        ["Microsoft.CodeAnalysis.IArrayTypeSymbol"] = new(
+            "GSharp.Core.CodeAnalysis.Symbols",
+            "SliceTypeSymbol",
+            "C# `T[]` translates to the G# slice `[]T`; G#'s ArrayTypeSymbol is the fixed-length `[N]T`."),
         ["Microsoft.CodeAnalysis.SyntaxReference"] = new(
             "GSharp.Core.CodeAnalysis.Syntax",
             "SyntaxNode",

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -253,6 +253,22 @@ public sealed class CSharpTypeMapper
     public IReadOnlyList<TypeDeclaration> PendingAnonymousDataClasses => this.pendingAnonymousDataClasses;
 
     /// <summary>
+    /// The G# spelling of a C# predefined type keyword (ADR-0115 §B.12's
+    /// width-bearing primitive names), or <see langword="null"/> when the
+    /// special type has no predefined G# name.
+    ///
+    /// <para>
+    /// Exposed for issue #3797: the analyzer-snippet marker re-placer needs to
+    /// know the ONE lexical rename translation applies inside expression text,
+    /// so a <c>[|typeof(int) != type|]</c> marker can still be placed on the
+    /// translated <c>typeof(int32) != type</c> instead of being dropped.
+    /// </para>
+    /// </summary>
+    /// <param name="specialType">The C# special type.</param>
+    /// <returns>The G# predefined name, or <see langword="null"/>.</returns>
+    public static string GetPredefinedName(SpecialType specialType) => MapPredefinedName(specialType);
+
+    /// <summary>
     /// Records a G# namespace substituted for a Roslyn API namespace in
     /// analyzer translation mode (ADR-0169), so the compilation-unit import
     /// synthesis emits it even though no C# symbol carries it.


### PR DESCRIPTION
Root causes #3794, #3797. Advances #3849 (3 failing → 1). Re-measures #3848. Exposes #3920. Parent #3501.

## What this is

`test/InternalAnalyzers.Tests` is one of the two migrated apps that are **not** behind the `Gsharp.Runtime.Channels` cascade. Its wall is test-parity: the migrated artifact translates, compiles and ILVerifies, and then the translated analyzers *disagree with their C# originals at runtime*.

## Re-measured first — both recorded counts were stale

Whole-repository `cs2gs migrate --translate-only` + `cs2gs validate --app …`, on `origin/main` **d75d6c4fc**, gsc `0.4.453+d75d6c4fc2`:

| app | recorded | measured on main | note |
|---|---|---|---|
| `test/InternalAnalyzers.Tests` | 4 failed of 18 | **3 failed, 15 passed of 18** | #3796 already cleared by #3847 |
| `test/LanguageServer.Tests` | 33 failed of 486 | **24 failed, 462 passed of 486** | #3851/#3852, #3865/#3871, #3892/#3912 cleared 9 |

Root-cause table for `LanguageServer.Tests`' remaining 24 is posted to #3848; this PR does not touch that wall.

## The three that remained — and the four more they were hiding

Two causes explained the three failures. Fixing them exposed four further **framework** gaps, every one of the shape #3795 warned about: a structural walk that returns `false` early and therefore presents as *silence*.

1. **Package collapse (#3794, ×2).** A G# compilation unit declares one `package`, so a multi-namespace C# snippet was collapsed into the first one. Every declaration silently changed namespace: GSA0004 reported **nothing** in a snippet whose C# original reports four times, and GSA0003 reported a false positive on a cache the C# exempts *only* because of its namespace. (A third test — GSA0004's negative — was passing **vacuously** for the same reason.) `SnippetTranslator` now emits one unit per declared package joined by a `// ---8<--- cs2gs:next-compilation-unit ---` line; `GSharpAnalyzerVerifier` splits on it and compiles the units **together**, comparing markers and diagnostics **per unit**. The harness signature is unchanged — one source string is what a translated Roslyn harness has in hand. A source with no separator is one unit, so every hand-written G# analyzer test is untouched.
2. **Marker rename (#3797, ×1).** C#'s predefined type keywords become G#'s width-bearing primitive names, so `[|typeof(int) != type|]` could not be placed on the printed `typeof(int32) != type` and was dropped. Placement now retries against the marker re-spelled from its own `PredefinedTypeSyntax` nodes (never by text substitution, so an identifier that merely contains the letters is untouched), with the ordinal measured in the equally re-spelled source. Also: a marker on a **declaration's name** is now placed on a declaration, never on a use — translation does not preserve occurrence counts, because cs2gs hoists a property initializer into a synthesized constructor and migrated `NullableCtorRefs` therefore occurs twice.
3. **`ImportedTypeSymbol.ConstructedTypeArguments` was CLR-derived.** A generic over a same-compilation user type is type-ERASED — `Dictionary[StructSymbol, MemberReferenceHandle]` is backed by `Dictionary<object, object>` — so GSA0004 saw `System.Object` for every cache key and matched nothing. It now prefers the symbolic arguments, which are what Roslyn's `INamedTypeSymbol.TypeArguments` corresponds to.
4. **`TupleTypeSymbol` implemented neither `IsTupleType` nor `TupleElements`**, so a tuple cache key looked like a type with no components.
5. **`IArrayTypeSymbol` mapped to `ArrayTypeSymbol`** — G#'s fixed-length `[N]T`, a shape cs2gs never emits. C# `T[]` translates to the slice `[]T`, so the map now names `SliceTypeSymbol` and the walk sees through a composite key struct's `TypeSymbol[]` field. Adapted fidelity: strictly better than "matches nothing at all".
6. **`PropertySymbol.Location` spanned the whole declaration**, swallowing the marker; it now points at the identifier, exactly as #3847 already did for fields.

## Evidence — all of it executes

`tools/cs2gs/Cs2Gs.Tests/Issue3794AnalyzerSnippetPackageSplitTests` (7 tests): the real analyzer source is translated, compiled by the **real G# compiler**, loaded through `GSharpAnalyzerHost`, and run through the **real `GSharpAnalyzerVerifier`** over the translated snippet. That is the migrated test's own path, end to end.

Positives and negatives share one parameterised path for **both** GSA0003 and GSA0004, so a rule that quietly stops reporting fails the positives instead of passing the negatives. The GSA0004 negative is a case that used to pass for the wrong reason; it now passes for the right one.

`test/Core.Tests/CodeAnalysis/Adr0169AnalyzerVerifierTests` adds three verifier-level tests including the falsifier: the same two units with the marker moved to the unit the rule does not police must **fail**, and the message must name the unit.

**Failing-on-main proof.** Before/after, same whole-repository pipeline, `test/InternalAnalyzers.Tests`:

| | translate | compile | ILVerify | test-parity |
|---|---|---|---|---|
| `origin/main` d75d6c4fc | PASS | PASS | PASS | **3 failed / 15 passed of 18** |
| this branch | PASS | PASS | PASS | **1 failed / 17 passed of 18** |

The tests genuinely run (18 executed, at or above the C# original's `[Fact]` bound). The four `CS2GS-ANALYZER-SNIPPET` collapse warnings and the dropped-marker warning the migrate log used to print are **gone** (8 → 0 occurrences), because the conditions no longer occur. `test/LanguageServer.Tests` is unchanged at 24 — no regression.

Suite runs on this branch: `test/Core.Tests` **8877/8877 pass**, `tools/cs2gs/Cs2Gs.Tests` **2790/2790 pass**. `test/Compiler.Tests` was not completed locally (the run was interrupted); CI covers it.

## Not fixed here — #3920

Clearing #3797 exposed the last failure: with the third marker finally placed, `ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces` gets past the marker/id count check and GSA0002 then reports **nothing**. Measured with an analyzer registered for every `BoundNodeKind`: a `==` over IMPORTED operands binds to `BoundClrBinaryOperatorExpression` and `object.ReferenceEquals` to `BoundImportedCallExpression`, while the translation registers `BinaryExpression` / `CallExpression` — so GSA0002 is dispatched zero times over exactly the reflection-`Type` code it exists to police. `OperationKindMap` has to become one-to-many and the handler shape has to accept both nodes. Filed as **#3920** with the full dispatch trace.

## Baseline note

The measurements above were taken against `origin/main` d75d6c4fc; the branch has since been rebased onto 64401d0c1. The rebase is textually clean and touches no file the intervening commits changed.
