### PR TITLE
gsc: emit a name-differing tuple instantiation as the identity it is (ADR-0172, #3956)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Conversions.cs
@@ -710,6 +710,33 @@ internal sealed partial class MethodBodyEmitter
             }
         }
 
+        // Issue #3956 / ADR-0172: the `from == to` fast path at the top of this
+        // method is symbol REFERENCE equality, but one CLR type is routinely
+        // minted as several non-reference-equal symbols — a nullability-
+        // annotated wrapper on one side, a `ValueTuple<…>` recovered from a CLR
+        // signature versus a `TupleTypeSymbol` carrying element NAMES on the
+        // other. Element names are metadata over the positional shape and never
+        // change the runtime type, so `KeyValuePair[string, (int32, int32,
+        // List[(int32, int32, int32)])]` and the same shape written with names
+        // are one type, and the binder duly classifies the conversion between
+        // them as IDENTITY — yet every structural arm above keys off a specific
+        // symbol shape and declines, leaving the crash below as the only
+        // outcome. Ask the classifier the SHAPE question the reference check
+        // cannot: when the two symbols denote the same type AND agree on their
+        // CLR backing, the conversion is representation-preserving and needs no
+        // IL at all, exactly like the `from == to` case. Both halves are
+        // load-bearing — a `NullableTypeSymbol` relays its UNDERLYING type's
+        // `ClrType` (#2051), so the CLR check alone would let a genuine
+        // `T -> Nullable<T>` lift through unwrapped, and the identity check
+        // alone would admit an alias whose backing legitimately differs.
+        if (from.ClrType != null
+            && to.ClrType != null
+            && ClrTypeUtilities.AreSame(from.ClrType, to.ClrType)
+            && Conversion.Classify(from, to).IsIdentity)
+        {
+            return;
+        }
+
         EmitDiagnosticException.Wrap(
             conv.Syntax,
             new NotSupportedException(

--- a/test/Compiler.Tests/Emit/Issue3956NamedTupleGenericArgumentIdentityTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3956NamedTupleGenericArgumentIdentityTests.cs
@@ -1,0 +1,199 @@
+// <copyright file="Issue3956NamedTupleGenericArgumentIdentityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3956 / ADR-0172: tuple element names are metadata over the positional
+/// shape, so a generic instantiation recovered from a CLR signature
+/// (<c>KeyValuePair&lt;string, ValueTuple&lt;…&gt;&gt;</c>) and the same
+/// instantiation written in G# with element NAMES are one and the same type.
+/// The binder classifies the conversion between them as identity; the emitter
+/// used to key its identity fast path on symbol REFERENCE equality alone and
+/// fell through every structural arm to a <c>NotSupportedException</c>.
+/// <para>The names sit two levels deep — inside a <c>List</c>, inside a tuple,
+/// inside a <c>KeyValuePair</c> — so a top-level-only fix does not pass these.
+/// Every case COMPILES, ILVERIFIES and EXECUTES: an emitter defect of this kind
+/// can bind clean and still produce a body the verifier or the runtime
+/// rejects.</para>
+/// </summary>
+public sealed class Issue3956NamedTupleGenericArgumentIdentityTests
+{
+    /// <summary>
+    /// The shape from the issue, verbatim: a LINQ call over a dictionary whose
+    /// value type is a named tuple carrying a <c>List</c> of named tuples. The
+    /// return type comes back from the CLR signature unnamed, and flows into a
+    /// slot whose declared type carries every name.
+    /// </summary>
+    [Fact]
+    public void NestedNamedTupleGenericArgument_ClrRecoveredKeyValuePair_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3956
+
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let blobs = Dictionary[string, (Rid int32, CatchHandlerPlusOne int32, Awaits List[(Yield int32, Resume int32, ResumeRid int32)])]()
+            let awaits = List[(Yield int32, Resume int32, ResumeRid int32)]()
+            awaits.Add((11, 22, 33))
+            blobs["sum2"] = (7, 9, awaits)
+
+            let only = Enumerable.Single(blobs, func(kv KeyValuePair[string, (Rid int32, CatchHandlerPlusOne int32, Awaits List[(Yield int32, Resume int32, ResumeRid int32)])]) bool {
+                return kv.Key == "sum2"
+            })
+
+            Console.WriteLine(only.Value.Rid)
+            Console.WriteLine(only.Value.CatchHandlerPlusOne)
+            Console.WriteLine(only.Value.Awaits[0].Resume)
+            """;
+
+        Assert.Equal(
+            $"7{Environment.NewLine}9{Environment.NewLine}22{Environment.NewLine}",
+            CompileVerifyAndRun(Source));
+    }
+
+    /// <summary>
+    /// The reverse direction: the CLR-recovered UNNAMED shape is the target and
+    /// the named shape is the source. Names are metadata in both directions.
+    /// </summary>
+    [Fact]
+    public void NestedNamedTupleGenericArgument_NamedSourceToUnnamedTarget_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3956
+
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let blobs = Dictionary[string, (Rid int32, Awaits List[(Yield int32, Resume int32)])]()
+            let awaits = List[(Yield int32, Resume int32)]()
+            awaits.Add((4, 5))
+            blobs["a"] = (1, awaits)
+
+            let only KeyValuePair[string, (int32, List[(int32, int32)])] = Enumerable.Single(blobs, func(kv KeyValuePair[string, (Rid int32, Awaits List[(Yield int32, Resume int32)])]) bool {
+                return kv.Key == "a"
+            })
+
+            Console.WriteLine(only.Value.Item1)
+            Console.WriteLine(only.Value.Item2[0].Item2)
+            """;
+
+        Assert.Equal($"1{Environment.NewLine}5{Environment.NewLine}", CompileVerifyAndRun(Source));
+    }
+
+    /// <summary>
+    /// A NESTED-ONLY name difference: both sides spell the outer tuple's names
+    /// identically and differ only inside the <c>List</c> element two levels
+    /// down. A fix that compares only the top-level tuple's names passes the
+    /// cases above and fails this one.
+    /// </summary>
+    [Fact]
+    public void NestedNamedTupleGenericArgument_InnerNamesOnly_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package Issue3956
+
+            import System
+            import System.Linq
+            import System.Collections.Generic
+
+            let blobs = Dictionary[string, (Rid int32, Awaits List[(Yield int32, Resume int32)])]()
+            let awaits = List[(Yield int32, Resume int32)]()
+            awaits.Add((6, 7))
+            blobs["a"] = (2, awaits)
+
+            let only KeyValuePair[string, (Rid int32, Awaits List[(int32, int32)])] = Enumerable.Single(blobs, func(kv KeyValuePair[string, (Rid int32, Awaits List[(Yield int32, Resume int32)])]) bool {
+                return kv.Key == "a"
+            })
+
+            Console.WriteLine(only.Value.Rid)
+            Console.WriteLine(only.Value.Awaits[0].Item1)
+            """;
+
+        Assert.Equal($"2{Environment.NewLine}6{Environment.NewLine}", CompileVerifyAndRun(Source));
+    }
+
+    private static string CompileVerifyAndRun(string source)
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue3956NamedTupleGenericArgumentIdentityTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var sourcePath = Path.Combine(directory, "Program.gs");
+            var outputPath = Path.Combine(directory, "Issue3956.dll");
+            File.WriteAllText(sourcePath, source);
+
+            var arguments = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/nowarn:GS9100",
+            };
+            foreach (var reference in ReferenceResolver.HostTrustedPlatformAssemblyPaths())
+            {
+                arguments.Add("/r:" + reference);
+            }
+
+            arguments.Add(sourcePath);
+
+            using var standardOut = new StringWriter();
+            using var standardError = new StringWriter();
+            var previousOut = Console.Out;
+            var previousError = Console.Error;
+            Console.SetOut(standardOut);
+            Console.SetError(standardError);
+            int exitCode;
+            try
+            {
+                exitCode = Program.Main(arguments.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousError);
+            }
+
+            Assert.True(exitCode == 0, $"gsc failed:{Environment.NewLine}{standardOut}{standardError}");
+            IlVerifier.Verify(outputPath);
+
+            using var process = Process.Start(new ProcessStartInfo("dotnet")
+            {
+                ArgumentList =
+                {
+                    "exec",
+                    "--runtimeconfig",
+                    Path.ChangeExtension(outputPath, ".runtimeconfig.json"),
+                    outputPath,
+                },
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            });
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            Assert.True(process.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(process.ExitCode == 0, error);
+            return output.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3956.

## Root cause

`KeyValuePair[string, (int32, int32, List[(int32, int32, int32)])]` recovered from a CLR signature and the same instantiation written with tuple element *names* are **one type** — ADR-0172 makes element names metadata over the positional shape — and `Conversion.Classify` already returns **Identity** for the pair. (I confirmed this by instrumenting the classifier: it was never the culprit, so no classifier change was needed.)

The emitter did not agree. Its identity fast path is `if (from == to)` — symbol **reference** equality — which two independently minted symbols for one CLR type never satisfy. Here `from` arrived as a `NullabilityAnnotatedTypeSymbol` over an `ImportedTypeSymbol` with **no symbolic type arguments** (minted straight from the CLR `Type`), while `to` was an `ImportedTypeSymbol` whose second type argument is a `TupleTypeSymbol` carrying the names. Every structural arm below the fast path keys off a specific symbol shape and declined, and emit fell through to the `GS9998` internal-error channel.

**What was keyed on identity that should have been keyed on shape:** the emitter's `from == to` no-op arm. It is the only identity test on the emit path, and it is a reference test.

## Fix

One arm, immediately before the `NotSupportedException` fallback: when both sides have a CLR backing, `ClrTypeUtilities.AreSame` agrees, **and** the classifier calls the conversion Identity, emit nothing — the conversion is representation-preserving, exactly like `from == to`.

Both halves of the guard are load-bearing. A `NullableTypeSymbol` relays its *underlying* type's `ClrType` (#2051), so the CLR check alone would let a genuine `T -> Nullable<T>` lift through unwrapped; the identity check alone would admit an alias whose backing legitimately differs. Placing the arm **last** means only programs that previously crashed change behaviour.

## Failure mode

The `NotSupportedException` is already contained — `EmitDiagnosticException.Wrap` reports it as `error GS9998` and gsc exits non-zero. It is the emitter's deliberate internal-error channel (there is no `DiagnosticBag` in scope on the emit path), not an unhandled crash, so no separate change was warranted there.

## Tests

`test/Compiler.Tests/Emit/Issue3956NamedTupleGenericArgumentIdentityTests.cs` — three cases, each of which **compiles, ILVerifies AND executes** (an emitter defect of this kind binds clean and still produces a body the verifier or the runtime rejects):

1. the issue's shape verbatim (`Enumerable.Single` over a `Dictionary` whose value is a named tuple holding a `List` of named tuples);
2. the reverse direction — named source into an unnamed target;
3. a **nested-only** name difference, where both sides spell the outer tuple's names identically and differ only inside the `List` element two levels down. A top-level-only fix passes 1 and 2 and fails this one.

All three fail on `main` with the exact `GS9998` from the issue (`Failed! - Failed: 3, Passed: 0`) and pass with the fix (`Passed! - Failed: 0, Passed: 3`).

## Scope

No name-propagation audit gaps surfaced beyond this one — the classifier's ADR-0172 handling was already correct at every level I probed, including nested. I deliberately reverted an earlier, broader experiment (relaxing `ImportedTypeSymbol.HasSubstitutableTypeArgument` for the conversion-identity question) once instrumentation showed classification was not the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs