### PR TITLE
gsc: four generic-context emit defects take migrated Gsharp.Runtime.Channels from 19 ilverify findings to 1 (#3932)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
+++ b/src/Core/CodeAnalysis/Binding/ConversionClassifier.cs
@@ -1351,6 +1351,23 @@ internal sealed class ConversionClassifier
             return true;
         }
 
+        // Issue #3932: an IMPORTED conversion operator whose declaring generic
+        // is closed over an OPEN type parameter — `[]T -> Memory[T]` — reaches
+        // neither branch here. The CLR branch above needs both sides to have a
+        // reflectible `ClrType` and an open `[]T` has none; the symbolic branch
+        // below only knows same-package operators. So the conversion was simply
+        // dropped and the emitter wrote the raw array into a `Memory[T]` slot.
+        // Resolve it off the target's OPEN definition instead, which is where
+        // `Memory`1::op_Implicit(!0[])` actually lives.
+        if (argument.Type != null
+            && expectedType != null
+            && argument.Type != TypeSymbol.Error
+            && TryResolveSymbolicImportedConversion(argument.Type, expectedType, out var openConvMethod))
+        {
+            converted = new BoundClrConversionCallExpression(null, argument, openConvMethod, expectedType);
+            return true;
+        }
+
         // Issue #1017: same-package user-defined implicit conversion operators
         // are modelled as static op_Implicit FunctionSymbols and have no
         // reflectible ClrType during binding, so resolve them symbolically.
@@ -1538,6 +1555,242 @@ internal sealed class ConversionClassifier
                 || TypeSymbol.ContainsNamedTupleElements(mapped))
             ? mapped
             : null;
