### PR TITLE
cs2gs: an identity-converted foreach emits no typed range clause, so its element keeps its promoted nullability (#3935)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3935ForEachTypeNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3935ForEachTypeNullabilityTests.cs
@@ -1,0 +1,311 @@
+// <copyright file="Issue3935ForEachTypeNullabilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Pipeline;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3935: #3925 started emitting the DECLARED <c>foreach</c> type as a
+/// typed range clause for every non-<c>var</c> loop. That type is mapped
+/// straight from the loop's type SYNTAX, so it bypasses the oblivious
+/// null-taint promotion every other declaration sink goes through — a tuple
+/// element the analysis rendered <c>([]uint8)?</c> at the parameter came back
+/// as a bare <c>[]uint8</c> on the loop variable alone, and the live
+/// <c>temporary.Original == nil</c> guard folded into GS0523 ("comparison of
+/// non-nullable with nil is always false"). This is the shape in
+/// <c>Cs2Gs.Pipeline</c>'s <c>SdkCompileRunner.RestoreTemporaryBuildProps</c>
+/// that took <c>Cs2Gs.Pipeline</c> and <c>Cs2Gs.Report</c> red.
+///
+/// <para>
+/// When the element conversion is an IDENTITY conversion the annotation carries
+/// no information — the loop variable's type IS the sequence's element type —
+/// so it is omitted and G# infers the promoted element type. A genuine element
+/// conversion still emits its typed range clause (that is what #3925 replaced
+/// <c>__foreachN</c> synthesis with), now routed through the same declaration
+/// promotion as any other local.
+/// </para>
+/// </summary>
+public sealed class Issue3935ForEachTypeNullabilityTests
+{
+    /// <summary>
+    /// A faithful reduction of <c>SdkCompileRunner</c>: a nullable-oblivious
+    /// tuple element that genuinely holds <see langword="null"/>, flowed through
+    /// a call so the taint analysis promotes the consumer's parameter, and read
+    /// back behind a live <c>== null</c> guard inside an explicitly typed
+    /// <c>foreach</c>. <c>Main</c> exercises BOTH guard branches.
+    /// </summary>
+    private const string TaintedTupleElementProgram = """
+        using System;
+        using System.Collections.Generic;
+
+        namespace Repro;
+
+        public static class Props
+        {
+            public static IReadOnlyList<(string Path, byte[] Original)> Prepare(IEnumerable<string> paths)
+            {
+                var prepared = new List<(string Path, byte[] Original)>();
+                foreach (string path in paths)
+                {
+                    byte[] original = path.Length > 3 ? new byte[path.Length] : null;
+                    prepared.Add((path, original));
+                }
+
+                return prepared;
+            }
+
+            public static void Restore(IEnumerable<(string Path, byte[] Original)> temporaryBuildProps)
+            {
+                foreach ((string Path, byte[] Original) temporary in temporaryBuildProps)
+                {
+                    if (temporary.Original == null)
+                    {
+                        Console.WriteLine("delete " + temporary.Path);
+                    }
+                    else
+                    {
+                        Console.WriteLine("restore " + temporary.Path + " " + temporary.Original.Length);
+                    }
+                }
+            }
+
+            public static void Main()
+            {
+                Restore(Prepare(new List<string> { "ab", "abcde" }));
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The regression test. On <c>origin/main</c> the loop variable is re-spelled
+    /// <c>(Path string, Original []uint8)</c> and gsc reports GS0523 on the guard.
+    /// </summary>
+    [Fact]
+    public void IdentityConvertedForEachOverPromotedTupleElement_KeepsGuardLiveAndExecutes()
+    {
+        string printed = Translate(TaintedTupleElementProgram, OutputKind.ConsoleApplication);
+
+        // The taint analysis promotes the consumer's parameter element...
+        Assert.Contains("Original []?uint8", printed, StringComparison.Ordinal);
+
+        // ...and the loop variable must not re-spell it as a bare `[]uint8`.
+        Assert.DoesNotContain("for temporary (Path string, Original []uint8) in", printed, StringComparison.Ordinal);
+        Assert.Contains("for temporary in temporaryBuildProps", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__foreach", printed, StringComparison.Ordinal);
+
+        // The `== null` guard is live in C#, so it must survive translation.
+        Assert.Contains("temporary.Original == nil", printed, StringComparison.Ordinal);
+
+        (string dllPath, string stdout, int exit) = CompileVerifyAndRun(printed, nameof(
+            IdentityConvertedForEachOverPromotedTupleElement_KeepsGuardLiveAndExecutes));
+
+        Assert.Equal(0, exit);
+
+        // Both branches of the guard actually run — binding alone would not
+        // prove the dead-comparison fold was avoided rather than hidden.
+        Assert.Equal(
+            new[] { "delete ab", "restore abcde 5" },
+            stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(l => l.Trim()).ToArray());
+
+        AssertIlVerifies(dllPath);
+    }
+
+    /// <summary>
+    /// An identity-converted loop over a plain (untainted) element type also
+    /// drops the redundant annotation, and the loop still binds and runs.
+    /// </summary>
+    [Fact]
+    public void IdentityConvertedForEachOverPlainElement_DropsRedundantType()
+    {
+        const string source = """
+            using System;
+            using System.Collections.Generic;
+
+            namespace Repro;
+
+            public static class Sum
+            {
+                public static int Total(IEnumerable<int> values)
+                {
+                    int total = 0;
+                    foreach (int value in values)
+                    {
+                        total += value;
+                    }
+
+                    return total;
+                }
+
+                public static void Main()
+                {
+                    Console.WriteLine(Total(new List<int> { 1, 2, 3 }));
+                }
+            }
+            """;
+
+        string printed = Translate(source, OutputKind.ConsoleApplication);
+
+        Assert.Contains("for value in values", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("for value int in", printed, StringComparison.Ordinal);
+
+        (string dllPath, string stdout, int exit) = CompileVerifyAndRun(
+            printed, nameof(IdentityConvertedForEachOverPlainElement_DropsRedundantType));
+        Assert.Equal(0, exit);
+        Assert.Equal("6", stdout.Trim());
+        AssertIlVerifies(dllPath);
+    }
+
+    /// <summary>
+    /// The anti-vacuity guard rail: a NON-identity element conversion still
+    /// emits its typed range clause, so #3925's win is intact. This assertion
+    /// (and <see cref="Issue2638TypedForEachTranslationTests"/>) passes on
+    /// <c>origin/main</c> too.
+    /// </summary>
+    [Fact]
+    public void NonIdentityElementConversion_StillEmitsTypedRangeClause()
+    {
+        const string source = """
+            using System;
+            using System.Collections;
+
+            namespace Repro;
+
+            public static class Widen
+            {
+                public static int Count(ArrayList items)
+                {
+                    int count = 0;
+                    foreach (string item in items)
+                    {
+                        count += item.Length;
+                    }
+
+                    return count;
+                }
+
+                public static void Main()
+                {
+                    Console.WriteLine(Count(new ArrayList { "ab", "cde" }));
+                }
+            }
+            """;
+
+        string printed = Translate(source, OutputKind.ConsoleApplication);
+
+        Assert.Contains("for item string in items", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__foreach", printed, StringComparison.Ordinal);
+
+        (string dllPath, string stdout, int exit) = CompileVerifyAndRun(
+            printed, nameof(NonIdentityElementConversion_StillEmitsTypedRangeClause));
+        Assert.Equal(0, exit);
+        Assert.Equal("5", stdout.Trim());
+        AssertIlVerifies(dllPath);
+    }
+
+    // ---- harness -----------------------------------------------------------
+
+    private static string Translate(string source, OutputKind outputKind)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Repro.cs", source) }, references: null, outputKind: outputKind);
+        Assert.True(project.BoundWithoutErrors, string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static (string DllPath, string Stdout, int Exit) CompileVerifyAndRun(string printed, string caseName)
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(
+            AppContext.BaseDirectory, nameof(Issue3935ForEachTypeNullabilityTests), caseName);
+        if (Directory.Exists(workDir))
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+
+        Directory.CreateDirectory(workDir);
+
+        string gsPath = Path.Combine(workDir, "Program.gs");
+        File.WriteAllText(gsPath, printed);
+        string dllPath = Path.Combine(workDir, "Program.dll");
+
+        (int compileExit, string compileOut) = RunDotnet(
+            $"\"{compiler}\" /target:exe /targetframework:net10.0 /out:\"{dllPath}\" \"{gsPath}\"");
+        Assert.True(
+            compileExit == 0,
+            "gsc must compile the translated program. Output:\n" + compileOut + "\n\nTranslated G#:\n" + printed);
+        Assert.DoesNotContain("GS0523", compileOut, StringComparison.Ordinal);
+
+        File.WriteAllText(
+            Path.Combine(workDir, "Program.runtimeconfig.json"),
+            "{\n  \"runtimeOptions\": {\n    \"tfm\": \"net10.0\",\n"
+                + "    \"framework\": { \"name\": \"Microsoft.NETCore.App\", \"version\": \""
+                + Environment.Version.Major + ".0.0\" }\n  }\n}\n");
+
+        (int exit, string output) = RunDotnet($"\"{dllPath}\"");
+        return (dllPath, output, exit);
+    }
+
+    private static void AssertIlVerifies(string dllPath)
+    {
+        IlVerifyResult result = new IlVerifyRunner().Verify(dllPath);
+        Assert.True(
+            result.Errors.Count == 0,
+            "ilverify reported findings:\n" + string.Join(Environment.NewLine, result.Errors.Select(e => e.RawLine)));
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(psi);
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(dir.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -3054,13 +3054,34 @@ public sealed partial class CSharpToGSharpTranslator
                         this.context.GetDeclaredSymbol(forEach),
                         forEach.Identifier.ValueText);
                     BlockStatement loopBody = this.TranslateStatementAsBlock(forEach.Statement);
+
+                    // Issue #3935: an IDENTITY element conversion means the
+                    // declared type IS the sequence's element type, so a typed
+                    // range clause (#3925) adds no information — and it actively
+                    // LOSES information, because the type comes from the loop's
+                    // type SYNTAX and so never passes through the oblivious
+                    // null-taint promotion every other declaration sink uses.
+                    // `foreach ((string Path, byte[] Original) t in props)` then
+                    // re-spelled an element the analysis had promoted to
+                    // `([]uint8)?` everywhere else as a bare `[]uint8`, and the
+                    // live `t.Original == null` guard folded into GS0523. Omitting
+                    // the redundant annotation lets G# infer the promoted element
+                    // type. A real element conversion still emits its type, which
+                    // is what #3925 replaced `__foreachN` synthesis with.
                     GTypeReference loopVariableType = null;
-                    if (!forEach.Type.IsVar)
+                    if (!forEach.Type.IsVar
+                        && !this.context.SemanticModel
+                            .GetForEachStatementInfo(forEach)
+                            .ElementConversion
+                            .IsIdentity)
                     {
                         ITypeSymbol targetSymbol = this.context.GetTypeInfo(forEach.Type).Type;
                         loopVariableType = targetSymbol != null
                             ? this.typeMapper.Map(targetSymbol, this.context, forEach.Type.GetLocation())
                             : new NamedTypeReference(forEach.Type.ToString());
+                        loopVariableType = this.PromoteIfUsedAsNullable(
+                            loopVariableType,
+                            this.context.GetDeclaredSymbol(forEach));
                     }
 
                     return new[]


### PR DESCRIPTION
Fixes #3935.

## Which of the two possibilities it is

**Neither the #3859 fold gap, nor a nullability *widening*.** It is a cs2gs **emit** defect: the loop variable's tuple element *lost* an annotation the rest of the translation had. The value is genuinely nullable, the guard is live, and folding it would have papered over a wrong type. GS0523 is correct about what it sees; what it sees is wrong.

The gate artifact names the site directly (`compile-c07c9ab0e4ec.json`, `SdkCompileRunner.gs (693,20)`, `if temporary.Original == nil`). In the gate's own migrated tree:

```
691:  internal func RestoreTemporaryBuildProps(temporaryBuildProps IEnumerable[(Path string, Original []?uint8)]) {
692:      for temporary (Path string, Original []uint8) in temporaryBuildProps.Reverse() {   <-- the `?` is gone
693:          if temporary.Original == nil {                                                  <-- GS0523
```

The parameter is `[]?uint8`; the loop variable alone is a bare `[]uint8`. The C# is `SdkCompileRunner.PrepareTemporaryBuildProps`, which stores `File.Exists(propsPath) ? File.ReadAllBytes(propsPath) : null` into that element — so it really does hold `null` and the guard really does run.

## Culprit

**#3925 (`653d3ec24`), "G#: add typed range clauses"** — specifically *"simplify cs2gs to emit declared foreach types directly and remove `__foreachN` synthesis"*.

Before #3925 the type was emitted only when `!elementConversion.IsImplicit`; #3925 widened that to every non-`var` loop, mapping the type from `GetTypeInfo(forEach.Type)` — the loop's type **syntax**. `ObliviousNullabilityAnalyzer` is *"consulted ONLY at declaration sites"*, and this new position is not one of them, so the promotion the analysis applied to the parameter, the return, the local and the `List<>` construction was silently dropped on the loop variable.

### Two premises in the issue are wrong, and one is worth correcting loudly

1. **#3930 (`f42549eff`) cannot be the culprit.** The failing run is `efd1b1a91`, and `f42549eff` is a *descendant* of it — #3930 landed **after** the run. `git log --oneline -18 efd1b1a91` shows it is not in the tree. (This also de-conflicts with the #3848-family-B agent building on #3930: my diagnosis does not land in the promotion/taint machinery they are changing — the taint analysis computed the right answer here and was simply never asked.)
2. **The bisect window is two commits, not five.** The previous nightly is run `33920662251` at `9572a509e`; between it and `efd1b1a91` only `653d3ec24` (#3925) and `c72fa6185` (#3927) carry code, plus a docs errata. #3922 and #3921 are ancestors of `9572a509e` and were already green. #3927 is a gsc change and is not involved.

## The fix (one layer: cs2gs translator)

`CSharpToGSharpTranslator.Constructors.cs`, the `ForEachStatementSyntax` case:

- Emit the typed range clause only when the element conversion is **not identity**. An identity conversion means the declared type *is* the sequence element type, so the annotation is pure redundancy — omitting it lets G# infer the promoted element type, which is exactly what cs2gs produced before #3925.
- When a type *is* still emitted (a real element conversion — #3925's replacement for `__foreachN`), route it through `PromoteIfUsedAsNullable` with the loop's declared local symbol, so it becomes a declaration sink like every other local instead of a syntax echo.

`Conversion.IsIdentity` ignores nullable annotations, so the NRT-enabled `foreach (string s in IEnumerable<string?>)` shape behaves exactly as it did pre-#3925.

## Before / after, both apps

Local PR guard over the **closure of the two red apps** (`SELFMIG_PR_GUARD_APPS` = InternalAnalyzers, Core, Cs2Gs.CodeModel, Cs2Gs.Translator, Cs2Gs.ProjectLoading, Cs2Gs.Pipeline, Cs2Gs.Report):

| app | gate `efd1b1a91` (before) | this branch (after) |
| --- | --- | --- |
| `tools/cs2gs/Cs2Gs.Pipeline` | **compile FAIL** — GS0523 | translate/compile/ilverify/test-parity **PASS** |
| `tools/cs2gs/Cs2Gs.Report` | **compile FAIL** — GS0523 | translate/compile/ilverify/test-parity **PASS** |
| other five in the closure | green | green |

`7/7 apps green`, and the emitted line is now:

```
691:  internal func RestoreTemporaryBuildProps(temporaryBuildProps IEnumerable[(Path string, Original []?uint8)]) {
692:      for temporary in temporaryBuildProps.Reverse() {
693:          if temporary.Original == nil {
```

**Honest caveat on that run:** it also printed `cs2gs: Repository migration produced unexpected file 'test/Shared/GoldenFile.gs'`, which sets the run-level `succeeded:false` even with 7/7 apps and 0 gaps. That is an artifact of the non-standard `--exclude` set my widened app list produces, not of this change; every per-app stage passes.

## Test evidence

New `tools/cs2gs/Cs2Gs.Tests/Issue3935ForEachTypeNullabilityTests.cs` — three cases, each **compile + ILVerify + run + assert stdout**, not binding-only:

| test | on `origin/main` | on this branch |
| --- | --- | --- |
| `IdentityConvertedForEachOverPromotedTupleElement_KeepsGuardLiveAndExecutes` | **FAIL** — emits `for temporary (Path string, Original []uint8) in`, gsc reports GS0523 | PASS; prints `delete ab` / `restore abcde 5`, i.e. **both** guard branches execute |
| `IdentityConvertedForEachOverPlainElement_DropsRedundantType` | **FAIL** | PASS (prints `6`) |
| `NonIdentityElementConversion_StillEmitsTypedRangeClause` | PASS (anti-vacuity guard rail) | PASS (prints `5`) |
| existing `Issue2638TypedForEachTranslationTests` | PASS (anti-vacuity guard rail) | PASS |

The first case is a faithful reduction of `SdkCompileRunner`: an oblivious tuple element that really holds `null`, flowed through a call so the taint analysis promotes the consumer's parameter, read back behind a live `== null` guard in an explicitly typed `foreach`. The executing assertion is the load-bearing one — binding alone cannot distinguish "the dead-comparison fold was avoided" from "it was hidden".

Suite runs on this branch:

- `Cs2Gs.Tests` (excluding `MigrationPipeline`): **2751 passed, 0 failed**
- `Cs2Gs.Tests` golden tests: **42 passed, 0 failed**
- Release `GSharp.sln` build: clean

## Residual risk

The nightly gate's `nullAssertionCeiling` and the other readability ceilings are not measured by the PR guard. This change restores the pre-#3925 emitted shape for identity-converted loops, and the baseline was last calibrated before #3925 (which did not touch `selfmig-baseline.json`), so the ceilings should move down or not at all — but only the nightly can confirm that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
