### PR TITLE
Migrated GSA0002 sees imported operands: one Roslyn operation is several G# bound nodes (#3920, #3955)

### DIFF
--- a/docs/adr/0169-gsharp-analyzer-framework.md
+++ b/docs/adr/0169-gsharp-analyzer-framework.md
@@ -79,6 +79,21 @@ member-level** — `BoundNodeKind` values are stable once shipped, but bound-nod
 member shapes may evolve with the language, the same posture Roslyn took with
 early `IOperation`.
 
+**One Roslyn operation is several G# bound nodes (issue #3920).** G# splits a
+construct by PROVENANCE where Roslyn does not: `a == b` binds to
+`BoundBinaryExpression` for a built-in operator and to
+`BoundClrBinaryOperatorExpression` when it resolves to an `op_Equality` method,
+and a call binds to `BoundCallExpression`, `BoundImportedCallExpression`, or
+`BoundImportedInstanceCallExpression` by where the callee lives. The split is a
+codegen distinction, so an analyzer must not have to know it: the nodes in each
+family derive from a shared analyzer-facing base —
+`BoundBinaryOperationExpression` (`Left`, `Right`, `BinaryOperatorKind`) and
+`BoundCallOperationExpression` (`CalledFunction`, `Arguments`) — and a rule
+registers every `BoundNodeKind` in the family. Registering one is a rule that
+silently sees a fraction of the program; it is how the migrated GSA0002
+observed none of the reflection-`Type` code it exists to police, since imported
+operands are exactly the ones it cares about.
+
 ### Supporting infrastructure promoted into Core
 
 - `DiagnosticDescriptor` becomes public and Roslyn-shaped

--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -101,7 +101,10 @@ Project-level detection, symbol-gated application:
     idiom-rewriter delegate for multi-node idioms;
   - `SyntaxKindMap`: C# `SyntaxKind` → 0..n G# `SyntaxKind`s;
   - `OperationKindMap` / `SymbolKindMap`: `OperationKind` → `BoundNodeKind`,
-    Roslyn `SymbolKind` → G# `SymbolKind`.
+    Roslyn `SymbolKind` → G# `SymbolKind`. `OperationKindDispatch` is the
+    one-to-many half of the first (#3920): a REGISTRATION must name every G#
+    bound-node kind the operation reaches, while a bare kind READ still maps
+    to the single kind it names.
 - Composition with `CSharpTypeMapper` is a single probe: if a symbol's
   containing assembly is a `Microsoft.CodeAnalysis` assembly, consult the map;
   on a miss, report a gap instead of falling into CLR-import passthrough.
@@ -448,16 +451,54 @@ Order: GSA0001 → GSA0003 → GSA0004 → GSA0002 → GSA0005; harness and pari
   test-parity **3 failing / 15 passing → 1 failing / 17 passing of 18**
   (translate, compile and ILVerify stay PASS on both sides).
 
-  **The one that remains is #3920**, and clearing #3797 is what exposed it: with
-  the third marker finally placed, `ReflectionTypeComparisonAnalyzerTests.
-  ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces` gets past the
-  marker/id count check and GSA0002 then reports **nothing**. `OperationKindMap`
-  maps each Roslyn operation kind to ONE G# bound-node kind, but a `==` over
-  IMPORTED operands binds to `BoundClrBinaryOperatorExpression` and a call to an
-  imported method to `BoundImportedCallExpression` — so the registrations the
-  translation emits (`BinaryExpression`, `CallExpression`) are dispatched zero
-  times for exactly the reflection-`Type` code the rule exists to police. The map
-  has to become one-to-many, and the handler shape has to accept both nodes.
+  **The last one (2026-09-05, issue #3920).** Clearing #3797 is what exposed it:
+  with the third marker finally placed,
+  `ReflectionTypeComparisonAnalyzerTests.ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces`
+  got past the marker/id count check and GSA0002 then reported **nothing**.
+
+  One Roslyn operation kind is SEVERAL G# bound nodes. `a == b` binds to
+  `BoundBinaryExpression` for a built-in operator and to
+  `BoundClrBinaryOperatorExpression` when it resolves to an `op_Equality`
+  method; a call binds to `BoundCallExpression`,
+  `BoundImportedCallExpression`, or `BoundImportedInstanceCallExpression` by
+  callee provenance. The split is a codegen distinction, not a
+  program-meaning one — Roslyn models each pair/triple as one operation — but
+  naming a single node in the map meant the migrated GSA0002 was dispatched
+  **zero times** over reflection-`Type` comparisons, which are imported by
+  construction. The rule existed only for code it could not see.
+
+  Fixed on both sides of the boundary:
+
+  1. **Framework (`src/Core`).** Two analyzer-facing abstract bases,
+     `BoundBinaryOperationExpression` (`Left`, `Right`, `BinaryOperatorKind`)
+     and `BoundCallOperationExpression` (`CalledFunction`, `Arguments`), now
+     span the provenance-split nodes. `BoundNodeKind` values, lowering and
+     emit are untouched — the bases add a shared *shape*, not a new node.
+     `Symbol.ContainingType` also stopped depending on having been anchored:
+     a method that knows its own declaring type (a `FunctionSymbol`'s
+     receiver/owner, an `ImportedFunctionSymbol`'s metadata declaring type)
+     now says so, because nothing anchors imported symbols and
+     `TargetMethod.ContainingType` read null for every call into metadata.
+  2. **Translation (`cs2gs`).** `RegisterOperationAction` expands to a
+     `RegisterBoundNodeAction` naming EVERY bound-node kind the operation
+     reaches (`RoslynAnalyzerApiMap.OperationKindDispatch`), the two
+     `IOperation` map entries name the shared bases, `TargetMethod` maps to
+     the `Symbol`-typed `CalledFunction`, and `IBinaryOperation.OperatorKind`
+     lowers to `BinaryOperatorKind` rather than `Op.Kind` — `Op` exists only
+     on the built-in node.
+
+     The dispatch set is deliberately separate from the enum-member rename: a
+     bare `OperationKind` READ (`node.Kind == OperationKind.TypeOf`) still
+     translates to the one kind it names, because a read tests one node's
+     identity while a registration must cover every node that can arrive.
+
+  `Issue3920Gsa0002ImportedOperandDispatchTests` puts the GSA0002 positive and
+  both negatives on one executing path — real analyzer, real G# compiler, real
+  verifier — so a rule that stops reporting fails the positive instead of
+  passing the negatives.
+
+  Whole-repository gate on the same tree: `test/InternalAnalyzers.Tests`
+  test-parity **1 failing / 17 passing → 0 failing / 18 passing of 18**.
 - **M6 Parity + self-migration** — `AnalyzerParityStage`; extend the
   Issue3347-style self-migration ratchet to translate
   `InternalAnalyzers.csproj` live. Exit criterion: all five translated

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryExpression.cs
@@ -10,7 +10,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// Bound binary expression.
 /// </summary>
-public sealed class BoundBinaryExpression : BoundExpression
+public sealed class BoundBinaryExpression : BoundBinaryOperationExpression
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundBinaryExpression"/> class.
@@ -41,10 +41,13 @@ public sealed class BoundBinaryExpression : BoundExpression
     /// <inheritdoc/>
     public override TypeSymbol Type => Op.Type;
 
+    /// <inheritdoc/>
+    public override BoundBinaryOperatorKind BinaryOperatorKind => Op.Kind;
+
     /// <summary>
     /// Gets the left bound expression.
     /// </summary>
-    public BoundExpression Left { get; }
+    public override BoundExpression Left { get; }
 
     /// <summary>
     /// Gets the bound binary operator.
@@ -54,7 +57,7 @@ public sealed class BoundBinaryExpression : BoundExpression
     /// <summary>
     /// Gets the rught bound expression.
     /// </summary>
-    public BoundExpression Right { get; }
+    public override BoundExpression Right { get; }
 
     /// <summary>
     /// Gets a value indicating whether this operator runs in a checked /

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperationExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperationExpression.cs
@@ -1,0 +1,90 @@
+// <copyright file="BoundBinaryOperationExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// The shape shared by every bound node that applies a BINARY OPERATOR to two
+/// operands (ADR-0169, issue #3920).
+/// </summary>
+/// <remarks>
+/// <para>
+/// G# binds <c>a == b</c> to two different nodes depending on where the
+/// operator comes from: <see cref="BoundBinaryExpression"/> when it is one of
+/// the language's built-in operators, and
+/// <see cref="BoundClrBinaryOperatorExpression"/> when it resolves to an
+/// <c>op_Equality</c>-style operator method on a CLR or same-compilation type.
+/// Both are "a binary operation" to anything reasoning about the program
+/// rather than about codegen — Roslyn models the pair as one
+/// <c>IBinaryOperation</c>.
+/// </para>
+/// <para>
+/// Without a shared shape an analyzer registered for binary operations has to
+/// know the split and cast twice, and one that does not know it silently sees
+/// half the program: GSA0002 police reflection <see cref="System.Type"/>
+/// comparisons, whose operands are IMPORTED by construction, and so matched
+/// exactly none of the code it exists for. This base is the analyzer-facing
+/// answer; the concrete nodes and their <see cref="BoundNode.Kind"/> values are
+/// unchanged, so nothing in lowering or emit is affected.
+/// </para>
+/// </remarks>
+public abstract class BoundBinaryOperationExpression : BoundExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundBinaryOperationExpression"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
+    private protected BoundBinaryOperationExpression(SyntaxNode? syntax)
+        : base(syntax)
+    {
+    }
+
+    /// <summary>Gets the left operand.</summary>
+    public abstract BoundExpression Left { get; }
+
+    /// <summary>Gets the right operand.</summary>
+    public abstract BoundExpression Right { get; }
+
+    /// <summary>
+    /// Gets the operator this node applies, in the language's operator
+    /// vocabulary. <see cref="BoundBinaryOperatorKind.Undefined"/> when the
+    /// operator token does not name a language-level binary operator.
+    /// </summary>
+    public abstract BoundBinaryOperatorKind BinaryOperatorKind { get; }
+
+    /// <summary>
+    /// Maps an operator TOKEN kind to the language-level operator it spells.
+    /// Used by nodes that carry the token rather than a bound operator.
+    /// </summary>
+    /// <param name="syntaxKind">The operator token kind.</param>
+    /// <returns>The operator kind, or <see cref="BoundBinaryOperatorKind.Undefined"/>.</returns>
+    private protected static BoundBinaryOperatorKind FromSyntaxKind(SyntaxKind syntaxKind)
+        => syntaxKind switch
+        {
+            SyntaxKind.PlusToken => BoundBinaryOperatorKind.Sum,
+            SyntaxKind.MinusToken => BoundBinaryOperatorKind.Difference,
+            SyntaxKind.StarToken => BoundBinaryOperatorKind.Product,
+            SyntaxKind.SlashToken => BoundBinaryOperatorKind.Quotient,
+            SyntaxKind.PercentToken => BoundBinaryOperatorKind.Remainder,
+            SyntaxKind.AmpersandToken => BoundBinaryOperatorKind.BitwiseAnd,
+            SyntaxKind.AmpersandHatToken => BoundBinaryOperatorKind.BitClear,
+            SyntaxKind.PipeToken => BoundBinaryOperatorKind.BitwiseOr,
+            SyntaxKind.HatToken => BoundBinaryOperatorKind.BitwiseXor,
+            SyntaxKind.ShiftLeftToken => BoundBinaryOperatorKind.ShiftLeft,
+            SyntaxKind.ShiftRightToken => BoundBinaryOperatorKind.ShiftRight,
+            SyntaxKind.UnsignedShiftRightToken => BoundBinaryOperatorKind.UnsignedShiftRight,
+            SyntaxKind.QuestionQuestionToken => BoundBinaryOperatorKind.NullCoalesce,
+            SyntaxKind.AmpersandAmpersandToken => BoundBinaryOperatorKind.LogicalAnd,
+            SyntaxKind.PipePipeToken => BoundBinaryOperatorKind.LogicalOr,
+            SyntaxKind.EqualsEqualsToken => BoundBinaryOperatorKind.Equals,
+            SyntaxKind.BangEqualsToken => BoundBinaryOperatorKind.NotEquals,
+            SyntaxKind.LessToken => BoundBinaryOperatorKind.Less,
+            SyntaxKind.LessOrEqualsToken => BoundBinaryOperatorKind.LessOrEquals,
+            SyntaxKind.GreaterToken => BoundBinaryOperatorKind.Greater,
+            SyntaxKind.GreaterOrEqualsToken => BoundBinaryOperatorKind.GreaterOrEquals,
+            _ => BoundBinaryOperatorKind.Undefined,
+        };
+}

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperatorKind.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperatorKind.cs
@@ -118,4 +118,13 @@ public enum BoundBinaryOperatorKind
     /// if non-nil, returns it; otherwise evaluates and returns the right.
     /// </summary>
     NullCoalesce,
+
+    /// <summary>
+    /// Not a language-level binary operator. Appended LAST so every existing
+    /// member keeps its ordinal. Reported by
+    /// <see cref="BoundBinaryOperationExpression.BinaryOperatorKind"/> for a
+    /// node whose operator token names no operator in this vocabulary; no
+    /// bound operator ever carries it.
+    /// </summary>
+    Undefined,
 }

--- a/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCallExpression.cs
@@ -11,7 +11,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// Bound call expression.
 /// </summary>
-public sealed class BoundCallExpression : BoundExpression
+public sealed class BoundCallExpression : BoundCallOperationExpression
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundCallExpression"/> class.
@@ -60,6 +60,9 @@ public sealed class BoundCallExpression : BoundExpression
     public override BoundNodeKind Kind => BoundNodeKind.CallExpression;
 
     /// <inheritdoc/>
+    public override Symbol CalledFunction => Function;
+
+    /// <inheritdoc/>
     public override TypeSymbol Type => ReturnType ?? Function.Type;
 
     /// <summary>
@@ -91,7 +94,7 @@ public sealed class BoundCallExpression : BoundExpression
     /// <summary>
     /// Gets the provided arguments.
     /// </summary>
-    public ImmutableArray<BoundExpression> Arguments { get; }
+    public override ImmutableArray<BoundExpression> Arguments { get; }
 
     /// <summary>Gets the call-site (post-substitution) return type for generic-function calls, or <c>null</c> for non-generic calls. Phase 4.1 / ADR-0020.</summary>
     public TypeSymbol? ReturnType { get; }

--- a/src/Core/CodeAnalysis/Binding/BoundCallOperationExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundCallOperationExpression.cs
@@ -1,0 +1,54 @@
+// <copyright file="BoundCallOperationExpression.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+
+namespace GSharp.Core.CodeAnalysis.Binding;
+
+/// <summary>
+/// The shape shared by every bound node that CALLS a method (ADR-0169, issue
+/// #3920).
+/// </summary>
+/// <remarks>
+/// <para>
+/// G# binds a call to three different nodes depending on where the callee comes
+/// from: <see cref="BoundCallExpression"/> for a same-compilation function,
+/// <see cref="BoundImportedCallExpression"/> for a static call into metadata,
+/// and <see cref="BoundImportedInstanceCallExpression"/> for an instance call
+/// into metadata. Roslyn models all three as one <c>IInvocationOperation</c>.
+/// </para>
+/// <para>
+/// The split is a codegen distinction, not a program-meaning one, and an
+/// analyzer that does not know it silently sees a fraction of the calls in the
+/// program — which is how the migrated GSA0002 never saw a single
+/// <c>object.ReferenceEquals</c>, the only call shape it exists to police. The
+/// concrete nodes and their <see cref="BoundNode.Kind"/> values are unchanged.
+/// </para>
+/// </remarks>
+public abstract class BoundCallOperationExpression : BoundExpression
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BoundCallOperationExpression"/> class.
+    /// </summary>
+    /// <param name="syntax">The originating syntax.</param>
+    private protected BoundCallOperationExpression(SyntaxNode? syntax)
+        : base(syntax)
+    {
+    }
+
+    /// <summary>
+    /// Gets the symbol of the called method — the Roslyn
+    /// <c>IInvocationOperation.TargetMethod</c> analogue. Typed as
+    /// <see cref="Symbol"/> because an imported callee is an
+    /// <see cref="ImportedFunctionSymbol"/>, which is not a
+    /// <see cref="FunctionSymbol"/>; <see cref="Symbol.Name"/> and
+    /// <see cref="Symbol.ContainingType"/> are meaningful on both.
+    /// </summary>
+    public abstract Symbol CalledFunction { get; }
+
+    /// <summary>Gets the arguments, in source order.</summary>
+    public abstract ImmutableArray<BoundExpression> Arguments { get; }
+}

--- a/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundClrBinaryOperatorExpression.cs
@@ -34,7 +34,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <c>EmitLiftedNullableClrBinary</c>) drive both the imported-CLR-type and
 /// same-compilation-struct cases uniformly.
 /// </remarks>
-public sealed class BoundClrBinaryOperatorExpression : BoundExpression
+public sealed class BoundClrBinaryOperatorExpression : BoundBinaryOperationExpression
 {
     public BoundClrBinaryOperatorExpression(SyntaxNode? syntax, SyntaxKind operatorKind, BoundExpression left, BoundExpression right, MethodInfo? method, TypeSymbol resultType)
         : this(syntax, operatorKind, left, right, method, null, null, resultType)
@@ -80,9 +80,9 @@ public sealed class BoundClrBinaryOperatorExpression : BoundExpression
 
     public SyntaxKind OperatorKind { get; }
 
-    public BoundExpression Left { get; }
+    public override BoundExpression Left { get; }
 
-    public BoundExpression Right { get; }
+    public override BoundExpression Right { get; }
 
     /// <summary>Gets the resolved imported-CLR-type operator method, or <see langword="null"/> when <see cref="Function"/> is used instead.</summary>
     public MethodInfo? Method { get; }
@@ -106,4 +106,7 @@ public sealed class BoundClrBinaryOperatorExpression : BoundExpression
     public override TypeSymbol Type { get; }
 
     public override BoundNodeKind Kind => BoundNodeKind.ClrBinaryOperatorExpression;
+
+    /// <inheritdoc/>
+    public override BoundBinaryOperatorKind BinaryOperatorKind => FromSyntaxKind(OperatorKind);
 }

--- a/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedCallExpression.cs
@@ -11,7 +11,7 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// <summary>
 /// Bound call expression.
 /// </summary>
-public sealed class BoundImportedCallExpression : BoundExpression
+public sealed class BoundImportedCallExpression : BoundCallOperationExpression
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundImportedCallExpression"/> class.
@@ -53,6 +53,9 @@ public sealed class BoundImportedCallExpression : BoundExpression
     public override BoundNodeKind Kind => BoundNodeKind.ImportedCallExpression;
 
     /// <inheritdoc/>
+    public override Symbol CalledFunction => Function;
+
+    /// <inheritdoc/>
     public override TypeSymbol Type { get; }
 
     /// <summary>
@@ -63,7 +66,7 @@ public sealed class BoundImportedCallExpression : BoundExpression
     /// <summary>
     /// Gets the provided arguments.
     /// </summary>
-    public ImmutableArray<BoundExpression> Arguments { get; }
+    public override ImmutableArray<BoundExpression> Arguments { get; }
 
     /// <summary>
     /// Gets the per-argument ref-kind annotations. May be default (all-None).

--- a/src/Core/CodeAnalysis/Binding/BoundImportedInstanceCallExpression.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundImportedInstanceCallExpression.cs
@@ -4,6 +4,7 @@
 
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -14,8 +15,10 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 /// Bound call expression for an instance method invoked on a value whose type
 /// originates from a CLR <see cref="System.Type"/>.
 /// </summary>
-public sealed class BoundImportedInstanceCallExpression : BoundExpression
+public sealed class BoundImportedInstanceCallExpression : BoundCallOperationExpression
 {
+    private ImportedFunctionSymbol? calledFunction;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="BoundImportedInstanceCallExpression"/> class.
     /// </summary>
@@ -84,6 +87,18 @@ public sealed class BoundImportedInstanceCallExpression : BoundExpression
     /// <inheritdoc/>
     public override BoundNodeKind Kind => BoundNodeKind.ImportedInstanceCallExpression;
 
+    /// <summary>
+    /// Gets the called method as a symbol (ADR-0169, issue #3920). Built on
+    /// demand from <see cref="Method"/>: this node stores the reflected
+    /// method rather than a symbol, and only the analyzer surface needs one.
+    /// </summary>
+    public override Symbol CalledFunction
+        => calledFunction ??= new ImportedFunctionSymbol(
+            Method.Name,
+            new ImportedClassSymbol(Method.DeclaringType ?? typeof(object), declaration: null),
+            Method,
+            declaration: null);
+
     /// <inheritdoc/>
     public override TypeSymbol Type { get; }
 
@@ -100,7 +115,7 @@ public sealed class BoundImportedInstanceCallExpression : BoundExpression
     /// <summary>
     /// Gets the bound arguments.
     /// </summary>
-    public ImmutableArray<BoundExpression> Arguments { get; }
+    public override ImmutableArray<BoundExpression> Arguments { get; }
 
     /// <summary>
     /// Gets the per-argument ref-kind annotations. May be default (all-None).

--- a/src/Core/CodeAnalysis/Symbols/EnumSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/EnumSymbol.cs
@@ -89,7 +89,7 @@ public sealed class EnumSymbol : TypeSymbol
     /// <param name="containingType">The enclosing user-defined type.</param>
     public void SetContainingType(TypeSymbol? containingType)
     {
-        ContainingType = containingType;
+        SetContainingTypeCore(containingType);
     }
 
     /// <summary>Sets the enum members after the owning enum symbol has been created.</summary>

--- a/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/FunctionSymbol.cs
@@ -628,4 +628,13 @@ public sealed class FunctionSymbol : Symbol
     {
         Declaration = declaration;
     }
+
+    /// <summary>
+    /// A method knows its own declaring type without being anchored (issue
+    /// #3920): the receiver for an instance method, the owner for a static
+    /// one. A free function has neither and stays null.
+    /// </summary>
+    /// <returns>The declaring type, or null for a free function.</returns>
+    private protected override TypeSymbol? DefaultContainingType()
+        => ReceiverType ?? StaticOwnerType;
 }

--- a/src/Core/CodeAnalysis/Symbols/ImportedFunctionSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/ImportedFunctionSymbol.cs
@@ -101,6 +101,19 @@ public sealed class ImportedFunctionSymbol : Symbol
         return AssemblyDocumentationProvider.Resolve(Method) ?? base.GetDocumentation();
     }
 
+    /// <summary>
+    /// An imported method knows its declaring type from metadata (issue
+    /// #3920), so it never depends on having been anchored — nothing anchors
+    /// imported symbols, and a migrated analyzer reading
+    /// <c>TargetMethod.ContainingType</c> saw null for every call into
+    /// metadata.
+    /// </summary>
+    /// <returns>The declaring type, or null for a global method.</returns>
+    private protected override TypeSymbol? DefaultContainingType()
+        => Method.DeclaringType is { } declaringType
+            ? ImportedTypeSymbol.Get(declaringType)
+            : null;
+
     private TypeSymbol GetMethodType(MethodInfo method)
     {
         var returnType = ClrNullability.GetReturnTypeSymbol(method);

--- a/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/InterfaceSymbol.cs
@@ -235,7 +235,7 @@ public sealed class InterfaceSymbol : TypeSymbol
     /// <param name="containingType">The enclosing user-defined type.</param>
     public void SetContainingType(TypeSymbol containingType)
     {
-        ContainingType = containingType;
+        SetContainingTypeCore(containingType);
     }
 
     /// <summary>Sets <see cref="Methods"/>. Intended to be called once by the binder.</summary>

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -667,7 +667,7 @@ public sealed class StructSymbol : TypeSymbol
     /// <param name="containingType">The enclosing user-defined type.</param>
     public void SetContainingType(TypeSymbol containingType)
     {
-        ContainingType = containingType;
+        SetContainingTypeCore(containingType);
     }
 
     /// <inheritdoc/>
@@ -1979,7 +1979,7 @@ public sealed class StructSymbol : TypeSymbol
             constructed.SetTypeParameters(definition.TypeParameters);
         }
 
-        constructed.ContainingType = definition.ContainingType;
+        constructed.SetContainingTypeCore(definition.ContainingType);
         return constructed;
     }
 
@@ -2024,7 +2024,7 @@ public sealed class StructSymbol : TypeSymbol
         // own-argument half keeps pairing each original own parameter with its
         // argument no matter when it is first computed.
         constructed.nestedOwnTypeParameters = definition.TypeParameters;
-        constructed.ContainingType = definition.ContainingType;
+        constructed.SetContainingTypeCore(definition.ContainingType);
         return constructed;
     }
 

--- a/src/Core/CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/Symbol.cs
@@ -15,6 +15,7 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 public abstract class Symbol
 {
     private DocumentationComment? authoredDocumentation;
+    private TypeSymbol? anchoredContainingType;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Symbol"/> class.
@@ -94,11 +95,13 @@ public abstract class Symbol
     /// <summary>
     /// Gets the type that declares this member, or <see langword="null"/> for
     /// top-level symbols — the Roslyn <c>ContainingType</c> analogue
-    /// (ADR-0169). Populated fill-once when symbols surface through the
-    /// analyzer driver or a <see cref="SemanticModel"/>; symbols observed
-    /// outside those surfaces may report null.
+    /// (ADR-0169). Anchored fill-once when symbols surface through the
+    /// analyzer driver or a <see cref="SemanticModel"/>; a symbol that can
+    /// name its own declaring type says so through
+    /// <see cref="DefaultContainingType"/> instead of depending on having been
+    /// anchored (issue #3920), and only a symbol with neither reports null.
     /// </summary>
-    public TypeSymbol? ContainingType { get; private protected set; }
+    public TypeSymbol? ContainingType => anchoredContainingType ??= DefaultContainingType();
 
     /// <summary>
     /// Gets the display name of the package (namespace) this symbol lives in,
@@ -183,9 +186,23 @@ public abstract class Symbol
     /// <param name="containingType">The declaring type.</param>
     internal void AnchorContainingType(TypeSymbol containingType)
     {
-        if (ContainingType is null)
-        {
-            ContainingType = containingType;
-        }
+        anchoredContainingType ??= containingType;
     }
+
+    /// <summary>
+    /// Assigns the declaring type outright, replacing whatever was there. The
+    /// binder's <c>SetContainingType</c> entry points use this; analyzer-side
+    /// anchoring uses <see cref="AnchorContainingType"/>, which is fill-once.
+    /// </summary>
+    /// <param name="containingType">The declaring type, or null.</param>
+    private protected void SetContainingTypeCore(TypeSymbol? containingType)
+        => anchoredContainingType = containingType;
+
+    /// <summary>
+    /// The declaring type this symbol can determine on its own, consulted when
+    /// nothing has anchored one (issue #3920). Null by default: most symbols
+    /// learn their container only from the declaration that holds them.
+    /// </summary>
+    /// <returns>The declaring type, or null.</returns>
+    private protected virtual TypeSymbol? DefaultContainingType() => null;
 }

--- a/test/Core.Tests/CodeAnalysis/Issue3920BoundOperationShapeTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Issue3920BoundOperationShapeTests.cs
@@ -1,0 +1,262 @@
+// <copyright file="Issue3920BoundOperationShapeTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using GSharp.CodeAnalysis.Analyzers.Testing;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Analyzers;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Symbols;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis;
+
+/// <summary>
+/// Issue #3920: the ADR-0169 analyzer surface over the bound tree's
+/// PROVENANCE SPLIT.
+///
+/// <para>
+/// G# binds one program construct to different nodes depending on where the
+/// operator or callee came from: <c>a == b</c> is a
+/// <see cref="BoundBinaryExpression"/> for a built-in operator and a
+/// <see cref="BoundClrBinaryOperatorExpression"/> when it resolves to an
+/// <c>op_Equality</c> method, and a call is one of three nodes by callee
+/// provenance. That is a codegen distinction; to an analyzer it is one shape,
+/// which is why <see cref="BoundBinaryOperationExpression"/> and
+/// <see cref="BoundCallOperationExpression"/> exist.
+/// </para>
+///
+/// <para>
+/// The failure this guards is SILENCE, not a wrong answer: a rule written
+/// against the built-in nodes alone sees none of the imported code, and code
+/// that compares reflection <see cref="System.Type"/> values is imported by
+/// construction — so GSA0002 policed exactly the program it could not observe.
+/// Each positive here therefore demands a diagnostic on an imported operand or
+/// an imported callee, and its companion demands silence where the construct
+/// is genuinely absent.
+/// </para>
+/// </summary>
+public class Issue3920BoundOperationShapeTests
+{
+    /// <summary>
+    /// An <c>==</c> over two imported <c>System.Type</c> values binds to
+    /// <see cref="BoundClrBinaryOperatorExpression"/>, and an analyzer
+    /// registered for both binary kinds sees it through the shared base —
+    /// operands and operator kind included.
+    /// </summary>
+    [Fact]
+    public void ImportedOperandEquality_IsSeenAsABinaryOperation()
+    {
+        GSharpAnalyzerVerifier<EqualityOverTypeAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+import System
+
+class C {
+    func Same(left Type, right Type) bool {
+        return [|left == right|]
+    }
+}
+",
+            "TESTGSA3920A");
+    }
+
+    /// <summary>
+    /// The built-in operator still arrives at the same handler: the base spans
+    /// both provenances rather than swapping one blind spot for the other.
+    /// </summary>
+    [Fact]
+    public void BuiltInOperandEquality_IsSeenAsTheSameBinaryOperation()
+    {
+        GSharpAnalyzerVerifier<EqualityAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+func Same(left int32, right int32) bool {
+    return [|left == right|]
+}
+",
+            "TESTGSA3920B");
+    }
+
+    /// <summary>
+    /// The falsifier for both: a comparison that is not an equality must not
+    /// report, so a handler that fired on every node it received could not
+    /// pass the positives above.
+    /// </summary>
+    [Fact]
+    public void NonEqualityComparison_IsNotReported()
+    {
+        GSharpAnalyzerVerifier<EqualityAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+func Less(left int32, right int32) bool {
+    return left < right
+}
+");
+    }
+
+    /// <summary>
+    /// A static call into metadata binds to
+    /// <c>BoundImportedCallExpression</c>, and the callee's declaring type is
+    /// reachable through <see cref="Symbol.ContainingType"/> — which used to be
+    /// null for every imported symbol, because nothing anchors them.
+    /// </summary>
+    [Fact]
+    public void ImportedStaticCall_ExposesItsDeclaringTypeThroughCalledFunction()
+    {
+        GSharpAnalyzerVerifier<ReferenceEqualsCallAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+import System
+
+class C {
+    func Same(left Type, right Type) bool {
+        return object.[|ReferenceEquals(left, right)|]
+    }
+}
+",
+            "TESTGSA3920C");
+    }
+
+    /// <summary>
+    /// The falsifier: a different imported static call reaches the same
+    /// handler and is rejected on its name and declaring type, so the positive
+    /// above is evidence the gate ran rather than evidence it was skipped.
+    /// </summary>
+    [Fact]
+    public void OtherImportedStaticCall_IsNotReported()
+    {
+        GSharpAnalyzerVerifier<ReferenceEqualsCallAnalyzer>.VerifyAnalyzer(
+            @"package App
+
+import System
+
+class C {
+    func Describe(value Type) string {
+        return string.Concat(value.Name, value.Name)
+    }
+}
+");
+    }
+
+    /// <summary>
+    /// Reports every equality binary operation, whatever node the binder chose
+    /// for it.
+    /// </summary>
+    [GSharpDiagnosticAnalyzer]
+    public sealed class EqualityAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA3920B",
+            "Equality binary operation",
+            "An equality binary operation.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+            => context.RegisterBoundNodeAction(
+                Analyze,
+                BoundNodeKind.BinaryExpression,
+                BoundNodeKind.ClrBinaryOperatorExpression);
+
+        private static void Analyze(BoundNodeAnalysisContext context)
+        {
+            var operation = (BoundBinaryOperationExpression)context.BoundNode;
+            if (operation.BinaryOperatorKind != BoundBinaryOperatorKind.Equals)
+            {
+                return;
+            }
+
+            Assert.NotNull(operation.Left);
+            Assert.NotNull(operation.Right);
+            context.ReportDiagnostic(Diagnostic.Create(Rule, operation.Syntax.Location));
+        }
+    }
+
+    /// <summary>
+    /// The same rule, restricted to operands of the imported reflection
+    /// <c>Type</c> — the shape that reaches the handler only as a
+    /// <see cref="BoundClrBinaryOperatorExpression"/>.
+    /// </summary>
+    [GSharpDiagnosticAnalyzer]
+    public sealed class EqualityOverTypeAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA3920A",
+            "Equality over reflection Type",
+            "An equality binary operation over reflection Type operands.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+            => context.RegisterBoundNodeAction(
+                Analyze,
+                BoundNodeKind.BinaryExpression,
+                BoundNodeKind.ClrBinaryOperatorExpression);
+
+        private static void Analyze(BoundNodeAnalysisContext context)
+        {
+            var operation = (BoundBinaryOperationExpression)context.BoundNode;
+            if (operation.BinaryOperatorKind != BoundBinaryOperatorKind.Equals
+                || operation.Left.Type?.ToDisplayString(DisplayFormat.FullyQualified) != "global::System.Type")
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, operation.Syntax.Location));
+        }
+    }
+
+    /// <summary>
+    /// Reports <c>object.ReferenceEquals</c> calls, identified through
+    /// <see cref="BoundCallOperationExpression.CalledFunction"/> and its
+    /// declaring type.
+    /// </summary>
+    [GSharpDiagnosticAnalyzer]
+    public sealed class ReferenceEqualsCallAnalyzer : GSharpDiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new(
+            "TESTGSA3920C",
+            "ReferenceEquals call",
+            "A call to object.ReferenceEquals.",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+            => context.RegisterBoundNodeAction(
+                Analyze,
+                BoundNodeKind.CallExpression,
+                BoundNodeKind.ImportedCallExpression,
+                BoundNodeKind.ImportedInstanceCallExpression);
+
+        private static void Analyze(BoundNodeAnalysisContext context)
+        {
+            var operation = (BoundCallOperationExpression)context.BoundNode;
+            if (operation.CalledFunction.Name != "ReferenceEquals"
+                || operation.Arguments.Length != 2
+                || operation.CalledFunction.ContainingType?.ToDisplayString(DisplayFormat.FullyQualified)
+                    != "global::System.Object")
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, operation.Syntax.Location));
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
@@ -241,10 +241,20 @@ public sealed class BinaryComparisonAnalyzer : DiagnosticAnalyzer
 ");
 
         Assert.Contains("RegisterBoundNodeAction", printed, StringComparison.Ordinal);
+
+        // Issue #3920: the registration names EVERY bound-node kind the Roslyn
+        // operation reaches, and the handler casts to the shared base — an
+        // `==` over imported operands is a ClrBinaryOperatorExpression, so
+        // naming BinaryExpression alone dispatched the rule zero times over
+        // exactly the code it exists for.
         Assert.Contains("BoundNodeKind.BinaryExpression", printed, StringComparison.Ordinal);
-        Assert.Contains("BoundBinaryExpression", printed, StringComparison.Ordinal);
-        Assert.Contains(".Op.Kind", printed, StringComparison.Ordinal);
-        Assert.Contains("BoundBinaryOperatorKind.Equals", printed, StringComparison.Ordinal);
+        Assert.Contains("BoundNodeKind.ClrBinaryOperatorExpression", printed, StringComparison.Ordinal);
+        Assert.Contains("cast[BoundBinaryOperationExpression]", printed, StringComparison.Ordinal);
+
+        // `Op` lives only on BoundBinaryExpression; the base normalizes both
+        // provenances onto BinaryOperatorKind.
+        Assert.DoesNotContain(".Op.Kind", printed, StringComparison.Ordinal);
+        Assert.Contains(".BinaryOperatorKind != BoundBinaryOperatorKind.Equals", printed, StringComparison.Ordinal);
         Assert.Contains("BoundNodeKind.TypeOfExpression", printed, StringComparison.Ordinal);
         Assert.Contains("BoundConversionExpression", printed, StringComparison.Ordinal);
         Assert.Contains("conversion.Expression", printed, StringComparison.Ordinal);

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3920Gsa0002ImportedOperandDispatchTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3920Gsa0002ImportedOperandDispatchTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue3920Gsa0002ImportedOperandDispatchTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using Cs2Gs.Translator.Analyzers;
+using GSharp.CodeAnalysis.Analyzers.Testing;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Analyzers;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// ADR-0169 M5, issue #3920: a Roslyn <c>OperationKind</c> corresponds to
+/// SEVERAL G# bound-node kinds, and the one GSA0002 exists to police is never
+/// the one the naive one-to-one map named.
+///
+/// <para>
+/// G# binds <c>a == b</c> over operands of an IMPORTED CLR type to
+/// <c>BoundClrBinaryOperatorExpression</c> (the resolved <c>op_Equality</c>),
+/// not to <c>BoundBinaryExpression</c>; and a call to an imported method such
+/// as <c>object.ReferenceEquals</c> to <c>BoundImportedCallExpression</c>, not
+/// to <c>BoundCallExpression</c>. Translating
+/// <c>RegisterOperationAction(h, OperationKind.BinaryOperator)</c> to a single
+/// <c>RegisterBoundNodeAction(h, BoundNodeKind.BinaryExpression)</c> therefore
+/// dispatched the migrated GSA0002 zero times over reflection-<c>Type</c>
+/// comparisons — which are imported by construction — and the rule reported
+/// nothing at all.
+/// </para>
+///
+/// <para>
+/// Every assertion here EXECUTES: the real analyzer is translated, compiled by
+/// the real G# compiler, loaded, and run through the real
+/// <see cref="GSharpAnalyzerVerifier"/> over the translated snippet. The
+/// positive and the two negatives share one path, so a rule that stops
+/// reporting fails the positive rather than passing the negatives quietly.
+/// </para>
+/// </summary>
+public sealed class Issue3920Gsa0002ImportedOperandDispatchTests : IDisposable
+{
+    // The real positive snippet from
+    // ReflectionTypeComparisonAnalyzerTests.ReportsTypeofReferenceComparisonsInCompilerMetadataNamespaces.
+    // All three sites compare an imported System.Type, so all three bind to
+    // the imported-operand node shapes.
+    private const string Gsa0002Positive = """
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Binding
+{
+    class C
+    {
+        bool EqualsTypeof(Type type) => [|type == typeof(string)|];
+        bool NotEqualsTypeof(Type type) => [|typeof(int) != type|];
+        bool ReferenceEqualsTypeof(Type type) => [|ReferenceEquals(type, typeof(string))|];
+    }
+}
+""";
+
+    // The real negative snippet from the same class: symbol comparisons, Type
+    // compared to Type (no typeof), null checks, and the two exempt utility
+    // types. Every one of these now REACHES the handler — before #3920 it was
+    // silent because nothing was dispatched at all.
+    private const string Gsa0002NegativeExemptions = """
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Symbols
+{
+    class Symbol { }
+    class C
+    {
+        bool Same(Symbol a, Symbol b) => ReferenceEquals(a, b) || a == b;
+        bool SameTypes(Type a, Type b) => ReferenceEquals(a, b) || a == b || a != b;
+        bool NullCheck(Type a) => a == null || null != a;
+    }
+
+    class ClrTypeUtilities
+    {
+        bool Same(Type a) => ReferenceEquals(a, typeof(string)) || a == typeof(int);
+    }
+
+    class TypeIdentityComparer
+    {
+        bool Same(Type a) => ReferenceEquals(a, typeof(string)) || a == typeof(int);
+    }
+}
+""";
+
+    // The real negative snippet whose only exemption is the namespace.
+    private const string Gsa0002NegativeNamespace = """
+using System;
+
+namespace GSharp.Core.CodeAnalysis.Syntax
+{
+    class C
+    {
+        bool Same(Type a) => ReferenceEquals(a, typeof(string)) || a == typeof(string);
+    }
+}
+""";
+
+    private readonly DirectoryInfo workDirectory =
+        Directory.CreateTempSubdirectory("cs2gs-gsa0002-dispatch");
+
+    /// <summary>Gets the GSA0002 positive and negative cases.</summary>
+    /// <returns>The theory data.</returns>
+    public static IEnumerable<object[]> Gsa0002Cases()
+    {
+        yield return new object[]
+        {
+            Gsa0002Positive,
+            new[] { "GSA0002", "GSA0002", "GSA0002" },
+        };
+        yield return new object[] { Gsa0002NegativeExemptions, Array.Empty<string>() };
+        yield return new object[] { Gsa0002NegativeNamespace, Array.Empty<string>() };
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        try
+        {
+            workDirectory.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// GSA0002, end to end, positive AND negatives on one path: the translated
+    /// rule reports at exactly the three re-placed markers of the positive
+    /// snippet — the case that reported NOTHING before the one-to-many kind
+    /// expansion — and stays silent over both negatives.
+    /// </summary>
+    /// <param name="markedSnippet">The C# snippet with its markers.</param>
+    /// <param name="ids">The expected diagnostic ids.</param>
+    [Theory]
+    [MemberData(nameof(Gsa0002Cases))]
+    public void TranslatedGsa0002_AgreesWithTheCSharpExpectation(string markedSnippet, string[] ids)
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(markedSnippet);
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+
+        string analyzerDll = Adr0169TranslatedAnalyzerHarness.CompileTranslatedAnalyzer(
+            workDirectory.FullName, "ReflectionTypeComparisonAnalyzer.cs", "TranslatedGsa0002");
+        ImmutableArray<GSharpDiagnosticAnalyzer> analyzers =
+            GSharpAnalyzerHost.Load(new[] { analyzerDll }, out ImmutableArray<Diagnostic> hostDiagnostics);
+        Assert.Empty(hostDiagnostics);
+        GSharpDiagnosticAnalyzer analyzer = Assert.Single(analyzers);
+
+        GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, result.GsWithMarkers, ids);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/Analyzers/RoslynAnalyzerApiMap.cs
@@ -166,8 +166,24 @@ internal static class RoslynAnalyzerApiMap
             "GSharp.Core.CodeAnalysis.Binding",
             "BoundExpression",
             "IOperation maps to BoundExpression (Type/ConstantValue live on expressions in G#); statement-level operation analyzers need review."),
-        ["Microsoft.CodeAnalysis.Operations.IBinaryOperation"] = new("GSharp.Core.CodeAnalysis.Binding", "BoundBinaryExpression"),
-        ["Microsoft.CodeAnalysis.Operations.IInvocationOperation"] = new("GSharp.Core.CodeAnalysis.Binding", "BoundCallExpression"),
+
+        // Issue #3920: NOT BoundBinaryExpression / BoundCallExpression. G#
+        // splits each of these Roslyn operations across several bound nodes by
+        // where the operator or callee comes from — `a == b` over imported
+        // operands binds to BoundClrBinaryOperatorExpression, and a call into
+        // metadata to BoundImported{,Instance}CallExpression. Naming one
+        // concrete node made a migrated handler cast-fail (or never run at
+        // all) on exactly the imported code the rules exist to police, so the
+        // map names the shared analyzer-facing base instead and
+        // OperationKindDispatch registers every kind that reaches it.
+        ["Microsoft.CodeAnalysis.Operations.IBinaryOperation"] = new(
+            "GSharp.Core.CodeAnalysis.Binding",
+            "BoundBinaryOperationExpression",
+            "G# has one bound node per operator provenance; the analyzer-facing base spans them, and Op/OperatorKind reads become BinaryOperatorKind."),
+        ["Microsoft.CodeAnalysis.Operations.IInvocationOperation"] = new(
+            "GSharp.Core.CodeAnalysis.Binding",
+            "BoundCallOperationExpression",
+            "G# has one bound node per callee provenance; the analyzer-facing base spans them, and TargetMethod becomes the Symbol-typed CalledFunction."),
         ["Microsoft.CodeAnalysis.Operations.IArgumentOperation"] = new(
             "GSharp.Core.CodeAnalysis.Binding",
             "BoundExpression",
@@ -212,6 +228,30 @@ internal static class RoslynAnalyzerApiMap
     };
 
     /// <summary>
+    /// Issue #3920: which G# bound-node kinds a Roslyn
+    /// <c>OperationKind</c> must REGISTER for. Roslyn has one operation kind
+    /// where G# has several bound nodes — a binary operator is a different
+    /// node depending on whether it is built in or resolves to an operator
+    /// method, and a call is a different node depending on whether the callee
+    /// is same-compilation, imported static, or imported instance. Registering
+    /// only the first meant a migrated rule was dispatched zero times over
+    /// imported code, which is exactly the code GSA0002 exists to police.
+    ///
+    /// <para>
+    /// This is the DISPATCH set, deliberately separate from
+    /// <see cref="EnumMemberMap"/>: a bare <c>OperationKind</c> read (e.g.
+    /// <c>node.Kind == OperationKind.TypeOf</c>) still translates to the one
+    /// kind it names, because a read tests a single node's identity while a
+    /// registration must cover every node that can arrive.
+    /// </para>
+    /// </summary>
+    private static readonly Dictionary<string, string[]> OperationKindDispatch = new(StringComparer.Ordinal)
+    {
+        ["BinaryOperator"] = new[] { "BinaryExpression", "ClrBinaryOperatorExpression" },
+        ["Invocation"] = new[] { "CallExpression", "ImportedCallExpression", "ImportedInstanceCallExpression" },
+    };
+
+    /// <summary>
     /// Instance member renames, keyed by the declaring Roslyn type's
     /// metadata name. A null G# name marks a member with NO G#
     /// counterpart: the access is replaced per the note (comparison sites
@@ -241,7 +281,10 @@ internal static class RoslynAnalyzerApiMap
             "Operation actions become bound-node actions; BoundNode member shapes are stable at the kind level only."),
         [("Microsoft.CodeAnalysis.Operations.IBinaryOperation", "LeftOperand")] = new(null, "Left"),
         [("Microsoft.CodeAnalysis.Operations.IBinaryOperation", "RightOperand")] = new(null, "Right"),
-        [("Microsoft.CodeAnalysis.Operations.IInvocationOperation", "TargetMethod")] = new(null, "Function"),
+        [("Microsoft.CodeAnalysis.Operations.IInvocationOperation", "TargetMethod")] = new(
+            null,
+            "CalledFunction",
+            "BoundCallOperationExpression.CalledFunction is Symbol-typed: an imported callee is an ImportedFunctionSymbol, not a FunctionSymbol (#3920)."),
         [("Microsoft.CodeAnalysis.IMethodSymbol", "OverriddenMethod")] = new(null, "OverriddenMethod"),
         [("Microsoft.CodeAnalysis.IMethodSymbol", "ReturnType")] = new(null, "Type"),
         [("Microsoft.CodeAnalysis.IParameterSymbol", "IsOptional")] = new(null, "HasExplicitDefaultValue"),
@@ -309,6 +352,16 @@ internal static class RoslynAnalyzerApiMap
         => type is INamedTypeSymbol named
         && named.Name == "INamespaceSymbol"
         && named.ContainingNamespace?.ToDisplayString() == "Microsoft.CodeAnalysis";
+
+    /// <summary>
+    /// The G# bound-node kinds a <c>RegisterOperationAction</c> for
+    /// <paramref name="operationKindMember"/> must register (issue #3920).
+    /// </summary>
+    /// <param name="operationKindMember">The <c>OperationKind</c> member name.</param>
+    /// <param name="boundNodeKinds">The G# <c>BoundNodeKind</c> member names.</param>
+    /// <returns>True when the kind fans out to more than the one it names.</returns>
+    public static bool TryMapOperationKindDispatch(string operationKindMember, out string[] boundNodeKinds)
+        => OperationKindDispatch.TryGetValue(operationKindMember, out boundNodeKinds);
 
     /// <summary>Maps a Roslyn enum member to its G# spelling.</summary>
     /// <param name="enumMetadataName">The declaring enum's metadata name.</param>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Analyzers.cs
@@ -139,10 +139,16 @@ public sealed partial class CSharpToGSharpTranslator
                 && this.context.GetSymbolInfo(member).Symbol is IPropertySymbol { Name: "OperatorKind" } operatorKind
                 && RoslynTypeMetadataName(operatorKind.ContainingType) == "Microsoft.CodeAnalysis.Operations.IBinaryOperation")
             {
-                // IBinaryOperation.OperatorKind -> BoundBinaryExpression.Op.Kind.
+                // IBinaryOperation.OperatorKind ->
+                // BoundBinaryOperationExpression.BinaryOperatorKind. NOT
+                // `.Op.Kind` (issue #3920): `Op` exists only on
+                // BoundBinaryExpression, and the operand shapes these rules
+                // care about bind to BoundClrBinaryOperatorExpression, which
+                // carries the operator TOKEN instead. The shared base
+                // normalizes both to the language operator vocabulary.
                 result = new MemberAccessExpression(
-                    new MemberAccessExpression(this.TranslateExpression(member.Expression), "Op", isArrow: false),
-                    "Kind",
+                    this.TranslateExpression(member.Expression),
+                    "BinaryOperatorKind",
                     isArrow: false);
                 return true;
             }
@@ -531,6 +537,13 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            if (method.Name == "RegisterOperationAction"
+                && invocation.Expression is MemberAccessExpressionSyntax registrationReceiver
+                && this.TryExpandOperationKindRegistration(invocation, registrationReceiver, out result))
+            {
+                return true;
+            }
+
             if (method.Name == "GetLocation"
                 && method.Parameters.Length == 0
                 && invocation.Expression is MemberAccessExpressionSyntax locationReceiver)
@@ -594,6 +607,80 @@ public sealed partial class CSharpToGSharpTranslator
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Expands <c>RegisterOperationAction(handler, OperationKind.X, …)</c>
+        /// into a <c>RegisterBoundNodeAction</c> naming EVERY G# bound-node
+        /// kind that operation reaches (issue #3920).
+        /// </summary>
+        /// <remarks>
+        /// Roslyn has one operation kind where G# has several bound nodes:
+        /// <c>a == b</c> binds to <c>BoundBinaryExpression</c> for a built-in
+        /// operator and to <c>BoundClrBinaryOperatorExpression</c> when it
+        /// resolves to an operator method, and a call binds to one of three
+        /// nodes by callee provenance. Registering only the kind the
+        /// <see cref="RoslynAnalyzerApiMap"/> enum rename names dispatched the
+        /// migrated GSA0002 zero times over reflection <c>Type</c>
+        /// comparisons — whose operands are imported by construction — so the
+        /// rule reported nothing at all rather than reporting wrongly.
+        /// </remarks>
+        /// <param name="invocation">The registration call.</param>
+        /// <param name="receiver">Its member-access callee.</param>
+        /// <param name="result">The expanded registration.</param>
+        /// <returns>True when at least one argument kind fanned out.</returns>
+        private bool TryExpandOperationKindRegistration(
+            InvocationExpressionSyntax invocation,
+            MemberAccessExpressionSyntax receiver,
+            out GExpression result)
+        {
+            result = null;
+            var arguments = new List<GExpression>();
+            var expanded = false;
+            foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments)
+            {
+                if (argument.Expression is MemberAccessExpressionSyntax kindAccess
+                    && this.context.GetSymbolInfo(kindAccess).Symbol is IFieldSymbol kindField
+                    && RoslynTypeMetadataName(kindField.ContainingType) == "Microsoft.CodeAnalysis.OperationKind"
+                    && RoslynAnalyzerApiMap.TryMapOperationKindDispatch(kindField.Name, out string[] boundNodeKinds))
+                {
+                    expanded = true;
+                    foreach (string boundNodeKind in boundNodeKinds)
+                    {
+                        arguments.Add(new MemberAccessExpression(
+                            new IdentifierExpression("BoundNodeKind"), boundNodeKind, isArrow: false));
+                    }
+
+                    continue;
+                }
+
+                arguments.Add(this.TranslateExpression(argument.Expression));
+            }
+
+            if (!expanded)
+            {
+                return false;
+            }
+
+            const string ShapeNote =
+                "'RegisterOperationAction' expanded to every G# bound-node kind the operation reaches: "
+                + "G# binds one Roslyn operation kind to several nodes by operator/callee provenance.";
+            this.context.Report(new TranslationDiagnostic(
+                "analyzer-api",
+                ShapeNote,
+                invocation.GetLocation(),
+                TranslationSeverity.Warning)
+            {
+                DiagnosticId = "CS2GS-ANALYZER-SHAPE",
+            });
+
+            result = new InvocationExpression(
+                new MemberAccessExpression(
+                    this.TranslateExpression(receiver.Expression),
+                    "RegisterBoundNodeAction",
+                    isArrow: false),
+                arguments);
+            return true;
         }
 
         private bool TryTranslateAnalyzerTypeNameSwitch(SwitchExpressionSyntax node, out GExpression result)


### PR DESCRIPTION
`test/InternalAnalyzers.Tests` was the nearest-to-green app in the #3501 self-migration gate at **1 failed / 17 passed of 18**. The migrated `ReflectionTypeComparisonAnalyzer` reported `(none)` — not a wrong answer, total silence.

## Defect class: two, and the more valuable one is the framework

**Neither suspect named on #3955 was the cause.** The marker moving behind the inserted `object.` receiver is benign (the call node's syntax is the `CallExpressionSyntax`, which starts exactly at the marker), and the `string?` namespace gate was already correct. The real cause is #3920, verified by running the migrated analyzer:

G# splits a construct by **provenance** where Roslyn does not. `a == b` binds to `BoundBinaryExpression` for a built-in operator and to `BoundClrBinaryOperatorExpression` when it resolves to an `op_Equality` method; a call binds to `BoundCallExpression`, `BoundImportedCallExpression`, or `BoundImportedInstanceCallExpression` by where the callee lives. Roslyn models each family as **one** operation kind, so translating `RegisterOperationAction(h, OperationKind.BinaryOperator)` to a single `RegisterBoundNodeAction(h, BoundNodeKind.BinaryExpression)` dispatched the rule **zero times** over reflection-`Type` comparisons — which are imported by construction. GSA0002 policed exactly the program it could not observe.

### Framework defect (`src/Core`) — affects every G# analyzer, not just the migration

- `BoundBinaryOperationExpression` (`Left`, `Right`, `BinaryOperatorKind`) and `BoundCallOperationExpression` (`CalledFunction`, `Arguments`) are the analyzer-facing bases spanning the provenance-split nodes. `BoundNodeKind` values, lowering and emit are untouched — this adds a shared *shape*, not a node.
- `Symbol.ContainingType` no longer depends on having been anchored: a method that knows its own declaring type now says so (`FunctionSymbol`'s receiver/owner, `ImportedFunctionSymbol`'s metadata declaring type). Nothing anchors imported symbols, so `TargetMethod.ContainingType` read null for **every** call into metadata — a second silent gate in the same handler, which would have kept the test red even after the dispatch fix.
- `BoundBinaryOperatorKind.Undefined` is appended **last** so every existing member keeps its ordinal.

### Translation defect (`cs2gs`)

- `RegisterOperationAction` expands to every bound-node kind the operation reaches (`RoslynAnalyzerApiMap.OperationKindDispatch`). The dispatch set is deliberately separate from the enum-member rename: a bare kind READ (`node.Kind == OperationKind.TypeOf`) still maps to the one kind it names, because a read tests one node's identity while a registration must cover every node that can arrive.
- The two `IOperation` map entries name the shared bases, `TargetMethod` maps to the `Symbol`-typed `CalledFunction`, and `IBinaryOperation.OperatorKind` lowers to `BinaryOperatorKind` rather than `Op.Kind` — `Op` exists only on the built-in node.

## Evidence

Targeted repository migration of the app and its full reference closure, through the **repacked Release SDK** (`gsc 0.4.483+dc4f56da10`):

```
app                                                          translate  compile  ilverify  test-parity
src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj     PASS       PASS     PASS      PASS
test/InternalAnalyzers.Tests/InternalAnalyzers.Tests.csproj  PASS       PASS     PASS      PASS

2/2 apps green; run PASSED.
```

with the parity summary line, quoted verbatim from the run's `test-parity.log`:

```
Passed!  - Failed:     0, Passed:    18, Skipped:     0, Total:    18, Duration: 1 s - GSharp.InternalAnalyzers.Tests.dll (net10.0)
```

`test/InternalAnalyzers.Tests` therefore becomes bankable in `greenApps`. **The ratchet is not touched here** — `selfmig-baseline.json` is unchanged, and no allow-list entry was added (`selfmig-test-allowlist.json` stays empty).

## Regression tests — both execute, both falsifiable

- `Issue3920Gsa0002ImportedOperandDispatchTests` translates the **real** analyzer, compiles it with the **real** G# compiler, loads it, and runs the **real** verifier over the real GSA0002 positive and both negatives on one parameterised path — so a rule that stops reporting fails the positive instead of passing the negatives quietly. Verified red before the fix (`Expected diagnostics [GSA0002, GSA0002, GSA0002] but the analyzer produced: (none)`), green after.
- `Issue3920BoundOperationShapeTests` pins the framework shapes directly — imported-operand equality, built-in equality, and an imported static call reached through `CalledFunction.ContainingType` — each with a companion that demands silence.

`Adr0169AnalyzerTranslationTests.OperationActionAnalyzer_TranslatesToBoundNodeApi` is updated to the new expectation and now also asserts `.Op.Kind` is *absent*.

## Local runs

- `Cs2Gs.Tests` (2826 tests): green apart from `Issue2819_SameVersionPackedToolAndSdk_...`, which needs a Release `nupkgs` feed that a Debug-only run has not produced — environmental, unrelated.
- `Core.Tests` (full suite, the one the `src/Core` change could break): `Passed!  - Failed:     0, Passed:  8909, Skipped:     0, Total:  8909` — no regression from the bound-tree bases or the `ContainingType` change.

Fixes #3920. Refs #3955, #3501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs
