### PR TITLE
Sdk.Tests: layout assertions must not assume the .cs/.csproj spelling (#3501)

### DIFF
--- a/test/Sdk.Tests/RepoRoot.cs
+++ b/test/Sdk.Tests/RepoRoot.cs
@@ -25,6 +25,44 @@ internal static class RepoRoot
     public static string SamplesDir { get; } =
         System.IO.Path.Combine(Path, "samples");
 
+    /// <summary>
+    /// Resolves a repository source path that survives the cs2gs
+    /// self-migration corpus, where every translated project file is renamed
+    /// <c>X.csproj</c> to <c>X.gsproj</c> and every translated source file is
+    /// renamed <c>X.cs</c> to <c>X.gs</c>. Layout assertions are about the
+    /// repository's shape, not about which language the file happens to be
+    /// written in, so they must find the file under either name.
+    /// </summary>
+    /// <param name="path">The C# spelling of the path.</param>
+    /// <returns>
+    /// <paramref name="path"/> when it exists, otherwise the migrated sibling.
+    /// </returns>
+    public static string ResolveSourcePath(string path)
+    {
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        var migrated = MigratedSpelling(path);
+        return File.Exists(migrated) ? migrated : path;
+    }
+
+    private static string MigratedSpelling(string path)
+    {
+        if (path.EndsWith(".csproj", StringComparison.Ordinal))
+        {
+            return path.Substring(0, path.Length - ".csproj".Length) + ".gsproj";
+        }
+
+        if (path.EndsWith(".cs", StringComparison.Ordinal))
+        {
+            return path.Substring(0, path.Length - ".cs".Length) + ".gs";
+        }
+
+        return path;
+    }
+
     private static string Find()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);

--- a/test/Sdk.Tests/SdkLayoutTests.cs
+++ b/test/Sdk.Tests/SdkLayoutTests.cs
@@ -20,6 +20,10 @@ public class SdkLayoutTests
     private static readonly XNamespace MsbuildNs =
         "http://schemas.microsoft.com/developer/msbuild/2003";
 
+    private static string SdkProjectPath =>
+        RepoRoot.ResolveSourcePath(
+            Path.Combine(RepoRoot.SdkSourceDir, "Gsharp.NET.Sdk.csproj"));
+
     [Fact]
     public void Sdk_Props_Imports_MicrosoftNetSdk_And_Gsharp_Build_Props()
     {
@@ -338,13 +342,18 @@ public class SdkLayoutTests
             "@(_GsharpAgentOwnedWatch)",
             (string)filterTarget.Descendants(MsbuildNs + "Watch").Single().Attribute("Remove"));
 
-        var agentPath = Path.GetFullPath(Path.Combine(
+        var agentPath = RepoRoot.ResolveSourcePath(Path.GetFullPath(Path.Combine(
             RepoRoot.SdkSourceDir,
             "..",
             "Gsharp.HotReload.Runtime",
-            "HotReloadAgent.cs"));
+            "HotReloadAgent.cs")));
         var agentText = File.ReadAllText(agentPath);
-        Assert.Contains("SemaphoreSlim updateGate", agentText, System.StringComparison.Ordinal);
+
+        // Declaration order differs between the C# and G# spellings of this
+        // file (`SemaphoreSlim updateGate` vs `updateGate SemaphoreSlim`), so
+        // assert on the two tokens rather than on one language's word order.
+        Assert.Contains("SemaphoreSlim", agentText, System.StringComparison.Ordinal);
+        Assert.Contains("updateGate", agentText, System.StringComparison.Ordinal);
         Assert.DoesNotContain("-p:IntermediateOutputPath=", agentText, System.StringComparison.Ordinal);
         Assert.DoesNotContain("-p:OutputPath=", agentText, System.StringComparison.Ordinal);
         Assert.DoesNotContain("-p:DotNetWatchBuild=true", agentText, System.StringComparison.Ordinal);
