### PR TITLE
gsc: the static-call sibling of the instance path — owner TypeSpec AND MethodSpec, not one or the other (#3939)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Expressions.cs
@@ -143,24 +143,35 @@ internal sealed partial class MethodBodyEmitter
                     }
                 }
 
-                // Issue #1433: a `shared` (static) method called on a
-                // constructed generic INTERFACE (`IBox[int32].Make()`) must be
+                // The OWNER token: which entity the call names. Three shapes —
+                // a `shared` method on a constructed generic INTERFACE
+                // (`IBox[int32].Make()`, issue #1433) or on a constructed
+                // generic user TYPE (`Box[int32].Make()`, issue #1209) must be
                 // referenced through a MemberRef parented at the construction's
-                // TypeSpec. The substituted method is not in the handle cache,
-                // so resolve it before the generic-struct/cache lookups below.
+                // TypeSpec; everything else is the bare MethodDef.
+                EntityHandle callTokenToEmit;
                 if (call.StaticGenericInterfaceOwnerType != null
                     && ReflectionMetadataEmitter.IsUserGenericInterfaceReference(call.StaticGenericInterfaceOwnerType))
                 {
-                    this.il.OpCode(ILOpCode.Call);
-                    this.il.Token(this.outer.userTokens.ResolveUserInterfaceStaticMethodToken(call.StaticGenericInterfaceOwnerType, call.Function));
-                    break;
+                    // The substituted method is not in the handle cache, so this
+                    // resolves without the generic-struct/cache lookups below.
+                    callTokenToEmit = this.outer.userTokens.ResolveUserInterfaceStaticMethodToken(
+                        call.StaticGenericInterfaceOwnerType,
+                        call.Function);
                 }
-
-                if (!this.outer.cache.FunctionHandles.TryGetValue(call.Function, out var fnHandle)
-                    && !this.outer.cache.MethodHandles.TryGetValue(call.Function, out fnHandle))
+                else
                 {
-                    throw new InvalidOperationException(
-                        $"Call to function '{call.Function.Name}' has no emitted MethodDef.");
+                    if (!this.outer.cache.FunctionHandles.TryGetValue(call.Function, out var fnHandle)
+                        && !this.outer.cache.MethodHandles.TryGetValue(call.Function, out fnHandle))
+                    {
+                        throw new InvalidOperationException(
+                            $"Call to function '{call.Function.Name}' has no emitted MethodDef.");
+                    }
+
+                    callTokenToEmit = call.StaticGenericOwnerType != null
+                        && ReflectionMetadataEmitter.IsUserGenericTypeReference(call.StaticGenericOwnerType)
+                        ? this.outer.userTokens.ResolveUserStaticMethodToken(call.StaticGenericOwnerType, call.Function)
+                        : fnHandle;
                 }
 
                 // ADR-0087 §3 R3+R4: when the target is a generic function,
@@ -168,25 +179,32 @@ internal sealed partial class MethodBodyEmitter
                 // the substituted type arguments — bare MethodDef tokens
                 // would carry MVAR slots and fail ilverify against the
                 // concrete argument types.
-                EntityHandle callTokenToEmit = fnHandle;
-                if (call.StaticGenericOwnerType != null
-                    && ReflectionMetadataEmitter.IsUserGenericTypeReference(call.StaticGenericOwnerType))
-                {
-                    // Issue #1209: a `shared` (static) method called on a
-                    // constructed generic user type (`Box[int32].Make()`) must
-                    // be referenced through a MemberRef parented at the
-                    // construction's TypeSpec; a bare MethodDef token is invalid
-                    // for a method of a generic type.
-                    callTokenToEmit = this.outer.userTokens.ResolveUserStaticMethodToken(call.StaticGenericOwnerType, call.Function);
-                }
-                else if (call.Function.IsGeneric && !call.Function.TypeParameters.IsDefaultOrEmpty)
+                //
+                // Issue #3939: this MUST be applied on TOP of whatever owner
+                // token was selected above, not INSTEAD of it. The two are
+                // independent axes — the owner token says which type the method
+                // belongs to, the MethodSpec says how the METHOD is
+                // instantiated — and a `shared func Make[U]()` on a generic
+                // `Box[T]` / `IBox[T]` needs both. Selecting one or the other
+                // (which is what an `else if` did here through #1209 and #1433)
+                // emitted `call Box`1<int32>::Make(!!0)` naming the OPEN generic
+                // method: `[found ref 'string'][expected ref '!!0']` from
+                // ILVerify and `InvalidOperationException: Could not execute the
+                // method because either the method itself or the containing type
+                // is not fully instantiated` at the first call. The INSTANCE
+                // sibling (`EmitUserInstanceCall` in MethodBodyEmitter.Calls.cs)
+                // has always done both, sequentially: it resolves a
+                // TypeSpec-parented MemberRef for a generic receiver and THEN
+                // wraps it in a MethodSpec whenever `call.Method.IsGeneric`.
+                // This is the static path catching up.
+                if (call.Function.IsGeneric && !call.Function.TypeParameters.IsDefaultOrEmpty)
                 {
                     // Issue #3226: a lifted call instantiates the MethodSpec at
                     // Nullable<X> so the erased `!!T` slots really carry the
                     // nullable representation the T? contract promises.
                     callTokenToEmit = nullableLift != null
-                        ? this.outer.userTokens.BuildMethodSpecForLiftedGenericCall(fnHandle, nullableLift.TypeArguments)
-                        : this.outer.userTokens.BuildMethodSpecForGenericCall(fnHandle, call);
+                        ? this.outer.userTokens.BuildMethodSpecForLiftedGenericCall(callTokenToEmit, nullableLift.TypeArguments)
+                        : this.outer.userTokens.BuildMethodSpecForGenericCall(callTokenToEmit, call);
                 }
 
                 this.il.OpCode(ILOpCode.Call);

--- a/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/ReflectionMetadataEmitter.cs
@@ -461,13 +461,12 @@ internal sealed class ReflectionMetadataEmitter
         // consulted both — this is the async path catching up. Instance methods
         // were unaffected, which is why the failure needed a `shared async
         // func` on a generic type to surface at all.
-        var receiverDef = (kickoff?.ReceiverType as StructSymbol ?? kickoff?.StaticOwnerType as StructSymbol) is { } receiver
-            ? (receiver.Definition ?? receiver)
-            : null;
-        var classTPs = receiverDef?.TypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;
-        var methodTPs = kickoff == null || kickoff.TypeParameters.IsDefaultOrEmpty
-            ? ImmutableArray<TypeParameterSymbol>.Empty
-            : kickoff.TypeParameters;
+        //
+        // Issue #3939: the same decision is needed by the KICKOFF BODY, which
+        // self-instantiates the struct this method reifies, so both now read it
+        // from one primitive on StateMachineEmitter instead of each deriving it
+        // — the kickoff's copy had never picked up the `StaticOwnerType` half.
+        var (receiverDef, classTPs, methodTPs) = StateMachineEmitter.GetAsyncKickoffGenericScope(kickoff);
 
         if (classTPs.IsDefaultOrEmpty && methodTPs.IsDefaultOrEmpty)
         {

--- a/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/StateMachineEmitter.cs
@@ -476,6 +476,59 @@ internal sealed class StateMachineEmitter
         public AsyncMethodSteppingInfo? AsyncStepping { get; }
     }
 
+    /// <summary>
+    /// Issue #3939: the single place that decides which type parameters are in
+    /// scope at an ASYNC kickoff method — the owning type's, then the kickoff's
+    /// own, in Roslyn order. Two emit paths depend on this list agreeing
+    /// exactly: <c>ReflectionMetadataEmitter.RegisterStateMachineEnclosingGenerics</c>
+    /// reifies the state-machine struct at this ARITY, and
+    /// <see cref="EmitAsyncKickoffBody"/> self-instantiates the struct with
+    /// this INSTANTIATION. They used to compute it independently, and the
+    /// second read only <c>ReceiverType</c> — so a <c>shared async func
+    /// Fetch[U]()</c> on a generic <c>Holder[T]</c> was reified at arity 2 and
+    /// then referenced as <c>&lt;Fetch&gt;d__0`2&lt;!!0&gt;</c>, which the
+    /// runtime rejects with <c>TypeLoadException</c> ("used with the wrong
+    /// number of generic arguments"). This is the same <c>StaticOwnerType</c>
+    /// gap #3932 root C closed on the reification side, still open on the
+    /// kickoff side; both now route through here, so they cannot drift again.
+    /// The ITERATOR sibling has always had this property — its kickoff
+    /// constructs over the very <c>scopeTPs</c> the class was reified from.
+    /// </summary>
+    /// <param name="kickoff">The async kickoff method, or <see langword="null"/>.</param>
+    /// <returns>The owning type's definition, its type parameters, and the kickoff's own.</returns>
+    internal static (StructSymbol? OwnerDefinition, ImmutableArray<TypeParameterSymbol> ClassTypeParameters, ImmutableArray<TypeParameterSymbol> MethodTypeParameters)
+        GetAsyncKickoffGenericScope(FunctionSymbol? kickoff)
+    {
+        // `StaticOwnerType` is the static counterpart of `ReceiverType`: a
+        // `shared` method has no receiver but still lives on the owning type.
+        var owner = (kickoff?.ReceiverType as StructSymbol) ?? (kickoff?.StaticOwnerType as StructSymbol);
+        var ownerDefinition = owner is null ? null : owner.Definition ?? owner;
+        var classTPs = ownerDefinition?.TypeParameters ?? ImmutableArray<TypeParameterSymbol>.Empty;
+        if (classTPs.IsDefault)
+        {
+            classTPs = ImmutableArray<TypeParameterSymbol>.Empty;
+        }
+
+        var methodTPs = kickoff is null || kickoff.TypeParameters.IsDefaultOrEmpty
+            ? ImmutableArray<TypeParameterSymbol>.Empty
+            : kickoff.TypeParameters;
+
+        return (ownerDefinition, classTPs, methodTPs);
+    }
+
+    /// <summary>
+    /// Issue #3939: the flattened form of <see cref="GetAsyncKickoffGenericScope"/>
+    /// — the state machine's slot order, class parameters before method
+    /// parameters.
+    /// </summary>
+    /// <param name="kickoff">The async kickoff method, or <see langword="null"/>.</param>
+    /// <returns>The in-scope type parameters in state-machine slot order.</returns>
+    internal static ImmutableArray<TypeParameterSymbol> GetAsyncKickoffTypeParametersInScope(FunctionSymbol? kickoff)
+    {
+        var (_, classTPs, methodTPs) = GetAsyncKickoffGenericScope(kickoff);
+        return classTPs.AddRange(methodTPs);
+    }
+
     private static ImmutableArray<TypeParameterSymbol> GetIteratorTypeParametersInScope(FunctionSymbol function)
     {
         var builder = ImmutableArray.CreateBuilder<TypeParameterSymbol>();
@@ -1746,18 +1799,17 @@ internal sealed class StateMachineEmitter
         // `kickoffSmType` pattern elsewhere in this file — otherwise the
         // emitted `!0` self-instantiation is meaningless outside the SM
         // struct (BadImageFormatException at load).
-        var kickoffClassTPs = function.ReceiverType is StructSymbol kickoffRecv
-            ? (kickoffRecv.Definition ?? kickoffRecv).TypeParameters
-            : ImmutableArray<TypeParameterSymbol>.Empty;
-        if (kickoffClassTPs.IsDefault)
-        {
-            kickoffClassTPs = ImmutableArray<TypeParameterSymbol>.Empty;
-        }
-
-        var kickoffMethodTPs = function.TypeParameters.IsDefaultOrEmpty
-            ? ImmutableArray<TypeParameterSymbol>.Empty
-            : function.TypeParameters;
-        var kickoffScopeTPs = kickoffClassTPs.AddRange(kickoffMethodTPs);
+        //
+        // Issue #3939: this instantiation must be exactly the list the struct
+        // was REIFIED from, so it comes from the shared
+        // GetAsyncKickoffTypeParametersInScope primitive rather than being
+        // recomputed here. Recomputing it is how the two drifted: this site
+        // read only `ReceiverType`, so a `shared async func Fetch[U]()` on a
+        // generic `Holder[T]` produced a 1-argument instantiation of a
+        // 2-parameter state machine (`TypeLoadException`, "used with the wrong
+        // number of generic arguments"), while the instance form on the same
+        // type and the `shared` form of a NON-generic method were both fine.
+        var kickoffScopeTPs = GetAsyncKickoffTypeParametersInScope(function);
         var kickoffSmStruct = kickoffScopeTPs.IsDefaultOrEmpty
             ? smStruct
             : StructSymbol.Construct(smStruct, kickoffScopeTPs.CastArray<TypeSymbol>());

--- a/test/Compiler.Tests/Emit/Issue3939GenericStaticSiblingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3939GenericStaticSiblingEmitTests.cs
@@ -82,6 +82,11 @@ class Holder[T] {
     // Control: the INSTANCE form of the failing shape, which has always
     // resolved the TypeSpec parent and the MethodSpec sequentially.
     func PlainInst[U](v T, other U) string -> v.ToString() + ""/"" + other.ToString()
+
+    // The SELF-reference shape: the same call from INSIDE the generic type,
+    // where the owner instantiation is the OPEN `!0` rather than a concrete
+    // `int32`. Both axes still apply, and the TypeSpec is the self one.
+    func CallSelf[U](v T, other U) string -> Plain[U](v, other)
 }
 
 // Control: a generic shared method on a NON-generic type, which needs a bare
@@ -96,6 +101,7 @@ Console.WriteLine(""shared="" + Holder[int32].Plain[string](41, ""b""))
 Console.WriteLine(""shared-other-inst="" + Holder[string].Plain[int32](""q"", 3))
 Console.WriteLine(""shared-ng="" + Holder[int32].PlainNG(5))
 Console.WriteLine(""inst="" + Holder[int32]().PlainInst[string](7, ""c""))
+Console.WriteLine(""self="" + Holder[int32]().CallSelf[string](8, ""d""))
 Console.WriteLine(""flat="" + Flat.Plain[int32](9))
 Console.WriteLine(""done"")
 ";
@@ -109,6 +115,7 @@ Console.WriteLine(""done"")
         Assert.Contains("shared-other-inst=q|3", lines);
         Assert.Contains("shared-ng=ng:5", lines);
         Assert.Contains("inst=7/c", lines);
+        Assert.Contains("self=8|d", lines);
         Assert.Contains("flat=flat/9", lines);
         Assert.Equal("done", lines[^1]);
 

--- a/test/Compiler.Tests/Emit/Issue3939GenericStaticSiblingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3939GenericStaticSiblingEmitTests.cs
@@ -1,0 +1,474 @@
+// <copyright file="Issue3939GenericStaticSiblingEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3939: two emit paths that reason about GENERIC context and disagreed
+/// with a sibling path a few lines away — the #3705 defect class, swept for in
+/// the emitter rather than waiting for a migrated app to trip over it.
+/// </summary>
+/// <remarks>
+/// <para>Finding A: a <c>shared</c> (static) call chose EITHER a
+/// TypeSpec-parented MemberRef (naming which type owns the method, #1209 /
+/// #1433) OR a MethodSpec (naming how the METHOD is instantiated, ADR-0087
+/// §3 R3+R4) with an <c>else if</c>. Those are independent axes and a
+/// <c>shared func Make[U]()</c> on a generic <c>Box[T]</c> needs both. The
+/// INSTANCE sibling in <c>MethodBodyEmitter.Calls.cs</c> — and
+/// <c>EmitMethodGroupTarget</c> in <c>MethodBodyEmitter.Closures.cs</c> — have
+/// always applied them sequentially.</para>
+/// <para>Finding B: <c>StateMachineEmitter.EmitAsyncKickoffBody</c> re-derived
+/// the type parameters in scope at an async kickoff instead of reading the list
+/// its state machine was REIFIED from, and its copy never picked up the
+/// <c>StaticOwnerType</c> half that #3932 root C added to the reification. Both
+/// now route through one primitive.</para>
+/// <para>Grouped by EMITTED IL, not by symptom: finding A's four surface shapes
+/// print three different diagnostics (ILVerify <c>[found ref
+/// 'string'][expected ref '!!0']</c>, <c>InvalidOperationException</c> "not
+/// fully instantiated", and — once A is fixed — B's <c>TypeLoadException</c>)
+/// and are one cause, <c>call &lt;TypeSpec-parented MemberRef naming an open
+/// generic method&gt;</c>.</para>
+/// <para>Every test COMPILES, ILVERIFIES, RUNS and asserts on behaviour. All
+/// three are load-bearing on the #3501 effort: within one week a defect
+/// ILVerified clean and threw <c>TypeLoadException</c> at load (#3936), and
+/// another passed an executing test and was caught only by ILVerify (#3900).
+/// Two tests additionally read the emitted metadata back, because "the token is
+/// a MethodSpec, not a bare MemberRef" and "the state machine's arity equals
+/// its self-instantiation's argument count" are encoding facts no behavioural
+/// assertion can name.</para>
+/// <para>Discrimination (ADR-0154): every test carries controls that passed
+/// BEFORE the fix — the same construct in its instance form, its non-generic-
+/// method form, and its non-generic-encloser form — so a mutant that applies
+/// the new path unconditionally is caught as surely as one that never applies
+/// it.</para>
+/// </remarks>
+public class Issue3939GenericStaticSiblingEmitTests
+{
+    /// <summary>
+    /// Finding A, the plain shape: a generic <c>shared</c> method on a generic
+    /// user CLASS. Before the fix the call emitted a TypeSpec-parented MemberRef
+    /// naming the OPEN generic method and no MethodSpec at all.
+    /// </summary>
+    [Fact]
+    public void GenericSharedMethodOnAGenericClass_GetsBothTheTypeSpecParentAndTheMethodSpec()
+    {
+        const string source = @"
+package main
+
+import System
+
+class Holder[T] {
+    shared {
+        // The failing shape: BOTH the owner and the method are generic.
+        func Plain[U](v T, other U) string -> v.ToString() + ""|"" + other.ToString()
+
+        // Control: a NON-generic shared method on the same generic type. #1209
+        // gave this a TypeSpec-parented MemberRef and no MethodSpec, which is
+        // right; a mutant that adds a MethodSpec unconditionally breaks it.
+        func PlainNG(v T) string -> ""ng:"" + v.ToString()
+    }
+
+    // Control: the INSTANCE form of the failing shape, which has always
+    // resolved the TypeSpec parent and the MethodSpec sequentially.
+    func PlainInst[U](v T, other U) string -> v.ToString() + ""/"" + other.ToString()
+}
+
+// Control: a generic shared method on a NON-generic type, which needs a bare
+// MethodDef parent and a MethodSpec — the other half of the pair.
+class Flat {
+    shared {
+        func Plain[U](other U) string -> ""flat/"" + other.ToString()
+    }
+}
+
+Console.WriteLine(""shared="" + Holder[int32].Plain[string](41, ""b""))
+Console.WriteLine(""shared-other-inst="" + Holder[string].Plain[int32](""q"", 3))
+Console.WriteLine(""shared-ng="" + Holder[int32].PlainNG(5))
+Console.WriteLine(""inst="" + Holder[int32]().PlainInst[string](7, ""c""))
+Console.WriteLine(""flat="" + Flat.Plain[int32](9))
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out var assemblyPath);
+
+        // Behaviour: both type arguments really reached the callee, and the
+        // SECOND instantiation pins that the MethodSpec is per-call rather than
+        // a single cached one — `Holder[string].Plain[int32]` swaps both.
+        Assert.Contains("shared=41|b", lines);
+        Assert.Contains("shared-other-inst=q|3", lines);
+        Assert.Contains("shared-ng=ng:5", lines);
+        Assert.Contains("inst=7/c", lines);
+        Assert.Contains("flat=flat/9", lines);
+        Assert.Equal("done", lines[^1]);
+
+        // Encoding: the token kind IS the bug. A MethodSpec is what carries the
+        // method instantiation; before the fix the site emitted the MemberRef
+        // directly. The control's kind must stay MemberReference, so a mutant
+        // that MethodSpecs every static call on a generic type is caught here.
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var kinds = CallTokenKinds(reader, pe, "<Program>", "<Main>$");
+
+        Assert.Contains(HandleKind.MethodSpecification, kinds);
+        Assert.Contains(HandleKind.MemberReference, kinds);
+    }
+
+    /// <summary>
+    /// Finding A on a generic user INTERFACE — the #1433 branch, which resolved
+    /// its TypeSpec-parented MemberRef and then <c>break</c>ed out of the case
+    /// entirely, so it could never reach the MethodSpec (or the #3226
+    /// nullable-lift unwrap) below.
+    /// </summary>
+    [Fact]
+    public void GenericSharedMethodOnAGenericInterface_GetsBothTheTypeSpecParentAndTheMethodSpec()
+    {
+        const string source = @"
+package main
+
+import System
+
+interface IBox[T] {
+    shared {
+        // The failing shape.
+        func Make[U](v T, other U) string {
+            return v.ToString() + ""|"" + other.ToString()
+        }
+
+        // Control: #1433's original shape, which must keep working unchanged.
+        func MakeNG(v T) string {
+            return ""ng:"" + v.ToString()
+        }
+    }
+}
+
+// Control: a generic shared method on a NON-generic interface.
+interface IFlat {
+    shared {
+        func Make[U](other U) string {
+            return ""flat/"" + other.ToString()
+        }
+    }
+}
+
+Console.WriteLine(""iface="" + IBox[int32].Make[string](41, ""b""))
+Console.WriteLine(""iface-ng="" + IBox[int32].MakeNG(5))
+Console.WriteLine(""iface-flat="" + IFlat.Make[int32](9))
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out _);
+
+        Assert.Contains("iface=41|b", lines);
+        Assert.Contains("iface-ng=ng:5", lines);
+        Assert.Contains("iface-flat=flat/9", lines);
+        Assert.Equal("done", lines[^1]);
+    }
+
+    /// <summary>
+    /// Finding A reached through an ITERATOR kickoff: a generic <c>shared</c>
+    /// iterator on a generic type. The state-machine machinery was never at
+    /// fault here — the CALL to the kickoff was — which is precisely why
+    /// grouping by symptom would have mis-attributed this to
+    /// <c>StateMachineEmitter</c>.
+    /// </summary>
+    [Fact]
+    public void GenericSharedIteratorOnAGenericType_RunsToCompletion()
+    {
+        const string source = @"
+package main
+
+import System
+
+class Holder[T] {
+    var seed T
+
+    init(seed T) {
+        this.seed = seed
+    }
+
+    shared {
+        // The failing shape.
+        func WalkSharedG[U](v T, other U) sequence[string] {
+            yield v.ToString()
+            yield other.ToString()
+        }
+
+        // Control: a non-generic shared iterator on the same generic type.
+        func WalkShared(v T) sequence[string] {
+            yield v.ToString()
+        }
+    }
+
+    // Control: the instance generic iterator form.
+    func WalkInstanceG[U](other U) sequence[string] {
+        yield seed.ToString()
+        yield other.ToString()
+    }
+}
+
+for x in Holder[int32].WalkSharedG[string](41, ""b"") {
+    Console.WriteLine(""sg="" + x)
+}
+
+for x in Holder[int32].WalkShared(5) {
+    Console.WriteLine(""s="" + x)
+}
+
+for x in Holder[int32](7).WalkInstanceG[string](""c"") {
+    Console.WriteLine(""ig="" + x)
+}
+
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out _);
+
+        // The ORDER matters: an iterator that ran but yielded in the wrong
+        // order, or dropped an element, is not caught by a Contains-only check.
+        Assert.Equal(
+            new[] { "sg=41", "sg=b", "s=5", "ig=7", "ig=c", "done" },
+            lines);
+    }
+
+    /// <summary>
+    /// Finding B: with A fixed, a generic <c>shared async</c> method on a
+    /// generic type still failed, because <c>EmitAsyncKickoffBody</c> derived
+    /// the kickoff's in-scope type parameters from <c>ReceiverType</c> alone —
+    /// the very <c>StaticOwnerType</c> gap #3932 root C closed one file over,
+    /// on the reification side. The struct was reified at arity 2 and
+    /// self-instantiated with 1 argument: <c>TypeLoadException</c>, "used with
+    /// the wrong number of generic arguments".
+    /// </summary>
+    [Fact]
+    public void GenericSharedAsyncOnAGenericType_SelfInstantiatesAtTheReifiedArity()
+    {
+        const string source = @"
+package main
+
+import System
+import System.Threading.Tasks
+
+class Holder[T] {
+    var seed T
+
+    init(seed T) {
+        this.seed = seed
+    }
+
+    shared {
+        // The failing shape: BOTH the encloser and the kickoff are generic,
+        // and the kickoff is `shared`.
+        async func FetchSharedG[U](v T, other U) ValueTask[string] {
+            await Task.Yield()
+            return v.ToString() + ""|"" + other.ToString()
+        }
+
+        // Control: a NON-generic `shared async` on a generic type — #3932
+        // root C's shape, arity 1, which must stay at arity 1.
+        async func FetchShared(v T) ValueTask[string] {
+            await Task.Yield()
+            return ""ng:"" + v.ToString()
+        }
+    }
+
+    // Control: the INSTANCE generic async form on a generic type, arity 2,
+    // which was already right.
+    async func FetchInstanceG[U](other U) ValueTask[string] {
+        await Task.Yield()
+        return seed.ToString() + ""/"" + other.ToString()
+    }
+}
+
+// Control: a generic `shared async` on a NON-generic type, arity 1 (the
+// method's own U only).
+class Flat {
+    shared {
+        async func FetchSharedG[U](other U) ValueTask[string] {
+            await Task.Yield()
+            return ""flat/"" + other.ToString()
+        }
+    }
+}
+
+Console.WriteLine(""sg="" + Holder[int32].FetchSharedG[string](41, ""b"").AsTask().GetAwaiter().GetResult())
+Console.WriteLine(""s="" + Holder[int32].FetchShared(5).AsTask().GetAwaiter().GetResult())
+Console.WriteLine(""ig="" + Holder[int32](7).FetchInstanceG[string](""c"").AsTask().GetAwaiter().GetResult())
+Console.WriteLine(""flat="" + Flat.FetchSharedG[int32](9).AsTask().GetAwaiter().GetResult())
+Console.WriteLine(""done"")
+";
+
+        var lines = CompileVerifyAndRun(source, out var assemblyPath);
+
+        Assert.Contains("sg=41|b", lines);
+        Assert.Contains("s=ng:5", lines);
+        Assert.Contains("ig=7/c", lines);
+        Assert.Contains("flat=flat/9", lines);
+        Assert.Equal("done", lines[^1]);
+
+        // Encoding: the arity of each state machine, read straight out of the
+        // metadata. The failing shape is 2 (T then U); every control pins a
+        // DIFFERENT expected arity, so a mutant that reifies unconditionally at
+        // 2 — or that reverts to `ReceiverType` only — is caught.
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        Assert.Equal(2, StateMachineGenericParameterCount(reader, "FetchSharedG", "Holder`1"));
+        Assert.Equal(1, StateMachineGenericParameterCount(reader, "FetchShared", "Holder`1"));
+        Assert.Equal(2, StateMachineGenericParameterCount(reader, "FetchInstanceG", "Holder`1"));
+        Assert.Equal(1, StateMachineGenericParameterCount(reader, "FetchSharedG", "Flat"));
+    }
+
+    /// <summary>
+    /// Returns the distinct handle kinds of every <c>call</c> token in
+    /// <paramref name="methodName"/>.
+    /// </summary>
+    /// <param name="reader">The metadata reader.</param>
+    /// <param name="pe">The PE reader.</param>
+    /// <param name="typeName">The declaring type's metadata name.</param>
+    /// <param name="methodName">The method whose body is scanned.</param>
+    /// <returns>The set of token kinds appearing on <c>call</c> instructions.</returns>
+    private static HashSet<HandleKind> CallTokenKinds(
+        MetadataReader reader,
+        PEReader pe,
+        string typeName,
+        string methodName)
+    {
+        var type = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name) == typeName);
+
+        var method = type.GetMethods()
+            .Select(reader.GetMethodDefinition)
+            .Single(m => reader.GetString(m.Name) == methodName);
+
+        var il = pe.GetMethodBody(method.RelativeVirtualAddress).GetILContent();
+        var kinds = new HashSet<HandleKind>();
+
+        // `call` is 0x28 followed by a 4-byte token. Scanning for the opcode
+        // byte can in principle land inside an operand; every hit is therefore
+        // required to decode to a token kind that a `call` can legally carry,
+        // and the assertions only ever check for PRESENCE of a kind.
+        for (var i = 0; i + 4 < il.Length; i++)
+        {
+            if (il[i] != 0x28)
+            {
+                continue;
+            }
+
+            var token = il[i + 1] | (il[i + 2] << 8) | (il[i + 3] << 16) | (il[i + 4] << 24);
+            if (token == 0)
+            {
+                continue;
+            }
+
+            var kind = MetadataTokens.EntityHandle(token).Kind;
+            if (kind is HandleKind.MethodDefinition or HandleKind.MemberReference or HandleKind.MethodSpecification)
+            {
+                kinds.Add(kind);
+            }
+        }
+
+        return kinds;
+    }
+
+    /// <summary>
+    /// Returns the generic-parameter count of the state machine synthesized for
+    /// <paramref name="methodName"/> inside <paramref name="enclosingTypeName"/>.
+    /// </summary>
+    /// <param name="reader">The metadata reader.</param>
+    /// <param name="methodName">The kickoff method's name.</param>
+    /// <param name="enclosingTypeName">The kickoff method's declaring type.</param>
+    /// <returns>The state-machine type's generic-parameter count.</returns>
+    private static int StateMachineGenericParameterCount(
+        MetadataReader reader,
+        string methodName,
+        string enclosingTypeName)
+    {
+        var enclosing = reader.TypeDefinitions
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name) == enclosingTypeName);
+
+        var stateMachine = enclosing.GetNestedTypes()
+            .Select(reader.GetTypeDefinition)
+            .Single(t => reader.GetString(t.Name).StartsWith("<" + methodName + ">d__", StringComparison.Ordinal));
+
+        return stateMachine.GetGenericParameters().Count;
+    }
+
+    private static string[] CompileVerifyAndRun(string source, out string assemblyPath)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3939_").FullName;
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+        var outPath = Path.Combine(tempDir, "Program.dll");
+        assemblyPath = outPath;
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+            srcPath,
+        };
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+        psi.ArgumentList.Add("exec");
+        psi.ArgumentList.Add("--runtimeconfig");
+        psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+        psi.ArgumentList.Add(outPath);
+
+        using var proc = Process.Start(psi);
+        var stdout = proc!.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+        Assert.True(
+            proc.ExitCode == 0,
+            $"sample exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+        return stdout
+            .ReplaceLineEndings(Environment.NewLine)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+    }
+}


### PR DESCRIPTION
A **proactive sweep** of gsc's emitter for #3705's defect class — *a path omits what a neighbouring path a few lines away already does correctly* — restricted to paths that must reason about **generic context**. #3934 and #3936 found seven instances of that class in emit in two PRs, all in generic context, all sibling-shaped, and every one of them found only because a migrated app happened to exercise it. This looks for the rest first.

Two live defects found and fixed; one more found and filed as **#3940**; seven sibling pairs checked and **cleared**.

Sweep and findings table: **#3939**.

## A — a generic `shared` method on a generic type loses its MethodSpec

```gs
class Holder[T] {
    shared {
        func Plain[U](v T, other U) string -> v.ToString() + "|" + other.ToString()
    }
}
Console.WriteLine(Holder[int32].Plain[string](41, "b"))
```

ILVerify: `[found ref 'string'][expected ref '!!0']`. Runtime: `InvalidOperationException: Could not execute the method because either the method itself or the containing type is not fully instantiated.`

**This is live and reachable from ordinary hand-written G#, not a migration artifact.** The snippet above is the whole reproducer: a `shared` generic method on a generic type, an unremarkable shape, written directly. gsc accepts it without a diagnostic and emits an assembly that does not verify and throws on the first call. The sweep was motivated by migration work, but this finding is a plain correctness bug for anyone writing G# today, and it should be reviewed as one.

The static-call path in `MethodBodyEmitter.Expressions.cs` chose between two **independent axes** with an `else if`:

- the **owner** token — which type the method belongs to. A `shared` method on a constructed generic type (#1209) or interface (#1433) needs a MemberRef parented at the construction's TypeSpec.
- the **MethodSpec** — how the *method* is instantiated (ADR-0087 §3 R3+R4).

A `shared func Make[U]()` on a generic `Box[T]` needs both, and got only the first: a TypeSpec-parented MemberRef naming the **open** generic method.

Neither #1209 nor #1433 was wrong. Each branch is correct for the case it was written for; the gap exists only where both conditions hold at once, and the composition was never considered.

**The already-correct siblings.** `EmitUserInstanceCall` (`MethodBodyEmitter.Calls.cs`) resolves a TypeSpec-parented MemberRef for a generic receiver and *then* wraps it in a MethodSpec whenever `call.Method.IsGeneric` — sequentially. So does `EmitMethodGroupTarget` (`MethodBodyEmitter.Closures.cs`), which is the model this fix follows. The non-generic `shared` form, the generic `shared` form on a *non*-generic type, and the instance form all stayed correct throughout.

Four surface shapes, **one** emitted-IL cause (`call <TypeSpec-parented MemberRef naming an open generic method>`): the plain class form; the interface form, whose #1433 branch resolved its token and then `break`ed out of the case entirely so it could never reach the MethodSpec *or* #3226's nullable-lift unwrap; the `shared` **iterator** form; and the `shared async` form. Grouping by symptom would have split these across three files and attributed two of them to `StateMachineEmitter` — where nothing is wrong.

## B — the async kickoff's self-instantiation, hidden behind A

```gs
class Holder[T] {
    shared {
        async func FetchSharedG[U](v T, other U) ValueTask[string] { … }
    }
}
```

With A fixed this surfaces on its own: `TypeLoadException: The generic type '<FetchSharedG>d__0`2' was used with the wrong number of generic arguments`.

The state-machine struct is reified over class-then-method parameters by `ReflectionMetadataEmitter.RegisterStateMachineEnclosingGenerics`. `StateMachineEmitter.EmitAsyncKickoffBody` re-derived the same list to self-instantiate it — and its copy read `ReceiverType` alone, so it never picked up the `StaticOwnerType` half **#3932 root C added to the reification one file over**. A `shared` kickoff therefore constructed a 2-parameter struct with 1 argument.

The **iterator** kickoff has never had this bug, and the reason is structural rather than lucky: it constructs over the very `scopeTPs` its class was reified from. One list, one decision. So the fix is at the shared primitive — `StateMachineEmitter.GetAsyncKickoffGenericScope`, which both the reification and the kickoff now read — in the spirit of the #3705 binder funnels (`ClrMemberVisibility`, `ClrLoadContext`) that made those fixes stick.

## Evidence

`test/Compiler.Tests/Emit/Issue3939GenericStaticSiblingEmitTests.cs` — four tests, each of which **COMPILES, ILVERIFIES, RUNS and asserts on behaviour**. All three are load-bearing on #3501, and this week supplied fresh proof of each: #3936's intermediate state ILVerified clean and threw `TypeLoadException` at load, #3900's first cut passed an executing test and was caught only by ILVerify.

Two also read the emitted metadata back, because the facts at issue are ones behaviour cannot name:

- A: the **token kind** in `<Main>$` — a `MethodSpecification` must be present (the fix) *and* a `MemberReference` must still be present (the non-generic-method control, which must not gain a MethodSpec).
- B: the **arity** of each state machine, with all four controls pinning *different* expected arities (2 / 1 / 2 / 1), so a mutant that reifies unconditionally at 2 is caught as surely as one that reverts to `ReceiverType`.

The iterator test asserts the **full ordered** output rather than `Contains`, so an iterator that runs but yields in the wrong order or drops an element is caught.

Discrimination (ADR-0154): every test carries controls that passed **before** the fix — the same construct in its instance form, its non-generic-*method* form, and its non-generic-*encloser* form.

**Anti-vacuity**, and it separates the two fixes:

| src/Core state | Issue3939 result |
|---|---|
| `origin/main` | **4 failed / 0 passed** |
| A only (`MethodBodyEmitter.Expressions.cs`) | 1 failed / 3 passed — the async test still fails, so B is independently load-bearing |
| A + B | 4 passed / 0 failed |

The middle row is the point: **B is independently load-bearing.** With A's fix in and B's reverted, three tests go green and the async one still fails — so B is not a speculative second fix riding along with the first, and "was the second change necessary?" has a measured answer rather than an argued one. B was simply invisible until A stopped failing first.

## Filed, not fixed

**#3940** — a nested generic type returned from a generic method keeps its **enclosing** type argument open at the call site: `Outer`1+Inner`1<!0,string>` where `<int32,string>` belongs, then `BadImageFormatException` at load. It reproduces with no `shared`, no state machine and no lambda, so it is not this family and does not belong in this change.

## Pairs checked and CLEARED

Knowing where the emitter is consistent is worth as much as knowing where it is not. Each of these was compiled, ilverified and run:

- async vs iterator state machine on a non-generic type nested in a generic outer (`Outer[T].Inner`) — both arity 1. `RegisterStateMachineEnclosingGenerics` does not walk `CollectEnclosingTypeParameters` while `GetIteratorTypeParametersInScope` does, but the nested definition's own `TypeParameters` already carries the re-declaration, so they arrive at the same list. **A textual asymmetry that is not a defect.**
- capture-free vs capturing lambda inside a **generic method** of a generic encloser, reading the encloser's `private` field — #3933 generalizes one type parameter deeper.
- iterator vs async **function literal** inside a generic method of a generic type — #3936's double-count shape, one parameter deeper.
- `EmitMethodGroupTarget`'s owner resolution vs its MethodSpec wrapping — sequential, and the model A's fix follows.
- static field read/write through a constructed generic type (`Box[int32].count`), per-instantiation.
- `MethodBodyPlanner.TryGetUserKickoffReceiverHandle` (async + iterator + async-iterator) vs `TryGetUserKickoffReceiverSymbol` (async only) — agree **in effect**: the only call site iterates `smStructsOrdered`, which is async SM *structs* only; iterator SMs are classes and take the other loop. The doc comment "the symbol counterpart of" overstates the relationship, but no shape reaches the gap.
- every emit-side `ReceiverType ?? StaticOwnerType` consultation — after B, they all read both.

## Premise notes

- Finding A is **not** a state-machine or closure bug. It reproduces with a plain non-async, non-iterator `shared func`; the async and iterator shapes are downstream of it. The sweep's framing anticipated `StateMachineEmitter` and `ClosureEmitter` as the likely sites, and the densest cause turned out to be neither.
- `ClosureEmitter` came out **clean**: every sibling pair probed there agreed. #3933/#3936 appear to have closed that area rather than partially closed it.

Refs #3939, #3940, #3705, #3707, #3716, #3741, #3932, #3933, #3934, #3936, #1209, #1433, #1465, #1467, #1512, #2030, #3226, #3501, ADR-0087, ADR-0154.

Closes #3939.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
