### PR TITLE
gsc: a chan[T] whose element is a structural type converts to in/out chan[T] (#3924)

### DIFF
--- a/bench/concurrency/gsharp/Bench.gs
+++ b/bench/concurrency/gsharp/Bench.gs
@@ -329,10 +329,7 @@ func chunkedArrays(size int32, count int32) TimeSpan {
     return sw.Elapsed
 }
 
-// `chan[[]int32]` rather than `out chan[[]int32]`: the directional view
-// conversion does not apply when the element type is an array, so the `out`
-// form does not bind (issue #3924). Bidirectional is only a workaround here.
-func produceArrays(ch chan[[]int32], count int32, size int32) {
+func produceArrays(ch out chan[[]int32], count int32, size int32) {
     var sent = 0
     while sent < count {
         var chunk = [size]int32{}

--- a/docs/adr/0174-goroutines-and-channels-wave-2.md
+++ b/docs/adr/0174-goroutines-and-channels-wave-2.md
@@ -2665,6 +2665,38 @@ implementation had to refine it.
     reader does not spend the effort on channels that the number appears to
     demand.
 
+37. **The direction lattice compares elements by runtime type, not by symbol
+    shape (issue #3924).** D2 says a `chan[T]` narrows to `in chan[T]` /
+    `out chan[T]`. It did not when `T` was a *structural* G# type — `[]int32`,
+    `map[string,int32]`, `[][]int32` — while the same narrowing over `int32`,
+    `string` or a same-compilation `struct` bound fine. The cause is errata 3:
+    the value a `chan[T](n)` expression produces is the runtime class, so the
+    conversion's source element is whatever `TypeSymbol.FromClrType` mints for
+    the *reflected* type argument, and a structural shape has no CLR
+    counterpart symbol — `[]int32` comes back as an imported `int32[]`, never
+    the `SliceTypeSymbol` the type clause bound. The lattice compared those two
+    symbols and saw two different types. It now falls back to comparing the
+    elements' effective CLR types, which is the only question `Channel<T>`'s
+    invariance actually asks. This is not merely a fix for what `chan[T](n)`
+    builds: a foreign `Channel<int32[]>` from C# failed identically, and its
+    element exists only as reflected metadata, so no amount of preserving G#
+    symbols at construction would have reached it. With it, the D11
+    array-transport rows (`chunk64-arrays`, `chunk1k-arrays`) declare their
+    producer `out chan[[]int32]`, as errata 28's `merge` discussion intends.
+    The fallback applies only when one side IS that metadata-recovered form.
+    A CLR type is coarser than the G# symbol above it — `[3]int32` and
+    `[4]int32` are both `int32[]` — so where both sides still carry their
+    symbols the finer comparison stands: `chan[[3]int32]` still does not
+    narrow to `out chan[[4]int32]`. Past a construction the distinction is
+    already gone and was before this change: `chan[[3]int32](1)` and
+    `chan[[4]int32](1)` build one `Chan<int32[]>`, which a bidirectional
+    `chan[[4]int32]` parameter has always accepted.
+
+    The `Chan[int32[]]` spelling in the pre-fix diagnostic is a separate
+    display gap, filed as issue #3959: the CLR fallback renderer spells a
+    rank-1 array in C# suffix form while rank ≥ 2 already uses G#'s prefix
+    form.
+
 ## Addendum A — The ten patterns, three ways
 
 The pattern study in the Context section gives ratings. This addendum gives

--- a/src/Core/CodeAnalysis/Binding/Conversion.cs
+++ b/src/Core/CodeAnalysis/Binding/Conversion.cs
@@ -3152,7 +3152,8 @@ public sealed class Conversion
             return false;
         }
 
-        if (!IsCrossContextIdenticalElement(fromElement, toElement))
+        if (!IsCrossContextIdenticalElement(fromElement, toElement)
+            && !AreSameRuntimeChannelElement(fromElement, toElement))
         {
             return false;
         }
@@ -3179,6 +3180,52 @@ public sealed class Conversion
         conversion = Conversion.None;
         return true;
     }
+
+    // Issue #3924: the element of a channel recovered from CLR metadata — the
+    // constructed `Chan<T>` that `chan[T](n)` builds, or a foreign
+    // `Channel<T>`/`ChannelReader<T>`/`ChannelWriter<T>` — is whatever
+    // `TypeSymbol.FromClrType` mints for the reflected type argument. For a
+    // structural G# shape that has no CLR counterpart symbol (`[]int32` comes
+    // back as an `ImportedTypeSymbol` over `int32[]`, `map[string,int32]` as
+    // one over `Dictionary<string, int32>`) that is never the
+    // `SliceTypeSymbol`/`MapTypeSymbol` the `chan[T]` type clause bound, so the
+    // element check above — which compares symbol shapes — fails even though
+    // both sides denote one runtime type. `Channel<T>` is invariant, so
+    // sameness of the elements' CLR types is exactly the question the
+    // direction lattice needs answered. Compare the EFFECTIVE CLR type
+    // (`ProjectElement` projects the element the same way): a
+    // `NullableTypeSymbol` borrows its underlying type's `ClrType`, and only
+    // the lifted form keeps `chan[int32?]` distinct from `chan[int32]`.
+    //
+    // One side must BE that metadata-recovered form for this to apply. A CLR
+    // type is coarser than the G# symbol above it — `[3]int32` and `[4]int32`
+    // are both `int32[]`, which is why
+    // `AreRuntimeEquivalentIgnoringReferenceNullability` compares the lengths
+    // instead — so where both sides still carry their symbols (two `chan[T]`
+    // type clauses) that finer answer is the right one and stands unchanged.
+    // The erasure is only unavoidable once an element has been through
+    // reflection: `chan[[3]int32](1)` and `chan[[4]int32](1)` construct the
+    // same `Chan<int32[]>`, and no comparison downstream of that can tell them
+    // apart.
+    //
+    // "Came back from reflection" means an imported symbol carrying NO
+    // symbolic type arguments, which is precisely what `FromClrType` mints
+    // (`ImportedTypeSymbol.Get`) and what `GetConstructed` — the
+    // source-constructed form — does not. A source-constructed generic still
+    // holds its arguments as symbols, and its own `ClrType` may have erased
+    // them to close over `object`: `List[Foo]` and `List[Bar]` over two
+    // same-compilation structs are one `List<object>`. Comparing THAT would
+    // conflate elements that are not the same type at all, so a
+    // source-constructed element is left to the symbol comparison above,
+    // which reads the arguments it still has.
+    private static bool AreSameRuntimeChannelElement(TypeSymbol from, TypeSymbol to)
+        => (IsMetadataRecoveredElement(from) || IsMetadataRecoveredElement(to))
+            && ClrTypeUtilities.AreSame(
+                NullableTypeSymbol.GetEffectiveClrType(from),
+                NullableTypeSymbol.GetEffectiveClrType(to));
+
+    private static bool IsMetadataRecoveredElement(TypeSymbol type)
+        => type is ImportedTypeSymbol { TypeArguments.IsDefaultOrEmpty: true };
 
     // Issue #2299: element-level identity check used by
     // `TryClassifyWrappedElementIdentity`. Reference-equal elements are

--- a/test/Compiler.Tests/Issue3924DirectionalChannelStructuralElementTests.cs
+++ b/test/Compiler.Tests/Issue3924DirectionalChannelStructuralElementTests.cs
@@ -1,0 +1,512 @@
+// <copyright file="Issue3924DirectionalChannelStructuralElementTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #3924: a channel whose element is a STRUCTURAL G# type — <c>[]int32</c>,
+/// <c>map[string,int32]</c>, <c>[][]int32</c> — did not convert to the
+/// <c>in</c>/<c>out</c> directional view (ADR-0174 D2), while the identical
+/// conversion over a named element (<c>int32</c>, <c>string</c>, a
+/// same-compilation <c>struct</c>) bound fine.
+/// </summary>
+/// <remarks>
+/// <para>Root cause: the direction lattice compares the two sides' element
+/// types by SYMBOL shape. A channel recovered from CLR metadata — both the
+/// constructed <c>Gsharp.Concurrency.Chan&lt;T&gt;</c> that <c>chan[T](n)</c>
+/// builds and a foreign BCL <c>Channel&lt;T&gt;</c> — carries whatever
+/// <c>TypeSymbol.FromClrType</c> mints for the reflected type argument, and a
+/// structural shape has no CLR counterpart symbol: <c>[]int32</c> comes back as
+/// an <c>ImportedTypeSymbol</c> over <c>int32[]</c>, never the
+/// <c>SliceTypeSymbol</c> the <c>chan[T]</c> type clause bound. The elements
+/// denote ONE runtime type, so the CLR-type comparison the fix adds is the
+/// question <c>Channel&lt;T&gt;</c>'s invariance actually asks.</para>
+/// <para>Discrimination (ADR-0154): every executable case below failed with
+/// GS0154 at bind on the pre-fix build (measured on <c>ffa46214</c>) EXCEPT
+/// <c>struct-slice-element</c>, which travels the symbolic-type-argument branch
+/// and passed before and after — it is the control that keeps a blanket
+/// "any channel converts to any channel" mutant from passing. The negative
+/// facts pin the other edge: a mismatched element (<c>[]int64</c> for
+/// <c>[]int32</c>), a nullable element (<c>int32?</c> for <c>int32</c> — the
+/// case that forces the EFFECTIVE CLR type, since a
+/// <c>NullableTypeSymbol</c> borrows its underlying type's <c>ClrType</c>), and
+/// <c>in</c> → <c>out</c> must all still be rejected. Three more are green
+/// before and after, and pin the fallback's "one side came back from
+/// reflection carrying no symbolic type arguments" guard: a fixed-array length
+/// mismatch between two type clauses, and two shapes over a source-constructed
+/// generic element, whose <c>ClrType</c> has erased the very arguments that
+/// distinguish it (<c>List[Foo]</c> and <c>List[Bar]</c> over two
+/// same-compilation structs are one <c>List&lt;object&gt;</c>).</para>
+/// <para>Every case compiles, IL-verifies AND runs: binding alone cannot tell
+/// whether <c>get_Reader</c>/<c>get_Writer</c> was really emitted for a
+/// structural element, which is the half of the fix that reaches metadata.</para>
+/// </remarks>
+public class Issue3924DirectionalChannelStructuralElementTests
+{
+    /// <summary>
+    /// Gets the executable cases: each is (name, source, expected stdout lines).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return new object[]
+        {
+            "slice-element-out-and-in",
+            """
+            package P
+            import System
+
+            func produce(w out chan[[]int32]) {
+                w <- [3]int32{1, 2, 3}
+                w <- [2]int32{4, 5}
+                w.Close()
+            }
+
+            func consume(r in chan[[]int32]) int32 {
+                var sum = 0
+                for batch in r {
+                    var i = 0
+                    while i < batch.Length {
+                        sum = sum + batch[i]
+                        i = i + 1
+                    }
+                }
+
+                return sum
+            }
+
+            let ch = chan[[]int32](4)
+            produce(ch)
+            Console.WriteLine(consume(ch))
+            """,
+            new[] { "15" },
+        };
+
+        yield return new object[]
+        {
+            "map-element-out-and-in",
+            """
+            package P
+            import System
+
+            func produce(w out chan[map[string,int32]]) {
+                var m = map[string,int32]{}
+                m["a"] = 2
+                m["b"] = 3
+                w <- m
+                w.Close()
+            }
+
+            func consume(r in chan[map[string,int32]]) int32 {
+                var total = 0
+                for entry in r {
+                    total = total + entry["a"] + entry["b"]
+                }
+
+                return total
+            }
+
+            let ch = chan[map[string,int32]](2)
+            produce(ch)
+            Console.WriteLine(consume(ch))
+            """,
+            new[] { "5" },
+        };
+
+        yield return new object[]
+        {
+            "nested-slice-element",
+            """
+            package P
+            import System
+
+            func produce(w out chan[[][]int32]) {
+                var outer = [2][]int32{}
+                outer[0] = [2]int32{1, 2}
+                outer[1] = [1]int32{4}
+                w <- outer
+                w.Close()
+            }
+
+            func consume(r in chan[[][]int32]) int32 {
+                var sum = 0
+                for rows in r {
+                    var i = 0
+                    while i < rows.Length {
+                        var j = 0
+                        while j < rows[i].Length {
+                            sum = sum + rows[i][j]
+                            j = j + 1
+                        }
+
+                        i = i + 1
+                    }
+                }
+
+                return sum
+            }
+
+            let ch = chan[[][]int32](2)
+            produce(ch)
+            Console.WriteLine(consume(ch))
+            """,
+            new[] { "7" },
+        };
+
+        yield return new object[]
+        {
+            "slice-of-string-element",
+            """
+            package P
+            import System
+
+            func produce(w out chan[[]string]) {
+                w <- [2]string{"a", "b"}
+                w.Close()
+            }
+
+            let ch = chan[[]string](2)
+            produce(ch)
+            for parts in ch {
+                Console.WriteLine(parts[0] + parts[1])
+            }
+            """,
+            new[] { "ab" },
+        };
+
+        // Control: a same-compilation struct element has no reference-context
+        // CLR type, so `chan[[]Point](2)` closes over a symbolic type argument
+        // and `TryGetChannelShape` reads the ORIGINAL element symbol back out
+        // of `TypeArguments[0]`. This bound before the fix and must keep
+        // binding after it.
+        yield return new object[]
+        {
+            "struct-slice-element",
+            """
+            package P
+            import System
+
+            struct Point {
+                var X int32
+            }
+
+            func produce(w out chan[[]Point]) {
+                var arr = [1]Point{}
+                arr[0].X = 9
+                w <- arr
+                w.Close()
+            }
+
+            let ch = chan[[]Point](2)
+            produce(ch)
+            for points in ch {
+                Console.WriteLine(points[0].X)
+            }
+            """,
+            new[] { "9" },
+        };
+
+        // A foreign BCL channel is the case the fix must cover that no amount
+        // of preserving G# element symbols at CONSTRUCTION could: this
+        // `Channel<int32[]>` was never built by `chan[T](n)`, so its element
+        // exists only as reflected CLR metadata.
+        yield return new object[]
+        {
+            "foreign-bcl-channel-with-slice-element",
+            """
+            package P
+            import System
+            import System.Threading.Channels
+
+            func produce(w out chan[[]int32]) {
+                w <- [2]int32{10, 20}
+                w.Close()
+            }
+
+            func consume(r in chan[[]int32]) int32 {
+                var sum = 0
+                for batch in r {
+                    var i = 0
+                    while i < batch.Length {
+                        sum = sum + batch[i]
+                        i = i + 1
+                    }
+                }
+
+                return sum
+            }
+
+            let ch = Channel.CreateBounded[[]int32](2)
+            produce(ch)
+            Console.WriteLine(consume(ch))
+            """,
+            new[] { "30" },
+        };
+    }
+
+    /// <summary>
+    /// Gets the rejection cases: each is (name, source, the expected substring
+    /// of the reported diagnostic).
+    /// </summary>
+    /// <returns>The case data.</returns>
+    public static IEnumerable<object[]> RejectedCases()
+    {
+        yield return new object[]
+        {
+            "mismatched-slice-element",
+            """
+            package P
+
+            func wants(w out chan[[]int32]) {
+            }
+
+            let wrong = chan[[]int64](1)
+            wants(wrong)
+            """,
+            "requires a value of type 'out chan[[]int32]'",
+        };
+
+        yield return new object[]
+        {
+            "nullable-element-is-not-the-bare-element",
+            """
+            package P
+
+            func wants(w out chan[int32?]) {
+            }
+
+            let plain = chan[int32](1)
+            wants(plain)
+            """,
+            "requires a value of type 'out chan[int32?]'",
+        };
+
+        // A no-regression pin, green before and after: where BOTH sides still
+        // carry their G# symbols, the fixed length discriminates, and the
+        // CLR-type fallback must not reach them — `[3]int32` and `[4]int32`
+        // are one `int32[]`. A mutant that drops the fallback's
+        // "one side came back from metadata" guard compiles this.
+        yield return new object[]
+        {
+            "fixed-array-lengths-still-discriminate",
+            """
+            package P
+
+            func wants(w out chan[[4]int32]) {
+            }
+
+            var a chan[[3]int32] = chan[[3]int32](1)
+            wants(a)
+            """,
+            "requires a value of type 'out chan[[4]int32]'",
+        };
+
+        // A source-constructed generic still holds its type arguments as
+        // SYMBOLS, and its own `ClrType` may have erased them to close over
+        // `object`: `List[Foo]` and `List[Bar]` over two same-compilation
+        // structs are one `List<object>`. Comparing that would conflate two
+        // elements that are not the same type at all — ordinary assignment
+        // rejects `List[Bar]` to `List[Foo]` with GS0155 — so the fallback
+        // must not reach a source-constructed element. A mutant that widens
+        // the guard from "no symbolic type arguments" to "any imported
+        // symbol" compiles both of these.
+        yield return new object[]
+        {
+            "source-constructed-generic-elements-are-not-conflated",
+            """
+            package P
+            import System.Collections.Generic
+
+            struct Foo {
+                var X int32
+            }
+
+            struct Bar {
+                var Y int32
+            }
+
+            func wants(w out chan[List[Foo]]) {
+            }
+
+            var barChan chan[List[Bar]] = chan[List[Bar]](1)
+            wants(barChan)
+            """,
+            "requires a value of type 'out chan[System.Collections.Generic.List[Foo]]'",
+        };
+
+        yield return new object[]
+        {
+            "fixed-array-length-inside-a-constructed-generic-element",
+            """
+            package P
+            import System.Collections.Generic
+
+            struct Foo {
+                var X int32
+            }
+
+            func wants(w out chan[List[[4]Foo]]) {
+            }
+
+            var nested chan[List[[3]Foo]] = chan[List[[3]Foo]](1)
+            wants(nested)
+            """,
+            "requires a value of type 'out chan[System.Collections.Generic.List[[4]Foo]]'",
+        };
+
+        yield return new object[]
+        {
+            "receive-only-does-not-satisfy-send-only",
+            """
+            package P
+
+            func wants(w out chan[[]int32]) {
+            }
+
+            func pass(r in chan[[]int32]) {
+                wants(r)
+            }
+            """,
+            "requires a value of type 'out chan[[]int32]'",
+        };
+    }
+
+    /// <summary>
+    /// Compiles each case to an executable, IL-verifies it, runs it, and
+    /// asserts the program's own output.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedLines">The expected stdout lines, in order.</param>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void DirectionalChannel_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3924_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, name + ".dll");
+            var (exitCode, diagnostics) = Compile(tempDir, source, outPath);
+            Assert.True(exitCode == 0, $"gsc failed for '{name}':\n{diagnostics}");
+
+            IlVerifier.Verify(outPath);
+
+            var (exit, output) = RunDotnet(outPath);
+            Assert.True(exit == 0, $"'{name}' must run to completion. Exit {exit}:\n{output}");
+
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A channel whose element is merely CLR-compatible, not the same type,
+    /// still fails to convert: the fix compares the element's effective CLR
+    /// type, it does not wave every channel through.
+    /// </summary>
+    /// <param name="name">The case name.</param>
+    /// <param name="source">The G# source.</param>
+    /// <param name="expectedMessage">The expected diagnostic substring.</param>
+    [Theory]
+    [MemberData(nameof(RejectedCases))]
+    public void MismatchedChannel_IsStillRejected(string name, string source, string expectedMessage)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3924_neg_").FullName;
+        try
+        {
+            var outPath = Path.Combine(tempDir, name + ".dll");
+            var (exitCode, diagnostics) = Compile(tempDir, source, outPath);
+            Assert.True(exitCode != 0, $"'{name}' must not compile, but gsc succeeded.");
+            Assert.Contains("GS0154", diagnostics, StringComparison.Ordinal);
+            Assert.Contains(expectedMessage, diagnostics, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string Diagnostics) Compile(string tempDir, string source, string outPath)
+    {
+        var srcPath = Path.Combine(tempDir, "Program.gs");
+        File.WriteAllText(srcPath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outPath,
+            "/target:exe",
+            "/targetframework:net10.0",
+        };
+        foreach (var reference in TrustedPlatformAssemblies())
+        {
+            args.Add("/reference:" + reference);
+        }
+
+        args.Add(srcPath);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        try
+        {
+            var exitCode = Program.Main(args.ToArray());
+            return (exitCode, compileOut.ToString() + compileErr.ToString());
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+    }
+
+    private static (int Exit, string Output) RunDotnet(string assemblyPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrEmpty(tpa))
+        {
+            return Enumerable.Empty<string>();
+        }
+
+        return tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}


### PR DESCRIPTION
Fixes #3924.

## The gap

ADR-0174 D2 makes `in`/`out` the ordinary way to express direction on a channel
parameter, but the narrowing did not bind when the element was a **structural** G# type
— `[]int32`, `map[string,int32]`, `[][]int32` — while the identical narrowing over
`int32`, `string` or a same-compilation `struct` bound fine. A producer of *batches*
could not be written `out chan[[]int32]`, which is why the D11 array-transport rows
added for #3902 S1d declare their producer bidirectionally with a comment pointing at
the issue.

## Root cause

Errata 3: the value `chan[T](n)` produces is the runtime class, so the conversion's
source element is whatever `TypeSymbol.FromClrType` mints for the **reflected** type
argument — and a structural shape has no CLR counterpart symbol. `[]int32` comes back as
an `ImportedTypeSymbol` over `int32[]`, never the `SliceTypeSymbol` the type clause
bound. The direction lattice compares elements by symbol shape, so it saw two different
types. (It is also where the issue's rendering asymmetry comes from: one side has a
`SliceTypeSymbol` to print, the other only a CLR type.)

## The fix

`Conversion.TryClassifyChannelConversion` now falls back to comparing the elements'
**effective** CLR types, which is the only question `Channel<T>`'s invariance asks.

This is not merely a fix for what `chan[T](n)` builds: a foreign `Channel<int32[]>` from
C# failed identically, and its element exists only as reflected metadata, so no amount
of preserving G# symbols at construction would have reached it. D2's identity
transparency to foreign channels is the reason the fix belongs at the comparison.

Two deliberate narrowings:

- **Effective** CLR type (`NullableTypeSymbol.GetEffectiveClrType`, the same projection
  `ChannelRuntimeBinder.ProjectElement` uses), because a `NullableTypeSymbol` borrows its
  underlying type's `ClrType` — only the lifted form keeps `chan[int32?]` distinct from
  `chan[int32]`.
- The fallback applies **only when one side is the metadata-recovered form**: an imported
  symbol carrying no symbolic type arguments, which is what `FromClrType` mints and what
  the source-constructed `GetConstructed` does not. A CLR type is coarser than the G#
  symbol above it — `[3]int32` and `[4]int32` are both `int32[]`, and `List[Foo]` and
  `List[Bar]` over two same-compilation structs are one `List<object>` — so an element
  that still carries its symbols is left to the finer comparison: `chan[[3]int32]` does
  not narrow to `out chan[[4]int32]`, nor `chan[List[Bar]]` to `out chan[List[Foo]]`.
  Past a construction the distinction is already gone, and was before this change:
  `chan[[3]int32](1)` and `chan[[4]int32](1)` build one `Chan<int32[]>`, which a
  bidirectional `chan[[4]int32]` parameter has always accepted.

One classification-kind change with no IL consequence: a constructed `Chan[T]` to a
bidirectional `chan[T]` with a structural element previously reached `Implicit` through
the general subclass rule and is now `Identity`. `EmitConversion`'s channel arm no-ops on
a same-direction pair either way.

## Discrimination (ADR-0154)

Ten new cases in `test/Compiler.Tests/Issue3924DirectionalChannelStructuralElementTests.cs`.
Every executable case compiles, **IL-verifies and runs**, so `get_Reader`/`get_Writer` is
proven emitted rather than merely bound — a bind-only assertion cannot tell the two apart.

| run | result |
|---|---|
| `Conversion.cs` reverted to the parent commit | **5 failed / 7 passed** — slice, string-slice, nested-slice, map and foreign-BCL-channel cases red with GS0154 |
| with the fix | **12 passed** |
| guard widened to "any imported symbol" | **2 failed** — `source-constructed-generic-elements-are-not-conflated`, `fixed-array-length-inside-a-constructed-generic-element` |
| guard dropped entirely | **1 more failed** — `fixed-array-lengths-still-discriminate` |

Four controls are green on both sides and are there to fail a blanket fix:
`struct-slice-element` (`[]Point`, the symbolic-type-argument branch, which always
bound), `fixed-array-lengths-still-discriminate`, and the two source-constructed-generic
cases added from review feedback. The other rejection cases pin a mismatched element
(`[]int64` for `[]int32`), a nullable element (`int32?` for `int32` — the case that
forces the effective CLR type), and `in` → `out`.

## Also in this PR

- `bench/concurrency/gsharp/Bench.gs`: `produceArrays` restored to `out chan[[]int32]`,
  the workaround comment removed. `python3 build/verify-concurrency-bench.py --smoke`
  passes and `chunk64-arrays` measures 5.70 ns/op on this machine.
- ADR-0174 errata 37 records the refinement and the guard's boundary.

## Test runs

`Compiler.Tests` 4754 passed, `Core.Tests` 8900 passed. The 7 failures across the two
suites share one cause — `targeting pack root '~/.dotnet/packs/NETStandard.Library.Ref'
missing` — and throw in fixture setup before anything is compiled; they are unrelated to
this change and fail identically on the parent commit.

## Related, not touched

- **#3876** — the imported-**constructor** applicability path with an open element. The
  issue wondered whether it shares a root; checked, and it does not.
- **#3959** — filed from this work: the CLR fallback renderer spells a rank-1 array
  `int32[]` rather than G#'s `[]int32`, which is the display half of the asymmetry #3924
  noticed. One line, but it moves every golden asserting the CLR spelling, so it is kept
  separate.
- **#3962** — filed from the review of this PR: a constructed generic over an
  array-shaped type argument compares by its erased CLR type, so `List[[3]int32]`
  converts to `List[[4]int32]`. Pre-existing (the repro has no channel in it and compiles
  on the parent commit) and left alone here; this PR's guard is deliberately strict
  enough not to add a second path to it.
- **#3958** — filed from this work: a conversion targeting `in chan[T]?` / `out chan[T]?`
  is not supported by the emitter. Pre-existing, independent of the element type, and
  ADR-0159's own GS0520 message recommends that spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVZ9GDN9g4NVF47GRNpWkL