@@ -371,7 +380,7 @@ public class SdkLayoutTests
     [Fact]
     public void Sdk_Csproj_Packs_As_MSBuildSdk()
     {
-        var csproj = Path.Combine(RepoRoot.SdkSourceDir, "Gsharp.NET.Sdk.csproj");
+        var csproj = SdkProjectPath;
         Assert.True(File.Exists(csproj), csproj);
 
         var text = File.ReadAllText(csproj);
@@ -392,13 +401,10 @@ public class SdkLayoutTests
     {
         // ADR-0174 D1: mirrors the hot-reload runtime wiring — build-only
         // ProjectReference for ordering, a pack target under tools/channels/.
-        var path = Path.Combine(RepoRoot.SdkSourceDir, "Gsharp.NET.Sdk.csproj");
+        var path = SdkProjectPath;
         var doc = XDocument.Load(path);
         var runtimeReference = doc.Descendants("ProjectReference")
-            .Single(reference =>
-                ((string)reference.Attribute("Include") ?? string.Empty).EndsWith(
-                    @"Gsharp.Runtime.Channels\Gsharp.Runtime.Channels.csproj",
-                    System.StringComparison.Ordinal));
+            .Single(reference => ReferencesProject(reference, "Gsharp.Runtime.Channels"));
 
         Assert.Equal("false", (string)runtimeReference.Attribute("Private"));
         Assert.Equal("false", (string)runtimeReference.Attribute("ReferenceOutputAssembly"));
@@ -436,13 +442,10 @@ public class SdkLayoutTests
     [Fact]
     public void Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime()
     {
-        var path = Path.Combine(RepoRoot.SdkSourceDir, "Gsharp.NET.Sdk.csproj");
+        var path = SdkProjectPath;
         var doc = XDocument.Load(path);
         var runtimeReference = doc.Descendants("ProjectReference")
-            .Single(reference =>
-                ((string)reference.Attribute("Include") ?? string.Empty).EndsWith(
-                    @"Gsharp.HotReload.Runtime\Gsharp.HotReload.Runtime.csproj",
-                    System.StringComparison.Ordinal));
+            .Single(reference => ReferencesProject(reference, "Gsharp.HotReload.Runtime"));
 
         Assert.Equal("false", (string)runtimeReference.Attribute("Private"));
         Assert.Equal("false", (string)runtimeReference.Attribute("ReferenceOutputAssembly"));
@@ -564,5 +567,24 @@ public class SdkLayoutTests
         Assert.Contains(
             doc.Descendants(MsbuildNs + "CompileDependsOn"),
             property => property.Value.Contains("AfterCompile", System.StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Matches a <c>ProjectReference</c> that points at
+    /// <c>&lt;projectName&gt;/&lt;projectName&gt;</c>, tolerating both path
+    /// separators and both project-file extensions. The cs2gs self-migration
+    /// corpus rewrites these references to <c>.gsproj</c> with forward slashes,
+    /// and the assertion is about the reference's target, not its spelling.
+    /// </summary>
+    /// <param name="reference">The <c>ProjectReference</c> element.</param>
+    /// <param name="projectName">The referenced project's directory and base file name.</param>
+    /// <returns><see langword="true"/> when the reference targets that project.</returns>
+    private static bool ReferencesProject(XElement reference, string projectName)
+    {
+        var include = ((string)reference.Attribute("Include") ?? string.Empty)
+            .Replace('\\', '/');
+        var stem = projectName + "/" + projectName + ".";
+        return include.EndsWith(stem + "csproj", System.StringComparison.Ordinal)
+            || include.EndsWith(stem + "gsproj", System.StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## What

Four `SdkLayoutTests` read repository files by their **C# name**:

- `Sdk_Csproj_Packs_As_MSBuildSdk`, `Sdk_Csproj_Uses_BuildOnly_Channels_Runtime_Reference_And_Packs_Runtime`, `Sdk_Csproj_Uses_BuildOnly_HotReload_Runtime_Reference_And_Packs_Runtime` open `src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj`;
- `Core_Targets_Pin_HotReload_Watch_Inputs_And_Serialized_Agent_Build` reads `Gsharp.HotReload.Runtime/HotReloadAgent.cs`.

Two of them additionally match a `ProjectReference` by the literal substring `Gsharp.HotReload.Runtime\Gsharp.HotReload.Runtime.csproj`, and one asserts on C#'s declaration word order (`SemaphoreSlim updateGate`).

In the cs2gs self-migration corpus every translated project file is renamed `.csproj` → `.gsproj` and every translated source `.cs` → `.gs`, references are rewritten with forward slashes, and G# spells the field `updateGate SemaphoreSlim`. So all four throw `FileNotFoundException` / fail to match there.

**These four are the entirety of `test/Sdk.Tests`' remaining self-migration gate failure** — gate run 33968896644 reports `Failed: 4, Passed: 88, Total: 92`.

Classification: **test defect** — the assertion's premise (a file's *spelling*) stops holding after migration, while the thing it is really asserting (the repository's shape) does not. No allow-list entry: the assertions stay, they just stop being coupled to one language's file extensions.

## How

- `RepoRoot.ResolveSourcePath` falls back to the migrated spelling when the C# one is absent.
- `SdkLayoutTests.ReferencesProject` matches a `ProjectReference` on its target project, tolerating both path separators and both project extensions.
- The hot-reload agent assertion checks for `SemaphoreSlim` and `updateGate` rather than for one language's declaration order.

## Proof

Both directions, since either alone is misleading:

- **C# repository:** `dotnet test test/Sdk.Tests -c Release --filter SdkLayoutTests` → `Passed: 23, Failed: 0`.
- **Migrated tree:** the same built test assembly, run with its `AppContext.BaseDirectory` inside the migrated tree from gate run 33968896644 (which contains only `Gsharp.NET.Sdk.gsproj` and `HotReloadAgent.gs`) → `Passed: 23, Failed: 0`. The pre-change assembly cannot open either file there.

Bankable once the nightly confirms: `test/Sdk.Tests/Sdk.Tests.csproj`.

Refs #3501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs