### PR TITLE
gsc: a facade call the author wrote is not a lowered channel operator (#3945)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ChannelRuntimeBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ChannelRuntimeBinder.cs
@@ -671,6 +671,36 @@ internal sealed class ChannelRuntimeBinder
             && call.Function.ImportedClass.ClassType.FullName == ChannelOpsTypeName;
 
     /// <summary>
+    /// ADR-0174 D4/D7: distinguishes a facade call the BINDER lowered from a
+    /// channel operator (<c>&lt;-ch</c>, <c>ch &lt;- v</c>, a channel
+    /// <c>range</c>, a <c>select</c> arm) from one the AUTHOR wrote by name.
+    /// </summary>
+    /// <remarks>
+    /// <para>Every lowered operation is bound with a cancellation the binder
+    /// itself supplied — the uncancellable default token when no lexical scope
+    /// encloses it, or that scope's <c>Context</c> when one does — precisely so
+    /// the suspension pass can later park it on the ambient context via
+    /// <see cref="RetargetFacadeCancellation"/>. A call written out as
+    /// <c>ChannelOps.Receive2(ch, token)</c> has already chosen its
+    /// cancellation, so there is nothing for that pass to retarget: it is an
+    /// ordinary blocking call to a public library method.</para>
+    /// <para>That distinction is load-bearing for the COLORING. Marking the
+    /// caller suspending prepends a hidden <c>Context</c> parameter and retypes
+    /// the return as <c>ValueTask</c> — an ABI change — which is the point for a
+    /// channel operator but is pure cost for a written facade call, whose body
+    /// the pass leaves untouched. It also breaks callers that reflect over the
+    /// signature: an xUnit <c>[Fact]</c> that drains a channel through the
+    /// facade is rejected at discovery as "not allowed to have parameters"
+    /// (#3501, migrated <c>test/Extensions.Tests</c>).</para>
+    /// </remarks>
+    /// <param name="call">A facade call, already matched by <see cref="IsFacadeCall"/>.</param>
+    /// <returns><see langword="true"/> when the trailing cancellation argument was written by the author rather than supplied by the binder.</returns>
+    public static bool HasAuthorWrittenCancellation(BoundImportedCallExpression call)
+        => call.Arguments.Length != 0
+            && call.Arguments[^1] is not BoundDefaultExpression
+            && call.Arguments[^1].Type?.ClrType?.FullName == CancellationTokenTypeName;
+
+    /// <summary>
     /// ADR-0174 D7: rebinds a facade call that was bound with the
     /// uncancellable default token so it parks on <paramref name="context"/>
     /// instead. Used by the suspension pass for operations that no lexical

--- a/src/Core/CodeAnalysis/Binding/Suspension/SuspensionPointCollector.cs
+++ b/src/Core/CodeAnalysis/Binding/Suspension/SuspensionPointCollector.cs
@@ -87,11 +87,18 @@ internal sealed class SuspensionPointCollector : BoundTreeWalker
     /// <inheritdoc/>
     protected override void VisitImportedCallExpression(BoundImportedCallExpression node)
     {
-        if (goDepth == 0 && lockDepth == 0
-            && (ChannelRuntimeBinder.IsFacadeCall(node, "Receive")
+        var isFacadeOperation =
+            (ChannelRuntimeBinder.IsFacadeCall(node, "Receive")
                 || ChannelRuntimeBinder.IsFacadeCall(node, "Receive2")
-                || ChannelRuntimeBinder.IsFacadeCall(node, "Send")
-                || LockRegions.IsBlockingBridge(node)))
+                || ChannelRuntimeBinder.IsFacadeCall(node, "Send"))
+
+            // A facade call the AUTHOR wrote with its own token is an ordinary
+            // blocking library call, not a lowered channel operator: the
+            // suspension pass has nothing to retarget on it, so coloring the
+            // caller would change its ABI for no gain (ADR-0174 D4/D7).
+            && !ChannelRuntimeBinder.HasAuthorWrittenCancellation(node);
+
+        if (goDepth == 0 && lockDepth == 0 && (isFacadeOperation || LockRegions.IsBlockingBridge(node)))
         {
             facts.HasDirectPoint = true;
         }

--- a/test/Compiler.Tests/Issue3945WrittenFacadeCallColoringTests.cs
+++ b/test/Compiler.Tests/Issue3945WrittenFacadeCallColoringTests.cs
@@ -1,0 +1,282 @@
+// <copyright file="Issue3945WrittenFacadeCallColoringTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3945: ADR-0174 D4 suspension inference colored a function that merely
+/// CALLED the blocking facade by name — <c>ChannelOps.Receive2(ch, token)</c> —
+/// exactly as if it had written a channel operator. Coloring prepends a hidden
+/// leading <c>Context</c> parameter (D7) and retypes the return as
+/// <c>ValueTask</c>, so a parameterless method silently acquired an argument.
+/// </summary>
+/// <remarks>
+/// <para>Why it stayed invisible: the ABI change is meant to be invisible, and
+/// inside G# it is. It became observable only where something reflects over the
+/// signature. In the #3501 self-migration, migrated
+/// <c>test/Extensions.Tests</c> translates four C# tests that drain a channel
+/// through the facade, and xUnit rejected all four at discovery with
+/// "[Fact] methods are not allowed to have parameters" — the app's only
+/// test-parity fingerprint, and one of the two banked apps holding the gate
+/// below its floor.</para>
+/// <para>The distinction the fix restores: every facade call the BINDER lowers
+/// from a channel operator is bound with a cancellation the binder supplied
+/// (the uncancellable default token, or an enclosing <c>scope</c>'s
+/// <c>Context</c>) precisely so the suspension pass can retarget it onto the
+/// ambient context. A call the AUTHOR wrote with its own token has already
+/// chosen its cancellation — the pass leaves the body untouched — so coloring
+/// the caller was pure ABI cost with no corresponding rewrite.</para>
+/// <para>Discrimination (ADR-0154): the operator control
+/// <c>OperatorReceive</c> must STILL be colored, so a mutant that stops
+/// coloring facade calls altogether fails as surely as one that colors written
+/// ones. The written and operator forms sit in one program and compile
+/// together, so the two paths cannot be satisfied by a blanket answer. Every
+/// case compiles, IL-verifies AND runs: on this effort a wrong fix has passed a
+/// binding-only assertion, and a defect has IL-verified clean yet failed at
+/// load.</para>
+/// </remarks>
+public class Issue3945WrittenFacadeCallColoringTests
+{
+    private const string Source = """
+        package main
+
+        import System
+        import System.Threading
+        import Gsharp.Concurrency
+        import System.Threading.Channels
+
+        class Probe {
+            // The regressed shape: a parameterless method — an xUnit `[Fact]`
+            // shape — whose only channel work is a facade call the author wrote
+            // out, with a token the author chose.
+            func WrittenFacadeCall() {
+                let ch = Chan[int32](1)
+                ch.TrySend(7)
+                let (value, ok) = ChannelOps.Receive2(ch, CancellationToken.None)
+                Console.WriteLine("w=" + value.ToString() + ":" + ok.ToString())
+            }
+
+            // Control that passed BEFORE the fix: a channel OPERATOR still
+            // colors its caller, which is the whole point of ADR-0174 D4.
+            func OperatorReceive() {
+                let ch = Chan[int32](1)
+                ch.TrySend(9)
+                let (value, ok) = <-ch
+                Console.WriteLine("o=" + value.ToString() + ":" + ok.ToString())
+            }
+
+            // Control: a body with no channel operation is never colored.
+            func NoChannelOp() {
+                Console.WriteLine("n=ok")
+            }
+        }
+
+        let p = Probe()
+        p.WrittenFacadeCall()
+        p.OperatorReceive()
+        p.NoChannelOp()
+        """;
+
+    /// <summary>
+    /// The behavioural half: all three methods run and print what they were
+    /// written to print. A written facade call still performs the receive — the
+    /// fix changes who carries the context, not what the call does.
+    /// </summary>
+    [Fact]
+    public void WrittenFacadeCall_StillReceives_AndTheProgramRuns()
+    {
+        var (_, lines) = CompileVerifyAndRun();
+
+        Assert.Equal(new[] { "w=7:True", "o=9:True", "n=ok" }, lines);
+    }
+
+    /// <summary>
+    /// The encoding half: "the method has no parameters" is a metadata fact no
+    /// behavioural assertion can name, and it is the exact fact xUnit reads.
+    /// Asserted against the emitted signature blob, which is what
+    /// <see cref="MethodBase.GetParameters"/> reports.
+    /// </summary>
+    [Fact]
+    public void WrittenFacadeCall_KeepsItsSignature_WhileTheOperatorFormIsStillColored()
+    {
+        var (assemblyPath, _) = CompileVerifyAndRun();
+
+        var written = SignatureOf(assemblyPath, "Probe", "WrittenFacadeCall");
+        var operatorForm = SignatureOf(assemblyPath, "Probe", "OperatorReceive");
+        var plain = SignatureOf(assemblyPath, "Probe", "NoChannelOp");
+
+        // The regression: this was `1 [Context] -> ValueTask`.
+        Assert.Equal(0, written.ParameterCount);
+        Assert.Equal("Void", written.ReturnType);
+
+        // Discrimination: the operator form MUST still gain the hidden context.
+        Assert.Equal(1, operatorForm.ParameterCount);
+        Assert.Equal("Context", operatorForm.ParameterTypes[0]);
+
+        Assert.Equal(0, plain.ParameterCount);
+        Assert.Equal("Void", plain.ReturnType);
+    }
+
+    private static (int ParameterCount, string[] ParameterTypes, string ReturnType) SignatureOf(
+        string assemblyPath,
+        string typeName,
+        string methodName)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var provider = new NameOnlySignatureProvider();
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(type.Name) != typeName)
+            {
+                continue;
+            }
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName)
+                {
+                    continue;
+                }
+
+                var signature = method.DecodeSignature(provider, genericContext: null);
+                return (
+                    signature.ParameterTypes.Length,
+                    signature.ParameterTypes.ToArray(),
+                    signature.ReturnType);
+            }
+        }
+
+        throw new InvalidOperationException($"{typeName}::{methodName} not found in {assemblyPath}");
+    }
+
+    private static (string AssemblyPath, string[] Lines) CompileVerifyAndRun()
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3945_facade_").FullName;
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, Source);
+        var outPath = Path.Combine(tempDir, "Program.dll");
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args.ToArray());
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+
+        Assert.True(compileExit == 0, $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+        IlVerifier.Verify(outPath);
+
+        var psi = new ProcessStartInfo("dotnet", $"\"{outPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = tempDir,
+        };
+
+        using var process = Process.Start(psi) ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        Assert.True(process.WaitForExit(60_000), "the sample timed out");
+        Assert.True(process.ExitCode == 0, $"the sample exited {process.ExitCode}:\n{output}");
+
+        var lines = output.ToString()
+            .Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0)
+            .ToArray();
+
+        return (outPath, lines);
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        if (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") is not string tpa || tpa.Length == 0)
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+
+    /// <summary>
+    /// Decodes a signature blob to type NAMES: the assertions here are about
+    /// arity and the identity of the hidden parameter, not full type identity.
+    /// </summary>
+    private sealed class NameOnlySignatureProvider : ISignatureTypeProvider<string, object>
+    {
+        public string GetArrayType(string elementType, ArrayShape shape) => elementType + "[]";
+
+        public string GetByReferenceType(string elementType) => elementType + "&";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature) => "fnptr";
+
+        public string GetGenericInstantiation(string genericType, System.Collections.Immutable.ImmutableArray<string> typeArguments)
+            => genericType + "<" + string.Join(",", typeArguments) + ">";
+
+        public string GetGenericMethodParameter(object genericContext, int index) => "!!" + index;
+
+        public string GetGenericTypeParameter(object genericContext, int index) => "!" + index;
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        public string GetPointerType(string elementType) => elementType + "*";
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeDefinition(handle).Name);
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeReference(handle).Name);
+
+        public string GetTypeFromSpecification(MetadataReader reader, object genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => "typespec";
+    }
+}


### PR DESCRIPTION
Fixes #3945. Takes migrated `test/Extensions.Tests` back to green, one of the two banked `greenApps` entries the gate reported as no longer green in run 33943018295.

## The premise correction first

The two apps the gate named were investigated together on the assumption that both regressed between `efd1b1a91` and `f1399b202`. Neither did.

- That window contains **six** commits, not the four usually cited: `#3930` (`f42549eff`) and `#3934` (`f7fde6d2f`) are also in it.
- More importantly, the **previous** gate run (33929083318, `efd1b1a91`) already flagged *both* apps as no longer green, at 39/53. It was not a both-green baseline.
- The last actually-green run was **33819616178** (`4ed74c3f4`, 2026-09-03 23:54); the first failing one was **33825780017** (`36a147f0f`). That range is a single merge: **#3882**, ADR-0174 wave 2.

Both apps trace to #3882, for two unrelated reasons.

## `bench/concurrency/clr/ClrBaseline.csproj` — not a defect, a stale ratchet entry

It is **absent from the corpus entirely** (0 of 53 apps are under `bench/`). #3882's commit `ec15e4958` added, deliberately and with a good rationale:

```
  # ADR-0174 D11: the concurrency benchmark's C# and Go sides are measurement
  # apparatus, not migration targets. Translating the CLR baseline would
  # measure the translator rather than the runtime …
  --exclude bench/concurrency/clr
  --exclude bench/concurrency/aot
```

It had been banked into `greenApps` the day before (gate run 33743456719). So the app was banked on 09-03 and excluded on 09-04 by the same wave that added it. **There is no code fix; it can never be green again by design.** The `greenApps` entry has to go.

That edit belongs in `tools/cs2gs/selfmig-baseline.json`, which this PR deliberately does not touch — #3944 owns it. Note that #3944 currently keeps the entry, on the stated grounds that the two apps "are being fixed, not absorbed". Half of that is right; ClrBaseline is not fixable.

**Corrected arithmetic.** With this PR's fix, and #3944's changes, and the phantom dropped:

| | |
|---|---|
| corpus | 53 |
| green now | 43 |
| green with this fix | **44** |
| `greenApps` after #3944 + dropping the phantom | 44 entries, all green |
| `greenFloor` | 44 — exactly met |

So the outcome is 43 → **44**, not 43 → 45.

## `test/Extensions.Tests` — the real defect

Its single test-parity fingerprint is four tests failing at xUnit *discovery*:

```
System.InvalidOperationException : [Fact] methods are not allowed to have parameters.
Failed!  - Failed: 4, Passed: 176, Skipped: 0, Total: 180
```

(A count with its `Failed! … Total:` line, per #3931.)

The four are exactly the four methods in `ConcurrencyTests` that call `ChannelOps.Receive2(reader, CancellationToken.None)`; the other tests in the class pass. Those tests were added by #3882 itself (`5976026ca`, `3f4e939cc`) — the same PR that introduced suspension inference — so the app broke by acquiring tests that exercise a defect the same PR shipped.

**Root cause.** ADR-0174 D4 inference (`SuspensionPointCollector.VisitImportedCallExpression`) treats any reach of `ChannelOps.Receive/Receive2/Send` as a direct suspension point, via `IsFacadeCall`, which matches on name and declaring type only. It does not distinguish the facade calls the **binder lowers** from a channel operator (`<-ch`, `ch <- v`, a channel `range`, a `select` arm) from those the **author writes out**.

Coloring is an ABI change — D7 prepends a hidden leading `Context` parameter and retypes the return as `ValueTask`. That is the whole point for an operator. For a written call it buys nothing: `RetargetFacadeCancellation` only retargets a facade call whose trailing cancellation is a `BoundDefaultExpression`, so a call already carrying the author's token is left untouched. The function pays the ABI cost with no corresponding rewrite — and anything reflecting over the signature breaks.

**The fix** uses the discriminator that path already relies on. A lowered operation is bound with a cancellation the binder supplied (the uncancellable default token, or an enclosing `scope`'s `Context`); a written call passes a `CancellationToken` expression of its own. Only the latter stops being a suspension point. Layer: `src/Core`, binding — not emit, and not cs2gs, whose translation of these calls is faithful.

## Before / after

Minimal repro, emitted signature blob (what `MethodInfo.GetParameters()` reads):

| method | on `9ec9a4c89` | with this PR |
|---|---|---|
| `WrittenFacadeCall` (`ChannelOps.Receive2(ch, CancellationToken.None)`) | `1 [Context] -> ValueTask` | **`0 [] -> Void`** |
| `OperatorReceive` (`let (v, ok) = <-ch`) | `1 [Context] -> ValueTask` | `1 [Context] -> ValueTask` (unchanged) |
| `NoChannelOp` | `0 [] -> Void` | `0 [] -> Void` |

## Test evidence

`test/Compiler.Tests/Issue3945WrittenFacadeCallColoringTests.cs` — compiles, **IL-verifies and runs**, and additionally reads the emitted signature back, because "the method has no parameters" is an encoding fact no behavioural assertion can name and is precisely what xUnit reads.

**Failing-on-main proof, honestly labelled.** With the discriminator reverted to main's behaviour:

```
Failed WrittenFacadeCall_KeepsItsSignature_WhileTheOperatorFormIsStillColored
Failed!  - Failed: 1, Passed: 1, Total: 2
```

The other test, `WrittenFacadeCall_StillReceives_AndTheProgramRuns`, **passes on main** — the program always ran correctly; only the signature was wrong. That is the anti-vacuity guard rail, and it is why a behaviour-only test would have passed a wrong fix here.

**Discrimination (ADR-0154).** `OperatorReceive` must still be colored and sits in the same program, so a mutant that stops coloring facade calls altogether fails as surely as one that colors written ones.

**No regressions**, targeted suites on this branch:

| suite | result |
|---|---|
| `Core.Tests` — Suspension / Adr0174 / Channel / Concurrency | 328 passed, 0 failed |
| `Compiler.Tests` — Adr0174 / Channel / Issue3932 / Issue3907 | 47 passed, 0 failed |
| `Extensions.Tests` (the C# oracle) | 180 passed, 0 failed |
| `Runtime.Channels.Tests` | 188 passed, 0 failed |

The cs2gs PR guard triggers automatically on `src/Core/**`, so it runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs