### PR TITLE
cs2gs tests: build the ADR-0169 parity control from the analyzer's own source (#3880)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerParityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerParityTests.cs
@@ -11,7 +11,6 @@ using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Analyzers;
 using Cs2Gs.Translator.Loading;
-using GSharp.InternalAnalyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
@@ -137,8 +136,14 @@ namespace App
         LoadedCSharpProject corpus = CSharpProjectLoader.LoadInMemory(new[] { ("Corpus.cs", CorpusSource) });
         Assert.True(corpus.BoundWithoutErrors, string.Join("\n", corpus.ErrorDiagnostics));
 
+        // Issue #3880: the Roslyn control is compiled from the analyzer's own
+        // source rather than named through the InternalAnalyzers project
+        // reference, which does not survive self-migration (ADR-0169 retargets
+        // that project onto the G# analyzer API).
+        DiagnosticAnalyzer roslynAnalyzer = Adr0169TranslatedAnalyzerHarness.CompileRoslynAnalyzer(
+            "StructFieldDefsReadAnalyzer.cs", "StructFieldDefsReadAnalyzer");
         var withAnalyzers = corpus.Compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(new StructFieldDefsReadAnalyzer()));
+            ImmutableArray.Create<DiagnosticAnalyzer>(roslynAnalyzer));
         return withAnalyzers.GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult()
             .Where(d => d.Id == "GSA0001")
             .OrderBy(d => d.Location.SourceSpan.Start)

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169Gsa0005ParityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169Gsa0005ParityTests.cs
@@ -11,7 +11,6 @@ using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Analyzers;
 using Cs2Gs.Translator.Loading;
-using GSharp.InternalAnalyzers;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 
@@ -22,7 +21,7 @@ namespace Cs2Gs.Tests;
 /// covered GSA0001 only, so a translated rule that stopped firing altogether
 /// passed every negative test and was caught only by a full migration run —
 /// which is exactly how #3795 escaped. This class runs the REAL Roslyn
-/// <see cref="RewriterClonePreservationAnalyzer"/> over each snippet of
+/// <c>RewriterClonePreservationAnalyzer</c> over each snippet of
 /// <c>test/InternalAnalyzers.Tests</c>, translates BOTH the snippet and the
 /// analyzer with cs2gs, compiles the translated analyzer with the real G#
 /// compiler, runs it over the translated snippet through the same host gsc
@@ -227,8 +226,13 @@ class ViaBaseResult : BoundTreeRewriter
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", csharpSource) });
         Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+        // Issue #3880: see Adr0169TranslatedAnalyzerHarness.CompileRoslynAnalyzer —
+        // the control is compiled from the analyzer's own source so the Roslyn
+        // half of the parity check survives self-migration.
+        DiagnosticAnalyzer roslynAnalyzer = Adr0169TranslatedAnalyzerHarness.CompileRoslynAnalyzer(
+            "RewriterClonePreservationAnalyzer.cs", "RewriterClonePreservationAnalyzer");
         return project.Compilation
-            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new RewriterClonePreservationAnalyzer()))
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(roslynAnalyzer))
             .GetAnalyzerDiagnosticsAsync().GetAwaiter().GetResult()
             .Count(d => d.Id == "GSA0005");
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169TranslatedAnalyzerHarness.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169TranslatedAnalyzerHarness.cs
@@ -6,10 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Analyzers;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Emit;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -33,6 +37,51 @@ public static class DiagnosticDescriptors
         ""GSA0001"", ""T"", ""M"", ""GSharp.InternalAnalyzers"", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 }
 ";
+
+    /// <summary>
+    /// Issue #3880: builds the parity tests' ROSLYN control by compiling one
+    /// real analyzer's own C# source with Roslyn and instantiating it out of
+    /// the emitted assembly, instead of naming the type from a project
+    /// reference on <c>src/Analyzers/InternalAnalyzers</c>.
+    /// <para>
+    /// The project reference does not survive self-migration: cs2gs retargets
+    /// <c>InternalAnalyzers</c> onto the G# analyzer API (ADR-0169), so the
+    /// migrated <c>StructFieldDefsReadAnalyzer</c> is a
+    /// <c>GSharpDiagnosticAnalyzer</c> and
+    /// <c>ImmutableArray.Create[DiagnosticAnalyzer](StructFieldDefsReadAnalyzer())</c>
+    /// has no applicable overload — the whole Roslyn half of the parity check
+    /// stops binding. Compiling the analyzer's source is also the more honest
+    /// control: it is exactly what the G# half already does (translate and
+    /// compile the same file), so both sides now start from the same bytes on
+    /// disk rather than one side starting from a build output.
+    /// </para>
+    /// </summary>
+    /// <param name="analyzerFileName">The analyzer source file name under <c>src/Analyzers/InternalAnalyzers</c>.</param>
+    /// <param name="analyzerTypeName">The analyzer type's simple name.</param>
+    /// <returns>A live Roslyn analyzer instance.</returns>
+    public static DiagnosticAnalyzer CompileRoslynAnalyzer(string analyzerFileName, string analyzerTypeName)
+    {
+        string analyzerDirectory = Path.Combine(
+            FindRepoRoot(), "src", "Analyzers", "InternalAnalyzers");
+
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[]
+        {
+            (analyzerFileName, File.ReadAllText(Path.Combine(analyzerDirectory, analyzerFileName))),
+            ("DiagnosticDescriptors.cs", File.ReadAllText(Path.Combine(analyzerDirectory, "DiagnosticDescriptors.cs"))),
+        });
+        Assert.True(project.BoundWithoutErrors, string.Join("\n", project.ErrorDiagnostics));
+
+        using var peStream = new MemoryStream();
+        EmitResult emitResult = project.Compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            $"Roslyn control analyzer {analyzerTypeName} should compile:\n"
+                + string.Join("\n", emitResult.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+
+        Assembly assembly = Assembly.Load(peStream.ToArray());
+        Type analyzerType = assembly.GetType("GSharp.InternalAnalyzers." + analyzerTypeName, throwOnError: true);
+        return (DiagnosticAnalyzer)Activator.CreateInstance(analyzerType);
+    }
 
     /// <summary>
     /// Translates and compiles the real GSA0001 into an analyzer assembly.


### PR DESCRIPTION
## Root cause — a test premise that stops holding once the repo migrates itself

The two ADR-0169 parity tests named their Roslyn control through the `GSharp.InternalAnalyzers` **project reference**:

```csharp
ImmutableArray.Create<DiagnosticAnalyzer>(new StructFieldDefsReadAnalyzer())
ImmutableArray.Create<DiagnosticAnalyzer>(new RewriterClonePreservationAnalyzer())
```

cs2gs retargets `src/Analyzers/InternalAnalyzers` onto the G# analyzer API (ADR-0169), so in the migrated tree those types are `GSharpDiagnosticAnalyzer`, not Roslyn `DiagnosticAnalyzer`. There is no applicable overload, and the whole fluent chain cascades:

```
GS0159 Cannot find function WithAnalyzers
GS0159 Cannot find function Create
GS0159 Cannot find function GetAnalyzerDiagnosticsAsync
```

None of which mentions the real problem — a masking shape of the #3823/#3842 family. **4 sites, 3 of the 5 `tools/cs2gs/Cs2Gs.Tests` gate fingerprints** on the newest completed nightly (`33973595210`, `run.merged.json`).

This is a **test defect**, not a translation defect and not a compiler defect: `Cs2Gs.Tests` cannot both migrate itself and keep a build-output reference to a project that migration deliberately retargets.

## Fix

New `Adr0169TranslatedAnalyzerHarness.CompileRoslynAnalyzer(analyzerFileName, analyzerTypeName)` compiles the analyzer's **own C# source** with Roslyn (via the loader the harness already uses), emits it to memory, loads it and instantiates the analyzer as a `DiagnosticAnalyzer`.

Nothing about what the test measures changes, and the two halves become symmetric: the G# half already reads the same file off disk, translates it in analyzer mode and compiles it with `gsc`. Both sides now start from the same bytes instead of one side starting from a build output — arguably a better control than the original.

No G# language surface was added to accommodate this; the new code is ordinary reflection that already translates.

## Verification

Both parity suites green in C#: 8 passed (`Adr0169AnalyzerParityTests`, `Adr0169Gsa0005ParityTests`).

Part of #3501. Advances #3880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs