### PR TITLE
gsc: six root causes take migrated Gsharp.Runtime.Channels from 7 compile errors to 0 (#3907)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -706,6 +706,15 @@ internal sealed class ConversionClassifier
 
         if (!conversion.Exists)
         {
+            // Issue #3907: the target parameter is annotated `@AllowNull`, so
+            // a `T?` argument is exactly what it declares itself willing to
+            // receive. See AcceptsNilAnnotatedArgument for why this is
+            // annotation-only and why it cannot reshape the emitted call.
+            if (AcceptsNilAnnotatedArgument(callParameter, expression.Type, type))
+            {
+                return expression;
+            }
+
             // Issue #1017: a user-defined conversion operator declared on a
             // same-package struct/class is modelled as a static op_Implicit /
             // op_Explicit FunctionSymbol — those types have no reflectible
@@ -2506,6 +2515,61 @@ internal sealed class ConversionClassifier
     internal static bool IsNumericReturnWidening(TypeSymbol source, TypeSymbol target)
     {
         return IsNumericReturnWideningCore(source, target);
+    }
+
+    /// <summary>
+    /// Issue #3907: true when <paramref name="parameter"/> is annotated
+    /// <c>@AllowNull</c> and <paramref name="sourceType"/> is the nullable
+    /// spelling of the parameter's own <paramref name="targetType"/> — i.e.
+    /// the argument is precisely the <c>nil</c>-carrying input the annotation
+    /// declares the parameter accepts.
+    /// </summary>
+    /// <remarks>
+    /// <para>Two properties make this safe, and both are load-bearing.</para>
+    /// <para><b>It is annotation-only.</b> The parameter's own
+    /// declared type is never widened. Widening it would make a
+    /// value-type <c>T</c> emit a <c>Nullable&lt;T&gt;</c> signature slot where
+    /// <c>T</c> is expected — wrong IL that ILVerify does not catch, because
+    /// the metadata is internally consistent and simply describes a different
+    /// method. Keeping the slot at <c>T</c> also preserves the asymmetry the
+    /// attribute exists for: reads of the parameter inside the body still see
+    /// a non-nullable <c>T</c> and still need the author's <c>!!</c>.</para>
+    /// <para><b>It never reshapes the emitted call.</b> The relaxation is
+    /// gated on <see cref="NullableLifting.IsAnyValueTypeNullable"/> being
+    /// false, so the source nullable is one whose runtime representation is
+    /// identical to its underlying (ADR-0001 §Phase 3.C.1: for a reference
+    /// type or an unconstrained type parameter, <c>T?</c> relays <c>T</c>'s
+    /// <c>ClrType</c> and the IL value is the same reference either way). A
+    /// value-type nullable — <c>int32?</c> into an <c>@AllowNull</c>
+    /// <c>int32</c> slot — really is <c>Nullable&lt;int32&gt;</c> on the
+    /// stack, is rejected by C# too, and stays rejected here. The underlying
+    /// must also be IDENTICAL to the target rather than merely convertible to
+    /// it, so this admits exactly <c>T?</c> at a <c>T</c> slot and no other
+    /// shape; the argument is returned unchanged, with no synthesized
+    /// conversion node.</para>
+    /// </remarks>
+    /// <param name="parameter">The target parameter, or <see langword="null"/> when not binding a call argument.</param>
+    /// <param name="sourceType">The argument's static type.</param>
+    /// <param name="targetType">The parameter's (substituted) declared type.</param>
+    /// <returns><see langword="true"/> when the argument is accepted as-is.</returns>
+    internal static bool AcceptsNilAnnotatedArgument(
+        ParameterSymbol? parameter,
+        TypeSymbol? sourceType,
+        TypeSymbol? targetType)
+    {
+        if (parameter is not { AllowsNullArgument: true }
+            || targetType == null
+            || targetType == TypeSymbol.Error
+            || sourceType is not NullableTypeSymbol nullableSource
+            || NullableLifting.IsAnyValueTypeNullable(nullableSource))
+        {
+            return false;
+        }
+
+        var underlying = nullableSource.UnderlyingType;
+        return underlying != null
+            && underlying != TypeSymbol.Error
+            && Conversion.Classify(underlying, targetType).IsIdentity;
     }
 
     // ----- Private helpers (kept here because they are only used by methods in this class) -----

--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -616,6 +616,14 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
+            // Issue #3907: an `@AllowNull` base-constructor parameter declares
+            // that it accepts a nil-carrying input.
+            if (ConversionClassifier.AcceptsNilAnnotatedArgument(parameter, argument.Type, parameter.Type))
+            {
+                convertedArgs.Add(argument);
+                continue;
+            }
+
             if (argument.Type != parameter.Type
                 && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit
                 && !ExpressionBinder.IsImplicitConstantNarrowingArgument(argument, parameter.Type))

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -3102,7 +3102,7 @@ internal sealed partial class ExpressionBinder
             lengthOf,
             statements);
 
-        var returnType = TypeSymbol.FromClrType(sliceMethod.ReturnType);
+        var returnType = SliceResultType(target, sliceMethod.ReturnType);
         var call = new BoundImportedInstanceCallExpression(
             null,
             srcRef,
@@ -3116,8 +3116,46 @@ internal sealed partial class ExpressionBinder
     private BoundExpression BindRangeIndexerSlice(BoundExpression target, RangeExpressionSyntax range, PropertyInfo indexer)
     {
         var rangeValue = BuildSystemRangeValue(range);
-        var resultType = TypeSymbol.FromClrType(indexer.PropertyType);
+        var resultType = SliceResultType(target, indexer.PropertyType);
         return new BoundClrIndexExpression(range, target, indexer, ImmutableArray.Create(rangeValue), resultType);
+    }
+
+    /// <summary>
+    /// Issue #3907: the static type of a range slice (<c>src[a..b]</c>) over an
+    /// imported slice shape.
+    /// </summary>
+    /// <remarks>
+    /// <para>The slice member is discovered by reflecting on the receiver's
+    /// <see cref="TypeSymbol.ClrType"/>, and issue #658 erases a type argument
+    /// that has no CLR representation while binding — so inside
+    /// <c>class Holder[T]</c> a <c>Span[T]</c> receiver reflects as
+    /// <c>Span&lt;object&gt;</c> and <c>Slice</c> reports that as its return
+    /// type. Taking the reflected answer verbatim threw the symbolic <c>T</c>
+    /// away: <c>destination[1..]</c> produced a <c>Span[object]</c> that no
+    /// longer converted back into the <c>Span[T]</c> slot it was sliced
+    /// from.</para>
+    /// <para>Every slice shape in the BCL — <c>Span&lt;T&gt;</c>,
+    /// <c>ReadOnlySpan&lt;T&gt;</c>, <c>Memory&lt;T&gt;</c>,
+    /// <c>ReadOnlyMemory&lt;T&gt;</c>, <c>string</c> — yields the RECEIVER'S
+    /// OWN type, so when the reflected result is identical to the receiver's
+    /// CLR type the symbolic answer is just the receiver's symbolic type,
+    /// which still carries <c>T</c>. Deliberately guarded on that identity:
+    /// a slice member returning anything else keeps the reflected answer
+    /// unchanged, and a receiver whose type argument is already concrete
+    /// (<c>Span[int32]</c>) gets back the same symbol it had before.</para>
+    /// </remarks>
+    /// <param name="target">The sliced receiver.</param>
+    /// <param name="reflectedResult">The slice member's reflected result type.</param>
+    /// <returns>The slice expression's static type.</returns>
+    private static TypeSymbol SliceResultType(BoundExpression target, Type reflectedResult)
+    {
+        var targetType = target.Type;
+        if (targetType?.ClrType != null && targetType.ClrType.IsSameAs(reflectedResult))
+        {
+            return targetType;
+        }
+
+        return TypeSymbol.FromClrType(reflectedResult);
     }
 
     // Issue #1016/#1022/#1038: construct a `System.Range` value from a range
@@ -3263,7 +3301,7 @@ internal sealed partial class ExpressionBinder
         {
             if (TryFindRangeIndexer(clrType, out var rangeIndexer))
             {
-                var resultType = TypeSymbol.FromClrType(rangeIndexer.PropertyType);
+                var resultType = SliceResultType(target, rangeIndexer.PropertyType);
                 return new BoundClrIndexExpression(null, target, rangeIndexer, ImmutableArray.Create(rangeValue), resultType);
             }
 
@@ -3278,7 +3316,7 @@ internal sealed partial class ExpressionBinder
                     lengthOf,
                     statements);
 
-                var returnType = TypeSymbol.FromClrType(sliceMethod.ReturnType);
+                var returnType = SliceResultType(target, sliceMethod.ReturnType);
                 var call = new BoundImportedInstanceCallExpression(
                     null,
                     srcRef,

--- a/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
+++ b/src/Core/CodeAnalysis/Binding/KnownAttributes.cs
@@ -403,6 +403,48 @@ internal static class KnownAttributes
     }
 
     /// <summary>
+    /// Returns <c>true</c> when <paramref name="attributes"/> carries
+    /// <see cref="System.Diagnostics.CodeAnalysis.AllowNullAttribute"/>
+    /// (issue #3907).
+    /// </summary>
+    /// <remarks>
+    /// <para><c>[AllowNull]</c> is the .NET-standard "this INPUT accepts
+    /// <c>null</c> even though its type is not nullable" annotation. It is the
+    /// one nullability contract G# cannot spell in a type, because ADR-0155
+    /// gives a declaration a single nullability (Kotlin-style) while C# gives
+    /// it separate input and output contracts. cs2gs widens a REFERENCE-typed
+    /// <c>[AllowNull]</c> declaration to <c>T?</c> (issue #3694) — the two
+    /// contracts then agree — but an UNCONSTRAINED type parameter has no such
+    /// widening, so <c>[AllowNull] T value</c> translates verbatim to
+    /// <c>@AllowNull value T</c> and only the annotation carries the
+    /// contract.</para>
+    /// <para>Consumed by <c>ConversionClassifier</c> to relax the ARGUMENT
+    /// conversion at a call site — never the parameter's own type, which is
+    /// exactly the asymmetry the attribute exists to express: reads inside the
+    /// body still see a non-nullable <c>T</c> and still require the author's
+    /// <c>!!</c>.</para>
+    /// </remarks>
+    /// <param name="attributes">The attribute list on a parameter symbol.</param>
+    /// <returns><c>true</c> when at least one <c>[AllowNull]</c> is present.</returns>
+    public static bool HasAllowNull(ImmutableArray<BoundAttribute> attributes)
+    {
+        if (attributes.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        foreach (var attr in attributes)
+        {
+            if (attr?.AttributeType?.ClrType.IsSameAs(typeof(System.Diagnostics.CodeAnalysis.AllowNullAttribute)) == true)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Returns <c>true</c> when <paramref name="attributes"/> contains at
     /// least one <c>[Conditional("SYMBOL")]</c> application and *none* of the
     /// named symbols is present in <paramref name="preprocessorSymbols"/>. In

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -1642,6 +1642,94 @@ internal sealed class MemberLookup
     }
 
     /// <summary>
+    /// Issue #3907: removes imported candidates that could only accept a
+    /// by-ref argument over a same-compilation user REFERENCE type by erasing
+    /// it — i.e. whose parameter at such a slot is a by-ref over a type that is
+    /// not generic in the OPEN definition.
+    /// </summary>
+    /// <remarks>
+    /// <para>C# requires a <c>ref</c> argument to match its parameter exactly,
+    /// and no imported signature can name a class this compilation has not
+    /// emitted yet, so a generic <c>ref T</c> is the only parameter such an
+    /// argument can legally reach. Without this filter the non-generic
+    /// <c>Interlocked.Exchange(ref object?, object?)</c> was an exact IDENTITY
+    /// match for <c>Interlocked.Exchange(&amp;nodeField, nil)</c> — the #658
+    /// erasure made <c>ref Node</c> look like <c>ref object</c> — so it beat
+    /// <c>Exchange&lt;T&gt;(ref T, T)</c>, a candidate csc never even
+    /// considers.</para>
+    /// <para>The filter runs on the OPEN candidates on purpose: once a generic
+    /// candidate is closed over the erasure its <c>ref T</c> has already become
+    /// <c>ref object</c> and is indistinguishable from the non-generic
+    /// overload's. Slots are matched positionally and the filter declines to
+    /// act when the call site uses named arguments, so it can never drop a
+    /// candidate whose parameter order it has not actually established.</para>
+    /// </remarks>
+    /// <param name="candidates">The imported candidates to filter.</param>
+    /// <param name="symbolicByRefArgs">Per-argument flags marking the symbolic by-ref slots; <see langword="null"/> disables the filter.</param>
+    /// <param name="argumentNames">Optional source argument names aligned with the arguments.</param>
+    /// <returns>Candidates that can accept the symbolic by-ref argument without erasing it.</returns>
+    public static IEnumerable<MethodInfo> ExcludeNonGenericByRefCandidates(
+        IEnumerable<MethodInfo> candidates,
+        IReadOnlyList<bool>? symbolicByRefArgs,
+        IReadOnlyList<string?>? argumentNames = null)
+    {
+        if (candidates == null || symbolicByRefArgs == null)
+        {
+            return candidates ?? Enumerable.Empty<MethodInfo>();
+        }
+
+        if (argumentNames != null)
+        {
+            foreach (var name in argumentNames)
+            {
+                if (name != null)
+                {
+                    return candidates;
+                }
+            }
+        }
+
+        var filtered = new List<MethodInfo>();
+        foreach (var candidate in candidates)
+        {
+            if (AcceptsSymbolicByRefSlots(candidate, symbolicByRefArgs))
+            {
+                filtered.Add(candidate);
+            }
+        }
+
+        return filtered;
+
+        static bool AcceptsSymbolicByRefSlots(MethodInfo candidate, IReadOnlyList<bool> symbolicByRefArgs)
+        {
+            var open = candidate.IsGenericMethod && !candidate.IsGenericMethodDefinition
+                ? candidate.GetGenericMethodDefinition()
+                : candidate;
+            var parameters = open.GetParameters();
+            for (var i = 0; i < symbolicByRefArgs.Count; i++)
+            {
+                if (!symbolicByRefArgs[i])
+                {
+                    continue;
+                }
+
+                if (i >= parameters.Length)
+                {
+                    return false;
+                }
+
+                var parameterType = parameters[i].ParameterType;
+                if (!parameterType.IsByRef || parameterType.GetElementType()?.IsGenericParameter != true)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Issue #2494: removes imported method candidates that are applicable only
     /// because a same-compilation enum was projected to its temporary CLR
     /// <c>int32</c> representation. The projection is a lookup aid; it is not a
@@ -3388,6 +3476,20 @@ internal sealed class MemberLookup
                 return IsSymbolicTypeArgument(slice.ElementType);
             case NullableTypeSymbol nullable when nullable.UnderlyingType != null:
                 return IsSymbolicTypeArgument(nullable.UnderlyingType);
+
+            // Issue #3907: a tuple type argument is symbolic exactly when one
+            // of its ELEMENTS is — `IValueTaskSource[(T, bool)]` closes over
+            // an open `T` just as surely as `IValueTaskSource[T]` does. The
+            // emitter's counterpart already recurses here (issue #1902's arm
+            // in ReflectionMetadataEmitter.ArgIsSymbolicUserDefined); the
+            // binder's did not, so the two disagreed about whether the
+            // interface survives erasure. Conformance then ran against the
+            // ERASED `IValueTaskSource<ValueTuple<object, bool>>` and demanded
+            // a `GetResult` returning `(object, bool)`, which is why the
+            // identical declaration over concrete element types
+            // (`(string, bool)`) has always worked.
+            case TupleTypeSymbol tuple:
+                return tuple.ElementTypes.Any(IsSymbolicTypeArgument);
             default:
                 return false;
         }
@@ -5512,6 +5614,39 @@ internal sealed class MemberLookup
         if (a is SliceTypeSymbol sliceA && b is SliceTypeSymbol sliceB)
         {
             return SameTypeSymbol(sliceA.ElementType, sliceB.ElementType);
+        }
+
+        // Issue #3907: two tuples are the same type when their SHAPES agree.
+        // Element names are deliberately not compared — ADR-0172 (as amended
+        // by #3643) makes same-shape tuples differing only in element names
+        // identity-convertible, which is also the CLR's answer, since both
+        // erase to the same `ValueTuple` instantiation.
+        //
+        // Without this arm the comparison fell through to the ClrType probe at
+        // the bottom, and a tuple containing a same-compilation or open type
+        // (`(T, bool)`) has no ClrType at all while binding — see
+        // `TupleTypeSymbol.BuildClrType`, which returns null as soon as one
+        // element cannot be projected (the #3748/#3910 hole, here on the
+        // interface-conformance side). So `class Node[T] :
+        // IValueTaskSource[(T, bool)]` could not satisfy its own
+        // `GetResult` slot, while the identical declaration over concrete
+        // element types (`(string, bool)`) always could.
+        if (a is TupleTypeSymbol tupleA && b is TupleTypeSymbol tupleB)
+        {
+            if (tupleA.Arity != tupleB.Arity)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < tupleA.Arity; i++)
+            {
+                if (!SameTypeSymbol(tupleA.ElementTypes[i], tupleB.ElementTypes[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         if (a is NullableTypeSymbol nullableA && b is NullableTypeSymbol nullableB)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -265,6 +265,43 @@ internal static class ClrOverloadResolution
 #pragma warning restore SA1201
 
     /// <summary>
+    /// Issue #3907: sentinel argument type representing a by-ref
+    /// (<c>ref</c>/<c>out</c>/<c>in</c>) argument whose pointee is a
+    /// same-compilation user REFERENCE type — a G# <c>class</c>, interface or
+    /// named delegate the current compilation is still emitting, and which
+    /// therefore has no CLR <see cref="Type"/> to match against.
+    /// </summary>
+    /// <remarks>
+    /// <para>By VALUE such an argument rides through the <c>object</c>
+    /// boundary harmlessly (issue #658) — a class instance really is an
+    /// <c>object</c>. By REFERENCE it does not: C# requires a <c>ref</c>
+    /// argument to match its parameter EXACTLY, so <c>ref Node</c> is not a
+    /// <c>ref object</c>. Erasing it made the non-generic
+    /// <c>Interlocked.Exchange(ref object, object)</c> an exact IDENTITY match
+    /// for <c>Interlocked.Exchange(&amp;nodeField, nil)</c>, so it beat the
+    /// <c>Exchange&lt;T&gt;(ref T, T) where T : class</c> the author meant and
+    /// the call's type silently became <c>object</c>. csc never considers that
+    /// overload at all.</para>
+    /// <para>Like the inline <c>out var</c> sentinel, this one classifies as an
+    /// identity conversion against any by-ref parameter and as inapplicable
+    /// against everything else, so it stays neutral during betterness ranking.
+    /// The <em>candidate</em> restriction — only a by-ref parameter that is
+    /// GENERIC in the open definition can accept it, because no imported
+    /// signature can name a type this compilation has not emitted yet — is
+    /// applied before resolution by
+    /// <c>MemberLookup.ExcludeNonGenericByRefCandidates</c>, since a candidate
+    /// closed over the erasure no longer remembers which of its by-ref
+    /// parameters were generic. The type argument is then recovered
+    /// symbolically (<c>MemberLookup.BuildSymbolicMethodTypeArgs</c> →
+    /// <c>TryRecoverErasedTypeArguments</c>), which is what makes the
+    /// resulting call's type the user's own class rather than
+    /// <c>object</c>.</para>
+    /// </remarks>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+    public static readonly Type SymbolicByRefArgumentType = typeof(SymbolicByRefArgumentMarker);
+#pragma warning restore SA1201
+
+    /// <summary>
     /// Issue #2126: reports whether <paramref name="argType"/> is a resolution
     /// sentinel — the inline <c>out var</c> placeholder
     /// (<see cref="InlineOutVarArgumentType"/>) or the untyped <c>default</c>
@@ -280,7 +317,9 @@ internal static class ClrOverloadResolution
     /// <param name="argType">The candidate argument/type-argument CLR type.</param>
     /// <returns><see langword="true"/> when the type is a resolution sentinel.</returns>
     public static bool IsResolutionSentinel(Type argType) =>
-        ReferenceEquals(argType, InlineOutVarArgumentType) || ReferenceEquals(argType, DefaultLiteralArgumentType);
+        ReferenceEquals(argType, InlineOutVarArgumentType)
+        || ReferenceEquals(argType, DefaultLiteralArgumentType)
+        || ReferenceEquals(argType, SymbolicByRefArgumentType);
 
     // Issue #658 / #1311 / #1634: the supplementary-interface and constant-
     // narrowing checks used to live here as mutable (later [ThreadStatic])
@@ -337,6 +376,16 @@ internal static class ClrOverloadResolution
         if (ReferenceEquals(source, DefaultLiteralArgumentType))
         {
             return target.IsByRef ? ImplicitConversionKind.None : ImplicitConversionKind.Identity;
+        }
+
+        // Issue #3907: a by-ref argument over a same-compilation user reference
+        // type matches a by-ref parameter whose element type is a generic
+        // parameter, and nothing else — see SymbolicByRefArgumentType. In
+        // particular it must NOT match `ref object`, which is what erasure
+        // used to make it do.
+        if (ReferenceEquals(source, SymbolicByRefArgumentType))
+        {
+            return target.IsByRef ? ImplicitConversionKind.Identity : ImplicitConversionKind.None;
         }
 
         // Issue #533: a null source represents the `nil` literal in G#.
@@ -5589,6 +5638,15 @@ internal static class ClrOverloadResolution
     /// <c>default</c> literal argument during overload resolution. Never instantiated.
     /// </summary>
     private sealed class DefaultLiteralArgumentMarker
+    {
+    }
+
+    /// <summary>
+    /// Issue #3907: private marker type whose <see cref="Type"/> identity is used
+    /// as the <see cref="SymbolicByRefArgumentType"/> sentinel for a by-ref
+    /// argument over a same-compilation user reference type. Never instantiated.
+    /// </summary>
+    private sealed class SymbolicByRefArgumentMarker
     {
     }
 }

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Constructors.cs
@@ -387,6 +387,14 @@ internal sealed partial class OverloadResolver
                     continue;
                 }
 
+                // Issue #3907: an `@AllowNull` parameter declares that it
+                // accepts a nil-carrying input, so the `T?` argument needs no
+                // conversion at all and is forwarded as-is.
+                if (ConversionClassifier.AcceptsNilAnnotatedArgument(parameter, argument.Type, parameter.Type))
+                {
+                    continue;
+                }
+
                 if (argument.Type != parameter.Type
                     && !Conversion.Classify(argument.Type, parameter.Type).IsImplicit)
                 {
@@ -656,6 +664,13 @@ internal sealed partial class OverloadResolver
             {
                 boundArguments[i] = Invariant.Required(methodGroupArg, "a successful constructor method-group binding produces a bound expression");
                 hasErrors |= methodGroupArg is BoundErrorExpression;
+                continue;
+            }
+
+            // Issue #3907: an `@AllowNull` parameter declares that it accepts a
+            // nil-carrying input, so the `T?` argument is forwarded as-is.
+            if (ConversionClassifier.AcceptsNilAnnotatedArgument(parameter, argument.Type, parameter.Type))
+            {
                 continue;
             }
 
@@ -1289,6 +1304,14 @@ internal sealed partial class OverloadResolver
                 && !ReferenceEquals(argument.Type, namedDelegateParamTarget))
             {
                 convertedArguments.Add(conversions.BindConversion(argLocation, argument, paramType));
+                continue;
+            }
+
+            // Issue #3907: an `@AllowNull` parameter declares that it accepts a
+            // nil-carrying input, so the `T?` argument is forwarded as-is.
+            if (ConversionClassifier.AcceptsNilAnnotatedArgument(parameter, argument.Type, paramType))
+            {
+                convertedArguments.Add(argument);
                 continue;
             }
 
@@ -2347,6 +2370,14 @@ internal sealed partial class OverloadResolver
                 && !ReferenceEquals(argument.Type, namedDelegateInitTarget))
             {
                 convertedArgs.Add(conversions.BindConversion(argLocation, argument, parameter.Type));
+                continue;
+            }
+
+            // Issue #3907: an `@AllowNull` parameter declares that it accepts a
+            // nil-carrying input, so the `T?` argument is forwarded as-is.
+            if (ConversionClassifier.AcceptsNilAnnotatedArgument(parameter, argument.Type, parameter.Type))
+            {
+                convertedArgs.Add(argument);
                 continue;
             }
 

--- a/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
+++ b/src/Core/CodeAnalysis/Binding/StatementBinder.Narrowing.cs
@@ -508,7 +508,8 @@ internal sealed partial class StatementBinder
             return false;
         }
 
-        if (!AssignmentTypePreservesNarrowing(assign.AssignedValueType, u))
+        if (!AssignmentTypePreservesNarrowing(assign.AssignedValueType, u)
+            && !NestedAssignmentPreservesNarrowing(assign.Expression, u))
         {
             return false;
         }
@@ -516,6 +517,61 @@ internal sealed partial class StatementBinder
         variable = assign.Variable;
         underlying = u;
         return true;
+    }
+
+    /// <summary>
+    /// Issue #3907: whether <paramref name="value"/> — the right-hand side of
+    /// an assignment — is itself an assignment whose own value proves the outer
+    /// target non-nil.
+    /// </summary>
+    /// <remarks>
+    /// <para>A nested assignment's STATIC type is its own target's DECLARED
+    /// type, so <c>order = (buffer = [8]int32)</c> types as <c>buffer</c>'s
+    /// <c>[]?int32</c> even though the value it propagates is the definitely
+    /// non-nil array literal. The outer assignment therefore failed
+    /// <see cref="AssignmentTypePreservesNarrowing"/> and <c>order</c> stayed
+    /// nullable, while the identical <c>order = [8]int32</c> narrowed — an
+    /// asymmetry with no justification, since the two assign the same value.
+    /// C# reaches the same conclusion: its flow analysis tracks the assigned
+    /// value's null-state, not the nested target's annotation.</para>
+    /// <para>Sound because the value of an assignment expression IS the value
+    /// assigned — not a re-read of the target — so <c>x = (y = v)</c> gives
+    /// <c>x</c> exactly the value <c>v</c> and must narrow on exactly the
+    /// evidence <c>x = v</c> narrows on. That is why this applies the SAME
+    /// <see cref="AssignmentTypePreservesNarrowing"/> test to the inner
+    /// operand rather than a weaker or stronger one: the rule is a
+    /// look-through, not a new narrowing source.</para>
+    /// </remarks>
+    /// <param name="value">The outer assignment's right-hand side.</param>
+    /// <param name="narrowedType">The outer target's underlying non-nullable type.</param>
+    /// <returns><see langword="true"/> when the nested assignment narrows the outer target.</returns>
+    private bool NestedAssignmentPreservesNarrowing(BoundExpression? value, TypeSymbol narrowedType)
+    {
+        while (value is BoundConversionExpression conversion)
+        {
+            value = conversion.Expression;
+        }
+
+        BoundExpression? inner = value switch
+        {
+            BoundAssignmentExpression nestedLocal => nestedLocal.Expression,
+            BoundFieldAssignmentExpression nestedField => nestedField.Value,
+            _ => null,
+        };
+
+        if (inner == null)
+        {
+            return false;
+        }
+
+        var innerValue = inner;
+        while (innerValue is BoundConversionExpression innerConversion)
+        {
+            innerValue = innerConversion.Expression;
+        }
+
+        return AssignmentTypePreservesNarrowing(innerValue.Type, narrowedType)
+            || NestedAssignmentPreservesNarrowing(innerValue, narrowedType);
     }
 
     private bool AssignmentPreservesNarrowing(BoundAssignmentExpression assignment, TypeSymbol narrowedType)

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -207,8 +207,8 @@ internal sealed partial class MethodBodyEmitter
         else if (receiverIface != null
             && ReflectionMetadataEmitter.IsUserGenericInterfaceReference(receiverIface))
         {
-            var openMethod = ResolveOpenInterfaceMethod(receiverIface, call.Method);
-            methodHandle = this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(receiverIface, openMethod);
+            var (slotIface, openMethod) = ResolveInterfaceSlotOwner(receiverIface, call.Method);
+            methodHandle = this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(slotIface, openMethod);
         }
         else if (call.Method.ReceiverType is StructSymbol importedReceiver && importedReceiver.ClrType != null)
         {
@@ -295,6 +295,52 @@ internal sealed partial class MethodBodyEmitter
     // open <c>FunctionSymbol</c> on the definition so the emitter can look
     // up its <c>MethodHandle</c> and parent the resulting MemberRef at the
     // constructed TypeSpec.
+
+    /// <summary>
+    /// Issue #3907: resolves the interface that actually DECLARES the slot a
+    /// call reaches through <paramref name="receiverIface"/>, together with
+    /// that interface's open method.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="ResolveOpenInterfaceMethod"/> only ever searched the
+    /// receiver interface's own definition, so a slot INHERITED from a base
+    /// interface found nothing and the call fell through to the bare-MethodDef
+    /// lookup, which threw "has no emitted handle". Parenting the MemberRef at
+    /// the receiver interface would have been just as wrong — the derived
+    /// interface's TypeSpec does not declare the method — so both halves have
+    /// to move together.</para>
+    /// <para><c>SelfAndAllBaseInterfaces</c> yields <c>this</c> first, so a
+    /// slot the receiver declares itself still wins, and each base arrives
+    /// ALREADY SUBSTITUTED with the receiver's type arguments (see
+    /// <c>InterfaceSymbol.BaseInterfaces</c>), which is what makes the
+    /// resulting MemberRef parent the constructed <c>IBase&lt;T&gt;</c> rather
+    /// than the open definition. <c>Methods</c> is per-interface and excludes
+    /// inherited members, so a candidate matching by identity is genuinely the
+    /// declarer.</para>
+    /// <para>This is the shape ADR-0174's channels runtime is built on:
+    /// <c>ISendSelectableCore[T] : ISelectableCore[T]</c>, with
+    /// <c>Deregister</c> declared on the base and called through the derived
+    /// interface.</para>
+    /// </remarks>
+    /// <param name="receiverIface">The receiver expression's interface type.</param>
+    /// <param name="substitutedMethod">The call's (substituted) method symbol.</param>
+    /// <returns>The declaring interface and its open method.</returns>
+    private static (InterfaceSymbol Interface, FunctionSymbol Method) ResolveInterfaceSlotOwner(
+        InterfaceSymbol receiverIface,
+        FunctionSymbol substitutedMethod)
+    {
+        foreach (var candidate in receiverIface.SelfAndAllBaseInterfaces())
+        {
+            var open = ResolveOpenInterfaceMethod(candidate, substitutedMethod);
+            if (!ReferenceEquals(open, substitutedMethod))
+            {
+                return (candidate, open);
+            }
+        }
+
+        return (receiverIface, substitutedMethod);
+    }
+
     private static FunctionSymbol ResolveOpenInterfaceMethod(InterfaceSymbol receiverIface, FunctionSymbol substitutedMethod)
     {
         var def = receiverIface.Definition ?? receiverIface;

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -301,9 +301,10 @@ public sealed class ImportedClassSymbol : Symbol
             // match, so it beat `Exchange[T](ref T, T) where T : class` and the
             // call's type silently became `object` (GS0156 at the use site, or
             // worse, no diagnostic at all where the result is discarded).
-            // The dedicated sentinel matches only a by-ref parameter whose
-            // element type is a generic parameter; the type argument is then
-            // recovered from `symbolicArgVector` below.
+            // The dedicated sentinel keeps the argument neutral during
+            // betterness ranking; `ExcludeNonGenericByRefCandidates` below
+            // drops the overloads it cannot legally reach, and the type
+            // argument is recovered from `symbolicArgVector`.
             if (arguments[i] is BoundAddressOfExpression { Operand.Type: { } refPointee }
                 && IsSameCompilationUserReferencePointee(refPointee))
             {

--- a/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedClassSymbol.cs
@@ -229,6 +229,12 @@ public sealed class ImportedClassSymbol : Symbol
 
         var argTypes = new Type?[arguments.Length];
         var hasUserClassArg = false;
+
+        // Issue #3907: slots carrying the SymbolicByRefArgumentType sentinel.
+        // The sentinel is not a real argument type, so it must be withheld from
+        // CLR type inference; the type argument comes from the symbolic vector
+        // instead (see the `deferredInferenceArgs` hand-off to Resolve below).
+        bool[]? symbolicByRefArgs = null;
         for (var i = 0; i < arguments.Length; i++)
         {
             // Issue #1391: the untyped `default` literal (bound as a
@@ -280,6 +286,30 @@ public sealed class ImportedClassSymbol : Symbol
                 && byRefPointee.ClrType == null)
             {
                 argTypes[i] = ClrOverloadResolution.InlineOutVarArgumentType;
+                continue;
+            }
+
+            // Issue #3907: the REFERENCE-type counterpart of #1599 above. A
+            // pre-declared `ref`/`out` whose pointee is a same-compilation user
+            // class/interface/named delegate also has no CLR type while
+            // binding, and issue #658's `object` ride-through — correct for a
+            // by-VALUE argument, since a class instance really is an `object` —
+            // is wrong by REFERENCE: C# requires a `ref` argument to match its
+            // parameter exactly, so `ref Node` is not a `ref object`. Left
+            // erased, `Interlocked.Exchange(&nodeField, nil)` made the
+            // non-generic `Exchange(ref object?, object?)` an exact IDENTITY
+            // match, so it beat `Exchange[T](ref T, T) where T : class` and the
+            // call's type silently became `object` (GS0156 at the use site, or
+            // worse, no diagnostic at all where the result is discarded).
+            // The dedicated sentinel matches only a by-ref parameter whose
+            // element type is a generic parameter; the type argument is then
+            // recovered from `symbolicArgVector` below.
+            if (arguments[i] is BoundAddressOfExpression { Operand.Type: { } refPointee }
+                && IsSameCompilationUserReferencePointee(refPointee))
+            {
+                argTypes[i] = ClrOverloadResolution.SymbolicByRefArgumentType;
+                symbolicByRefArgs ??= new bool[arguments.Length];
+                symbolicByRefArgs[i] = true;
                 continue;
             }
 
@@ -368,11 +398,14 @@ public sealed class ImportedClassSymbol : Symbol
             receiverType: null,
             ImmutableArray.CreateRange(arguments.Select(a => a.Type)));
         var filteredNameMatches = new List<MethodInfo>();
-        foreach (var method in MemberLookup.ExcludeErasureOnlyEnumCandidates(
-                     nameMatches,
-                     symbolicArgVector,
-                     argumentNames,
-                     SymbolicReceiver))
+        foreach (var method in MemberLookup.ExcludeNonGenericByRefCandidates(
+                     MemberLookup.ExcludeErasureOnlyEnumCandidates(
+                         nameMatches,
+                         symbolicArgVector,
+                         argumentNames,
+                         SymbolicReceiver),
+                     symbolicByRefArgs,
+                     argumentNames))
         {
             filteredNameMatches.Add(method);
         }
@@ -407,7 +440,8 @@ public sealed class ImportedClassSymbol : Symbol
                 type =>
                 {
                     return Invariant.Required(ProjectMethodGroupType(type), "an imported method-group type must be projectable");
-                }));
+                }),
+            deferredInferenceArgs: symbolicByRefArgs);
 
         switch (result.Outcome)
         {
@@ -681,6 +715,33 @@ public sealed class ImportedClassSymbol : Symbol
         var remove = eventInfo.RemoveMethod;
         return (add != null && IsVisibleToCurrentCompilation(add))
             || (remove != null && IsVisibleToCurrentCompilation(remove));
+    }
+
+    /// <summary>
+    /// Issue #3907: whether a by-ref argument's pointee is a same-compilation
+    /// user REFERENCE type — a G# <c>class</c>, interface or named delegate
+    /// whose CLR <see cref="Type"/> does not exist yet — optionally behind a
+    /// reference-nullable <c>?</c>, which is a pure annotation and does not
+    /// change the pointee's runtime representation.
+    /// </summary>
+    /// <remarks>
+    /// A same-compilation user VALUE type is deliberately excluded: it is
+    /// already handled by the #1599/#1601 branch above, whose sentinel has the
+    /// wider "matches any by-ref parameter" meaning those cases need.
+    /// </remarks>
+    /// <param name="pointee">The by-ref argument's pointee type.</param>
+    /// <returns><see langword="true"/> when the sentinel applies.</returns>
+    private static bool IsSameCompilationUserReferencePointee(TypeSymbol pointee)
+    {
+        while (pointee is NullableTypeSymbol nullable
+            && !NullableLifting.IsAnyValueTypeNullable(nullable)
+            && nullable.UnderlyingType != null)
+        {
+            pointee = nullable.UnderlyingType;
+        }
+
+        return pointee.ClrType == null
+            && pointee is StructSymbol { IsClass: true } or InterfaceSymbol or DelegateTypeSymbol;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ParameterSymbol.cs
@@ -80,6 +80,22 @@ public sealed class ParameterSymbol : LocalVariableSymbol
     public object? ExplicitDefaultValue { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether this parameter carries
+    /// <c>@AllowNull</c> (issue #3907), the .NET-standard annotation for "this
+    /// input accepts <c>nil</c> even though its type is not nullable".
+    /// </summary>
+    /// <remarks>
+    /// <para>Purely an ANNOTATION: <c>Type</c> is untouched, so a
+    /// value-type <c>T</c> keeps its <c>T</c> signature slot and never becomes
+    /// <c>Nullable&lt;T&gt;</c>, and reads of the parameter inside the body
+    /// still see a non-nullable <c>T</c>. Only the ARGUMENT conversion at a
+    /// call site is relaxed, and only where the nullable source and the
+    /// non-nullable target share a runtime representation — see
+    /// <c>ConversionClassifier.AcceptsNilAnnotatedArgument</c>.</para>
+    /// </remarks>
+    public bool AllowsNullArgument => Binding.KnownAttributes.HasAllowNull(Attributes);
+
+    /// <summary>
     /// Gets the resolved <c>@MarshalAs(UnmanagedType.…)</c> override for
     /// this parameter (ADR-0096 / issue #762), or <see langword="null"/>
     /// when the parameter has no such annotation. Attached by

--- a/test/Compiler.Tests/Issue3907AllowNullParameterTests.cs
+++ b/test/Compiler.Tests/Issue3907AllowNullParameterTests.cs
@@ -1,0 +1,360 @@
+// <copyright file="Issue3907AllowNullParameterTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3907: <c>@AllowNull</c> on a parameter. C# gives a declaration two
+/// nullability contracts, an INPUT one and an OUTPUT one;
+/// <c>[AllowNull] T value</c> says "this input accepts <c>null</c> even though
+/// its type is not nullable". ADR-0155 gives a G# declaration a single
+/// nullability, so for a REFERENCE type cs2gs widens the declaration to
+/// <c>T?</c> (issue #3694) and the two agree — but an UNCONSTRAINED type
+/// parameter has no such widening, so the attribute is the whole contract and
+/// gsc had to honour it. It did not: it had no <c>AllowNull</c> support at all,
+/// and <c>ReceiveResult&lt;T&gt;</c>'s <c>([AllowNull] T value, bool ok)</c>
+/// constructor rejected the <c>T?</c> the channels runtime passes it.
+/// </summary>
+/// <remarks>
+/// <para>The fix is deliberately ANNOTATION-ONLY. Widening the parameter's own
+/// type would make a value-type <c>T</c> emit a <c>Nullable&lt;T&gt;</c>
+/// signature slot where <c>T</c> is expected — wrong IL that ILVerify does NOT
+/// catch, because the metadata is internally consistent and simply describes a
+/// different method. <see cref="AllowNullParameter_EmitsTheBareTypeNotNullable"/>
+/// reads the emitted signature back and pins exactly that.</para>
+/// <para>Witnesses of discrimination (ADR-0154): a parameter WITHOUT the
+/// annotation still rejects a <c>T?</c> argument, and a value-type nullable
+/// (<c>int32?</c> at an <c>@AllowNull int32</c> slot) stays rejected — it
+/// really is a <c>Nullable&lt;int32&gt;</c> on the stack, and C# rejects it
+/// too. A mutant that relaxes unconditionally fails both.</para>
+/// </remarks>
+public class Issue3907AllowNullParameterTests
+{
+    // The `ReceiveResult<T>` shape from src/Sdk/Gsharp.Runtime.Channels, cut
+    // down to the parts that matter: an `@AllowNull T` constructor parameter, a
+    // `T?` value flowing into it, and both a reference and a value-type
+    // instantiation of the same generic code.
+    private const string BoxSource = @"
+package Demo
+
+import System
+import System.Diagnostics.CodeAnalysis
+
+struct Box[T] {
+    let Value T
+    let Ok bool
+
+    init(@AllowNull value T, ok bool) {
+        Value = value
+        Ok = ok
+    }
+}
+
+func Closed[T]() Box[T] {
+    var v T? = nil
+    return Box[T](v, false)
+}
+
+func Delivered[T](value T) Box[T] {
+    return Box[T](value, true)
+}
+";
+
+    [Fact]
+    public void AllowNullParameter_AcceptsANilCarryingArgumentAndRuns()
+    {
+        var source = BoxSource + @"
+let cs = Closed[string]()
+Console.WriteLine(""closed-string="" + cs.Ok.ToString() + "":"" + (if cs.Value == nil { ""nil"" } else { ""set"" }))
+let ci = Closed[int32]()
+Console.WriteLine(""closed-int="" + ci.Ok.ToString() + "":"" + ci.Value.ToString())
+let ds = Delivered[string](""hi"")
+Console.WriteLine(""delivered-string="" + ds.Ok.ToString() + "":"" + ds.Value)
+let di = Delivered[int32](7)
+Console.WriteLine(""delivered-int="" + di.Ok.ToString() + "":"" + di.Value.ToString())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out _);
+
+        // The nil really reaches the field, and the value-type instantiation
+        // stores the element's zero value rather than a lifted `Nullable`.
+        Assert.Contains("closed-string=False:nil", lines);
+        Assert.Contains("closed-int=False:0", lines);
+        Assert.Contains("delivered-string=True:hi", lines);
+        Assert.Contains("delivered-int=True:7", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    [Fact]
+    public void AllowNullParameter_EmitsTheBareTypeNotNullable()
+    {
+        // THE failure mode this fix was written to avoid. `@AllowNull` must
+        // change what the ARGUMENT conversion accepts and nothing else; if it
+        // widened the parameter's declared type instead, `Box[T]`'s constructor
+        // would take `Nullable<T>` and every caller compiled against it would
+        // be calling a method that does not exist in the shape they expect.
+        // ILVerify cannot see that — the assembly is internally consistent —
+        // so the signature is read back out of the emitted metadata.
+        var source = BoxSource + @"
+Console.WriteLine(""done"")
+";
+
+        _ = CompileVerifyAndRun(source, out var assemblyPath);
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        var boxType = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name).StartsWith("Box", StringComparison.Ordinal));
+
+        var ctor = boxType.GetMethods()
+            .Select(reader.GetMethodDefinition)
+            .Single(m => reader.GetString(m.Name) == ".ctor");
+
+        var signature = ctor.DecodeSignature(new SignatureText(), genericContext: null);
+
+        Assert.Equal(2, signature.ParameterTypes.Length);
+
+        // `!0` is the type parameter itself. Anything mentioning Nullable — in
+        // particular `valuetype [System.Runtime]System.Nullable`1<!0>` — is the
+        // wrong-IL bug.
+        Assert.Equal("!0", signature.ParameterTypes[0]);
+        Assert.DoesNotContain("Nullable", signature.ParameterTypes[0], StringComparison.Ordinal);
+        Assert.Equal("bool", signature.ParameterTypes[1]);
+    }
+
+    [Fact]
+    public void WithoutTheAnnotation_ANilCarryingArgumentIsStillRejected()
+    {
+        // Anti-vacuity guard: the ONLY thing that admits the `T?` argument is
+        // the annotation. Passes both before and after the fix.
+        const string source = @"
+package Demo
+
+import System
+
+struct Plain[T] {
+    let Value T
+
+    init(value T) {
+        Value = value
+    }
+}
+
+func Make[T]() Plain[T] {
+    var v T? = nil
+    return Plain[T](v)
+}
+
+Console.WriteLine(""unreachable"")
+";
+
+        var log = CompileExpectingFailure(source);
+
+        Assert.Contains("GS0154", log, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllowNullOnAValueTypeParameter_StillRejectsAValueTypeNullable()
+    {
+        // The other half of the guard, and the reason the relaxation is gated
+        // on `NullableLifting.IsAnyValueTypeNullable`. `int32?` really IS a
+        // `Nullable<int32>` on the evaluation stack, so admitting it at an
+        // `int32` slot would be a stack-shape error, not an annotation. C#
+        // rejects the same call.
+        const string source = @"
+package Demo
+
+import System
+import System.Diagnostics.CodeAnalysis
+
+struct ValueBox {
+    let Value int32
+
+    init(@AllowNull value int32) {
+        Value = value
+    }
+}
+
+func Make(v int32?) ValueBox {
+    return ValueBox(v)
+}
+
+Console.WriteLine(""unreachable"")
+";
+
+        var log = CompileExpectingFailure(source);
+
+        Assert.Contains("GS0154", log, StringComparison.Ordinal);
+    }
+
+    private static string[] CompileVerifyAndRun(string source, out string assemblyPath)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_allownull_").FullName;
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+        var outPath = Path.Combine(tempDir, "Program.dll");
+        assemblyPath = outPath;
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        var (compileExit, compileLog) = RunCompiler(args);
+        Assert.True(compileExit == 0, $"gsc failed:\n{compileLog}");
+
+        IlVerifier.Verify(outPath);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc!.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return stdout
+            .ReplaceLineEndings(Environment.NewLine)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_allownull_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + Path.Combine(tempDir, "Program.dll"),
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            var (compileExit, compileLog) = RunCompiler(args);
+            Assert.True(compileExit != 0, $"gsc unexpectedly succeeded:\n{compileLog}");
+            return compileLog;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static (int Exit, string Log) RunCompiler(List<string> args)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            var exit = Program.Main(args.ToArray());
+            return (exit, compileOut + "\n" + compileErr);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ISignatureTypeProvider{TType, TGenericContext}"/> that
+    /// renders a signature element as ILAsm-ish text, so the assertion above can
+    /// name the exact shape it requires without depending on a reflection
+    /// context.
+    /// </summary>
+    private sealed class SignatureText : ISignatureTypeProvider<string, object?>
+    {
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
+        {
+            PrimitiveTypeCode.Boolean => "bool",
+            PrimitiveTypeCode.Int32 => "int32",
+            PrimitiveTypeCode.String => "string",
+            PrimitiveTypeCode.Object => "object",
+            PrimitiveTypeCode.Void => "void",
+            _ => typeCode.ToString(),
+        };
+
+        public string GetGenericTypeParameter(object? genericContext, int index) => "!" + index;
+
+        public string GetGenericMethodParameter(object? genericContext, int index) => "!!" + index;
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeDefinition(handle).Name);
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeReference(handle).Name);
+
+        public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+        public string GetGenericInstantiation(string genericType, System.Collections.Immutable.ImmutableArray<string> typeArguments)
+            => genericType + "<" + string.Join(",", typeArguments) + ">";
+
+        public string GetArrayType(string elementType, ArrayShape shape) => elementType + "[]";
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetByReferenceType(string elementType) => elementType + "&";
+
+        public string GetPointerType(string elementType) => elementType + "*";
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetFunctionPointerType(MethodSignature<string> signature) => "fnptr";
+
+        public string GetTypeFromSerializedName(string name) => name;
+
+        public PrimitiveTypeCode GetUnderlyingEnumType(string type) => PrimitiveTypeCode.Int32;
+
+        public bool IsSystemType(string type) => false;
+    }
+}

--- a/test/Compiler.Tests/Issue3907AllowNullParameterTests.cs
+++ b/test/Compiler.Tests/Issue3907AllowNullParameterTests.cs
@@ -309,7 +309,7 @@ Console.WriteLine(""unreachable"")
     /// name the exact shape it requires without depending on a reflection
     /// context.
     /// </summary>
-    private sealed class SignatureText : ISignatureTypeProvider<string, object?>
+    private sealed class SignatureText : ISignatureTypeProvider<string, object>
     {
         public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
         {
@@ -321,9 +321,9 @@ Console.WriteLine(""unreachable"")
             _ => typeCode.ToString(),
         };
 
-        public string GetGenericTypeParameter(object? genericContext, int index) => "!" + index;
+        public string GetGenericTypeParameter(object genericContext, int index) => "!" + index;
 
-        public string GetGenericMethodParameter(object? genericContext, int index) => "!!" + index;
+        public string GetGenericMethodParameter(object genericContext, int index) => "!!" + index;
 
         public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
             => reader.GetString(reader.GetTypeDefinition(handle).Name);
@@ -331,7 +331,7 @@ Console.WriteLine(""unreachable"")
         public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
             => reader.GetString(reader.GetTypeReference(handle).Name);
 
-        public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+        public string GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
             => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
 
         public string GetGenericInstantiation(string genericType, System.Collections.Immutable.ImmutableArray<string> typeArguments)

--- a/test/Compiler.Tests/Issue3907NarrowingAndInterfaceSlotTests.cs
+++ b/test/Compiler.Tests/Issue3907NarrowingAndInterfaceSlotTests.cs
@@ -1,0 +1,287 @@
+// <copyright file="Issue3907NarrowingAndInterfaceSlotTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3907: the last two defects standing between the migrated
+/// <c>src/Sdk/Gsharp.Runtime.Channels</c> and a clean compile.
+/// </summary>
+/// <remarks>
+/// <para><b>Narrowing lost a nested assignment's value.</b>
+/// <c>SelectRandom.Shuffle</c>'s cache-or-grow idiom is
+/// <c>order = (buffer = new int[…])</c>; the nested assignment's STATIC type
+/// is <c>buffer</c>'s declared <c>[]?int32</c>, so the outer assignment looked
+/// like it stored a nullable and <c>order</c> stayed nullable for the rest of
+/// the method — while the identical <c>order = [8]int32</c> narrowed.</para>
+/// <para><b>An inherited interface slot had no emitted handle.</b> ADR-0174's
+/// <c>ISendSelectableCore[T] : ISelectableCore[T]</c> declares
+/// <c>Deregister</c> on the BASE; calling it through the derived interface
+/// crashed the emitter, because the resolver only ever searched the receiver
+/// interface's own definition.</para>
+/// <para>Both cases COMPILE, ILVERIFY and RUN, and both carry a control that
+/// passed before the fix (ADR-0154) — the direct assignment, and a slot the
+/// receiver interface declares itself.</para>
+/// </remarks>
+public class Issue3907NarrowingAndInterfaceSlotTests
+{
+    [Fact]
+    public void NestedAssignmentValue_NarrowsTheOuterTargetLikeADirectOne()
+    {
+        // `Direct` is the control: it narrowed before the fix, so a mutant that
+        // narrows nothing fails it, and a mutant that narrows everything is
+        // caught by `StillNullable` below.
+        const string source = @"
+package Demo
+
+import System
+
+class Cache {
+    shared {
+        private var buffer []?int32
+
+        func Nested(n int32) int32 {
+            var order []?int32 = buffer
+            if order == nil || order.Length < n {
+                // The cache-or-grow idiom: assign through the field.
+                order = (buffer = [Math.Max(n, 8)]int32)
+            }
+            for var i = 0; i < n; i++ {
+                order[i] = i
+            }
+            var total = 0
+            for var i = n - 1; i > 0; i-- {
+                let j = i - 1
+                // A deconstruction assignment whose TARGETS index the narrowed
+                // local: the shape that surfaced this in SelectRandom.gs.
+                order[i], order[j] = order[j], order[i]
+                total = total + order[i]
+            }
+            return total + order.Length
+        }
+
+        func Direct(n int32) int32 {
+            var order []?int32 = buffer
+            if order == nil || order.Length < n {
+                order = [Math.Max(n, 8)]int32
+            }
+            return order.Length
+        }
+    }
+}
+
+Console.WriteLine(""nested="" + Cache.Nested(4).ToString())
+Console.WriteLine(""direct="" + Cache.Direct(4).ToString())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        // 8 is Math.Max(4, 8); the swap sum over 0..3 is 0+1+2 = 3 for the
+        // three iterations, so the numbers pin real execution, not just
+        // binding.
+        Assert.Contains("nested=11", lines);
+        Assert.Contains("direct=8", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    [Fact]
+    public void ANullableSlotWithoutTheAssignment_IsStillRejected()
+    {
+        // Anti-vacuity guard: the narrowing must come from an assignment that
+        // actually stores a non-nil value. Passes both before and after.
+        const string source = @"
+package Demo
+
+import System
+
+func Use(order []?int32) int32 {
+    return order.Length
+}
+
+Console.WriteLine(""unreachable"")
+";
+
+        var log = CompileExpectingFailure(source);
+
+        Assert.Contains("GS0158", log, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InheritedGenericInterfaceSlot_EmitsAndDispatches()
+    {
+        // `Deregister` is declared on the BASE interface and called through a
+        // receiver typed as the DERIVED one — ADR-0174's
+        // `ISendSelectableCore[T] : ISelectableCore[T]` shape. `Register` is
+        // the control: declared on the derived interface itself, it resolved
+        // before the fix, so a mutant that re-parents everything at the base
+        // fails it.
+        const string source = @"
+package Demo
+
+import System
+
+internal interface IBase[T] {
+    func Deregister(node T) string;
+}
+
+internal interface IDerived[T] : IBase[T] {
+    func Register(node T) string;
+}
+
+class Impl[T] : IDerived[T] {
+    func Deregister(node T) string -> ""dereg:"" + node!!.ToString()!!
+
+    func Register(node T) string -> ""reg:"" + node!!.ToString()!!
+}
+
+class Arm[T] {
+    let Selectable IDerived[T]
+
+    init(selectable IDerived[T]) {
+        Selectable = selectable
+    }
+
+    func Go(n T) string {
+        let a = Selectable.Register(n)
+        let b = Selectable.Deregister(n)
+        return a + ""|"" + b
+    }
+}
+
+Console.WriteLine(""str="" + Arm[string](Impl[string]()).Go(""x""))
+Console.WriteLine(""int="" + Arm[int32](Impl[int32]()).Go(7))
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        // Both slots run, in order, and dispatch to the right implementation.
+        Assert.Contains("str=reg:x|dereg:x", lines);
+        Assert.Contains("int=reg:7|dereg:7", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    private static string[] CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_narrow_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Program.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            var (compileExit, compileLog) = RunCompiler(args);
+            Assert.True(compileExit == 0, $"gsc failed:\n{compileLog}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc!.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout
+                .ReplaceLineEndings(Environment.NewLine)
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static string CompileExpectingFailure(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_narrow_neg_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + Path.Combine(tempDir, "Program.dll"),
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            var (compileExit, compileLog) = RunCompiler(args);
+            Assert.True(compileExit != 0, $"gsc unexpectedly succeeded:\n{compileLog}");
+            return compileLog;
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+
+    private static (int Exit, string Log) RunCompiler(List<string> args)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            var exit = Program.Main(args.ToArray());
+            return (exit, compileOut + "\n" + compileErr);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+}

--- a/test/Compiler.Tests/Issue3907SymbolicErasureTests.cs
+++ b/test/Compiler.Tests/Issue3907SymbolicErasureTests.cs
@@ -1,0 +1,370 @@
+// <copyright file="Issue3907SymbolicErasureTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3907: three places where issue #658's type-argument erasure — a
+/// same-compilation type or an open type parameter has no CLR
+/// <see cref="Type"/> while binding, so it rides through as
+/// <c>System.Object</c> — was allowed to decide a question it cannot answer,
+/// and the symbolic type the author wrote was lost.
+/// </summary>
+/// <remarks>
+/// <para>All three surfaced in the migrated
+/// <c>src/Sdk/Gsharp.Runtime.Channels</c> after #3915's performance rewrite,
+/// and each has a control case in this file that passed BEFORE the fix — the
+/// same construct over a concrete/BCL type — so a mutant that erases
+/// unconditionally, or one that never erases, is caught by discrimination
+/// rather than by a single green assertion (ADR-0154).</para>
+/// <para>Every case COMPILES, ILVERIFIES and RUNS the emitted program.
+/// Both checks are load-bearing on the #3501 effort: an executing test has
+/// passed a broken build that only ILVerify caught, and an ILVerify-clean
+/// build has produced a wrong runtime answer.</para>
+/// </remarks>
+public class Issue3907SymbolicErasureTests
+{
+    [Fact]
+    public void RangeSliceOverAnOpenSpan_KeepsItsElementType()
+    {
+        // `destination[1..]` reflects the slice member off the receiver's
+        // ERASED ClrType, so inside `Holder[T]` a `Span[T]` reports
+        // `Span<object>` as Slice's return type. Taking that verbatim made the
+        // slice unusable at the `Span[T]` slot it was sliced from — which is
+        // exactly `Chan{T}.DrainBufferInto(destination[first..])`.
+        //
+        // Controls that already passed: `.Slice(1)` (an ordinary method call,
+        // never routed through the range path) and the whole shape over a
+        // concrete `Span[int32]`.
+        const string source = @"
+package Demo
+
+import System
+
+class Holder[T] {
+    func Copy(source Span[T], destination Span[T]) int32 {
+        // Range slice on both sides, feeding a `Span[T]` parameter.
+        let tail = destination[1..]
+        source[..tail.Length].CopyTo(tail)
+        return Consume(tail)
+    }
+
+    func ViaSliceMethod(destination Span[T]) int32 {
+        // Control: the method form always kept `Span[T]`.
+        return Consume(destination.Slice(1))
+    }
+
+    func Consume(s Span[T]) int32 -> s.Length
+}
+
+class Concrete {
+    func Copy(destination Span[int32]) int32 {
+        // Control: a concrete element type was never erased.
+        let tail = destination[1..]
+        tail[0] = 42
+        return tail.Length
+    }
+}
+
+var backing = []string{ ""a"", ""b"", ""c"" }
+var target = []string{ """", """", """" }
+let h = Holder[string]()
+Console.WriteLine(""copied="" + h.Copy(backing.AsSpan(), target.AsSpan()).ToString())
+Console.WriteLine(""target1="" + target[1])
+Console.WriteLine(""target2="" + target[2])
+Console.WriteLine(""viaSlice="" + h.ViaSliceMethod(target.AsSpan()).ToString())
+
+var nums = []int32{ 1, 2, 3 }
+Console.WriteLine(""concrete="" + Concrete().Copy(nums.AsSpan()).ToString())
+Console.WriteLine(""nums1="" + nums[1].ToString())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        // The slice really is the tail of the SAME buffer: the copy lands at
+        // index 1 and 2, not at 0, and the elements are the source's.
+        Assert.Contains("copied=2", lines);
+        Assert.Contains("target1=a", lines);
+        Assert.Contains("target2=b", lines);
+        Assert.Contains("viaSlice=2", lines);
+        Assert.Contains("concrete=2", lines);
+        Assert.Contains("nums1=42", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementationOverATupleTypeArgument_BindsAndDispatches()
+    {
+        // `class Node[T] : IValueTaskSource[(Value T, Ok bool)]` could not
+        // satisfy its own `GetResult` slot: the binder's
+        // `MemberLookup.IsSymbolicTypeArgument` had no tuple arm, so the
+        // interface was verified against the ERASED
+        // `IValueTaskSource<ValueTuple<object, bool>>` and demanded a
+        // `GetResult` returning `(object, bool)`. The emitter's counterpart
+        // (`ArgIsSymbolicUserDefined`, issue #1902) already recursed into
+        // tuples, so the two disagreed.
+        //
+        // The `NodeB`/`NodeC` shapes are the controls that already passed: a
+        // named tuple over CONCRETE elements (whose ClrType builds fine) and a
+        // bare `T`. The assertions dispatch through BOTH slots on the same
+        // object, so a mutant that collapses the two implementations is caught.
+        const string source = @"
+package Demo
+
+import System
+import System.Threading.Tasks.Sources
+
+class Node[T] : IValueTaskSource[(Value T, Ok bool)], IValueTaskSource[T] {
+    private var payload T
+    private var ok bool
+
+    init(payload T, ok bool) {
+        this.payload = payload
+        this.ok = ok
+    }
+
+    private func (IValueTaskSource[(Value T, Ok bool)]) GetResult(token int16) (Value T, Ok bool) {
+        return (payload, ok)
+    }
+
+    private func (IValueTaskSource[(Value T, Ok bool)]) GetStatus(token int16) ValueTaskSourceStatus -> ValueTaskSourceStatus.Succeeded
+
+    private func (IValueTaskSource[(Value T, Ok bool)]) OnCompleted(
+        continuation (object?) -> void,
+        state object?,
+        token int16,
+        flags ValueTaskSourceOnCompletedFlags) {
+    }
+
+    private func (IValueTaskSource[T]) GetResult(token int16) T -> payload
+
+    private func (IValueTaskSource[T]) GetStatus(token int16) ValueTaskSourceStatus -> ValueTaskSourceStatus.Succeeded
+
+    private func (IValueTaskSource[T]) OnCompleted(
+        continuation (object?) -> void,
+        state object?,
+        token int16,
+        flags ValueTaskSourceOnCompletedFlags) {
+    }
+}
+
+// Control: a named tuple over CONCRETE element types always worked.
+class Fixed : IValueTaskSource[(Value string, Ok bool)] {
+    private func (IValueTaskSource[(Value string, Ok bool)]) GetResult(token int16) (Value string, Ok bool) -> (""fixed"", true)
+
+    private func (IValueTaskSource[(Value string, Ok bool)]) GetStatus(token int16) ValueTaskSourceStatus -> ValueTaskSourceStatus.Succeeded
+
+    private func (IValueTaskSource[(Value string, Ok bool)]) OnCompleted(
+        continuation (object?) -> void,
+        state object?,
+        token int16,
+        flags ValueTaskSourceOnCompletedFlags) {
+    }
+}
+
+func ReadPair[T](n Node[T]) (Value T, Ok bool) {
+    let src IValueTaskSource[(Value T, Ok bool)] = n
+    return src.GetResult(0)
+}
+
+func ReadOne[T](n Node[T]) T {
+    let src IValueTaskSource[T] = n
+    return src.GetResult(0)
+}
+
+let s = Node[string](""hi"", true)
+let pair = ReadPair[string](s)
+Console.WriteLine(""pair="" + pair.Value + "":"" + pair.Ok.ToString())
+Console.WriteLine(""one="" + ReadOne[string](s))
+
+let i = Node[int32](7, false)
+let ipair = ReadPair[int32](i)
+Console.WriteLine(""ipair="" + ipair.Value.ToString() + "":"" + ipair.Ok.ToString())
+
+let f IValueTaskSource[(Value string, Ok bool)] = Fixed()
+Console.WriteLine(""fixed="" + f.GetResult(0).Value)
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        // Both slots exist on the same object and dispatch separately: the
+        // tuple slot yields the pair, the bare-T slot yields the value alone.
+        Assert.Contains("pair=hi:True", lines);
+        Assert.Contains("one=hi", lines);
+
+        // A value-type instantiation exercises the `ValueTuple<int32, bool>`
+        // shape the erased form would have got wrong in the other direction.
+        Assert.Contains("ipair=7:False", lines);
+        Assert.Contains("fixed=fixed", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    [Fact]
+    public void ByRefArgumentOverAUserClass_PicksTheGenericOverload()
+    {
+        // `Interlocked` declares BOTH `Exchange<T>(ref T, T) where T : class`
+        // and the non-generic `Exchange(ref object?, object?)`. The #658
+        // erasure made `&nodeField` look like `ref object`, which is an exact
+        // IDENTITY match for the non-generic overload, so it won and the
+        // call's type became `object` (GS0156 at the use site). csc never
+        // considers that overload at all: a `ref` argument requires exact type
+        // identity.
+        //
+        // The `StringPool` control — the identical shape over a BCL element
+        // type, where no erasure happens — passed before the fix. The
+        // assertions RUN the pool, so the test would also catch an
+        // `Exchange` that type-checks but does not actually swap.
+        const string source = @"
+package Demo
+
+import System
+import System.Threading
+
+class Node {
+    var Tag string
+
+    init(tag string) {
+        Tag = tag
+    }
+}
+
+class Pool {
+    private var slot Node?
+
+    func Rent(tag string) Node -> Interlocked.Exchange(&slot, nil) ?? Node(tag)
+
+    func Return(n Node) {
+        Volatile.Write(&slot, n)
+    }
+
+    func Peek() Node? -> Volatile.Read(&slot)
+
+    func Swap(n Node?) Node? -> Interlocked.Exchange(&slot, n)
+}
+
+// Control: the same shape over a BCL element type never erased.
+class StringPool {
+    private var slot string?
+
+    func Rent() string -> Interlocked.Exchange(&slot, nil) ?? ""fresh""
+}
+
+let p = Pool()
+Console.WriteLine(""rent1="" + p.Rent(""a"").Tag)
+Console.WriteLine(""empty="" + (if p.Peek() == nil { ""nil"" } else { ""set"" }))
+p.Return(Node(""pooled""))
+Console.WriteLine(""peek="" + p.Peek()!!.Tag)
+Console.WriteLine(""rent2="" + p.Rent(""b"").Tag)
+Console.WriteLine(""drained="" + (if p.Peek() == nil { ""nil"" } else { ""set"" }))
+let previous = p.Swap(Node(""next""))
+Console.WriteLine(""swapped="" + (if previous == nil { ""nil"" } else { previous!!.Tag }))
+Console.WriteLine(""after="" + p.Peek()!!.Tag)
+Console.WriteLine(""control="" + StringPool().Rent())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source);
+
+        // The pool actually pools: an empty slot manufactures a node, a
+        // returned node is handed back, and the rent CLEARS the slot — that
+        // last one is the observable proof that the selected `Exchange` really
+        // performed the exchange rather than merely type-checking.
+        Assert.Contains("rent1=a", lines);
+        Assert.Contains("empty=nil", lines);
+        Assert.Contains("peek=pooled", lines);
+        Assert.Contains("rent2=pooled", lines);
+        Assert.Contains("drained=nil", lines);
+        Assert.Contains("swapped=nil", lines);
+        Assert.Contains("after=next", lines);
+        Assert.Contains("control=fresh", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    private static string[] CompileVerifyAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3907_erasure_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(srcPath, source);
+            var outPath = Path.Combine(tempDir, "Program.dll");
+
+            var args = new List<string>
+            {
+                "/out:" + outPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                srcPath,
+            };
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc!.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout
+                .ReplaceLineEndings(Environment.NewLine)
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Picks up where #3916 left off.** Based on `64401d0c1`.

## Re-measured first, and the count had moved the wrong way

Scale: **deduplicated compile-error artifacts**, the same one #3914/#3916 used for 27/11/3. Measured end to end on the real pipeline (translate → compile through the repacked Release `Gsharp.NET.Sdk` nupkg), isolated to this one app with `--exclude` for the other 61 projects.

| stage | compile-error artifacts |
|---|---:|
| `origin/main` (`64401d0c1`) | **7** |
| + this PR | **0** |

**#3916 measured 3, and it was right when it measured.** It was based on `d75d6c4fc`; between that base and its merge, **#3915's performance rewrite of the channels runtime landed** — 12 `Gsharp.Runtime.Channels` files, +1510 lines — and added four artifacts nobody saw, because `Channels` is deliberately outside the PR guard. That is the #3831/#3896/#3905 hazard happening a fourth time, on the one app the guard does not cover.

## The six root causes

Three of the four new ones and one of the two carried over are the same family: **issue #658's type-argument erasure deciding a question it cannot answer.** A same-compilation type or an open type parameter has no CLR `Type` while binding, so it rides through as `System.Object`; that is load-bearing and harmless by value, and wrong wherever the symbolic type is the answer.

**1. gsc — a range slice over an open `Span[T]` kept its element type.** (`Chan{T}.Batch.gs`, `Chan{T}.gs` — GS0154 + GS0155.) The slice member is found by reflecting on the receiver's ClrType, so inside `class Holder[T]` a `Span[T]` reports `Span<object>` as `Slice`'s return type, and `destination[first..]` produced a `Span[object]` that no longer fitted the `Span[T]` slot it was sliced from. Every BCL slice shape returns the receiver's own type, so when the reflected result is identical to the receiver's CLR type the answer is the receiver's symbolic type. `destination.Slice(1)` — an ordinary call — was always right, and `Span[int32]` was always right; both are controls in the test.

**2. gsc — a tuple type argument is symbolic when an element is.** (`ParkedNode{T}.gs` — GS0187 + GS0494.) `MemberLookup.IsSymbolicTypeArgument` had no tuple arm, so `class OpReceiveNode[T] : IValueTaskSource[(Value T, Ok bool)]` was verified against the ERASED `IValueTaskSource<ValueTuple<object, bool>>` and could not satisfy its own `GetResult` slot. The emitter's counterpart already recursed into tuples (#1902), so binder and emit disagreed — the doc comment claiming they mirror each other was stale. `SameTypeSymbol` needed the matching arm for the same reason (`TupleTypeSymbol.BuildClrType` returns null as soon as one element cannot be projected — the #3748/#3910 hole, here on the conformance side). The identical declaration over concrete element types always worked, and is the control.

**3. gsc — a by-ref argument over a same-compilation user class is not a `ref object`.** (`Chan{T}.gs` — GS0156.) `Interlocked` declares both `Exchange<T>(ref T, T) where T : class` and the non-generic `Exchange(ref object?, object?)`. Erasure made `&receiveNodePool` an exact IDENTITY match for the non-generic overload, so it won and the call's type became `object`. **csc never considers it: a `ref` argument requires exact type identity.** A dedicated sentinel now marks such an argument, a candidate filter drops any overload whose parameter at that slot is a by-ref over a non-generic type (applied on the OPEN candidates, because a closed generic's `ref T` has already become `ref object`), and the type argument is recovered symbolically.

> **The latent bug #3916 flagged beside this one does not exist, and I can show it.** `System.Threading.Volatile` has **no** non-generic `object` overload — only `Read<T>(ref T)` / `Write<T>(ref T, T)` — so `Volatile.Write(&receiveNodePool, node)` never had a wrong overload to bind to. Enumerated at runtime, and the pool round-trips correctly under ILVerify. Nothing to file.

**4. gsc — `@AllowNull` on a parameter.** (`Chan{T}.gs` — GS0154.) `[AllowNull] T value` is C#'s "this INPUT accepts null though its type is not nullable". cs2gs widens a REFERENCE-typed `[AllowNull]` declaration to `T?` (#3694) so the two contracts agree, but an unconstrained type parameter has no such widening, so `ReceiveResult<T>([AllowNull] T value, bool ok)` translates verbatim to `init(@AllowNull value T, …)` and the annotation is the whole contract. gsc had no `AllowNull` support at all.

> The fix is **annotation-only**, which is the trap #3916 backed out of. The parameter's declared type is never widened — a value-type `T` would then emit a `Nullable<T>` signature slot where `T` is expected, wrong IL that ILVerify does not catch because the assembly is internally consistent and simply describes a different method. `AllowNullParameter_EmitsTheBareTypeNotNullable` reads the ctor signature back out of the emitted metadata and asserts `!0`. The relaxation is also gated on the source nullable being representation-identical to its underlying, so `int32?` at an `@AllowNull int32` slot stays rejected — as it is in C#.

**5. gsc — narrowing lost a nested assignment's value.** (`SelectRandom.gs` — GS0116.) `order = (buffer = new int[…])` types as `buffer`'s declared `[]?int32`, so the outer assignment looked like it stored a nullable and `order` stayed nullable — while the identical `order = [8]int32` narrowed. The value of an assignment expression IS the value assigned, so this is a pure look-through applying the same test to the inner operand.

**6. gsc — an inherited interface slot had no emitted handle.** (`ArmDescriptor.gs` — GS9998, an emitter crash.) ADR-0174's `ISendSelectableCore[T] : ISelectableCore[T]` declares `Deregister` on the BASE; the resolver only searched the receiver interface's own definition, so the call fell through to the bare-MethodDef lookup and threw. Parenting the MemberRef at the derived interface would have been equally wrong, so both halves move together.

**Root 3's premise correction is worth carrying forward** and so is **#3916's third item**: `SelectRandom.gs:59` is a real defect after all, not a polish artifact. The polish pass never touched that file — instrumented and confirmed, 26 stripped sites, none in `SelectRandom.gs`. It did **not** self-heal, and would not have.

## Layer judgement

**All six are gsc.** In each case the C# is ordinary and legal, csc accepts it, and gsc's own neighbouring path already got it right: `.Slice()` keeps `Span[T]` where `[a..]` did not; the emitter recurses into tuples where the binder did not; `ref` identity is C#'s rule; a direct assignment narrows where the nested one did not; a slot the receiver interface declares itself resolves where an inherited one did not. These are wrong for every G# program, not just this app. **No source edits** — I did not touch #3882's or #3915's C#.

## Evidence

- **Nine executing cases** across three new test classes: each **compiles, ILVERIFIES and RUNS** the emitted program and asserts observable behaviour — the slice really is the tail of the same buffer, both interface slots dispatch separately on the same object, the pool actually pools and the rent actually clears the slot, the nil actually reaches the field, the swap actually swaps, the inherited slot actually runs. Both checks are load-bearing on this effort: an executing test has passed a broken build that only ILVerify caught, and an ILVerify-clean build has produced a wrong runtime answer.
- **Controls that passed before the fix** are in every case (ADR-0154 discrimination), plus two negative tests that must fail both ways.
- `Issue3907*`: **22 passed / 0 failed** (10 new + the 12 from #3914/#3916).

## What this does NOT do

**`Channels` is not green.** Its compile stage passes for the first time, and the ILVERIFY stage — never before reached — now reports **19 findings** over roughly eight distinct emitter defects (open-vs-closed generic self-reference in `.ctor`, an erased lambda adapter typed `Task` where `ValueTask` is expected, `ReceiveResult` ref-vs-value on the stack, `Memory<T>` vs `T[]`). Those were invisible while the app could not compile. They are a separate PR.

`src/Sdk/Gsharp.Runtime.Channels` therefore stays **out** of `run-cs2gs-selfmig-pr-guard.sh`'s `guard_apps`: the script's own note explains why a day-one-red guard is worse than none, and the guard runs translate → compile → **ilverify** → test-parity.

Refs #3907, #3501, #3915, #3916, #658, #1902, #3694, #3748, ADR-0155, ADR-0172, ADR-0174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
