### PR TITLE
bench: pair every Go-compared row against equivalent work (#3902 S1 a-d)

### DIFF
--- a/bench/concurrency/baseline.json
+++ b/bench/concurrency/baseline.json
@@ -20,6 +20,10 @@
     "'aot' object is the NativeAOT mode, which is what compares like-for-like",
     "with Go's ahead-of-time binary. They regress for different reasons, so",
     "neither ceiling is allowed to stand in for the other.",
+    "Two rows carry no ceiling: select-park and spawn. Both depend on thread-pool",
+    "wake-up and are not reproducible run to run on this machine, which is the",
+    "same effect issue #3901 traced to CPU idle states. See unbudgeted_reason.",
+    "",
     "",
     "target_vs_go is the ADR's aspiration; target_status stays 'provisional'",
     "until the ratio has met it on three separate runs on the same hardware",
@@ -35,13 +39,13 @@
   "launches": 7,
   "scenarios": {
     "buf64": {
-      "median_ns": 129.79,
+      "median_ns": 130.02,
       "ci95_ns": [
-        128.83,
-        131.27
+        126.79,
+        134.33
       ],
-      "ceiling_ns": 149.26,
-      "go_median_ns": 93.7,
+      "ceiling_ns": 149.52,
+      "go_median_ns": 69.2,
       "target_vs_go": null,
       "target_status": "provisional",
       "history": [
@@ -51,15 +55,22 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 130.02,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 152.26,
+        "median_ns": 150.53,
         "ci95_ns": [
-          152.23,
-          155.06
+          148.91,
+          152.43
         ],
-        "ceiling_ns": 175.1,
+        "ceiling_ns": 173.11,
         "history": [
           {
             "median_ns": 152.26,
@@ -67,6 +78,13 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 150.53,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
@@ -74,12 +92,12 @@
       "runs": 3
     },
     "rendezvous": {
-      "median_ns": 122.9,
+      "median_ns": 123.82,
       "ci95_ns": [
-        122.3,
-        123.53
+        122.89,
+        125.72
       ],
-      "ceiling_ns": 141.34,
+      "ceiling_ns": 142.39,
       "go_median_ns": 643.6,
       "target_vs_go": null,
       "target_status": "provisional",
@@ -90,15 +108,22 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 123.82,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 146.71,
+        "median_ns": 142.92,
         "ci95_ns": [
-          146.65,
-          147.24
+          142.05,
+          146.27
         ],
-        "ceiling_ns": 168.72,
+        "ceiling_ns": 164.36,
         "history": [
           {
             "median_ns": 146.71,
@@ -106,6 +131,52 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 142.92,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+          }
+        ],
+        "runs": 3
+      },
+      "runs": 3
+    },
+    "pingpong": {
+      "median_ns": 245.26,
+      "ci95_ns": [
+        245.2,
+        253.39
+      ],
+      "ceiling_ns": 282.05,
+      "go_median_ns": 457.8,
+      "target_vs_go": null,
+      "target_status": "provisional",
+      "history": [
+        {
+          "median_ns": 245.26,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+        }
+      ],
+      "aot": {
+        "median_ns": 295.98,
+        "ci95_ns": [
+          292.98,
+          300.42
+        ],
+        "ceiling_ns": 340.38,
+        "history": [
+          {
+            "median_ns": 295.98,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
@@ -113,13 +184,13 @@
       "runs": 3
     },
     "closed-recv": {
-      "median_ns": 10.69,
+      "median_ns": 10.33,
       "ci95_ns": [
-        10.39,
-        10.73
+        10.25,
+        10.5
       ],
-      "ceiling_ns": 12.29,
-      "go_median_ns": 16.1,
+      "ceiling_ns": 11.88,
+      "go_median_ns": 15.8,
       "target_vs_go": null,
       "target_status": "provisional",
       "history": [
@@ -129,15 +200,22 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 10.33,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 10.58,
+        "median_ns": 10.34,
         "ci95_ns": [
-          10.57,
-          10.63
+          10.34,
+          10.73
         ],
-        "ceiling_ns": 12.17,
+        "ceiling_ns": 11.89,
         "history": [
           {
             "median_ns": 10.58,
@@ -145,6 +223,13 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 10.34,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
@@ -152,51 +237,46 @@
       "runs": 3
     },
     "spawn": {
-      "median_ns": 514.33,
-      "ci95_ns": [
-        495.95,
-        525.74
-      ],
-      "ceiling_ns": 591.48,
-      "go_median_ns": 268.5,
+      "median_ns": null,
+      "ci95_ns": null,
+      "ceiling_ns": null,
+      "go_median_ns": 254.4,
       "target_vs_go": null,
       "target_status": "provisional",
       "history": [
         {
-          "median_ns": 514.33,
+          "median_ns": 417.2,
           "samples": 21,
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
-          "reason": null
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 485.5,
-        "ci95_ns": [
-          481.49,
-          486.83
-        ],
-        "ceiling_ns": 558.32,
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
         "history": [
           {
-            "median_ns": 485.5,
+            "median_ns": 327.41,
             "samples": 21,
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
-            "reason": null
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
       },
-      "runs": 3
+      "runs": 3,
+      "unbudgeted_reason": "No ceiling recorded: 16% between runs. Both rows depend on thread-pool wake-up, which issue #3901 traced to CPU idle states \u2014 select-park measured 284.5 / 200.7 / 281.7 across three runs, with the middle run's own launches spanning 195-298. A ceiling from a bimodal row either sits above both modes and gates nothing, or fails whenever the fast mode is missed."
     },
     "select-ready": {
-      "median_ns": 153.08,
+      "median_ns": 153.01,
       "ci95_ns": [
-        152.86,
-        153.94
+        152.19,
+        154.48
       ],
-      "ceiling_ns": 176.04,
+      "ceiling_ns": 175.96,
       "go_median_ns": 85.7,
       "target_vs_go": null,
       "target_status": "provisional",
@@ -207,15 +287,22 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 153.01,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 165.61,
+        "median_ns": 162.73,
         "ci95_ns": [
-          165.46,
-          165.69
+          161.84,
+          165.74
         ],
-        "ceiling_ns": 190.45,
+        "ceiling_ns": 187.14,
         "history": [
           {
             "median_ns": 165.61,
@@ -223,6 +310,52 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 162.73,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+          }
+        ],
+        "runs": 3
+      },
+      "runs": 3
+    },
+    "select-stream": {
+      "median_ns": 290.13,
+      "ci95_ns": [
+        286.85,
+        293.29
+      ],
+      "ceiling_ns": 333.65,
+      "go_median_ns": 80.0,
+      "target_vs_go": null,
+      "target_status": "provisional",
+      "history": [
+        {
+          "median_ns": 290.13,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+        }
+      ],
+      "aot": {
+        "median_ns": 273.06,
+        "ci95_ns": [
+          272.4,
+          284.07
+        ],
+        "ceiling_ns": 314.02,
+        "history": [
+          {
+            "median_ns": 273.06,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
@@ -230,12 +363,9 @@
       "runs": 3
     },
     "select-park": {
-      "median_ns": 293.29,
-      "ci95_ns": [
-        293.09,
-        299.44
-      ],
-      "ceiling_ns": 337.28,
+      "median_ns": null,
+      "ci95_ns": null,
+      "ceiling_ns": null,
       "go_median_ns": null,
       "target_vs_go": null,
       "target_status": "provisional",
@@ -246,15 +376,19 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 281.68,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 298.28,
-        "ci95_ns": [
-          293.58,
-          298.42
-        ],
-        "ceiling_ns": 343.02,
+        "median_ns": null,
+        "ci95_ns": null,
+        "ceiling_ns": null,
         "history": [
           {
             "median_ns": 298.28,
@@ -262,19 +396,27 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 278.5,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
       },
-      "runs": 3
+      "runs": 3,
+      "unbudgeted_reason": "No ceiling recorded: bimodal within a single run. Both rows depend on thread-pool wake-up, which issue #3901 traced to CPU idle states \u2014 select-park measured 284.5 / 200.7 / 281.7 across three runs, with the middle run's own launches spanning 195-298. A ceiling from a bimodal row either sits above both modes and gates nothing, or fails whenever the fast mode is missed."
     },
     "chunk64": {
-      "median_ns": 8.13,
+      "median_ns": 7.86,
       "ci95_ns": [
-        8.1,
-        8.14
+        7.67,
+        7.98
       ],
-      "ceiling_ns": 9.35,
+      "ceiling_ns": 9.04,
       "go_median_ns": 8.6,
       "target_vs_go": null,
       "target_status": "provisional",
@@ -285,15 +427,22 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 7.86,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 8.6,
+        "median_ns": 8.35,
         "ci95_ns": [
-          8.54,
-          8.69
+          8.26,
+          8.75
         ],
-        "ceiling_ns": 9.89,
+        "ceiling_ns": 9.6,
         "history": [
           {
             "median_ns": 8.6,
@@ -301,6 +450,13 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 8.35,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3
@@ -308,12 +464,12 @@
       "runs": 3
     },
     "chunk1k": {
-      "median_ns": 3.3,
+      "median_ns": 3.2,
       "ci95_ns": [
-        3.22,
-        3.31
+        3.1,
+        3.23
       ],
-      "ceiling_ns": 3.79,
+      "ceiling_ns": 3.68,
       "go_median_ns": 1.5,
       "target_vs_go": null,
       "target_status": "provisional",
@@ -324,15 +480,22 @@
           "runs": 3,
           "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
           "reason": null
+        },
+        {
+          "median_ns": 3.2,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
         }
       ],
       "aot": {
-        "median_ns": 3.64,
+        "median_ns": 3.52,
         "ci95_ns": [
-          3.59,
-          3.67
+          3.49,
+          3.65
         ],
-        "ceiling_ns": 4.19,
+        "ceiling_ns": 4.05,
         "history": [
           {
             "median_ns": 3.64,
@@ -340,6 +503,91 @@
             "runs": 3,
             "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
             "reason": null
+          },
+          {
+            "median_ns": 3.52,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+          }
+        ],
+        "runs": 3
+      },
+      "runs": 3
+    },
+    "chunk64-arrays": {
+      "median_ns": 5.56,
+      "ci95_ns": [
+        5.28,
+        5.67
+      ],
+      "ceiling_ns": 6.39,
+      "go_median_ns": 7.0,
+      "target_vs_go": null,
+      "target_status": "provisional",
+      "history": [
+        {
+          "median_ns": 5.56,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+        }
+      ],
+      "aot": {
+        "median_ns": 5.64,
+        "ci95_ns": [
+          5.62,
+          5.85
+        ],
+        "ceiling_ns": 6.49,
+        "history": [
+          {
+            "median_ns": 5.64,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+          }
+        ],
+        "runs": 3
+      },
+      "runs": 3
+    },
+    "chunk1k-arrays": {
+      "median_ns": 2.95,
+      "ci95_ns": [
+        2.82,
+        2.95
+      ],
+      "ceiling_ns": 3.39,
+      "go_median_ns": 1.1,
+      "target_vs_go": null,
+      "target_status": "provisional",
+      "history": [
+        {
+          "median_ns": 2.95,
+          "samples": 21,
+          "runs": 3,
+          "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+          "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
+        }
+      ],
+      "aot": {
+        "median_ns": 2.86,
+        "ci95_ns": [
+          2.84,
+          3.01
+        ],
+        "ceiling_ns": 3.29,
+        "history": [
+          {
+            "median_ns": 2.86,
+            "samples": 21,
+            "runs": 3,
+            "hardwareClass": "linux-x86_64-20-13th-gen-intel-r-core-tm-i7-13800h",
+            "reason": "S1 a-d reshaped four scenarios; previous medians measured different work"
           }
         ],
         "runs": 3

--- a/bench/concurrency/gsharp/Bench.gs
+++ b/bench/concurrency/gsharp/Bench.gs
@@ -52,6 +52,7 @@ let ops = 2000000
 let closedOps = 25000000
 let spawnOps = 750000
 let pingPongOps = 2000000
+let roundTripOps = 1000000
 let parkOps = 900000
 let chunk64Ops = 32000000
 let chunk1kOps = 75000000
@@ -91,7 +92,9 @@ func produce(ch out chan[int32], count int32) {
 }
 
 // Capacity 0: a send completes only when a receiver takes the value, so this
-// measures the hand-off itself rather than the buffer.
+// measures the hand-off itself rather than the buffer. ONE hand-off per counted
+// operation, which is why it has no Go counterpart — Go's `pingpong` counts a
+// round trip. `pingpong` below is the row that pairs with it (issue #3902 S1a).
 func rendezvous(count int32) TimeSpan {
     let ch = chan[int32](0)
     let sw = Stopwatch.StartNew()
@@ -104,6 +107,33 @@ func rendezvous(count int32) TimeSpan {
 
     sw.Stop()
     return sw.Elapsed
+}
+
+// Go's `pingpong`, shape for shape: a round trip over two rendezvous channels,
+// counted per ROUND TRIP and therefore two hand-offs per operation. The rows
+// this replaces compared one hand-off against two and flattered G# by 2x.
+func pingpong(count int32) TimeSpan {
+    let a = chan[int32](0)
+    let b = chan[int32](0)
+    let sw = Stopwatch.StartNew()
+    scope {
+        go echo(a, b, count)
+        for i in 0 ... count {
+            a <- i
+            let got = <-b
+            let ignored = got
+        }
+    }
+
+    sw.Stop()
+    return sw.Elapsed
+}
+
+func echo(a in chan[int32], b out chan[int32], count int32) {
+    for i in 0 ... count {
+        let v = <-a
+        b <- v
+    }
 }
 
 // The 382x defect ADR-0174 D2 removes: a receive from a closed, drained
@@ -121,18 +151,15 @@ func closedRecv(count int32) TimeSpan {
     return sw.Elapsed
 }
 
-// Spawn cost: `go` is a thread-pool work item, not a Task.
+// Spawn cost: `go` is a thread-pool work item, not a Task. Go's counterpart
+// times the spawn and a WaitGroup join, so this does the same — it used to add
+// a send and a receive per goroutine that Go never paid for (issue #3902 S1c).
+// `scope` exit IS the join.
 func spawn(count int32) TimeSpan {
-    let done = chan[int32](count)
     let sw = Stopwatch.StartNew()
     scope {
         for i in 0 ... count {
-            go signal(done)
-        }
-
-        for j in 0 ... count {
-            let (value, ok) = <-done
-            let ignored = value
+            go noop()
         }
     }
 
@@ -140,13 +167,15 @@ func spawn(count int32) TimeSpan {
     return sw.Elapsed
 }
 
-func signal(done out chan[int32]) {
-    done <- 1
+func noop() {
 }
 
-// A select whose arms are already ready: the fast path, no registration and no
+// A select whose arms are ALREADY READY: the fast path, no registration and no
 // park. Both arms are refilled each round so the uniform-random choice always
-// has two candidates.
+// has two candidates. Four channel operations per counted iteration (two sends,
+// the select, one drain), so it has NO Go counterpart — `select-stream` below
+// is the row that pairs with Go. Keeping this one G#-only is what preserves a
+// genuine ready-path measurement for gate G5 (issue #3902 S1b).
 func selectReady(count int32) TimeSpan {
     let a = chan[int32](1)
     let b = chan[int32](1)
@@ -166,6 +195,42 @@ func selectReady(count int32) TimeSpan {
 
     sw.Stop()
     return sw.Elapsed
+}
+
+// Go's `selectCost`, shape for shape: a producer fills one buffered arm and the
+// timed loop performs exactly ONE select receive per counted operation. The
+// consumer outruns the producer, so this measures a MIX of ready and parked
+// selects — which is what Go's row measures too, and why it is a separate row
+// from `select-ready` rather than a replacement for it.
+func selectStream(count int32) TimeSpan {
+    let a = chan[int32](1024)
+    let b = chan[int32](1024)
+    let sw = Stopwatch.StartNew()
+    scope {
+        go feed(a, count)
+        var got = 0
+        while got < count {
+            select {
+            case let v = <-a {
+                got = got + 1
+            }
+            case let w = <-b {
+                got = got + 1
+            }
+            }
+        }
+    }
+
+    sw.Stop()
+    return sw.Elapsed
+}
+
+// Like `produce` but leaves the channel open: a closed arm would make the
+// select return immediately with the zero value and miscount the loop.
+func feed(ch out chan[int32], count int32) {
+    for i in 0 ... count {
+        ch <- i
+    }
 }
 
 // A select with no ready arm: registration on every arm, a park, and a
@@ -241,6 +306,49 @@ func produceBatched(ch chan[int32], count int32, size int32) {
 }
 
 
+// Go's chunk rows send whole `[]int` slices over a `chan []int`; the `chunks()`
+// rows above are a G# construct that copies elements into a fresh array per
+// chunk. Comparing the two measured different transports (issue #3902 S1d), so
+// this is the row that pairs with Go, and `chunk64`/`chunk1k` are now G#-only.
+func chunkedArrays(size int32, count int32) TimeSpan {
+    let ch = chan[[]int32](64)
+    let sw = Stopwatch.StartNew()
+    scope {
+        go produceArrays(ch, count, size)
+        var sum = 0
+        for batch in ch {
+            var i = 0
+            while i < batch.Length {
+                sum = sum + batch[i]
+                i = i + 1
+            }
+        }
+    }
+
+    sw.Stop()
+    return sw.Elapsed
+}
+
+// `chan[[]int32]` rather than `out chan[[]int32]`: the directional view
+// conversion does not apply when the element type is an array, so the `out`
+// form does not bind (issue #3924). Bidirectional is only a workaround here.
+func produceArrays(ch chan[[]int32], count int32, size int32) {
+    var sent = 0
+    while sent < count {
+        var chunk = [size]int32{}
+        var i = 0
+        while i < size && sent + i < count {
+            chunk[i] = sent + i
+            i = i + 1
+        }
+
+        ch <- chunk
+        sent = sent + i
+    }
+
+    ch.Close()
+}
+
 func run(name string) {
     if name == "buf64" {
         report("buf64", buf64(ops), ops)
@@ -252,12 +360,20 @@ func run(name string) {
         report("spawn", spawn(spawnOps), spawnOps)
     } else if name == "select-ready" {
         report("select-ready", selectReady(ops), ops)
+    } else if name == "select-stream" {
+        report("select-stream", selectStream(ops), ops)
     } else if name == "select-park" {
         report("select-park", selectPark(parkOps), parkOps)
     } else if name == "chunk64" {
         report("chunk64", chunked(64, chunk64Ops), chunk64Ops)
     } else if name == "chunk1k" {
         report("chunk1k", chunked(1024, chunk1kOps), chunk1kOps)
+    } else if name == "pingpong" {
+        report("pingpong", pingpong(roundTripOps), roundTripOps)
+    } else if name == "chunk64-arrays" {
+        report("chunk64-arrays", chunkedArrays(64, chunk64Ops), chunk64Ops)
+    } else if name == "chunk1k-arrays" {
+        report("chunk1k-arrays", chunkedArrays(1024, chunk1kOps), chunk1kOps)
     }
 }
 
@@ -274,16 +390,24 @@ func runWarmup(name string) {
         let ignored = spawn(warmupOps)
     } else if name == "select-ready" {
         let ignored = selectReady(warmupOps)
+    } else if name == "select-stream" {
+        let ignored = selectStream(warmupOps)
     } else if name == "select-park" {
         let ignored = selectPark(warmupOps)
     } else if name == "chunk64" {
         let ignored = chunked(64, warmupOps)
     } else if name == "chunk1k" {
         let ignored = chunked(1024, warmupOps)
+    } else if name == "pingpong" {
+        let ignored = pingpong(warmupOps)
+    } else if name == "chunk64-arrays" {
+        let ignored = chunkedArrays(64, warmupOps)
+    } else if name == "chunk1k-arrays" {
+        let ignored = chunkedArrays(1024, warmupOps)
     }
 }
 
-let all = []string{"buf64", "rendezvous", "closed-recv", "spawn", "select-ready", "select-park", "chunk64", "chunk1k"}
+let all = []string{"buf64", "rendezvous", "pingpong", "closed-recv", "spawn", "select-ready", "select-stream", "select-park", "chunk64", "chunk1k", "chunk64-arrays", "chunk1k-arrays"}
 let requested = Environment.GetEnvironmentVariable("GSHARP_BENCH_SCENARIO")
 
 Console.WriteLine("runtime " + Environment.Version.ToString() + " cores " + Environment.ProcessorCount.ToString())

--- a/bench/concurrency/scenarios.json
+++ b/bench/concurrency/scenarios.json
@@ -1,14 +1,20 @@
 {
   "$comment": [
     "ADR-0174 D11: the scenario registry the concurrency benchmark runs.",
-    "Each row pairs a G# scenario with the Go program's counterpart, so the",
-    "runner can report both a within-runtime regression check (the gate) and a",
-    "G#-vs-Go ratio (informational, because it moves with the Go toolchain and",
-    "the machine).",
     "",
-    "`gsharp` is the scenario name Bench.gs prints; `go` is the row name",
-    "main.go prints. A null `go` row means the scenario has no Go counterpart",
-    "yet and only the within-runtime check applies."
+    "Each row pairs a G# scenario with the Go program's counterpart, so the",
+    "runner can report both a within-runtime regression check and a G#-vs-Go",
+    "ratio (informational, because it moves with the Go toolchain and the",
+    "machine).",
+    "",
+    "A null `go` row means the scenario has NO Go counterpart, and several are",
+    "deliberately null (issue #3902 S1). A pairing is only honest when both",
+    "sides do the same work per counted operation: `rendezvous` counts one",
+    "hand-off where Go's pingpong counts two, `select-ready` performs four",
+    "channel operations where Go's select row performs one, and `chunks()`",
+    "copies elements where Go passes a slice header. Those rows are now G#-only,",
+    "and `pingpong`, `select-stream`, `chunk64-arrays` and `chunk1k-arrays` are",
+    "the rows shaped to match Go."
   ],
   "schemaVersion": 1,
   "scenarios": [
@@ -21,26 +27,38 @@
     {
       "name": "rendezvous",
       "gsharp": "rendezvous",
+      "go": null,
+      "what": "Capacity 0, so the number is the hand-off rather than the buffer. ONE hand-off per operation; `pingpong` is the Go-paired counterpart."
+    },
+    {
+      "name": "pingpong",
+      "gsharp": "pingpong",
       "go": "go-pingpong",
-      "what": "Capacity 0, so the number is the hand-off rather than the buffer."
+      "what": "A round trip over two rendezvous channels: TWO hand-offs per counted operation, shaped exactly like Go's."
     },
     {
       "name": "closed-recv",
       "gsharp": "closed-recv",
       "go": "go-closed",
-      "what": "A receive from a closed, drained channel — the exception-based defect D2 removes."
+      "what": "A receive from a closed, drained channel \u2014 the exception-based defect D2 removes."
     },
     {
       "name": "spawn",
       "gsharp": "spawn",
       "go": "go-spawn",
-      "what": "Spawn cost: `go` is a thread-pool work item, not a Task."
+      "what": "Spawn cost: `go` is a thread-pool work item, not a Task. Times the spawn and the join only, as Go's WaitGroup row does."
     },
     {
       "name": "select-ready",
       "gsharp": "select-ready",
+      "go": null,
+      "what": "A select whose arms are ready: no registration, no park. Four channel operations per counted iteration, so G#-only; `select-stream` is the Go-paired row."
+    },
+    {
+      "name": "select-stream",
+      "gsharp": "select-stream",
       "go": "go-select2",
-      "what": "A select whose arms are ready: no registration, no park."
+      "what": "One select receive per operation against a producer filling one buffered arm \u2014 a mix of ready and parked selects, as Go's row is."
     },
     {
       "name": "select-park",
@@ -51,14 +69,26 @@
     {
       "name": "chunk64",
       "gsharp": "chunk64",
-      "go": "go-chunk64",
-      "what": "D10 batching at 64 elements per chunk."
+      "go": null,
+      "what": "D10 batching at 64 elements per chunk. G#-only: `chunks()` copies elements where Go passes a slice header."
     },
     {
       "name": "chunk1k",
       "gsharp": "chunk1k",
-      "go": "go-chunk1k",
+      "go": null,
       "what": "D10 batching at 1024 elements per chunk. The curve between this and chunk64 is the point, not either number."
+    },
+    {
+      "name": "chunk64-arrays",
+      "gsharp": "chunk64-arrays",
+      "go": "go-chunk64",
+      "what": "Whole arrays over a `chan[[]int32]` at 64 elements: the transport Go's `chan []int` actually is."
+    },
+    {
+      "name": "chunk1k-arrays",
+      "gsharp": "chunk1k-arrays",
+      "go": "go-chunk1k",
+      "what": "Whole arrays over a `chan[[]int32]` at 1024 elements."
     }
   ]
 }


### PR DESCRIPTION
Closes #3902's S1 (a)–(d). Item (e) landed in #3918; these are the four that were left.

**Three published ratios were comparing different work on the two sides.** That mattered little when
every median was null; it matters now that the baseline is official.

## What each item did

**(a) `pingpong` added.** `rendezvous` counts one hand-off, Go's `pingpong` counts two. A new scenario
mirrors Go shape for shape; `rendezvous` becomes G#-only.

The check that the pairing is now honest: **pingpong 245.26 ns per round trip against rendezvous'
123.82 per hand-off — 1.98×.** Two rows measuring the same primitive at different granularities have to
agree like that, and they do.

**(b) split, not replaced — and my first attempt was wrong.** Reshaping `select-ready` to match Go made
the consumer outrun the producer, so the select **parked** and the row read 305 ns, *slower* than
`select-park`. Nonsense for a fast path. Go's row has that property too, but the ADR gates this row on
the no-park path (G5), so replacing it would have destroyed the measurement G5 depends on.
`select-ready` keeps its guaranteed-ready four-operation shape as G#-only; a new `select-stream`
mirrors Go.

**(c) `spawn`** timed a send and a receive per goroutine that Go's WaitGroup row never paid for. Now
spawn + scope join only.

**(d) `chunk64-arrays` / `chunk1k-arrays`** send whole arrays over `chan[[]int32]` — the transport Go's
`chan []int` actually is. The `chunks()` rows become G#-only, since they copy elements where Go passes
a slice header.

**Six of twelve rows now have no Go counterpart, deliberately.** A pairing that compares different work
is worse than no pairing, because it looks like a result.

## The honest ratios

| row | G# | Go | ratio |
|---|---:|---:|---:|
| pingpong | 245.26 | 457.80 | **0.54×** |
| closed-recv | 10.33 | 15.80 | **0.65×** |
| chunk64-arrays | 5.56 | 7.00 | **0.79×** |
| spawn | 417.20 | 254.40 | 1.64× |
| buf64 | 130.02 | 69.20 | 1.88× |
| chunk1k-arrays | 2.95 | 1.10 | 2.68× |
| select-stream | 290.13 | 80.00 | **3.63×** |

**`select-stream` at 3.63× is what the old pairing was hiding.** One select against a racing producer is
where G# is furthest behind Go, and the four-operation `select-ready` shape averaged that away. That is
the most useful thing this PR surfaces, and it is a worse number than the one it replaces.

## Two rows are left unbudgeted on purpose

Budgets come from three full runs; ten of twelve rows agreed to 1.5–7.4%. **`select-park` measured
284.5 / 200.7 / 281.7, and the middle run's own launches spanned 195–298** — it is bimodal *within* a
run, not merely noisy between them. `spawn` spread 16%. Both depend on thread-pool wake-up, the effect
#3901 traced to CPU idle states.

A ceiling from a bimodal row either sits above both modes and gates nothing, or fails whenever the fast
mode is missed. `baseline.json` records an `unbudgeted_reason` instead of a number.

## Filed along the way

**[#3924](https://github.com/DavidObando/gsharp/issues/3924)** — a `chan[T]` whose element is an array
does not convert to `out chan[T]`. `out chan[int32]` binds, plain `chan[[]int32]` binds, only the
combination fails. `produceArrays` takes a bidirectional channel as a workaround, with a comment
pointing there.

Refs #3902, #3901, #3924, ADR-0174 D11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
