### PR TITLE
gsc: read `X.Member[i](args)` as indexer-then-invoke when the generic reading fails (#3880)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -672,6 +672,23 @@ internal sealed partial class ExpressionBinder
 
         if (!MemberLookup.TryGetDelegateFunctionTypeFromSymbol(callableType, out var functionType))
         {
+            // Issue #3880: ADR-0020 commits `X.Member[i](args)` to a GENERIC
+            // call site — a single bracketed simple name scans as a type clause
+            // and `(` is in the follow-set — and indexer-then-invoke was never
+            // reconsidered afterwards. A dictionary of factories
+            // (`GNodeSamples.All[type]()`) therefore reported GS0158 on the
+            // member, while the identical `let f = GNodeSamples.All[type]`
+            // followed by `f()` bound fine: the `.` follow-set already got this
+            // treatment for the single-argument shape in issue #942, the `(`
+            // follow-set did not. The parser cannot decide this — `Map[int](xs)`
+            // is a real generic instantiation with the same token shape — so
+            // the binder decides it, and only where the generic reading has
+            // already failed: the member is not itself callable.
+            if (TryBindIndexedCallableMemberInvocation(ce, memberLoad, arguments, out result))
+            {
+                return true;
+            }
+
             return false;
         }
 
@@ -769,6 +786,136 @@ internal sealed partial class ExpressionBinder
             memberLoad,
             callableType,
             functionType,
+            convertedArgs.MoveToImmutable());
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #3880: whether a bracketed list is the one shape where the
+    /// ADR-0020 generic-call-site commitment is genuinely ambiguous with an
+    /// indexer — a single bare identifier. Everything a type clause can spell
+    /// that an index expression cannot (<c>T?</c>, <c>[]T</c>, <c>List[T]</c>,
+    /// a qualified name, a tuple, a function type) stays unambiguously a type
+    /// argument.
+    /// </summary>
+    /// <param name="typeArgumentList">The bracketed list from the call site.</param>
+    /// <returns><see langword="true"/> when the bracket could equally be an index.</returns>
+    private static bool IsAmbiguousSingleIdentifierTypeArgument(TypeArgumentListSyntax? typeArgumentList)
+    {
+        if (typeArgumentList is not { } bracketed || bracketed.Arguments.Count != 1)
+        {
+            return false;
+        }
+
+        var item = bracketed.Arguments[0];
+        return item.Identifier != null
+            && !item.HasQualifier
+            && !item.IsArray
+            && !item.IsNullable
+            && !item.IsTuple
+            && item.FuncKeyword == null
+            && item.TypeArguments is not { Count: > 0 };
+    }
+
+    /// <summary>
+    /// Issue #3880: whether <paramref name="receiverType"/> has a readable
+    /// VALUE member (field or property) named <paramref name="memberName"/> —
+    /// the precondition for reading <c>receiver.Member[i](args)</c> as
+    /// indexer-then-invoke rather than as a generic method call.
+    /// </summary>
+    /// <param name="receiverType">The receiver's type.</param>
+    /// <param name="memberName">The member name at the call site.</param>
+    /// <returns><see langword="true"/> when such a member exists.</returns>
+    private static bool HasCallableIndexableValueMember(TypeSymbol receiverType, string memberName)
+    {
+        if (receiverType is StructSymbol structSymbol)
+        {
+            for (StructSymbol? current = structSymbol; current != null; current = current.BaseClass)
+            {
+                if (current.TryGetField(memberName, out _))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return TypeMemberModel.TryGetPropertyWithOwner(receiverType, memberName, out var property, out _)
+            && property is { HasGetter: true };
+    }
+
+    /// <summary>
+    /// Issue #3880: the indexer-then-invoke reading of <c>X.Member[i](args)</c>,
+    /// attempted only after the generic-method reading the parser committed to
+    /// has already failed and the member itself turned out not to be callable.
+    /// <para>
+    /// Deliberately narrow. The bracketed item must be a bare identifier — the
+    /// only shape that is genuinely ambiguous, because anything a type clause
+    /// can spell but an index expression cannot (<c>T?</c>, <c>[]T</c>,
+    /// <c>List[T]</c>, a qualified name) is unambiguously a type argument, and
+    /// anything an index expression can spell but a type clause cannot
+    /// (<c>All[0]()</c>, <c>All["k"]()</c>) never reached the generic reading
+    /// in the first place. The index bind is speculative: its diagnostics are
+    /// rolled back on failure so a genuine "no such generic method" still
+    /// reports the generic-reading diagnostic the caller would have produced.
+    /// </para>
+    /// </summary>
+    private bool TryBindIndexedCallableMemberInvocation(
+        CallExpressionSyntax ce,
+        BoundExpression memberLoad,
+        ImmutableArray<BoundExpression> arguments,
+        [NotNullWhen(true)] out BoundExpression? result)
+    {
+        result = null;
+
+        if (ce.NullableQuestionToken != null
+            || !IsAmbiguousSingleIdentifierTypeArgument(ce.TypeArgumentList)
+            || Invariant.Required(ce.TypeArgumentList, "an ambiguous bracket has a type-argument list").Arguments[0].Identifier
+                is not { } indexIdentifier)
+        {
+            return false;
+        }
+
+        var mark = Diagnostics.Count;
+        var indexed = BindIndexAgainstTarget(
+            memberLoad,
+            new NameExpressionSyntax(ce.SyntaxTree, indexIdentifier),
+            ce.Identifier.Location);
+
+        if (indexed is BoundErrorExpression
+            || Diagnostics.Count != mark
+            || indexed.Type == null
+            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(indexed.Type, out var indexedFunctionType)
+            || indexedFunctionType.ParameterTypes.Length != arguments.Length)
+        {
+            Diagnostics.TruncateTo(mark);
+            return false;
+        }
+
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var argLoc = i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
+            var argument = arguments[i];
+            if (argument is BoundErrorExpression { Syntax: LambdaExpressionSyntax lambda }
+                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(indexedFunctionType.ParameterTypes[i], out var lambdaTarget))
+            {
+                argument = lambdas.BindLambdaExpression(lambda, lambdaTarget);
+            }
+
+            convertedArgs.Add(conversions.BindConversion(argLoc, argument, indexedFunctionType.ParameterTypes[i]));
+        }
+
+        if (Diagnostics.Count != mark)
+        {
+            Diagnostics.TruncateTo(mark);
+            return false;
+        }
+
+        result = BuildDelegateMemberInvocation(
+            ce,
+            indexed,
+            indexed.Type,
+            indexedFunctionType,
             convertedArgs.MoveToImmutable());
         return true;
     }

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -684,12 +684,23 @@ internal sealed partial class ExpressionBinder
             // is a real generic instantiation with the same token shape — so
             // the binder decides it, and only where the generic reading has
             // already failed: the member is not itself callable.
-            if (TryBindIndexedCallableMemberInvocation(ce, memberLoad, arguments, out result))
+            //
+            // The indexed value REPLACES the callable and falls through, so
+            // everything below — named-delegate ref kinds, variadic packing,
+            // optional and named arguments — applies to it unchanged. An
+            // earlier revision converted the arguments here instead, which
+            // implemented only fixed-arity by-value shapes and rejected
+            // `b.Named[k](",", "a", "b", "c")` against a variadic named
+            // delegate.
+            if (!TryBindAmbiguousBracketAsIndex(ce, memberLoad, out var indexedValue)
+                || indexedValue.Type is not { } indexedType
+                || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(indexedType, out functionType))
             {
-                return true;
+                return false;
             }
 
-            return false;
+            memberLoad = indexedValue;
+            callableType = indexedType;
         }
 
         if (callableType is DelegateTypeSymbol namedDelegate)
@@ -839,8 +850,42 @@ internal sealed partial class ExpressionBinder
             }
         }
 
-        return TypeMemberModel.TryGetPropertyWithOwner(receiverType, memberName, out var property, out _)
-            && property is { HasGetter: true };
+        if (TypeMemberModel.TryGetPropertyWithOwner(receiverType, memberName, out var property, out _)
+            && property is { HasGetter: true })
+        {
+            return true;
+        }
+
+        // Issue #3880: the parser ambiguity this recovery exists for is
+        // receiver-AGNOSTIC — `x.Callbacks[key]()` reads identically whether
+        // `Callbacks` is declared in this compilation or comes from a
+        // referenced assembly. Recognising only source members would make the
+        // feature work or not purely by where the receiver was declared, which
+        // is not something a user can reason about from the call site. So the
+        // imported CLR field/property shapes are recognised on the same terms
+        // TryBindClrDelegateMemberInvocation uses: a readable non-indexer
+        // property first, then a field.
+        if (receiverType.ClrType is { } receiverClrType)
+        {
+            var clrProperty = ClrTypeUtilities.SafeGetProperty(
+                receiverClrType,
+                memberName,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            if (clrProperty is { CanRead: true } && clrProperty.GetIndexParameters().Length == 0)
+            {
+                return true;
+            }
+
+            if (ClrTypeUtilities.SafeGetField(
+                    receiverClrType,
+                    memberName,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static) != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -859,13 +904,12 @@ internal sealed partial class ExpressionBinder
     /// reports the generic-reading diagnostic the caller would have produced.
     /// </para>
     /// </summary>
-    private bool TryBindIndexedCallableMemberInvocation(
+    private bool TryBindAmbiguousBracketAsIndex(
         CallExpressionSyntax ce,
         BoundExpression memberLoad,
-        ImmutableArray<BoundExpression> arguments,
-        [NotNullWhen(true)] out BoundExpression? result)
+        [NotNullWhen(true)] out BoundExpression? indexed)
     {
-        result = null;
+        indexed = null;
 
         if (ce.NullableQuestionToken != null
             || !IsAmbiguousSingleIdentifierTypeArgument(ce.TypeArgumentList)
@@ -876,47 +920,20 @@ internal sealed partial class ExpressionBinder
         }
 
         var mark = Diagnostics.Count;
-        var indexed = BindIndexAgainstTarget(
+        var bound = BindIndexAgainstTarget(
             memberLoad,
             new NameExpressionSyntax(ce.SyntaxTree, indexIdentifier),
             ce.Identifier.Location);
 
-        if (indexed is BoundErrorExpression
+        if (bound is BoundErrorExpression
             || Diagnostics.Count != mark
-            || indexed.Type == null
-            || !MemberLookup.TryGetDelegateFunctionTypeFromSymbol(indexed.Type, out var indexedFunctionType)
-            || indexedFunctionType.ParameterTypes.Length != arguments.Length)
+            || bound.Type == null)
         {
             Diagnostics.TruncateTo(mark);
             return false;
         }
 
-        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(arguments.Length);
-        for (var i = 0; i < arguments.Length; i++)
-        {
-            var argLoc = i < ce.Arguments.Count ? ce.Arguments[i].Location : ce.Location;
-            var argument = arguments[i];
-            if (argument is BoundErrorExpression { Syntax: LambdaExpressionSyntax lambda }
-                && MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(indexedFunctionType.ParameterTypes[i], out var lambdaTarget))
-            {
-                argument = lambdas.BindLambdaExpression(lambda, lambdaTarget);
-            }
-
-            convertedArgs.Add(conversions.BindConversion(argLoc, argument, indexedFunctionType.ParameterTypes[i]));
-        }
-
-        if (Diagnostics.Count != mark)
-        {
-            Diagnostics.TruncateTo(mark);
-            return false;
-        }
-
-        result = BuildDelegateMemberInvocation(
-            ce,
-            indexed,
-            indexed.Type,
-            indexedFunctionType,
-            convertedArgs.MoveToImmutable());
+        indexed = bound;
         return true;
     }
 
@@ -1030,7 +1047,7 @@ internal sealed partial class ExpressionBinder
             System.Reflection.FieldInfo f => f.FieldType,
             _ => null,
         };
-        if (memberClrType == null || !ClrTypeUtilities.IsDelegateType(memberClrType))
+        if (memberClrType == null)
         {
             return false;
         }
@@ -1044,6 +1061,29 @@ internal sealed partial class ExpressionBinder
 
         BoundExpression delegateLoad = ApplyMemberNarrowing(
             new BoundClrPropertyAccessExpression(null, receiver, member, memberTypeSymbol));
+
+        if (!ClrTypeUtilities.IsDelegateType(memberClrType))
+        {
+            // Issue #3880, the imported twin of the source-receiver recovery in
+            // TryBindUserCallableMemberInvocation. `x.Callbacks[key]()` where
+            // `Callbacks` is a CLR field/property of a referenced assembly is
+            // the SAME parser ambiguity; binding it only for source-declared
+            // receivers would make the feature depend on which assembly the
+            // type happened to be compiled into. The indexed value replaces the
+            // delegate load and falls through to the same `Invoke` dispatch
+            // below, which already owns named arguments, ref/in/out and
+            // variadic packing.
+            if (!TryBindAmbiguousBracketAsIndex(ce, delegateLoad, out var indexedValue)
+                || indexedValue.Type?.ClrType is not { } indexedClrType
+                || !ClrTypeUtilities.IsDelegateType(indexedClrType))
+            {
+                return false;
+            }
+
+            delegateLoad = indexedValue;
+            memberClrType = indexedClrType;
+        }
+
         var effectiveMemberType = delegateLoad.Type;
 
         if (ce.NullableQuestionToken == null

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -2737,10 +2737,28 @@ internal sealed partial class ExpressionBinder
         // Issue #311: resolve an explicit `[T1, T2]` type-argument list (e.g.
         // `Array.Empty[string]()`) into mapped CLR types up front so every
         // generic-method dispatch path below can close the candidate.
+        var typeArgMark = Diagnostics.Count;
         if (!TryResolveExplicitMethodTypeArgs(ce.TypeArgumentList, out var explicitTypeArgs, out var typeArgSymbols))
         {
-            Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
-            return new BoundErrorExpression(null);
+            // Issue #3880: `receiver.Member[i](args)` is committed to a generic
+            // call site by ADR-0020's follow-set rule, so `i` is resolved here
+            // as a TYPE and the call dies with "type 'i' doesn't exist" before
+            // the indexer-then-invoke reading is ever considered. Recover only
+            // where that reading is actually available — the bracket holds a
+            // bare identifier and the receiver really has a VALUE member of
+            // this name — so a genuine unresolvable type argument on a generic
+            // method still reports its own diagnostic.
+            if (!IsAmbiguousSingleIdentifierTypeArgument(ce.TypeArgumentList)
+                || receiver?.Type is not { } receiverType
+                || !HasCallableIndexableValueMember(receiverType, methodName))
+            {
+                Diagnostics.ReportUnableToFindFunction(ce.Location, methodName);
+                return new BoundErrorExpression(null);
+            }
+
+            Diagnostics.TruncateTo(typeArgMark);
+            explicitTypeArgs = null;
+            typeArgSymbols = default;
         }
 
         var boundArguments = ImmutableArray.CreateBuilder<BoundExpression>();

--- a/test/Compiler.Tests/Emit/Issue3880IndexedCallableMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3880IndexedCallableMemberEmitTests.cs
@@ -1,0 +1,210 @@
+// <copyright file="Issue3880IndexedCallableMemberEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3880: ADR-0020's follow-set rule commits <c>X.Member[i](args)</c> to
+/// a generic call site, and indexer-then-invoke was never reconsidered — so a
+/// dictionary of factories (<c>GNodeSamples.All[type]()</c> in the migrated
+/// <c>tools/cs2gs/Cs2Gs.Tests</c>) reported GS0158/GS0159 while the identical
+/// <c>let f = GNodeSamples.All[type]</c> followed by <c>f()</c> bound fine.
+/// The binder now falls back to the indexed reading, but only where the
+/// generic reading has already failed, the bracket holds a bare identifier
+/// (the one genuinely ambiguous shape), and the member really is a value.
+/// Pinned end to end so the emitted call is executed, not merely bound.
+/// </summary>
+public class Issue3880IndexedCallableMemberEmitTests
+{
+    [Fact]
+    public void IndexedCallableMember_InvokesThroughStaticAndInstanceReceivers()
+    {
+        var output = CompileAndRun("""
+            package P
+            import System
+            import System.Collections.Generic
+
+            class Samples {
+                shared {
+                    let All Dictionary[Type, Func[string]] = Dictionary[Type, Func[string]]()
+                    func Seed() {
+                        All[typeof(string)] = func() string { return "made-string" }
+                    }
+                }
+            }
+
+            class Box {
+                var Table Dictionary[string, Func[int32, string]] = Dictionary[string, Func[int32, string]]()
+                var Rows []Func[string] = []Func[string]{}
+            }
+
+            class Generic {
+                shared {
+                    func Make[T]() string { return typeof(T).Name }
+                }
+            }
+
+            func Main() {
+                Samples.Seed()
+                let t = typeof(string)
+
+                // Static receiver, indexer then invoke.
+                Console.WriteLine(Samples.All[t]())
+
+                // The un-invoked form has always worked; it must keep working.
+                let f = Samples.All[t]
+                Console.WriteLine(f())
+
+                // Instance receiver, indexer then invoke — with an argument.
+                let b = Box()
+                let key = "k"
+                b.Table[key] = func(n int32) string { return "n=" + n.ToString() }
+                Console.WriteLine(b.Table[key](7))
+
+                // An array-typed member indexed by a local, then invoked.
+                b.Rows = []Func[string]{func() string { return "row0" }}
+                let i = 0
+                Console.WriteLine(b.Rows[i]())
+
+                // The GENERIC reading must still win where it is the real one.
+                Console.WriteLine(Generic.Make[int32]())
+            }
+            """);
+
+        Assert.Equal(
+            "made-string" + Environment.NewLine
+                + "made-string" + Environment.NewLine
+                + "n=7" + Environment.NewLine
+                + "row0" + Environment.NewLine
+                + "Int32" + Environment.NewLine,
+            output);
+    }
+
+    [Fact]
+    public void UnresolvableTypeArgumentOnAGenericMethod_StillReportsItsOwnDiagnostic()
+    {
+        // The recovery must not swallow the diagnostic for a genuine bad type
+        // argument: it only fires when the receiver really has a value member
+        // of that name.
+        var errors = CompileExpectingErrors("""
+            package P
+            import System
+
+            class Holder {
+                func Pick[T]() string { return typeof(T).Name }
+                shared {
+                    func Make[T]() string { return typeof(T).Name }
+                }
+            }
+
+            func Main() {
+                let h = Holder()
+                Console.WriteLine(h.Pick[NotAType]())
+                Console.WriteLine(Holder.Make[AlsoNotAType]())
+            }
+            """);
+
+        Assert.Contains("GS0113", errors, StringComparison.Ordinal);
+        Assert.Contains("NotAType", errors, StringComparison.Ordinal);
+        Assert.Contains("AlsoNotAType", errors, StringComparison.Ordinal);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3880_indexed_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+            RunGsc(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", srcPath });
+            IlVerifier.Verify(outPath);
+
+            var psi = new System.Diagnostics.ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = System.Diagnostics.Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(proc.ExitCode == 0, $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private static string CompileExpectingErrors(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3880_indexed_neg_").FullName;
+        var srcPath = Path.Combine(tempDir, "test.gs");
+        var outPath = Path.Combine(tempDir, "test.dll");
+        File.WriteAllText(srcPath, source);
+
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", srcPath });
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(compileExit != 0, "the bad type arguments should still fail the compile");
+        return compileOut.ToString() + compileErr.ToString();
+    }
+
+    private static void RunGsc(string[] args)
+    {
+        using var compileOut = new StringWriter();
+        using var compileErr = new StringWriter();
+        var prevOut = Console.Out;
+        var prevErr = Console.Error;
+        Console.SetOut(compileOut);
+        Console.SetError(compileErr);
+        int compileExit;
+        try
+        {
+            compileExit = Program.Main(args);
+        }
+        finally
+        {
+            Console.SetOut(prevOut);
+            Console.SetError(prevErr);
+        }
+
+        Assert.True(
+            compileExit == 0,
+            $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+    }
+}

--- a/test/Compiler.Tests/Emit/Issue3880IndexedCallableMemberEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3880IndexedCallableMemberEmitTests.cs
@@ -114,6 +114,132 @@ public class Issue3880IndexedCallableMemberEmitTests
         Assert.Contains("AlsoNotAType", errors, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void IndexedNamedDelegate_KeepsVariadicAndNamedArgumentSupport()
+    {
+        // Review finding on PR #3966: the first revision converted the
+        // arguments itself with an exact-arity check and a plain by-value
+        // loop, so anything the canonical argument binders handle — variadic
+        // packing, optional/named arguments, ref-kind metadata — was lost.
+        // `b.Named[k](",", "a", "b", "c")` (arity 2, four arguments) reported
+        // GS0159. The indexed value now REPLACES the callable and falls
+        // through to the same machinery the non-indexed delegate member uses.
+        var output = CompileAndRun("""
+            package P
+            import System
+            import System.Collections.Generic
+
+            delegate Joiner(sep string, parts ...string) string;
+
+            class Box {
+                var Named Dictionary[string, Joiner] = Dictionary[string, Joiner]()
+            }
+
+            func Main() {
+                let b = Box()
+                let k = "k"
+                b.Named[k] = func(sep string, parts ...string) string { return string.Join(sep, parts) }
+                Console.WriteLine(b.Named[k](",", "a", "b", "c"))
+                Console.WriteLine(b.Named[k]("-"))
+            }
+            """);
+
+        Assert.Equal($"a,b,c{Environment.NewLine}{Environment.NewLine}", output);
+    }
+
+    [Fact]
+    public void IndexedCallableMember_WorksThroughAnImportedReceiver()
+    {
+        // Review finding on PR #3966: the parser ambiguity is receiver-agnostic,
+        // so the recovery must not depend on whether the receiver's type was
+        // declared in this compilation. Before the fix this exact consumer
+        // reported GS0159 + a misleading GS0113 ("Type 'k' doesn't exist" for a
+        // local variable) purely because `Registry` came from a reference.
+        var output = CompileLibraryAndRun(
+            library: """
+                package LibIndexed
+                import System
+                import System.Collections.Generic
+
+                class Registry {
+                    var Callbacks Dictionary[string, Func[string]] = Dictionary[string, Func[string]]()
+                }
+                """,
+            consumer: """
+                package P
+                import System
+                import System.Collections.Generic
+                import LibIndexed
+
+                func Main() {
+                    let r = Registry()
+                    let k = "k"
+                    r.Callbacks[k] = func() string { return "from-imported" }
+                    Console.WriteLine(r.Callbacks[k]())
+                }
+                """);
+
+        Assert.Equal($"from-imported{Environment.NewLine}", output);
+    }
+
+    private static string CompileLibraryAndRun(string library, string consumer)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3880_indexed_lib_").FullName;
+        try
+        {
+            var libSrc = Path.Combine(tempDir, "lib.gs");
+
+            // ilverify resolves a reference by SIMPLE ASSEMBLY NAME against the
+            // file name, so the output file has to be named for the package or
+            // the consumer fails to verify with FileLoadErrorGeneric.
+            var libDll = Path.Combine(tempDir, "LibIndexed.dll");
+            File.WriteAllText(libSrc, library);
+            RunGsc(new[] { "/out:" + libDll, "/target:library", "/targetframework:net10.0", libSrc });
+
+            var consumerSrc = Path.Combine(tempDir, "consumer.gs");
+            var consumerDll = Path.Combine(tempDir, "consumer.dll");
+            File.WriteAllText(consumerSrc, consumer);
+            RunGsc(new[]
+            {
+                "/out:" + consumerDll,
+                "/target:exe",
+                "/targetframework:net10.0",
+                "/r:" + libDll,
+                consumerSrc,
+            });
+            IlVerifier.Verify(consumerDll, new[] { libDll });
+
+            var psi = new System.Diagnostics.ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(consumerDll, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(consumerDll);
+
+            using var proc = System.Diagnostics.Process.Start(psi)!;
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(proc.ExitCode == 0, $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
     private static string CompileAndRun(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_3880_indexed_").FullName;
@@ -159,29 +285,42 @@ public class Issue3880IndexedCallableMemberEmitTests
     private static string CompileExpectingErrors(string source)
     {
         var tempDir = Directory.CreateTempSubdirectory("gs_3880_indexed_neg_").FullName;
-        var srcPath = Path.Combine(tempDir, "test.gs");
-        var outPath = Path.Combine(tempDir, "test.dll");
-        File.WriteAllText(srcPath, source);
-
-        using var compileOut = new StringWriter();
-        using var compileErr = new StringWriter();
-        var prevOut = Console.Out;
-        var prevErr = Console.Error;
-        Console.SetOut(compileOut);
-        Console.SetError(compileErr);
-        int compileExit;
         try
         {
-            compileExit = Program.Main(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", srcPath });
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[] { "/out:" + outPath, "/target:exe", "/targetframework:net10.0", srcPath });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(compileExit != 0, "the bad type arguments should still fail the compile");
+            return compileOut.ToString() + compileErr.ToString();
         }
         finally
         {
-            Console.SetOut(prevOut);
-            Console.SetError(prevErr);
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
         }
-
-        Assert.True(compileExit != 0, "the bad type arguments should still fail the compile");
-        return compileOut.ToString() + compileErr.ToString();
     }
 
     private static void RunGsc(string[] args)


### PR DESCRIPTION
## Root cause

ADR-0020's follow-set rule commits `Name[...]` to a **generic call site** whenever the bracket contents scan as type clauses and the next token is one of `(`, `{`, `.`. The `(` marker is arity-agnostic, so a single bracketed *simple name* is committed too — and indexer-then-invoke is never reconsidered afterwards.

```gs
class Samples {
    shared {
        let All Dictionary[Type, Func[string]] = Dictionary[Type, Func[string]]()
    }
}

Samples.All[t]()          // error GS0158: Cannot find member All
let f = Samples.All[t]    // binds fine
f()                       // binds fine
```

Issue #942 already made this call for the `.` follow-set — a single bracketed argument followed by `.` is an indexer, because an indexer can only ever hold one index. The `(` follow-set never got the equivalent treatment.

This is the `Coverage/PrinterExhaustivenessTests.gs:57` site (`GNodeSamples.All[type]()`) — 1 of the 5 gate fingerprints on the migrated `tools/cs2gs/Cs2Gs.Tests`.

## Why the parser cannot fix it

`Map[int](xs)` is a genuine generic instantiation with the identical token shape. The two readings are distinguishable only by what `All` / `Map` turns out to be, which is a binder fact. So the parser keeps its commitment and the **binder** falls back — and only after the generic reading has already failed.

## Fix

Two edits, one rule.

- **`ExpressionBinder.Calls.Arguments`** — inside `TryBindUserCallableMemberInvocation`, once the member turns out not to be callable, bind the bracketed identifier as an **index** against the member load and, when the result is a delegate of matching arity, invoke it. The index bind is speculative (`Diagnostics.TruncateTo` on failure), so a genuine "no such generic method" still reports the diagnostic the caller would have produced.
- **`ExpressionBinder.Calls.Invocation`** — the instance path resolves the type-argument list eagerly and bailed with `GS0113: Type 'key' doesn't exist` long before the member was looked at. It now falls through to the indexed reading, but **only** when the bracket is a bare identifier *and* the receiver really has a readable value member of that name.

Only a bare identifier is treated as ambiguous:

- anything a type clause can spell that an index cannot (`T?`, `[]T`, `List[T]`, a qualified name, a tuple, a function type) stays a type argument;
- anything an index can spell that a type clause cannot (`All[0]()`, `All["k"]()`) never reached the generic reading in the first place.

## Verification

`test/Compiler.Tests/Emit/Issue3880IndexedCallableMemberEmitTests.cs` — **executes** end to end (ILVerify + run), covering static receiver, instance receiver with an argument, an array-typed member, the un-invoked form, and `Generic.Make[int32]()` as the control that the generic reading must still win. A second test pins that `h.Pick[NotAType]()` and `Holder.Make[AlsoNotAType]()` keep reporting their own `GS0113` rather than having it swallowed by the recovery.

Full `Core.Tests`: 8904 passed.

Part of #3501. Advances #3880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs