### PR TITLE
gsc: a variadic carrier passed whole binds in normal form during overload ranking (#3880)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -461,6 +461,28 @@ internal sealed partial class OverloadResolver
                 && variadicElement != TypeSymbol.Error
                 ? variadicElement
                 : null;
+
+            // Issue #3880: a single trailing argument that already IS the
+            // variadic carrier (`F(existingArray)` against `F(xs ...string)`)
+            // binds the candidate in NORMAL form, not expanded form — the same
+            // pass-through the applicability filter recognises via
+            // IsVariadicCarrierPassThrough. Ranking used to classify it as an
+            // expanded tail slot against the ELEMENT type, which both mis-rates
+            // the conversion (`[]string -> string`) and leaves ParamTypes[i]
+            // null, so the Reference "better conversion target" tie-break could
+            // not run and two variadic siblings
+            // (`F(xs ...string)` / `F(refs IReadOnlyList[string]?, xs ...string)`)
+            // tied and reported a spurious GS0266 where C# picks the first.
+            var variadicCarrierType = isVariadic
+                ? cand.Parameters[cand.Parameters.Length - 1].Type
+                : null;
+            var bindsCarrierInNormalForm = isVariadic
+                && !HasNamedArguments(argumentNames)
+                && argumentCount - paramCountForScore == 1
+                && paramCountForScore < boundArguments.Count
+                && boundArguments[paramCountForScore]?.Type is { } carrierPassThroughArgType
+                && variadicCarrierType != null
+                && IsVariadicCarrierPassThrough(carrierPassThroughArgType, variadicCarrierType);
             for (var i = 0; i < boundArguments.Count; i++)
             {
                 var slot = MapArgumentIndexToParameterSlot(cand, argumentNames, i, parameterOffset, paramLen);
@@ -486,8 +508,21 @@ internal sealed partial class OverloadResolver
                     // one purely because its tail was compared favourably.
                     // Between two variadic candidates (both expanded), the
                     // element-type kind still decides genuine betterness.
-                    isTailSlot[i] = true;
                     var tailArgType = boundArguments[i]?.Type;
+                    if (bindsCarrierInNormalForm)
+                    {
+                        // Normal form (issue #3880): rank against the carrier
+                        // itself, in a normal-form slot, so an exact `[]string`
+                        // beats a sibling's `IReadOnlyList[string]?` widening.
+                        var normalFormCarrier = Invariant.Required(
+                            variadicCarrierType,
+                            "a carrier pass-through candidate has a variadic carrier parameter");
+                        paramTypes[i] = normalFormCarrier;
+                        kinds[i] = ClassifyUserArgumentConversionKind(tailArgType, normalFormCarrier);
+                        continue;
+                    }
+
+                    isTailSlot[i] = true;
                     kinds[i] = elementType == null
                         ? ClrOverloadResolution.ImplicitConversionKind.Identity
                         : ClassifyUserArgumentConversionKind(tailArgType, elementType);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -473,9 +473,22 @@ internal sealed partial class OverloadResolver
             // not run and two variadic siblings
             // (`F(xs ...string)` / `F(refs IReadOnlyList[string]?, xs ...string)`)
             // tied and reported a spurious GS0266 where C# picks the first.
+            // The carrier must be CLOSED before it is compared to the argument.
+            // A generic variadic candidate (`func Take[T](values ...T)`) whose
+            // inference already ran declares the carrier as the open `[]T`;
+            // ranking `[]string` against `[]T` classifies an identity as a
+            // reference conversion and hands the call to a fixed
+            // `IEnumerable[string]` sibling that C# does not choose. The
+            // non-tail slots below already substitute through candSubstitution
+            // for exactly this reason.
             var variadicCarrierType = isVariadic
                 ? cand.Parameters[cand.Parameters.Length - 1].Type
                 : null;
+            if (variadicCarrierType != null && candSubstitution != null)
+            {
+                variadicCarrierType = Binder.SubstituteType(variadicCarrierType, candSubstitution);
+            }
+
             var bindsCarrierInNormalForm = isVariadic
                 && !HasNamedArguments(argumentNames)
                 && argumentCount - paramCountForScore == 1

--- a/test/Compiler.Tests/Emit/Issue3880VariadicPassThroughOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3880VariadicPassThroughOverloadEmitTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="Issue3880VariadicPassThroughOverloadEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3880: a single argument that already IS the variadic carrier binds
+/// the candidate in NORMAL form (C# §12.6.4.2), so it ranks against the
+/// carrier type, not the element type. Overload ranking used to classify that
+/// argument as an expanded-form tail slot against the element type, which both
+/// mis-rated the conversion and left the slot's parameter type unset, so the
+/// "better conversion target" tie-break could not run: the migrated
+/// <c>Cs2Gs.Tests</c> pair
+/// <c>AssertBindsAgainstGsCore(printedSources ...string)</c> /
+/// <c>AssertBindsAgainstGsCore(refs IReadOnlyList[string]?, printedSources ...string)</c>
+/// called with one <c>[]string</c> tied and reported a spurious GS0266 where
+/// C# picks the first. Pinned end to end, not merely bound, so the selected
+/// overload is witnessed at runtime.
+/// </summary>
+public class Issue3880VariadicPassThroughOverloadEmitTests
+{
+    [Fact]
+    public void CarrierPassThrough_PrefersTheNormalFormOverload()
+    {
+        var output = CompileAndRun("""
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Asserts {
+                shared {
+                    func Bind(printedSources ...string) int32 { return printedSources.Length }
+                    func Bind(refs IReadOnlyList[string]?, printedSources ...string) int32 { return 100 + printedSources.Length }
+                }
+            }
+
+            func run() {
+                let printed = []string{"a", "b"}
+
+                // Normal form: `printed` IS the carrier, so the one-parameter
+                // overload wins on an identity conversion.
+                Console.WriteLine(Asserts.Bind(printed))
+
+                // Expanded form still packs into the same overload.
+                Console.WriteLine(Asserts.Bind("a", "b", "c"))
+
+                // The two-parameter overload is still reachable.
+                Console.WriteLine(Asserts.Bind(nil, "a"))
+            }
+
+            run()
+            """);
+
+        Assert.Equal($"2{Environment.NewLine}3{Environment.NewLine}101{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void CarrierPassThrough_BeatsAWideningSiblingOnTheSameArity()
+    {
+        // The sibling is NOT variadic at the pass-through slot, so the fix must
+        // rank the carrier candidate's identity conversion above the sibling's
+        // implicit reference conversion rather than penalising it as expanded.
+        var output = CompileAndRun("""
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Pick {
+                shared {
+                    func Take(values ...string) string { return "carrier" }
+                    func Take(values IEnumerable[string]) string { return "sequence" }
+                }
+            }
+
+            func run() {
+                let arr = []string{"a"}
+                Console.WriteLine(Pick.Take(arr))
+                Console.WriteLine(Pick.Take("a", "b"))
+            }
+
+            run()
+            """);
+
+        Assert.Equal($"carrier{Environment.NewLine}carrier{Environment.NewLine}", output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3880_overload_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            RunGsc(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", srcPath });
+            IlVerifier.Verify(outPath);
+
+            var psi = new System.Diagnostics.ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = System.Diagnostics.Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(proc.ExitCode == 0, $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static void RunGsc(string[] args)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3880VariadicPassThroughOverloadEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3880VariadicPassThroughOverloadEmitTests.cs
@@ -89,6 +89,46 @@ public class Issue3880VariadicPassThroughOverloadEmitTests
         Assert.Equal($"carrier{Environment.NewLine}carrier{Environment.NewLine}", output);
     }
 
+    [Fact]
+    public void GenericCarrierPassThrough_ClosesTheCarrierBeforeRanking()
+    {
+        // Review finding on PR #3964, confirmed against csc: a GENERIC variadic
+        // candidate declares its carrier open (`[]T`). Ranking `[]string`
+        // against `[]T` classifies an identity as a reference conversion, and
+        // the call is handed to a fixed sibling. C# picks the generic carrier
+        // in both shapes below (verified with csc on net10.0); gsc picked
+        // "sequence" and "two-param" — a SILENT wrong-overload selection that
+        // bound clean, verified clean and returned the wrong answer at
+        // runtime, which is why this test executes rather than asserting a
+        // successful bind. The carrier is now closed through the candidate's
+        // inferred substitution, exactly as the non-tail slots already were.
+        var output = CompileAndRun("""
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Pick {
+                shared {
+                    func Take[T](values ...T) string { return "generic-carrier" }
+                    func Take(values IEnumerable[string]) string { return "sequence" }
+
+                    func Two[T](values ...T) string { return "generic-carrier" }
+                    func Two(refs IReadOnlyList[string], values ...string) string { return "two-param" }
+                }
+            }
+
+            func run() {
+                let arr = []string{"a"}
+                Console.WriteLine(Pick.Take(arr))
+                Console.WriteLine(Pick.Two(arr))
+            }
+
+            run()
+            """);
+
+        Assert.Equal($"generic-carrier{Environment.NewLine}generic-carrier{Environment.NewLine}", output);
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_3880_overload_").FullName;


### PR DESCRIPTION
## Root cause

C# §12.6.4.2: when a single trailing argument already **is** the params carrier, the candidate is applicable in **normal form** — that argument ranks against the carrier type, not the element type.

gsc's user-symbolic overload ranking (`OverloadResolver.SelectBestInstanceOverload`) classified that argument as an *expanded-form tail slot* and compared it to the element type. Two failures compounded:

1. the conversion kind was mis-rated (`[]string` against `string`), and
2. `ParamTypes[i]` is only populated on the non-tail branch, so the `Reference` "better conversion target" tie-break in `CompareUserConversions` was skipped (its `paramA != null && paramB != null` guard failed).

Both siblings landed on `Reference` with null parameter types, tied at 0, and then tied on every later axis — defaulted-parameter count, variadic-ness, genericity — so `GS0266` was reported.

Minimal repro (compiled with a locally built `gsc`):

```gs
class C {
    shared {
        func F(printedSources ...string) int32 { return 1 }
        func F(additionalReferencePaths IReadOnlyList[string]?, printedSources ...string) int32 { return 2 }
    }
}
let arr = []string{"a", "b"}
C.F(arr)   // GS0266 before; binds to overload 1 (as C# does) after
```

This is exactly the migrated `tools/cs2gs/Cs2Gs.Tests` pair `AssertBindsAgainstGsCore` at `Adr0169AnalyzerTranslationTests.gs` lines 788 and 820 — 2 sites, 1 of the 5 gate fingerprints on that app.

## Fix

The applicability filter already recognised this shape via `IsVariadicCarrierPassThrough`. Ranking now uses the same test: when the call binds the carrier whole, the slot is ranked as a normal-form slot against the carrier type.

## Verification

- New `test/Compiler.Tests/Emit/Issue3880VariadicPassThroughOverloadEmitTests.cs` — **executes**, so the *selected* overload is witnessed at runtime, not merely bound. ILVerify runs on the emitted assembly.
- `Core.Tests` filtered `Overload|Variadic|Params`: 479 passed.
- `Compiler.Tests` filtered `Overload|Variadic|Params`: 196 passed.

Part of #3501. Advances #3880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs