### PR TITLE
cs2gs: a doc line must never start with a tag gsc does not know (#3501)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Adr0179DocCommentLineStructureTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0179DocCommentLineStructureTests.cs
@@ -96,6 +96,36 @@ namespace Cs2Gs.Tests
             TranslationTestValidation.AssertBinds(printed);
         }
 
+        [Fact]
+        public void CodeSpanWrappedAcrossSourceLines_DoesNotStartALineWithAStrayTag()
+        {
+            // Issue #3501: src/Sdk/Gsharp.NET.Sdk/GsgenTask.cs writes
+            // `<c>dotnet &lt;tool&gt;.dll @rsp</c>` with the author's own line
+            // break falling INSIDE the code span, right before `@rsp`. Phase
+            // 9a preserves that line structure, so the emitted G# began a doc
+            // line with `@rsp` — which gsc reads as a block tag and rejects
+            // with GS0231 "Unknown documentation tag", failing the whole
+            // project. The break carries no meaning inside a span, so it heals.
+            string printed = Translate("""
+                public class Widget
+                {
+                    /// <summary>Short.</summary>
+                    /// <remarks>
+                    /// Modeled EXACTLY on the build task: same <c>dotnet &lt;tool&gt;.dll
+                    /// @rsp</c> process launch, the same response-file writer.
+                    /// </remarks>
+                    public int Mass() => 42;
+                }
+                """);
+
+            Assert.All(DocLines(printed), line => Assert.False(
+                line.StartsWith("/// @rsp", StringComparison.Ordinal),
+                "A doc line must not start with an unknown block tag: " + line));
+            Assert.Contains("@rsp`", printed, StringComparison.Ordinal);
+            Assert.Contains("response-file writer.", printed, StringComparison.Ordinal);
+            TranslationTestValidation.AssertBinds(printed);
+        }
+
         private static List<string> DocLines(string printed) => printed
             .Split('\n')
             .Select(line => line.Trim())

--- a/tools/cs2gs/Cs2Gs.Translator/XmlDocMarkdownConverter.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/XmlDocMarkdownConverter.cs
@@ -36,6 +36,16 @@ internal static class XmlDocMarkdownConverter
     private const int MaxDocLineWidth = 100;
 
     /// <summary>
+    /// ADR-0057 block tags: the only <c>@name</c> heads gsc accepts at the
+    /// start of a doc-comment line. Anything else there is GS0231.
+    /// </summary>
+    private static readonly string[] BlockTags =
+    {
+        "@param", "@typeparam", "@returns", "@remarks",
+        "@value", "@exception", "@seealso",
+    };
+
+    /// <summary>
     /// Converts one raw documentation-comment trivia string (the `///`-prefixed
     /// lines) into ADR-0057 Markdown doc-comment lines, each already carrying
     /// the <c>///</c> marker.
@@ -164,7 +174,7 @@ internal static class XmlDocMarkdownConverter
         // (```…```) is untouched.
         var wrapped = new List<string>(output.Count);
         bool inFence = false;
-        foreach (string line in output)
+        foreach (string line in JoinStrayTagStarts(output))
         {
             if (line.TrimStart().StartsWith("```", StringComparison.Ordinal))
             {
@@ -206,7 +216,13 @@ internal static class XmlDocMarkdownConverter
         var current = new StringBuilder();
         foreach (string atom in SplitIntoAtoms(line))
         {
-            if (current.Length > 0 && current.Length + 1 + atom.Length > MaxDocLineWidth)
+            // Never START a line with something gsc would read as a block tag
+            // but does not recognise: a continuation line beginning `@rsp` is
+            // GS0231, not prose. Overflowing the width beats emitting a doc
+            // comment the compiler rejects.
+            if (current.Length > 0
+                && current.Length + 1 + atom.Length > MaxDocLineWidth
+                && !IsStrayTagStart(atom))
             {
                 yield return current.ToString();
                 current.Clear();
@@ -224,6 +240,66 @@ internal static class XmlDocMarkdownConverter
         {
             yield return current.ToString();
         }
+    }
+
+    /// <summary>
+    /// Issue #3501: joins any prose line that begins with an <c>@word</c> gsc
+    /// does not recognise as a block tag onto the line before it.
+    /// </summary>
+    /// <remarks>
+    /// ADR-0179 phase 9a preserves the author's own <c>///</c> line structure,
+    /// which is how <c>&lt;c&gt;dotnet &lt;tool&gt;.dll\n/// @rsp&lt;/c&gt;</c>
+    /// — a C# inline code span the author happened to wrap mid-span — reached
+    /// the emitted G# as a line starting <c>@rsp</c>. gsc reads a line-leading
+    /// <c>@word</c> as a block tag and fails the whole project with GS0231
+    /// "Unknown documentation tag". The author's line break inside the span
+    /// carries no meaning in Markdown, so healing it here is lossless.
+    /// </remarks>
+    private static List<string> JoinStrayTagStarts(List<string> lines)
+    {
+        var joined = new List<string>(lines.Count);
+        bool inFence = false;
+        foreach (string line in lines)
+        {
+            if (line.TrimStart().StartsWith("```", StringComparison.Ordinal))
+            {
+                inFence = !inFence;
+                joined.Add(line);
+                continue;
+            }
+
+            if (!inFence
+                && IsStrayTagStart(line)
+                && joined.Count > 0
+                && !string.IsNullOrWhiteSpace(joined[^1])
+                && !joined[^1].TrimStart().StartsWith("```", StringComparison.Ordinal))
+            {
+                joined[^1] = joined[^1].TrimEnd() + " " + line.TrimStart();
+                continue;
+            }
+
+            joined.Add(line);
+        }
+
+        return joined;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="text"/> starts with an <c>@word</c> that is not
+    /// one of ADR-0057's block tags — i.e. text that must not be allowed to
+    /// begin an emitted doc line.
+    /// </summary>
+    private static bool IsStrayTagStart(string text)
+    {
+        string trimmed = text.TrimStart();
+        if (!trimmed.StartsWith("@", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        int end = trimmed.IndexOf(' ');
+        string head = end < 0 ? trimmed : trimmed.Substring(0, end);
+        return !BlockTags.Contains(head, StringComparer.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
## The defect

ADR-0179 phase 9a preserves the author's own `///` line structure instead of recomputing it. `src/Sdk/Gsharp.NET.Sdk/GsgenTask.cs` writes:

```csharp
/// Modeled EXACTLY on <see cref="BuildTask"/>: same <c>dotnet &lt;tool&gt;.dll
/// @rsp</c> process launch, the same response-file writer, ...
```

The author's line break falls **inside** the `<c>` span, immediately before `@rsp`. Preserving that break puts `@rsp` at the start of an emitted G# doc line, and gsc reads a line-leading `@word` as an ADR-0057 block tag:

```
error GS0231: Unknown documentation tag '@rsp`'. Valid tags are: @param,
@typeparam, @returns, @remarks, @value, @exception, @seealso.
```

That is a hard compile error on `src/Sdk/Gsharp.NET.Sdk`, which takes the SDK project **and everything that project-references it** red in the #3501 self-migration gate.

**This is a regression against current main that no completed nightly has observed yet.** Run 33968896644 (`9ec9a4c89`) and run 33973595210 (`483ec1709`) both predate phase 9a's tighter re-wrap; `ffa462149` is where the wrap changed. Confirmed by migrating the repository twice locally — the C# source of `GsgenTask.cs` is byte-identical between `9ec9a4c89` and `ffa462149`, only the emitted line structure differs.

Classification: **cs2gs translation defect**.

## The fix

A line break inside a Markdown inline span carries no meaning, so healing it is lossless. Two guards, both keyed on ADR-0057's block-tag list:

- `JoinStrayTagStarts` folds a prose line beginning with an unrecognised `@word` back onto the line before it (fenced ` ```xmldoc ` blocks untouched).
- the wrap backstop refuses to **start** a new line with such an atom, even when that overflows the width — an over-wide doc line beats one gsc rejects.

## Proof

All three gate checks, against a locally migrated repository (`cs2gs validate --app test/Sdk.Tests/Sdk.Tests.csproj`):

```
app                              compile  ilverify  test-parity
test/Sdk.Tests/Sdk.Tests.csproj  PASS     PASS      PASS
```

Before the fix the same app is `compile FAIL(1)` on exactly this GS0231. A scan of the two migrated trees finds one `/// @rsp` line before the fix and none after; every remaining line-leading `@` is a real block tag (`@param`/`@returns`/`@remarks`/`@typeparam`/`@exception`/`@seealso`).

New regression test `Adr0179DocCommentLineStructureTests.CodeSpanWrappedAcrossSourceLines_DoesNotStartALineWithAStrayTag` reproduces the exact source shape and ends in `TranslationTestValidation.AssertBinds`, so it fails on the diagnostic rather than only on the text.

Refs #3501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs