### PR TITLE
cs2gs: all three corpora emit a readability-counter job summary, with a per-family synthetic-identifier table (#3501)

### DIFF
--- a/build/cs2gs-counters.sh
+++ b/build/cs2gs-counters.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Issue #3501: the readability counters, shared by EVERY cs2gs corpus.
+#
+# Three jobs translate a whole C# repository to G# and can therefore measure
+# the same things: the repo self-migration (build/run-cs2gs-selfmig*.sh), Oahu
+# (build/run-cs2gs-oahu.sh) and code-exploder (build/run-cs2gs-code-exploder.sh).
+# Until now only the self-migration reported any of it, so a synthetic
+# identifier that the gsharp corpus happens not to produce was invisible to CI.
+# That is not hypothetical: #3897 found THREE families no counter knew about
+# (`__caught`, `__gsAsyncVoid*`/`__asyncVoid_*`, `__foreachN`) only because a
+# human translated Oahu and read the output. All three have since been retired
+# by language work (#3899 rethrow, #3913 ADR-0177 catch parity, #3921 native
+# async void, #3925 typed range clauses) — this file exists so the NEXT one
+# shows up in a job summary instead of waiting for someone to notice.
+#
+# Hence the catch-all family: every `__`-prefixed identifier that matches none
+# of the known families is counted, and its distinct spellings are named. The
+# definition of done for #3501 is ZERO `__`-prefixed synthetic identifiers, so
+# this table is the progress measure for that goal.
+#
+# COUNTS EVERYWHERE, RATCHET ONLY WHERE ONE ALREADY EXISTS. This file measures;
+# it never gates. The self-migration keeps its ceilings from
+# tools/cs2gs/selfmig-baseline.json (applied in build/selfmig-common.sh); Oahu
+# and code-exploder report the same counters with no thresholds, because a
+# ceiling nobody has baselined is red on day one.
+#
+# Sourced, never executed.
+
+# The known synthetic-identifier families, as IDENTIFIER PREFIXES. Longest
+# match wins, so `__gotoCase` is not swallowed by a shorter sibling. Anything
+# starting `__` that matches none of these lands in the catch-all row.
+#
+# Format: "<prefix>|<note>". The note is documentation printed in the table —
+# where the family comes from, or what retired it.
+# The LIVE families are the string literals the translator actually emits —
+#   grep -rhoE '"__[A-Za-z0-9_]+' tools/cs2gs/Cs2Gs.{Translator,Pipeline,CodeModel} src/Core
+# — so this list is derived, not remembered. The RETIRED ones are kept as rows
+# so that a family coming back reads as a regression rather than as a new
+# discovery; they must stay 0.
+cs2gs_synthetic_families=(
+  # live
+  '__cs2gs_|translator-reserved prefix'
+  '__anon|anonymous-type temporary'
+  '__arg|argument spill (evaluation order)'
+  '__decon|deconstruction temporary'
+  '__generatedRegex_|[GeneratedRegex] backing member'
+  '__local_|lifted local helper (GATED: liftedLocalCeiling)'
+  '__pattern|pattern-matching temporary'
+  '__q|query/LINQ range temporary'
+  '__scrutinee|switch scrutinee temporary'
+  '__spill|expression spill temporary'
+  '__underscore|discard rename'
+  # retired: these must stay 0
+  '__switchExit|switch lowering label (GATED: syntheticLabelCeiling)'
+  '__iteratorExit|iterator lowering label (GATED: syntheticLabelCeiling)'
+  '__gotoCase|goto-case label (GATED: syntheticLabelCeiling)'
+  '__gotoDefault|goto-default label (GATED: syntheticLabelCeiling)'
+  '__patternGuardEnd|pattern-guard label (GATED: syntheticLabelCeiling)'
+  '__caught|retired by #3899 (rethrow)'
+  '__gsAsyncVoid|retired by #3921 (native async void)'
+  '__asyncVoid_|retired by #3921 (native async void)'
+  '__foreach|retired by #3925 (typed range clauses)'
+  '__cast|retired (explicit-cast temporary)'
+  '__coalesce|retired (?? lowering temporary)'
+  '__init|retired (object-initializer temporary)'
+  '__spread|retired (collection-spread temporary)'
+  '__using|retired (using-statement temporary)'
+)
+
+# How many distinct unknown identifiers to name in the table before truncating.
+cs2gs_unknown_sample_limit=${CS2GS_UNKNOWN_SAMPLE_LIMIT:-25}
+
+# Emits the CODE lines of a migrated tree: every line of every .gs file minus
+# the ones that are not code for metric purposes.
+#
+# The exclusions are inherited verbatim from selfmig_code_grep, deliberately:
+# migrated test sources embed expected-output strings and docs quote G#
+# constructs, so a line containing a string quote, or a line that is a comment,
+# is dropped before counting. That filter UNDERCOUNTS — #3937's one removed `!!`
+# was invisible because its line read `Arguments: []object{uri!!, ...}` — but
+# the self-migration ceilings in tools/cs2gs/selfmig-baseline.json were all
+# measured through it, so changing it would silently move every ceiling. The
+# filter therefore stays exactly as it was and the RAW count is reported
+# alongside, clearly labelled, so the gap is visible instead of merely absent.
+cs2gs_code_lines() {
+  local tree=$1
+  find "$tree" -name '*.gs' -type f -exec cat {} + 2>/dev/null \
+    | grep -v '"' | grep -vE '^[[:space:]]*//' || true
+}
+
+# Every line of every .gs file, unfiltered.
+cs2gs_raw_lines() {
+  local tree=$1
+  find "$tree" -name '*.gs' -type f -exec cat {} + 2>/dev/null || true
+}
+
+# Counts occurrences of an extended regex in a stream on stdin.
+#
+# A ZERO-match metric is success, not failure: without the `|| true`, the
+# no-match grep's exit 1 kills the caller under `set -eo pipefail` before the
+# ceilings are ever checked (exactly what happened once the synthetic label
+# count reached 0).
+cs2gs_count_stream() {
+  local pattern=$1 count
+  count=$(grep -oE "$pattern" | wc -l | tr -d ' ') || true
+  echo "${count:-0}"
+}
+
+# Reads `__`-prefixed identifiers on stdin, one per line, and writes
+# "<family>\t<identifier>" — family being the longest matching known prefix, or
+# the literal `(unknown)`.
+cs2gs_classify_synthetics() {
+  local prefixes
+  prefixes=$(printf '%s\n' "${cs2gs_synthetic_families[@]}" | cut -d'|' -f1 | tr '\n' ' ')
+  awk -v prefixes="$prefixes" '
+    BEGIN { n = split(prefixes, p, " ") }
+    {
+      fam = "(unknown)"; best = 0
+      for (i = 1; i <= n; i++) {
+        if (index($0, p[i]) == 1 && length(p[i]) > best) { fam = p[i]; best = length(p[i]) }
+      }
+      print fam "\t" $0
+    }'
+}
+
+# Extracts every `__`-prefixed identifier occurrence from a stream on stdin.
+cs2gs_extract_synthetics() {
+  grep -oE '__[A-Za-z0-9_]+' || true
+}
+
+# Reads "<family> <count>" tally lines and prints the count for one family, or
+# 0 when the family did not occur. A family with zero occurrences must print 0,
+# not vanish and not abort the run.
+cs2gs_tally_lookup() {
+  local tally=$1 family=$2
+  awk -v f="$family" '$1 == f { print $2; found = 1 } END { if (!found) print 0 }' "$tally"
+}
+
+# Writes the markdown job-summary section for a migrated tree to stdout.
+#
+#   cs2gs_counter_report <migrated-tree> <heading>
+#
+# Two tables under one heading: the corpus-wide counters, then the synthetic
+# `__identifier` breakdown per family with the catch-all row last. Both carry a
+# "code" column (the quote/comment-filtered count the ceilings are measured
+# against) and a "raw" column (unfiltered), because the two disagree and the
+# disagreement is itself information.
+#
+# Callers append the output to $GITHUB_STEP_SUMMARY, print it, or both. It is
+# pure text — this function neither gates nor exits.
+cs2gs_counter_report() {
+  local tree=$1 heading=$2
+  local tmp code_lines raw_lines code_ids raw_ids code_tally raw_tally
+  tmp=$(mktemp -d)
+  code_lines="$tmp/code" raw_lines="$tmp/raw"
+  code_ids="$tmp/code-ids" raw_ids="$tmp/raw-ids"
+  code_tally="$tmp/code-tally" raw_tally="$tmp/raw-tally"
+
+  cs2gs_code_lines "$tree" > "$code_lines"
+  cs2gs_raw_lines "$tree" > "$raw_lines"
+  cs2gs_extract_synthetics < "$code_lines" | cs2gs_classify_synthetics > "$code_ids"
+  cs2gs_extract_synthetics < "$raw_lines" | cs2gs_classify_synthetics > "$raw_ids"
+  # "<family> <count>" per line. One pass each; bash 3.2 (macOS) has no
+  # associative arrays, so the tally lives in a file and is looked up per row.
+  awk -F'\t' '{ c[$1]++ } END { for (f in c) print f, c[f] }' "$code_ids" > "$code_tally"
+  awk -F'\t' '{ c[$1]++ } END { for (f in c) print f, c[f] }' "$raw_ids" > "$raw_tally"
+
+  local gs_files bangs bangs_raw long_lines syn_total syn_total_raw
+  gs_files=$(find "$tree" -name '*.gs' -type f | wc -l | tr -d ' ')
+  bangs=$(cs2gs_count_stream '!!' < "$code_lines")
+  bangs_raw=$(cs2gs_count_stream '!!' < "$raw_lines")
+  long_lines=$(awk 'length($0)>300' "$raw_lines" | wc -l | tr -d ' ')
+  syn_total=$(wc -l < "$code_ids" | tr -d ' ')
+  syn_total_raw=$(wc -l < "$raw_ids" | tr -d ' ')
+
+  echo "### $heading"
+  echo ''
+  echo "| counter | code | raw |"
+  echo "|---|---:|---:|"
+  echo "| \`.gs\` files | $gs_files | $gs_files |"
+  echo "| \`!!\` null assertions | $bangs | $bangs_raw |"
+  echo "| lines >300 chars | $long_lines | $long_lines |"
+  echo "| synthetic \`__\` identifiers | $syn_total | $syn_total_raw |"
+  echo ''
+  echo "Synthetic \`__identifier\`s by family (#3501 target: all zero)"
+  echo ''
+  echo "| family | code | raw | note |"
+  echo "|---|---:|---:|---|"
+
+  local entry prefix note n n_raw
+  for entry in "${cs2gs_synthetic_families[@]}"; do
+    prefix=${entry%%|*}
+    note=${entry#*|}
+    n=$(cs2gs_tally_lookup "$code_tally" "$prefix")
+    n_raw=$(cs2gs_tally_lookup "$raw_tally" "$prefix")
+    echo "| \`$prefix\` | $n | $n_raw | $note |"
+  done
+
+  local unknown unknown_raw
+  unknown=$(cs2gs_tally_lookup "$code_tally" '(unknown)')
+  unknown_raw=$(cs2gs_tally_lookup "$raw_tally" '(unknown)')
+  echo "| **other \`__\` (unknown family)** | ${unknown:-0} | ${unknown_raw:-0} | see below |"
+  echo ''
+
+  if (( unknown_raw > 0 )); then
+    local names total_distinct
+    names=$(awk -F'\t' '$1 == "(unknown)" { print $2 }' "$raw_ids" | sort | uniq -c | sort -rn)
+    total_distinct=$(printf '%s\n' "$names" | wc -l | tr -d ' ')
+    echo "UNKNOWN synthetic identifier families ($total_distinct distinct). These match no family this"
+    echo "counter knows about — either a new lowering shipped, or a family was renamed. Add it to"
+    echo "\`cs2gs_synthetic_families\` in \`build/cs2gs-counters.sh\` (or retire it in the compiler)."
+    echo ''
+    echo '```'
+    printf '%s\n' "$names" | head -n "$cs2gs_unknown_sample_limit"
+    if (( total_distinct > cs2gs_unknown_sample_limit )); then
+      echo "... $(( total_distinct - cs2gs_unknown_sample_limit )) more"
+    fi
+    echo '```'
+    echo ''
+  fi
+
+  rm -rf "$tmp"
+}
+
+# Convenience wrapper: print the report to the log AND to the job summary.
+cs2gs_emit_counter_report() {
+  local tree=$1 heading=$2 report
+  if [[ ! -d "$tree" ]]; then
+    echo "cs2gs counters: no migrated tree at '$tree'; skipping the summary." >&2
+    return 0
+  fi
+  report=$(cs2gs_counter_report "$tree" "$heading")
+  printf '%s\n' "$report"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}

--- a/build/cs2gs-counters.sh
+++ b/build/cs2gs-counters.sh
@@ -138,7 +138,7 @@ cs2gs_tally_lookup() {
 
 # Writes the markdown job-summary section for a migrated tree to stdout.
 #
-#   cs2gs_counter_report <migrated-tree> <heading>
+#   cs2gs_counter_report <migrated-tree> <heading> [subtitle]
 #
 # Two tables under one heading: the corpus-wide counters, then the synthetic
 # `__identifier` breakdown per family with the catch-all row last. Both carry a
@@ -149,7 +149,7 @@ cs2gs_tally_lookup() {
 # Callers append the output to $GITHUB_STEP_SUMMARY, print it, or both. It is
 # pure text — this function neither gates nor exits.
 cs2gs_counter_report() {
-  local tree=$1 heading=$2
+  local tree=$1 heading=$2 subtitle=${3:-}
   local tmp code_lines raw_lines code_ids raw_ids code_tally raw_tally
   tmp=$(mktemp -d)
   code_lines="$tmp/code" raw_lines="$tmp/raw"
@@ -175,6 +175,10 @@ cs2gs_counter_report() {
 
   echo "### $heading"
   echo ''
+  if [[ -n "$subtitle" ]]; then
+    echo "$subtitle"
+    echo ''
+  fi
   echo "| counter | code | raw |"
   echo "|---|---:|---:|"
   echo "| \`.gs\` files | $gs_files | $gs_files |"
@@ -224,12 +228,12 @@ cs2gs_counter_report() {
 
 # Convenience wrapper: print the report to the log AND to the job summary.
 cs2gs_emit_counter_report() {
-  local tree=$1 heading=$2 report
+  local tree=$1 heading=$2 subtitle=${3:-} report
   if [[ ! -d "$tree" ]]; then
     echo "cs2gs counters: no migrated tree at '$tree'; skipping the summary." >&2
     return 0
   fi
-  report=$(cs2gs_counter_report "$tree" "$heading")
+  report=$(cs2gs_counter_report "$tree" "$heading" "$subtitle")
   printf '%s\n' "$report"
   if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"

--- a/build/run-cs2gs-code-exploder.sh
+++ b/build/run-cs2gs-code-exploder.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# Issue #3501: the same readability counters the self-migration reports, so the
+# three corpora are comparable at a glance. Counts only — code-exploder has no
+# ratcheting baseline and deliberately gets no ceilings here.
+# shellcheck source=build/cs2gs-counters.sh
+source "$repo_root/build/cs2gs-counters.sh"
 manifest="$repo_root/tools/cs2gs/external/code-exploder.json"
 label=${CODE_EXPLODER_GATE_LABEL:-pinned}
 work_root=${CODE_EXPLODER_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-code-exploder/$label"}
@@ -61,6 +66,10 @@ dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
   --config Release | tee "$log_file"
 migrate_exit=${PIPESTATUS[0]}
 set -e
+
+# Before the exit check: a failed migration still produced whatever it emitted,
+# and the counters over a partial tree are more useful than none.
+cs2gs_emit_counter_report "$migrated_dir" 'cs2gs code-exploder: readability counters' || true
 
 if (( migrate_exit != 0 )); then
   exit "$migrate_exit"

--- a/build/run-cs2gs-code-exploder.sh
+++ b/build/run-cs2gs-code-exploder.sh
@@ -69,7 +69,8 @@ set -e
 
 # Before the exit check: a failed migration still produced whatever it emitted,
 # and the counters over a partial tree are more useful than none.
-cs2gs_emit_counter_report "$migrated_dir" 'cs2gs code-exploder: readability counters' || true
+cs2gs_emit_counter_report "$migrated_dir" 'cs2gs code-exploder: readability counters' \
+  'Counts only — code-exploder has no ratcheting baseline, so nothing here gates the job.' || true
 
 if (( migrate_exit != 0 )); then
   exit "$migrate_exit"

--- a/build/run-cs2gs-oahu.sh
+++ b/build/run-cs2gs-oahu.sh
@@ -69,7 +69,8 @@ set -e
 
 # Before the exit check: a failed migration still produced whatever it emitted,
 # and the counters over a partial tree are more useful than none.
-cs2gs_emit_counter_report "$migrated_dir" 'cs2gs Oahu: readability counters' || true
+cs2gs_emit_counter_report "$migrated_dir" 'cs2gs Oahu: readability counters' \
+  'Counts only — Oahu has no ratcheting baseline, so nothing here gates the job.' || true
 
 if (( migrate_exit != 0 )); then
   exit "$migrate_exit"

--- a/build/run-cs2gs-oahu.sh
+++ b/build/run-cs2gs-oahu.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# Issue #3501: the same readability counters the self-migration reports, so the
+# three corpora are comparable at a glance. Counts only — Oahu has no ratcheting
+# baseline and deliberately gets no ceilings here.
+# shellcheck source=build/cs2gs-counters.sh
+source "$repo_root/build/cs2gs-counters.sh"
 manifest="$repo_root/tools/cs2gs/external/oahu.json"
 label=${OAHU_GATE_LABEL:-pinned}
 work_root=${OAHU_GATE_ROOT:-"${TMPDIR:-/tmp}/gsharp-cs2gs-oahu/$label"}
@@ -61,6 +66,10 @@ dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
   --config Release | tee "$log_file"
 migrate_exit=${PIPESTATUS[0]}
 set -e
+
+# Before the exit check: a failed migration still produced whatever it emitted,
+# and the counters over a partial tree are more useful than none.
+cs2gs_emit_counter_report "$migrated_dir" 'cs2gs Oahu: readability counters' || true
 
 if (( migrate_exit != 0 )); then
   exit "$migrate_exit"

--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -167,7 +167,8 @@ selfmig_apply_baseline() {
   # are untouched, and nothing below participates in the pass/fail decision.
   if [[ -n "${selfmig_measured_tree:-}" && -d "${selfmig_measured_tree:-}" ]]; then
     cs2gs_emit_counter_report "$selfmig_measured_tree" \
-      'cs2gs self-migration: readability counters (gsharp)' || true
+      'cs2gs self-migration: readability counters (gsharp)' \
+      'Breakdown only — the gated numbers are the table above; nothing here changes the verdict.' || true
   fi
 
   local status=0

--- a/build/selfmig-common.sh
+++ b/build/selfmig-common.sh
@@ -10,6 +10,12 @@
 #
 # Sourced, never executed. Callers set `repo_root` before sourcing.
 
+# Issue #3501: the counter definitions themselves are shared with the OTHER two
+# corpora (Oahu, code-exploder) so all three report the same table. Only the
+# ceilings below are specific to the self-migration.
+# shellcheck source=build/cs2gs-counters.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/cs2gs-counters.sh"
+
 # E2E fixtures that are not migration targets are excluded via --exclude.
 # The Visual Studio extension stays in C# by decision (like the VSCode
 # extension stays in TypeScript), so all three vs-gsharp apps are excluded:
@@ -63,6 +69,14 @@ selfmig_build_prerequisites() {
 # Metrics count CODE, not fixtures: migrated test sources embed expected-output
 # strings (and docs quote constructs), so lines containing a string quote or
 # leading with a comment marker are excluded before counting.
+#
+# The line filter now lives in build/cs2gs-counters.sh (cs2gs_code_lines) so the
+# three corpora measure identically; the counting semantics here are UNCHANGED,
+# and deliberately so. The quote exclusion undercounts (#3937: a removed `!!` on
+# a line reading `Arguments: []object{uri!!, ...}` was invisible to the metric),
+# but every ceiling in tools/cs2gs/selfmig-baseline.json was measured through
+# it, so "fixing" it would silently move all of them. The gated numbers keep the
+# old behaviour; the raw counts are reported alongside in the counter table.
 selfmig_code_grep() {
   local migrated_dir=$1 pattern=$2
   # A ZERO-match metric is success, not failure: without the || true, the
@@ -70,8 +84,7 @@ selfmig_code_grep() {
   # the ceilings are ever checked (exactly what happened once the synthetic
   # label count reached 0).
   local count
-  count=$(grep -rhE "$pattern" "$migrated_dir" --include='*.gs' 2>/dev/null \
-    | grep -v '"' | grep -vE '^[[:space:]]*//' | grep -oE "$pattern" | wc -l | tr -d ' ') || true
+  count=$(cs2gs_code_lines "$migrated_dir" | cs2gs_count_stream "$pattern") || true
   echo "${count:-0}"
 }
 
@@ -107,6 +120,9 @@ selfmig_hash_tree() {
 # commit produce byte-identical trees (measured on #3895).
 selfmig_measure() {
   local migrated_dir=$1
+  # Remembered so selfmig_apply_baseline can add the per-family synthetic
+  # breakdown (#3501) to the job summary without changing its signature.
+  selfmig_measured_tree=$migrated_dir
   labels=$(selfmig_code_grep "$migrated_dir" '__(switchExit|iteratorExit|gotoCase|gotoDefault|patternGuardEnd)')
   lifts=$(selfmig_code_grep "$migrated_dir" '__local_')
   long_lines=$(find "$migrated_dir" -name '*.gs' -exec awk 'length($0)>300' {} + 2>/dev/null | wc -l | tr -d ' ')
@@ -142,7 +158,16 @@ selfmig_apply_baseline() {
       echo "| \`__local_\` lifts | $lifts | ceiling $lift_ceiling |"
       echo "| lines >300 chars | $long_lines | ceiling $long_ceiling |"
       echo "| \`!!\` assertions | $bangs | ceiling $bang_ceiling |"
+      echo ''
     } >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  # Issue #3501: the per-family synthetic-identifier breakdown, printed to the
+  # log and appended to the job summary. It is ADDITIVE — the gated rows above
+  # are untouched, and nothing below participates in the pass/fail decision.
+  if [[ -n "${selfmig_measured_tree:-}" && -d "${selfmig_measured_tree:-}" ]]; then
+    cs2gs_emit_counter_report "$selfmig_measured_tree" \
+      'cs2gs self-migration: readability counters (gsharp)' || true
   fi
 
   local status=0


### PR DESCRIPTION
Closes nothing on its own; this is instrumentation for #3501.

## What

All three cs2gs corpora — the repo self-migration, Oahu, and code-exploder — now emit a job summary with the readability counters, including a **per-family breakdown of synthetic `__identifier`s** and a catch-all row for families no counter knows about.

Before this, only the self-migration reported anything; `build/run-cs2gs-oahu.sh` and `build/run-cs2gs-code-exploder.sh` had zero occurrences of `GITHUB_STEP_SUMMARY`. A synthetic identifier the gsharp corpus happens not to produce was invisible to CI — which is exactly how #3897 happened: three families no counter knew about (`__caught`, `__gsAsyncVoid*`/`__asyncVoid_*`, `__foreachN`) were found only because a human translated Oahu and read the output. All three have since been retired (#3899, #3913, #3921, #3925). The catch-all row exists so the next one shows up in CI automatically.

## Shared implementation

New `build/cs2gs-counters.sh`, sourced by `build/selfmig-common.sh`, `build/run-cs2gs-oahu.sh` and `build/run-cs2gs-code-exploder.sh`. One definition, three callers — no copies to rot.

The **live** family list is derived from the string literals the translator actually emits (`grep -rhoE '"__[A-Za-z0-9_]+' tools/cs2gs/Cs2Gs.{Translator,Pipeline,CodeModel} src/Core`), not from memory. The **retired** families stay as rows so a family coming back reads as a regression rather than as a discovery.

## Counts everywhere, ratchet only where one already exists

The gsharp gate is unchanged: same four counters, same ceilings from `tools/cs2gs/selfmig-baseline.json`, same pass/fail decision. The new table is appended after the existing one and participates in nothing. Oahu and code-exploder get counts with **no** thresholds — a ceiling nobody has baselined would be red on day one. `selfmig-baseline.json` is untouched.

## `code_grep`'s quote exclusion

Kept, deliberately. It undercounts (#3937: a removed `!!` on a line reading `Arguments: []object{uri!!, ...}` was invisible to the metric), but every ceiling in the baseline was measured through it, so changing it would silently move all of them — a ratchet change disguised as a refactor. Instead every row now carries **both** a `code` column (the filtered count the ceilings use) and a `raw` column (unfiltered), so the gap is visible rather than merely absent. On the gsharp tree the two differ by a third for `!!` (17451 vs 24303).

The `|| true` that keeps a no-match grep from killing the run under `set -eo pipefail` is preserved, and every family with zero occurrences prints `0`.
