### PR TITLE
cs2gs: use analyzer detector verdict for project transforms (#3791)

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -206,12 +206,10 @@ Detection is per project on both halves: `AnalyzerProjectDetector` gained
 `IsAnalyzerTestProject` — a project that **declares an analyzer test harness**
 (`IsAnalyzerTestHarnessEntry`: a static method taking a `DiagnosticAnalyzer` and
 a source `string`) **and** instantiates an analyzer declared in a referenced,
-non-Roslyn assembly — and `GSharpProjectTransformer` recognizes the
-structural counterpart (a `ProjectReference` to an analyzer project that is not
-an `OutputItemType="Analyzer"` consumer reference) to inject the two assemblies
-the migrated tests bind — `GSharp.Core` and the verifier — both copied to the
-test output, because a test assembly is loaded by the test host rather than by
-gsc.
+non-Roslyn assembly. The pipeline passes that verdict to
+`GSharpProjectTransformer`, which uses it to inject the two assemblies the
+migrated tests bind — `GSharp.Core` and the verifier — both copied to the test
+output, because a test assembly is loaded by the test host rather than by gsc.
 
 Why the harness, and not instantiation alone (issue #3789): analyzer mode maps
 a project's **whole** `Microsoft.CodeAnalysis` surface, so it may only claim a

--- a/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/CompileStage.cs
@@ -82,6 +82,7 @@ public sealed class CompileStage : IMigrationStage
                         context.ArtifactDir,
                         context.Options.Config,
                         context.Options.GeneratedProjectPaths,
+                        context.IsAnalyzerTestProject,
                         survey ? NullAssertionPolishPass.SurveyWarningsNotAsErrors : null)
                     : runner.Compile(
                         context.ProjectOutputDir,

--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -41,12 +41,16 @@ internal static class GSharpProjectTransformer
     /// <param name="generatedProjectPaths">
     /// Canonical source-project paths mapped to their generated project paths.
     /// </param>
+    /// <param name="isAnalyzerTestProject">
+    /// The translate-stage detector's analyzer-test-project verdict.
+    /// </param>
     /// <returns>The transformed project document.</returns>
     internal static XDocument Transform(
         string sourceProjectPath,
         string destinationProjectDirectory,
         string gsharpSdk,
-        IReadOnlyDictionary<string, string> generatedProjectPaths)
+        IReadOnlyDictionary<string, string> generatedProjectPaths,
+        bool isAnalyzerTestProject = false)
     {
         if (sourceProjectPath is null)
         {
@@ -77,11 +81,6 @@ internal static class GSharpProjectTransformer
         string sourceProjectDirectory = Path.GetDirectoryName(Path.GetFullPath(sourceProjectPath));
         string fullDestinationDirectory = Path.GetFullPath(destinationProjectDirectory);
 
-        // ADR-0169 M5 / issue #3686: read while the ProjectReference includes
-        // still point at the SOURCE .csproj files — RewriteProjectReferences
-        // below repoints them at the generated .gsproj paths.
-        bool referencesAnalyzerProject = ReferencesAnAnalyzerProject(document, sourceProjectDirectory);
-
         RewriteProjectReferences(
             document,
             sourceProjectDirectory,
@@ -96,7 +95,7 @@ internal static class GSharpProjectTransformer
         RewriteOutputType(document);
         RewriteCompileItems(document);
         RewriteCSharpMetadata(document);
-        RewriteAnalyzerProject(document, referencesAnalyzerProject);
+        RewriteAnalyzerProject(document, isAnalyzerTestProject);
         RewriteAnalyzerConsumerReferences(document);
 
         return document;
@@ -480,18 +479,15 @@ internal static class GSharpProjectTransformer
     // netstandard2.0 does not exist for G#), drops the Roslyn compiler
     // packages and Roslyn-analyzer-authoring properties, and references the
     // G# analyzer API assembly loaded by the compiler host.
-    private static void RewriteAnalyzerProject(XDocument document, bool referencesAnalyzerProject)
+    private static void RewriteAnalyzerProject(XDocument document, bool isAnalyzerTestProject)
     {
         bool isAnalyzerProject = IsAnalyzerProjectXml(document);
 
         // ADR-0169 M5 / issue #3686: the analyzer's TEST project gets the same
         // treatment — it too translates in analyzer-API mode, so its Roslyn
         // packages are gone and it binds the G# analyzer API plus the verifier.
-        // It is recognized structurally: it project-references an analyzer
-        // project. (The translator's own detector is semantic; the transformer
-        // has no compilation, which is why the two live apart — see
-        // docs/cs2gs-analyzer-translation.md §Detection.)
-        bool isAnalyzerTestProject = !isAnalyzerProject && referencesAnalyzerProject;
+        // Issue #3791: consume the semantic detector's verdict rather than
+        // re-deriving test-project status from a ProjectReference.
         if (!isAnalyzerProject && !isAnalyzerTestProject)
         {
             return;
@@ -576,56 +572,6 @@ internal static class GSharpProjectTransformer
                     AttributeNamed(reference, "PrivateAssets")?.Value?.Trim(),
                     "all",
                     StringComparison.OrdinalIgnoreCase));
-
-    // MSBuild item metadata may be written as an attribute or a child element;
-    // read either.
-    private static string Metadata(XElement item, string name)
-        => AttributeNamed(item, name)?.Value?.Trim()
-            ?? item.Elements().FirstOrDefault(child =>
-                string.Equals(child.Name.LocalName, name, StringComparison.OrdinalIgnoreCase))?.Value?.Trim();
-
-    private static bool ReferencesAnAnalyzerProject(XDocument document, string sourceProjectDirectory)
-    {
-        if (string.IsNullOrEmpty(sourceProjectDirectory))
-        {
-            return false;
-        }
-
-        foreach (XElement reference in ElementsNamed(document, "ProjectReference"))
-        {
-            string include = AttributeNamed(reference, "Include")?.Value;
-            if (string.IsNullOrWhiteSpace(include))
-            {
-                continue;
-            }
-
-            // An analyzer's CONSUMER (src/Core: OutputItemType="Analyzer",
-            // ReferenceOutputAssembly="false") references the analyzer to RUN
-            // it, not to compile against it — it is ordinary C# and must keep
-            // its own Roslyn packages. Only a reference that pulls the
-            // analyzer's assembly in as a library marks a test project.
-            if (string.Equals(Metadata(reference, "OutputItemType"), "Analyzer", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(Metadata(reference, "ReferenceOutputAssembly"), "false", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            string referencedPath = Path.GetFullPath(Path.Combine(
-                sourceProjectDirectory,
-                include.Trim().Replace('\\', Path.DirectorySeparatorChar)));
-            if (!File.Exists(referencedPath))
-            {
-                continue;
-            }
-
-            if (IsAnalyzerProjectXml(XDocument.Parse(File.ReadAllText(referencedPath))))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     // ADR-0169: retain analyzer project references while changing Roslyn's
     // analyzer item type to the G# SDK item type.

--- a/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/IMigrationStage.cs
@@ -163,6 +163,11 @@ public sealed class StageExecutionContext
     public bool IsAnalyzerProject { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the analyzer detector classified the app as a test project.
+    /// </summary>
+    public bool IsAnalyzerTestProject { get; set; }
+
+    /// <summary>
     /// Gets the source project's declared build/dev-only <c>PackageReference</c>s
     /// (issue #2267) — e.g. a version-bumped <c>Nerdbank.GitVersioning</c> — that
     /// must be re-declared into the isolated <c>--via-sdk</c> gsproj because they

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -204,6 +204,8 @@ public sealed class MigrationPipeline
                     "Could not resolve a local Gsharp.NET.Sdk package for the mirrored projects.");
             }
 
+            this.options.RepositorySdkMoniker = sdkMoniker;
+
             foreach (CorpusApp app in apps)
             {
                 string generatedProjectPath =

--- a/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
@@ -131,6 +131,9 @@ public sealed class PipelineOptions
     /// <summary>Gets or sets source projects loaded once for repository-wide analysis.</summary>
     internal IReadOnlyDictionary<string, LoadedCSharpProject> RepositoryLoadedProjects { get; set; }
 
+    /// <summary>Gets or sets the pinned SDK moniker used by repository project transforms.</summary>
+    internal string RepositorySdkMoniker { get; set; }
+
     /// <summary>Gets or sets extra G# files required when one C# file declares multiple namespaces.</summary>
     internal ISet<string> RepositoryAdditionalFiles { get; set; }
 

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -86,6 +86,7 @@ public sealed class SdkCompileRunner
     /// <param name="artifactDirectory">The external build and log directory.</param>
     /// <param name="config">The build configuration.</param>
     /// <param name="generatedProjectPaths">The complete source-to-generated project map.</param>
+    /// <param name="isAnalyzerTestProject">The translate-stage detector's analyzer-test-project verdict.</param>
     /// <param name="warningsNotAsErrors">
     /// Issue #3782: diagnostic ids to keep at warning severity for this build
     /// despite the mirror's <c>TreatWarningsAsErrors</c>. The redundant-<c>!!</c>
@@ -99,6 +100,7 @@ public sealed class SdkCompileRunner
         string artifactDirectory,
         string config,
         IReadOnlyDictionary<string, string> generatedProjectPaths,
+        bool isAnalyzerTestProject,
         string warningsNotAsErrors = null)
     {
         string repoRoot = GsharpTestProjectRunner.FindRepoRoot();
@@ -119,7 +121,8 @@ public sealed class SdkCompileRunner
             sourceProjectPath,
             projectDirectory,
             sdkMoniker,
-            generatedProjectPaths);
+            generatedProjectPaths,
+            isAnalyzerTestProject);
         project.Save(generatedProjectPath, System.Xml.Linq.SaveOptions.DisableFormatting);
 
         string projectNugetConfig = Directory.EnumerateFiles(projectDirectory)

--- a/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs
@@ -331,13 +331,31 @@ public sealed class TranslateStage : IMigrationStage
             // pair must translate against the SAME analyzer API — otherwise
             // the migrated tests hand a GSharpDiagnosticAnalyzer to a
             // parameter still typed Microsoft's DiagnosticAnalyzer (GS0154).
-            bool analyzerApiMode = Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
-                .IsAnalyzerProject(currentProject.Compilation)
-                || Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
+            bool isAnalyzerProject = Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
+                .IsAnalyzerProject(currentProject.Compilation);
+            bool isAnalyzerTestProject = !isAnalyzerProject
+                && Cs2Gs.Translator.Analyzers.AnalyzerProjectDetector
                     .IsAnalyzerTestProject(currentProject.Compilation);
+            bool analyzerApiMode = isAnalyzerProject || isAnalyzerTestProject;
             if (!isReferencedProject)
             {
                 context.IsAnalyzerProject = analyzerApiMode;
+                context.IsAnalyzerTestProject = isAnalyzerTestProject;
+                if (context.Options.OutputLayout == MigrationOutputLayout.Repository
+                    && !string.IsNullOrEmpty(context.Options.RepositorySdkMoniker)
+                    && context.Options.GeneratedProjectPaths?.TryGetValue(
+                        Path.GetFullPath(context.App.ProjectPath),
+                        out string generatedProjectPath) == true)
+                {
+                    GSharpProjectTransformer.Transform(
+                        context.App.ProjectPath,
+                        Path.GetDirectoryName(generatedProjectPath),
+                        context.Options.RepositorySdkMoniker,
+                        context.Options.GeneratedProjectPaths,
+                        isAnalyzerTestProject).Save(
+                            generatedProjectPath,
+                            System.Xml.Linq.SaveOptions.DisableFormatting);
+                }
             }
 
             // Issue #3645: an executable another app compiles against keeps its

--- a/tools/cs2gs/Cs2Gs.Pipeline/ValidationManifest.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/ValidationManifest.cs
@@ -57,19 +57,26 @@ public sealed class ValidationManifest
     [JsonPropertyOrder(3)]
     public bool IsAnalyzerProject { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the analyzer detector classified the app as a test project.
+    /// </summary>
+    [JsonPropertyName("isAnalyzerTestProject")]
+    [JsonPropertyOrder(4)]
+    public bool IsAnalyzerTestProject { get; set; }
+
     /// <summary>Gets or sets the source project's root namespace.</summary>
     [JsonPropertyName("rootNamespace")]
-    [JsonPropertyOrder(4)]
+    [JsonPropertyOrder(5)]
     public string RootNamespace { get; set; }
 
     /// <summary>Gets or sets the source project's assembly name.</summary>
     [JsonPropertyName("assemblyName")]
-    [JsonPropertyOrder(5)]
+    [JsonPropertyOrder(6)]
     public string AssemblyName { get; set; }
 
     /// <summary>Gets or sets the friend assemblies contributed by generated sources.</summary>
     [JsonPropertyName("generatedFriendAssemblies")]
-    [JsonPropertyOrder(6)]
+    [JsonPropertyOrder(7)]
     public List<string> GeneratedFriendAssemblies { get; set; } = new List<string>();
 
     /// <summary>
@@ -80,12 +87,12 @@ public sealed class ValidationManifest
     /// that a shard cannot see is additive, never load-bearing.
     /// </summary>
     [JsonPropertyName("externalReferences")]
-    [JsonPropertyOrder(7)]
+    [JsonPropertyOrder(8)]
     public List<string> ExternalReferences { get; set; } = new List<string>();
 
     /// <summary>Gets or sets the emitted G# files, relative to the migrated tree root.</summary>
     [JsonPropertyName("emittedFiles")]
-    [JsonPropertyOrder(8)]
+    [JsonPropertyOrder(9)]
     public List<ValidationManifestFile> EmittedFiles { get; set; } = new List<ValidationManifestFile>();
 
     /// <summary>
@@ -112,6 +119,7 @@ public sealed class ValidationManifest
             Translated = translated,
             IsTestProject = context.IsTestProject,
             IsAnalyzerProject = context.IsAnalyzerProject,
+            IsAnalyzerTestProject = context.IsAnalyzerTestProject,
             RootNamespace = context.RootNamespace,
             AssemblyName = context.AssemblyName,
         };
@@ -210,6 +218,7 @@ public sealed class ValidationManifest
         string root = Path.GetFullPath(migratedRoot ?? throw new ArgumentNullException(nameof(migratedRoot)));
         context.IsTestProject = this.IsTestProject;
         context.IsAnalyzerProject = this.IsAnalyzerProject;
+        context.IsAnalyzerTestProject = this.IsAnalyzerTestProject;
         context.RootNamespace = this.RootNamespace;
         context.AssemblyName = this.AssemblyName;
 

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3668ShardedValidationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3668ShardedValidationTests.cs
@@ -66,6 +66,7 @@ public class Issue3668ShardedValidationTests
             new TriageBuilder("run", "ts", "gsc", app.Id));
         context.IsTestProject = true;
         context.IsAnalyzerProject = true;
+        context.IsAnalyzerTestProject = true;
         context.RootNamespace = "Lib";
         context.AssemblyName = "Lib";
         context.GeneratedFriendAssemblies.Add("Lib.Tests");
@@ -96,6 +97,7 @@ public class Issue3668ShardedValidationTests
 
         Assert.True(rehydrated.IsTestProject);
         Assert.True(rehydrated.IsAnalyzerProject);
+        Assert.True(rehydrated.IsAnalyzerTestProject);
         Assert.Equal("Lib", rehydrated.RootNamespace);
         Assert.Equal("Lib", rehydrated.AssemblyName);
         Assert.Equal(new[] { "Lib.Tests" }, rehydrated.GeneratedFriendAssemblies.ToArray());

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3686AnalyzerTestHarnessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3686AnalyzerTestHarnessTests.cs
@@ -359,7 +359,8 @@ public static class Tool
     <ProjectReference Include=""..\Analyzer\Analyzer.csproj"" />
     <PackageReference Include=""Microsoft.CodeAnalysis.CSharp"" Version=""5.6.0"" />
   </ItemGroup>
-</Project>");
+</Project>",
+            isAnalyzerTestProject: true);
 
         List<XElement> references = transformed.Descendants()
             .Where(e => e.Name.LocalName == "Reference")
@@ -403,6 +404,50 @@ public static class Tool
         Assert.Contains(
             transformed.Descendants().Where(e => e.Name.LocalName == "PackageReference"),
             p => p.Attribute("Include")?.Value == "Microsoft.CodeAnalysis.CSharp");
+    }
+
+    /// <summary>
+    /// Issue #3791: project transformation consumes the semantic detector's
+    /// verdict. A structural analyzer reference and an unused analyzer-testing
+    /// package do not claim a library consumer; adding the declared harness
+    /// plus referenced-analyzer instantiation flips both stages together.
+    /// </summary>
+    [Fact]
+    public void AnalyzerDetectorAndProjectTransformer_Agree()
+    {
+        const string projectXml = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <ItemGroup>
+    <ProjectReference Include=""..\Analyzer\Analyzer.csproj"" />
+    <PackageReference Include=""Microsoft.CodeAnalysis.CSharp"" Version=""5.6.0"" />
+    <PackageReference Include=""Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit"" Version=""1.1.2"" />
+  </ItemGroup>
+</Project>";
+
+        LoadedCSharpProject tooling = LoadToolingProject();
+        bool toolingVerdict = AnalyzerProjectDetector.IsAnalyzerTestProject(tooling.Compilation);
+        XDocument toolingProject = TransformPair(projectXml, toolingVerdict);
+
+        Assert.False(toolingVerdict);
+        Assert.DoesNotContain(
+            toolingProject.Descendants().Where(e => e.Name.LocalName == "Reference"),
+            r => r.Attribute("Include")?.Value?.StartsWith("GSharp.", StringComparison.Ordinal) == true);
+        Assert.Contains(
+            toolingProject.Descendants().Where(e => e.Name.LocalName == "PackageReference"),
+            p => p.Attribute("Include")?.Value == "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit");
+
+        LoadedCSharpProject tests = Load(
+            new[] { ("Harness.cs", HarnessSource), ("Tests.cs", TestsUsing("new Sample.SampleAnalyzer()")) },
+            CSharpProjectLoader.RuntimeReferences().Append(CompileAnalyzerToReference()).ToList());
+        bool testsVerdict = AnalyzerProjectDetector.IsAnalyzerTestProject(tests.Compilation);
+        XDocument testProject = TransformPair(projectXml, testsVerdict);
+
+        Assert.True(testsVerdict);
+        Assert.Contains(
+            testProject.Descendants().Where(e => e.Name.LocalName == "Reference"),
+            r => r.Attribute("Include")?.Value == "GSharp.CodeAnalysis.Analyzers.Testing");
+        Assert.DoesNotContain(
+            testProject.Descendants().Where(e => e.Name.LocalName == "PackageReference"),
+            p => p.Attribute("Include")?.Value?.StartsWith("Microsoft.CodeAnalysis", StringComparison.Ordinal) == true);
     }
 
     private static string TestsUsing(string construction) => @"
@@ -486,7 +531,7 @@ public sealed class SampleAnalyzerTests
                 + string.Join("\n", errors.Select(d => d.Message)) + "\n---\n" + printed);
     }
 
-    private static XDocument TransformPair(string testProjectXml)
+    private static XDocument TransformPair(string testProjectXml, bool isAnalyzerTestProject = false)
     {
         string root = Path.Combine(Path.GetTempPath(), "cs2gs-3686-" + Guid.NewGuid().ToString("N"));
         try
@@ -512,7 +557,8 @@ public sealed class SampleAnalyzerTests
                 testProjectPath,
                 testDirectory,
                 "Gsharp.NET.Sdk/1.0.0",
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+                isAnalyzerTestProject);
         }
         finally
         {


### PR DESCRIPTION
Closes #3791.

## What changed

- Preserve the translate-stage `AnalyzerProjectDetector.IsAnalyzerTestProject` verdict separately from the broader analyzer-API mode.
- Pass that verdict into `GSharpProjectTransformer` for repository translation, SDK compilation, and sharded validation instead of structurally re-deriving it from `ProjectReference`.
- Remove the weaker structural analyzer-test probe.
- Keep the detector's declared-harness + referenced-analyzer-instantiation rule unchanged.
- Add a focused detector/transformer agreement test covering a tooling/library consumer, the unused analyzer-testing package, and a real analyzer harness.

This leaves ordinary analyzer consumers such as `src/Core` unclaimed and prevents incidental analyzer references in `Cs2Gs.Tests` from injecting `GSharp.Core` or the verifier.

## Validation

- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter 'FullyQualifiedName~Issue3686AnalyzerTestHarnessTests|FullyQualifiedName~Adr0169AnalyzerProjectTransformTests|FullyQualifiedName~GSharpProjectTransformerTests|FullyQualifiedName~MigrationPipelineTests|FullyQualifiedName~Issue3668ShardedValidationTests' --no-restore`
  - Passed: 53, Failed: 0
- Full `Cs2Gs.Tests` run:
  - Passed: 2824, Failed: 3
  - The failures were outside this change's paths in direct-gsc parity tests: two `Issue3090AwaitInvocationArgumentTests` cases and one `Issue3413NestedPrivateClassTranslationTests` case; each reached translate and failed compile.