+    }
+
+    /// <summary>
+    /// Issue #3932: resolves an IMPORTED user-defined implicit conversion
+    /// operator whose declaring generic type is closed over a symbolic or open
+    /// type argument — the <c>[]T -&gt; System.Memory[T]</c> shape that
+    /// <see cref="ClrOperatorResolution"/> cannot see because an open
+    /// <c>[]T</c> has no reflectible <see cref="Type"/>.
+    /// <para>The operator is looked up on the target's OPEN definition
+    /// (<c>Memory`1::op_Implicit(!0[])</c>) and accepted only when BOTH its
+    /// parameter and its return type, mapped through the target's symbolic type
+    /// arguments, match the source and the target exactly. That two-sided match
+    /// is what keeps this from firing on an unrelated operator that merely
+    /// happens to be named <c>op_Implicit</c>.</para>
+    /// <para>The returned <see cref="MethodInfo"/> is the OPEN one, which the
+    /// emitter recognises (see <c>MethodBodyEmitter.EmitCallResolvedConversion</c>)
+    /// as its signal to parent the MemberRef at the symbolic TypeSpec rather
+    /// than at the erased <c>Memory&lt;object&gt;</c>.</para>
+    /// </summary>
+    /// <param name="source">The source type symbol.</param>
+    /// <param name="target">The conversion target type symbol.</param>
+    /// <param name="conversion">The resolved OPEN conversion operator.</param>
+    /// <returns>Whether a symbolic imported implicit conversion applies.</returns>
+    public static bool TryResolveSymbolicImportedConversion(
+        TypeSymbol? source,
+        TypeSymbol? target,
+        [NotNullWhen(true)] out MethodInfo? conversion)
+    {
+        conversion = null;
+        if (source == null
+            || target is not ImportedTypeSymbol { OpenDefinition: { } openDefinition } imported
+            || imported.TypeArguments.IsDefaultOrEmpty)
+        {
+            return false;
+        }
+
+        // Only the symbolic/open case is in scope: a fully CLR-backed target
+        // already resolves through ClrOperatorResolution, and re-resolving it
+        // here would change which operator a concrete call site picks.
+        var needsSymbolic = false;
+        foreach (var typeArgument in imported.TypeArguments)
+        {
+            if (TypeSymbol.ContainsTypeParameter(typeArgument)
+                || TypeSymbol.RequiresSymbolicProjection(typeArgument))
+            {
+                needsSymbolic = true;
+                break;
+            }
+        }
+
+        if (!needsSymbolic)
+        {
+            return false;
+        }
+
+        MethodInfo[] candidates;
+        try
+        {
+            candidates = openDefinition.GetMethods(BindingFlags.Public | BindingFlags.Static);
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (!string.Equals(candidate.Name, "op_Implicit", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var parameters = candidate.GetParameters();
+            if (parameters.Length != 1)
+            {
+                continue;
+            }
+
+            var mappedParameter = MemberLookup.MapOpenClrTypeToSymbolic(
+                parameters[0].ParameterType,
+                openDefinition,
+                imported.TypeArguments);
+            var mappedReturn = MemberLookup.MapOpenClrTypeToSymbolic(
+                candidate.ReturnType,
+                openDefinition,
+                imported.TypeArguments);
+
+            // The return must be the target's OWN generic, substituted with the
+            // target's own arguments — compared by open definition rather than
+            // by symbol identity, because the mapped projection is a fresh
+            // ImportedTypeSymbol instance that never reference-equals the
+            // target even when it is structurally the same `Memory[T]`.
+            if (mappedParameter == null
+                || mappedParameter == TypeSymbol.Error
+                || !mappedParameter.Equals(source)
+                || mappedReturn is not ImportedTypeSymbol { OpenDefinition: { } returnOpenDefinition }
+                || returnOpenDefinition != openDefinition)
+            {
+                continue;
+            }
+
+            conversion = candidate;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #3932: the <c>newobj</c> analogue of
+    /// <see cref="TrySubstituteParameterTypeFromReceiver"/> and
+    /// <see cref="TryRecoverReceiverTypeParameterSlot"/>. A constructor has no
+    /// receiver, so neither of those helpers can fire and a CLR ctor parameter
+    /// declared as the declaring generic's own slot (<c>ValueTask&lt;T&gt;(!0)</c>)
+    /// stayed at the type-erased closed shape — <c>object</c> — for the whole
+    /// argument-conversion pass. The argument was then classified as a boxing
+    /// conversion, so gsc emitted <c>box !!T</c> in front of a <c>newobj</c>
+    /// whose parent TypeSpec is the correctly symbolic <c>ValueTask`1&lt;!!T&gt;</c>
+    /// — invalid IL that ILVerify reports as
+    /// <c>[found ref 'T'][expected value 'T']</c>. The equivalent method call
+    /// (<c>List[T].Add(v)</c>) has always emitted the raw <c>T</c>, so this is a
+    /// ctor-only hole in machinery gsc already had.
+    /// <para>Mapping the OPEN constructor's parameter type through the
+    /// construction's symbolic type arguments recovers the real slot. Bare type
+    /// parameters are accepted here (unlike the #765 receiver gate, which
+    /// deliberately skips them and leaves that case to #1540's helper) because
+    /// for a ctor there is no second pass to fall back to.</para>
+    /// </summary>
+    /// <param name="openGenericDefinition">The open generic definition being constructed, if any.</param>
+    /// <param name="symbolicTypeArgs">The construction's symbolic type arguments.</param>
+    /// <param name="closedConstructor">The resolved (closed, erased) CLR constructor.</param>
+    /// <param name="paramIndex">Zero-based index into the constructor's parameter list.</param>
+    /// <returns>The recovered symbolic parameter type, or <see langword="null"/>.</returns>
+    public static TypeSymbol? TrySubstituteCtorParameterTypeFromConstructedType(
+        Type? openGenericDefinition,
+        ImmutableArray<TypeSymbol> symbolicTypeArgs,
+        ConstructorInfo? closedConstructor,
+        int paramIndex)
+    {
+        if (openGenericDefinition == null
+            || closedConstructor == null
+            || symbolicTypeArgs.IsDefaultOrEmpty
+            || paramIndex < 0)
+        {
+            return null;
+        }
+
+        ConstructorInfo? openCtor = null;
+        try
+        {
+            foreach (var candidate in openGenericDefinition.GetConstructors(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (candidate.MetadataToken == closedConstructor.MetadataToken
+                    && candidate.Module == closedConstructor.Module)
+                {
+                    openCtor = candidate;
+                    break;
+                }
+            }
+        }
+        catch (Exception ex) when (ClrTypeUtilities.IsMetadataLoadFailure(ex))
+        {
+            return null;
+        }
+
+        if (openCtor == null)
+        {
+            return null;
+        }
+
+        var openParams = openCtor.GetParameters();
+        if (paramIndex >= openParams.Length)
+        {
+            return null;
+        }
+
+        var openParamType = openParams[paramIndex].ParameterType;
+        if (openParamType.IsByRef)
+        {
+            // A by-ref ctor slot is emitted as an address, never boxed, so it
+            // is already correct and rewriting it here would change RefKind
+            // handling downstream.
+            return null;
+        }
+
+        // Only a parameter that actually MENTIONS the declaring generic's own
+        // parameters can have been erased. A genuine `object` slot (e.g.
+        // `List[T](object)`) has no generic parameter in it and must keep
+        // boxing, so leaving it alone here is what preserves #1196.
+        if (!MentionsTypeGenericParameter(openParamType))
+        {
+            return null;
+        }
+
+        var mapped = MemberLookup.MapOpenClrTypeToSymbolic(
+            openParamType,
+            openGenericDefinition,
+            symbolicTypeArgs,
+            openMethodDefinition: null,
+            methodTypeArguments: default);
+        return mapped != null && mapped != TypeSymbol.Error ? mapped : null;
+
+        // Whether an open CLR type mentions a TYPE-level generic parameter
+        // anywhere in its shape (directly, or nested through arrays, by-ref,
+        // pointers and constructed generics).
+        static bool MentionsTypeGenericParameter(Type? type)
+        {
+            if (type == null)
+            {
+                return false;
+            }
+
+            if (type.IsGenericParameter)
+            {
+                return type.DeclaringMethod == null;
+            }
+
+            if (type.HasElementType)
+            {
+                return MentionsTypeGenericParameter(type.GetElementType());
+            }
+
+            if (type.IsGenericType)
+            {
+                foreach (var argument in type.GetGenericArguments())
+                {
+                    if (MentionsTypeGenericParameter(argument))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.cs
@@ -2016,6 +2016,41 @@ internal sealed partial class ExpressionBinder
             }
         }
 
+        // Issue #3932: a ctor has no receiver, so neither #765's
+        // TrySubstituteParameterTypeFromReceiver nor #1540's
+        // TryRecoverReceiverTypeParameterSlot — the two helpers that keep a
+        // `List[T].Add(v)` argument OFF the boxing path — can fire for a
+        // `newobj`. Recover the same symbolic slot from the construction's own
+        // type arguments instead, so `ValueTask[T](v)` converts `v` to `T` (the
+        // real `!0` slot) rather than to the erased `object`. Without this the
+        // binder inserts a boxing conversion and the emitter writes
+        // `box !!T; newobj ValueTask`1<!!T>::.ctor(!0)` — unverifiable IL.
+        // Runs AFTER the delegate targets above and never overwrites one: the
+        // #1638 delegate recovery is strictly more specific.
+        if (openGenericDefinition != null && !symbolicTypeArgs.IsDefaultOrEmpty)
+        {
+            for (var p = 0; p < ctorParameters.Length; p++)
+            {
+                if (ctorParameterTypeOverrides != null && ctorParameterTypeOverrides.ContainsKey(p))
+                {
+                    continue;
+                }
+
+                var recovered = ConversionClassifier.TrySubstituteCtorParameterTypeFromConstructedType(
+                    openGenericDefinition,
+                    symbolicTypeArgs,
+                    bestCtor,
+                    p);
+                if (recovered == null)
+                {
+                    continue;
+                }
+
+                ctorParameterTypeOverrides ??= new Dictionary<int, TypeSymbol>();
+                ctorParameterTypeOverrides[p] = recovered;
+            }
+        }
+
         // Issue #1638: route through the shared CLR call-argument-construction
         // pipeline (interpolation rebind → handler args → delegate rebind →
         // parameter conversions) so a Func/Action-literal argument to a CLR

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -1339,6 +1339,36 @@ internal sealed partial class OverloadResolver
 
                 if (TypeSymbol.ContainsTypeParameter(expectedType))
                 {
+                    // Issue #3932: the skip below is right for a BARE open `T`
+                    // slot (erased to System.Object, emitter boxes), but it
+                    // fired for anything that merely CONTAINS a type parameter
+                    // — including `Memory[T]`, which emits as a REAL
+                    // constructed slot `Memory`1<!!0>`, not as `object`. A
+                    // `[]T` argument there needs `Memory`1::op_Implicit` and
+                    // got nothing, so the raw array reached the slot and
+                    // ILVerify reported `[found ref 'T0[]'][expected value
+                    // 'Memory`1<T0>']`. The identical call with a CONCRETE
+                    // element type has always emitted the operator — the
+                    // conversion was only ever lost when the element was open.
+                    // This is the same bare-vs-constructed distinction #3222
+                    // taught the plain-function argument path; the extension
+                    // path never learned it.
+                    //
+                    // Only APPLIES a conversion that resolves; when none does,
+                    // the historical unconverted pass-through is unchanged, so
+                    // the bare-`T` case this skip exists for is untouched.
+                    if (permutedArguments[i].Type is { } openArgumentType
+                        && openArgumentType != TypeSymbol.Error
+                        && openArgumentType != expectedType
+                        && conversions.TryApplyUserDefinedImplicitArgumentConversion(
+                            permutedArguments[i],
+                            expectedType,
+                            out var openTargetConverted))
+                    {
+                        convertedArgs.Add(openTargetConverted);
+                        continue;
+                    }
+
                     // A parameter typed as an open T is encoded as System.Object in
                     // the emitted signature; pass the argument unconverted so the
                     // emitter inserts box / unbox.any around the erased boundary.

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -101,10 +101,31 @@ internal sealed partial class MethodBodyEmitter
     private void EmitConstructorChaining(BoundConstructorChainingExpression call)
     {
         if (call.SelectedConstructor == null
-            || !this.outer.cache.ExplicitCtorHandles.TryGetValue(call.SelectedConstructor, out var ctorHandle))
+            || !this.outer.cache.ExplicitCtorHandles.TryGetValue(call.SelectedConstructor, out var ctorDefHandle))
         {
             throw new InvalidOperationException(
                 $"Constructor chaining target on '{call.SelectedConstructor?.DeclaringType?.Name}' has no emitted handle.");
+        }
+
+        EntityHandle ctorHandle = ctorDefHandle;
+
+        // ADR-0087 §3 R3+R4 / issue #3932: inside a GENERIC aggregate the
+        // sibling `.ctor` must be referenced through a MemberRef parented at
+        // the self TypeSpec (`Chan`1<!0>::.ctor`), exactly as
+        // `EmitConstructorCall`'s `newobj` does. The bare MethodDef names the
+        // OPEN definition, so the verifier sees `call Chan`1::.ctor` applied to
+        // a `Chan`1<!0>` receiver: `this` is never marked initialized
+        // (ILVerify `CallCtor` + `ThisUninitReturn`) and the argument slots
+        // stay at their uninstantiated `!0` shape (`StackUnexpected`). Every
+        // OTHER self-reference in a generic body — field access, instance
+        // calls, `newobj` — already routes through this TypeSpec; only the
+        // chained initializer did not.
+        var chainOwner = call.SelectedConstructor.DeclaringType;
+        if (chainOwner != null && ReflectionMetadataEmitter.IsUserGenericTypeReference(chainOwner))
+        {
+            ctorHandle = this.outer.userTokens.ResolveUserCtorTokenForExplicit(
+                chainOwner,
+                call.SelectedConstructor);
         }
 
         // Load `this` then evaluate each argument in order. Parameters of a

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -1418,7 +1418,22 @@ internal sealed partial class MethodBodyEmitter
             "a non-lifted imported conversion carries a CLR method");
         this.EmitExpression(conv.Source);
         this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(method));
+
+        // Issue #3932: `ConversionClassifier.TryResolveSymbolicImportedConversion`
+        // hands back the OPEN operator (`Memory`1::op_Implicit`) precisely
+        // because the target is symbolic (`Memory[T]` for an open `T`).
+        // Referencing it through the plain MemberRef path parents it at the
+        // OPEN `Memory`1`, which is the same open-vs-closed defect the chained
+        // `.ctor` had; route it through the #671 symbolic-container factory so
+        // the parent is the `Memory`1<!!T>` TypeSpec. An open declaring type is
+        // a shape ordinary CLR operator resolution never produces, so this
+        // cannot re-target an existing conversion.
+        this.il.Token(method.DeclaringType is { IsGenericTypeDefinition: true }
+            ? this.outer.memberRefs.GetMethodEntityHandle(
+                method,
+                default(ImmutableArray<TypeSymbol?>),
+                conv.Type)
+            : this.outer.memberRefs.GetMethodReference(method));
         this.EmitErasedObjectReturnWidening(TypeSymbol.FromClrType(method.ReturnType), conv.Type);
 
         // Issue #663: when the operator returns a non-nullable value type T but the
@@ -1538,10 +1553,20 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
-        this.il.OpCode(ILOpCode.Call);
-        this.il.Token(this.outer.memberRefs.GetMethodReference(Invariant.Required(
+        var conversionMethod = Invariant.Required(
             conversion.Method,
-            "an imported conversion carries a CLR method")));
+            "an imported conversion carries a CLR method");
+
+        // Issue #3932: as in EmitClrConversionCall — a symbolically resolved
+        // operator arrives as the OPEN method and must be parented at the
+        // constructed TypeSpec rather than at the open definition.
+        this.il.OpCode(ILOpCode.Call);
+        this.il.Token(conversionMethod.DeclaringType is { IsGenericTypeDefinition: true }
+            ? this.outer.memberRefs.GetMethodEntityHandle(
+                conversionMethod,
+                default(ImmutableArray<TypeSymbol?>),
+                conversion.Type)
+            : this.outer.memberRefs.GetMethodReference(conversionMethod));
     }
 
     private static bool IsNullableValueType(Type t)

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -449,7 +449,19 @@ internal sealed class ReflectionMetadataEmitter
     /// <param name="kickoff">The async kickoff method.</param>
     private void RegisterStateMachineEnclosingGenerics(StructSymbol smStruct, FunctionSymbol kickoff)
     {
-        var receiverDef = kickoff?.ReceiverType is StructSymbol receiver
+        // Issue #3932: a STATIC (`shared`) async method has no `ReceiverType`,
+        // so reading only that left `classTPs` empty and the state machine was
+        // reified at arity ZERO even though the owning type is generic — every
+        // hoisted field then carried a dangling `!0`
+        // (`Chan`1/ChanReader/'<ReadSlowAsync>d__0'` where csc emits
+        // `…/<ReadSlowAsync>d__0`1<T>`), which ILVerify reports as
+        // `[found …`1<T0>][expected …`1<!0>]`. `StaticOwnerType` is the static
+        // counterpart of `ReceiverType`, and the ITERATOR sibling
+        // (`StateMachineEmitter.GetIteratorTypeParametersInScope`) has always
+        // consulted both — this is the async path catching up. Instance methods
+        // were unaffected, which is why the failure needed a `shared async
+        // func` on a generic type to surface at all.
+        var receiverDef = (kickoff?.ReceiverType as StructSymbol ?? kickoff?.StaticOwnerType as StructSymbol) is { } receiver
             ? (receiver.Definition ?? receiver)
             : null;
         var classTPs = receiverDef?.TypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;

--- a/test/Compiler.Tests/Issue3932GenericEmitSitesTests.cs
+++ b/test/Compiler.Tests/Issue3932GenericEmitSitesTests.cs
@@ -1,0 +1,524 @@
+// <copyright file="Issue3932GenericEmitSitesTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3932: four places where gsc emitted IL for a GENERIC context using a
+/// shape that is only correct for a non-generic one. Each one compiled without
+/// a diagnostic and each one produced IL the verifier rejects, so they were
+/// invisible until <c>src/Sdk/Gsharp.Runtime.Channels</c> compiled cleanly for
+/// the first time (#3907) and its ilverify stage became reachable.
+/// </summary>
+/// <remarks>
+/// <para>What makes all four the same story: in every case gsc's OWN
+/// neighbouring path already got it right, and only one sibling was missed.
+/// A <c>newobj</c> on a generic user type parents its ctor MemberRef at the
+/// self TypeSpec, but the chained <c>init(...)</c> did not. An imported generic
+/// METHOD slot takes a raw <c>T</c>, but the imported generic CTOR slot boxed
+/// it. An INSTANCE async method reifies its state machine over the enclosing
+/// type's parameters, but a <c>shared</c> one did not. A CONCRETE element type
+/// emits <c>Memory`1::op_Implicit</c> at an extension-call argument, but an
+/// open one emitted nothing.</para>
+/// <para>Every case COMPILES, ILVERIFIES and RUNS, and asserts on observed
+/// behaviour — all three are load-bearing on the #3501 effort, where an
+/// executing test has passed a build only ILVerify caught and an ILVerify-clean
+/// build has produced a wrong runtime answer. Two cases additionally read the
+/// emitted metadata back, because "the token is a MethodDef, not a
+/// TypeSpec-parented MemberRef" and "the state machine has arity 0" are
+/// encoding facts a behavioural assertion cannot name.</para>
+/// <para>Discrimination (ADR-0154): every test carries a control that passed
+/// BEFORE the fix — the same construct in the non-generic / instance /
+/// concrete-element form — so a mutant that applies the new path
+/// unconditionally is caught as surely as one that never applies it.</para>
+/// </remarks>
+public class Issue3932GenericEmitSitesTests
+{
+    /// <summary>
+    /// Root 1 (9 of the 19 ilverify findings): a <c>convenience init</c>
+    /// delegating to a sibling inside a GENERIC aggregate emitted
+    /// <c>call Box`1::.ctor</c> against the raw MethodDef, which names the OPEN
+    /// definition. The verifier then sees a <c>Box`1&lt;!0&gt;</c> receiver
+    /// handed to a ctor on <c>Box`1</c>: <c>this</c> is never marked
+    /// initialized (<c>CallCtor</c> + <c>ThisUninitReturn</c>) and the argument
+    /// slots stay uninstantiated (<c>StackUnexpected</c>).
+    /// </summary>
+    [Fact]
+    public void ChainedInitInsideAGenericType_TargetsTheSelfTypeSpec()
+    {
+        const string source = @"
+package main
+
+import System
+
+class Box[T] {
+    var items []T
+    var tag string
+
+    // Two hops of chaining, so a fix that only handles the last one is caught.
+    convenience init() {
+        init(4, ""default"")
+    }
+
+    convenience init(capacity int32) {
+        init(capacity, ""sized"")
+    }
+
+    init(capacity int32, tag string) {
+        items = [capacity]T
+        this.tag = tag
+    }
+
+    func Describe() string -> tag + "":"" + items.Length.ToString()
+}
+
+// Control: the identical chaining shape on a NON-generic type has always been
+// correct, because a bare MethodDef IS the right token there.
+class Plain {
+    var tag string
+
+    convenience init() {
+        init(""plain"")
+    }
+
+    init(tag string) {
+        this.tag = tag
+    }
+
+    func Describe() string -> tag
+}
+
+Console.WriteLine(""zeroArg="" + Box[int32]().Describe())
+Console.WriteLine(""oneArg="" + Box[string](7).Describe())
+Console.WriteLine(""twoArg="" + Box[int32](2, ""explicit"").Describe())
+Console.WriteLine(""plain="" + Plain().Describe())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out var assemblyPath);
+
+        // Behaviour: both convenience hops really ran the designated
+        // initializer, so the tag and the buffer length are the chained ones
+        // rather than a default-constructed instance's.
+        Assert.Contains("zeroArg=default:4", lines);
+        Assert.Contains("oneArg=sized:7", lines);
+        Assert.Contains("twoArg=explicit:2", lines);
+        Assert.Contains("plain=plain", lines);
+        Assert.Equal("done", lines[^1]);
+
+        // Encoding: the chained call must go through a MemberRef (which carries
+        // the TypeSpec parent) on the GENERIC type, and must stay a plain
+        // MethodDef on the non-generic one. Reading the token kind out of the
+        // emitted body is the only way to state that; ILVerify agrees but says
+        // it as a stack-shape complaint three instructions later.
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        Assert.Equal(
+            HandleKind.MemberReference,
+            SingleChainedCtorCallTokenKind(reader, pe, "Box`1"));
+        Assert.Equal(
+            HandleKind.MethodDefinition,
+            SingleChainedCtorCallTokenKind(reader, pe, "Plain"));
+    }
+
+    /// <summary>
+    /// Root 2 (7 of the 19): an argument at an IMPORTED generic constructor's
+    /// own type-parameter slot (<c>ValueTask&lt;T&gt;(!0)</c>) was converted to
+    /// the type-erased <c>object</c>, so gsc emitted <c>box !!T</c> in front of
+    /// a <c>newobj</c> whose parent TypeSpec is the correctly symbolic
+    /// <c>ValueTask`1&lt;!!T&gt;</c>.
+    /// </summary>
+    /// <remarks>
+    /// A ctor has no receiver, so neither #765's
+    /// <c>TrySubstituteParameterTypeFromReceiver</c> nor #1540's
+    /// <c>TryRecoverReceiverTypeParameterSlot</c> — the two helpers that keep
+    /// <c>List[T].Add(v)</c> off the boxing path — could fire.
+    /// <c>ViaMethod</c> below is exactly that already-correct sibling, and it
+    /// is what makes this a ctor-only hole rather than a general erasure gap.
+    /// </remarks>
+    [Fact]
+    public void ImportedGenericCtorSlot_TakesTheRawTypeParameterNotABox()
+    {
+        const string source = @"
+package main
+
+import System
+import System.Collections.Generic
+import System.Threading.Tasks
+
+class Ops {
+    shared {
+        // Control: the imported generic METHOD slot has always been correct.
+        func ViaMethod[T](v T) List[T] {
+            var l = List[T]()
+            l.Add(v)
+            return l
+        }
+
+        // The failing shape: the imported generic CTOR slot.
+        func ViaCtor[T](v T) ValueTask[T] {
+            return ValueTask[T](v)
+        }
+
+        // The same defect one level in: the boxed operand also dragged the
+        // TUPLE's own element type to `object`, emitting
+        // `ValueTuple`2<object,bool>` where `ValueTuple`2<!!T,bool>` belongs.
+        func ViaCtorTuple[T](v T, ok bool) ValueTask[(Value T, Ok bool)] {
+            return ValueTask[(Value T, Ok bool)]((v, ok))
+        }
+    }
+}
+
+// A VALUE type is the discriminating instantiation: a stray box on a
+// reference `T` is merely redundant, but on `int32` it changes the value's
+// representation at the slot.
+Console.WriteLine(""method-int="" + Ops.ViaMethod[int32](7)[0].ToString())
+Console.WriteLine(""ctor-int="" + Ops.ViaCtor[int32](7).Result.ToString())
+Console.WriteLine(""ctor-string="" + Ops.ViaCtor[string](""hi"").Result)
+
+let t = Ops.ViaCtorTuple[int32](9, true)
+let (value, ok) = t.Result
+Console.WriteLine(""tuple-int="" + value.ToString() + "":"" + ok.ToString())
+
+let s = Ops.ViaCtorTuple[string](""nine"", false)
+let (svalue, sok) = s.Result
+Console.WriteLine(""tuple-string="" + svalue + "":"" + sok.ToString())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out _);
+
+        Assert.Contains("method-int=7", lines);
+        Assert.Contains("ctor-int=7", lines);
+        Assert.Contains("ctor-string=hi", lines);
+        Assert.Contains("tuple-int=9:True", lines);
+        Assert.Contains("tuple-string=nine:False", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    /// <summary>
+    /// Root 3: a <c>shared</c> (static) async method on a generic type has no
+    /// <c>ReceiverType</c>, so the state-machine reifier saw no class type
+    /// parameters and emitted the struct at arity ZERO — leaving every hoisted
+    /// field carrying a dangling <c>!0</c>.
+    /// </summary>
+    /// <remarks>
+    /// The instance form has always been right, and so has the iterator
+    /// sibling, whose scope collection consults <c>StaticOwnerType</c> as well.
+    /// </remarks>
+    [Fact]
+    public void SharedAsyncOnAGenericType_ReifiesItsStateMachineOverTheTypeParameters()
+    {
+        const string source = @"
+package main
+
+import System
+import System.Threading.Tasks
+
+class Holder[T] {
+    var seed T
+
+    init(seed T) {
+        this.seed = seed
+    }
+
+    shared {
+        // The failing shape: `shared async` on a generic type.
+        async func FetchShared(v T) ValueTask[T] {
+            await Task.Yield()
+            return v
+        }
+    }
+
+    // Control: the instance form always reified at the right arity.
+    async func FetchInstance() ValueTask[T] {
+        await Task.Yield()
+        return seed
+    }
+}
+
+// Control: `shared async` on a NON-generic type needs no reification at all.
+class Flat {
+    shared {
+        async func FetchShared(v int32) ValueTask[int32] {
+            await Task.Yield()
+            return v
+        }
+    }
+}
+
+Console.WriteLine(""shared-int="" + Holder[int32].FetchShared(41).AsTask().GetAwaiter().GetResult().ToString())
+Console.WriteLine(""shared-string="" + Holder[string].FetchShared(""hi"").AsTask().GetAwaiter().GetResult())
+Console.WriteLine(""instance-int="" + Holder[int32](7).FetchInstance().AsTask().GetAwaiter().GetResult().ToString())
+Console.WriteLine(""flat="" + Flat.FetchShared(3).AsTask().GetAwaiter().GetResult().ToString())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out var assemblyPath);
+
+        Assert.Contains("shared-int=41", lines);
+        Assert.Contains("shared-string=hi", lines);
+        Assert.Contains("instance-int=7", lines);
+        Assert.Contains("flat=3", lines);
+        Assert.Equal("done", lines[^1]);
+
+        // Encoding: the arity of the emitted state machine IS the bug. Read it
+        // straight out of the metadata so a regression is named precisely
+        // rather than inferred from a stack-shape complaint.
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        Assert.Equal(1, StateMachineGenericParameterCount(reader, "FetchShared", "Holder`1"));
+        Assert.Equal(1, StateMachineGenericParameterCount(reader, "FetchInstance", "Holder`1"));
+
+        // Control, in metadata: the non-generic encloser's state machine must
+        // stay at arity 0. A mutant that reifies unconditionally fails here.
+        Assert.Equal(0, StateMachineGenericParameterCount(reader, "FetchShared", "Flat"));
+    }
+
+    /// <summary>
+    /// Root 4: at an extension-call argument whose parameter type still
+    /// CONTAINS a type parameter, gsc skipped conversion entirely. That skip is
+    /// right for a BARE open <c>T</c> slot (erased to <c>object</c>, boxed by
+    /// the emitter) but wrong for <c>Memory[T]</c>, which emits as a real
+    /// constructed slot — so a <c>[]T</c> argument reached it with no
+    /// <c>Memory`1::op_Implicit</c> at all.
+    /// </summary>
+    [Fact]
+    public void OpenElementArrayAtAMemorySlot_EmitsTheImplicitConversion()
+    {
+        const string source = @"
+package main
+
+import System
+import System.Collections.Generic
+
+// An extension function, which is the shape the channels runtime uses
+// (`reader.ReceiveBatch(buffer, …)`).
+func (list List[T]) TakeMemory[T](m Memory[T]) int32 -> m.Length * 10 + list.Count
+
+// The bare-`T` slot the skip actually exists for: it must keep passing the
+// argument through unconverted, so a mutant that converts everything is caught.
+func (list List[T]) TakeBare[T](v T) string -> v.ToString() + "":"" + list.Count.ToString()
+
+class Ops {
+    shared {
+        // The failing shape: an OPEN element array at a Memory[T] slot.
+        func ViaOpen[T](l List[T], buffer []T) int32 -> l.TakeMemory(buffer)
+
+        // Control: the identical call with a CONCRETE element has always
+        // emitted the operator.
+        func ViaConcrete(l List[int32], buffer []int32) int32 -> l.TakeMemory(buffer)
+
+        func ViaBare[T](l List[T], v T) string -> l.TakeBare(v)
+    }
+}
+
+Console.WriteLine(""open-string="" + Ops.ViaOpen[string](List[string]{ ""z"" }, []string{ ""a"", ""b"", ""c"" }).ToString())
+Console.WriteLine(""open-int="" + Ops.ViaOpen[int32](List[int32]{ 9, 9 }, []int32{ 1, 2 }).ToString())
+Console.WriteLine(""concrete="" + Ops.ViaConcrete(List[int32]{ 9 }, []int32{ 1, 2 }).ToString())
+Console.WriteLine(""bare-int="" + Ops.ViaBare[int32](List[int32]{ 5 }, 4))
+Console.WriteLine(""bare-string="" + Ops.ViaBare[string](List[string]{ ""q"" }, ""w""))
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out _);
+
+        // The arithmetic pins that the CONVERTED value carried the right
+        // length: a `Memory` built from a 3-element array reports 3, so
+        // 3*10 + 1 = 31. A dropped conversion cannot produce this at all
+        // (the assembly does not verify), and a conversion applied to the
+        // wrong operand would not produce these exact numbers.
+        Assert.Contains("open-string=31", lines);
+        Assert.Contains("open-int=22", lines);
+        Assert.Contains("concrete=21", lines);
+        Assert.Contains("bare-int=4:1", lines);
+        Assert.Contains("bare-string=w:1", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    /// <summary>
+    /// Returns the token kind of the single chained-constructor <c>call</c>
+    /// inside <paramref name="typeName"/>'s parameterless convenience ctor.
+    /// </summary>
+    /// <param name="reader">The metadata reader.</param>
+    /// <param name="pe">The PE reader.</param>
+    /// <param name="typeName">The emitted type's metadata name.</param>
+    /// <returns>The handle kind of the called constructor's token.</returns>
+    private static HandleKind SingleChainedCtorCallTokenKind(MetadataReader reader, PEReader pe, string typeName)
+    {
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name) == typeName);
+
+        // The parameterless ctor is the convenience one that chains.
+        var ctor = type.GetMethods()
+            .Select(reader.GetMethodDefinition)
+            .Single(m => reader.GetString(m.Name) == ".ctor"
+                && m.DecodeSignature(new SignatureArity(), genericContext: null).ParameterTypes.Length == 0);
+
+        var body = pe.GetMethodBody(ctor.RelativeVirtualAddress);
+        var il = body.GetILContent();
+
+        // `ldarg.0` (0x02) then the argument loads, then `call` (0x28) with a
+        // 4-byte token, then `ret`. Scan for the single `call`.
+        for (var i = 0; i < il.Length - 4; i++)
+        {
+            if (il[i] != 0x28)
+            {
+                continue;
+            }
+
+            var token = il[i + 1] | (il[i + 2] << 8) | (il[i + 3] << 16) | (il[i + 4] << 24);
+            return MetadataTokens.EntityHandle(token).Kind;
+        }
+
+        throw new InvalidOperationException($"No 'call' instruction found in {typeName}'s parameterless constructor.");
+    }
+
+    /// <summary>
+    /// Returns the generic-parameter count of the async state machine
+    /// synthesized for <paramref name="methodName"/> inside
+    /// <paramref name="enclosingTypeName"/>.
+    /// </summary>
+    /// <param name="reader">The metadata reader.</param>
+    /// <param name="methodName">The kickoff method's name.</param>
+    /// <param name="enclosingTypeName">The kickoff method's declaring type.</param>
+    /// <returns>The state-machine type's generic-parameter count.</returns>
+    private static int StateMachineGenericParameterCount(MetadataReader reader, string methodName, string enclosingTypeName)
+    {
+        var enclosing = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name) == enclosingTypeName);
+
+        var stateMachine = enclosing.GetNestedTypes()
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name).StartsWith("<" + methodName + ">d__", StringComparison.Ordinal));
+
+        return stateMachine.GetGenericParameters().Count;
+    }
+
+    private static string[] CompileVerifyAndRun(string source, out string assemblyPath)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3932_").FullName;
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+        var outPath = Path.Combine(tempDir, "Program.dll");
+        assemblyPath = outPath;
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc!.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return stdout
+            .ReplaceLineEndings(Environment.NewLine)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    /// <summary>
+    /// Minimal signature provider used only to count a constructor's
+    /// parameters, so the chaining assertion can pick the parameterless
+    /// overload without depending on a reflection context.
+    /// </summary>
+    private sealed class SignatureArity : ISignatureTypeProvider<string, object>
+    {
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetGenericTypeParameter(object genericContext, int index) => "!" + index;
+
+        public string GetGenericMethodParameter(object genericContext, int index) => "!!" + index;
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeDefinition(handle).Name);
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeReference(handle).Name);
+
+        public string GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+        public string GetGenericInstantiation(string genericType, System.Collections.Immutable.ImmutableArray<string> typeArguments)
+            => genericType + "<" + string.Join(",", typeArguments) + ">";
+
+        public string GetArrayType(string elementType, ArrayShape shape) => elementType + "[]";
+
+        public string GetByReferenceType(string elementType) => elementType + "&";
+
+        public string GetPointerType(string elementType) => elementType + "*";
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature) => "method*";
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        public string GetTypeFromSerializedName(string name) => name;
+
+        public PrimitiveTypeCode GetUnderlyingEnumType(string type) => PrimitiveTypeCode.Int32;
+
+        public bool IsSystemType(string type) => false;
+    }
+}


### PR DESCRIPTION
gsc: four generic-context emit defects take migrated Gsharp.Runtime.Channels from 19 ilverify findings to 1 (#3932)

#3907 closed the compile wall for migrated `src/Sdk/Gsharp.Runtime.Channels`
(194 -> 0 across #3910/#3914/#3916/#3927), which made that app's **ilverify**
stage reachable for the first time. It reported **19 findings**. Triage
(deduplicated ilverify artifacts, the same scale #3914/#3916/#3927 used)
collapsed them to **five** root causes; this fixes four of them, taking the app
to **FAIL(1)**.

All five are gsc, and in every one gsc's own neighbouring path already got it
right. That is the shape of this whole wall: not five unrelated gaps but five
siblings of already-correct code, each missed by one condition. No source edit
to the runtime's C# — it is ordinary, legal C# that csc compiles to verifiable
IL.

| # | cause | findings | layer |
|---|---|---:|---|
| A | a chained `init(...)` inside a GENERIC aggregate emits the bare MethodDef, naming the OPEN definition, so `this` is never marked initialized and the argument slots stay uninstantiated | 9 | emitter |
| B | an argument at an IMPORTED generic ctor's own type-parameter slot converts to the erased `object`, emitting `box !!T` before a `newobj` whose parent TypeSpec is correctly symbolic | 7 | binder |
| C | a `shared` (static) async method on a generic type has no `ReceiverType`, so its state machine reifies at arity 0 with every hoisted field carrying a dangling `!0` | 1 | emitter |
| D | at an extension-call argument whose target still CONTAINS a type parameter, conversion is skipped entirely — right for a bare open `T`, wrong for `Memory[T]`, which emits as a real constructed slot | 1 | binder + emitter |
| E | a capture-free lambda inside a GENERIC type is hoisted to `<Program>` and loses access to the encloser's private members | 1 | **filed as #3933** |

The already-correct siblings, one per cause: `newobj` on the same generic type
has always used the self TypeSpec; the imported generic METHOD slot
(`List[T].Add(v)`) has always taken the raw `T`; the instance async form and the
iterator path both consult `StaticOwnerType`; the same extension call with a
CONCRETE element type has always emitted `op_Implicit`.

B is worth calling out: it accounts for 7 findings across three shapes that
looked unrelated in the raw list (`found ref 'T' / expected value 'T'`,
`found ref 'ReceiveResult`1<T0>' / expected value`, and
`ValueTuple`2<object,bool>` where `ValueTuple`2<T0,bool>` belongs). All one
spurious `box !!T`.

## Evidence

`test/Compiler.Tests/Issue3932GenericEmitSitesTests.cs` — four tests, each of
which COMPILES, ILVERIFIES, RUNS and asserts on behaviour. Both checks are
load-bearing on #3501: an executing test has passed a build only ILVerify
caught, and an ILVerify-clean build has produced a wrong runtime answer.

Two also read the emitted metadata back, because "the token is a MethodDef, not
a TypeSpec-parented MemberRef" and "the state machine has arity 0" are encoding
facts a behavioural assertion cannot name:

- root A reads the chained call's token KIND out of the emitted method body
  (MemberReference on the generic type, MethodDefinition on the non-generic
  control);
- root C reads the state machine's generic-parameter COUNT out of the metadata
  (1 for the `shared` and instance forms on a generic encloser, 0 for the
  non-generic control).

Discrimination (ADR-0154): every test carries a control that passed BEFORE the
fix — the same construct in the non-generic / instance / concrete-element /
bare-`T` form — so a mutant that applies the new path unconditionally is caught
as surely as one that never applies it.

Anti-vacuity: all four FAIL on `origin/main` (verified by reverting only
`src/Core` to `origin/main` and re-running: 4 failed / 0 passed; restored: 4
passed / 0 failed).

## What this does NOT do

**`Channels` is not green** — root E (#3933) still fails ilverify — so
`src/Sdk/Gsharp.Runtime.Channels` stays OUT of
`build/run-cs2gs-selfmig-pr-guard.sh`'s `guard_apps`. That guard runs
translate -> compile -> ilverify -> test-parity, so adding it today gives
exactly the day-one-red guard the script's own note warns against. The line goes
in the moment #3933 lands; nothing else needs to change.

Also checked, per #3907's ask: `test/Core.Tests`' remaining `GS9998` emitter
`NotSupportedException` over a nested named tuple as a generic argument does NOT
share a root with any of the five, and is untouched by these fixes.

Refs #3932, #3933, #3907, #3501, #1469, #1512, #765, #1540, #3222, #671,
ADR-0087.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
