### PR TITLE
gsc: infer generic inputs from single method groups

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2518,6 +2518,26 @@ internal sealed partial class ExpressionBinder
             return null;
         }
 
+        if (userGroup.Candidates.Length == 1
+            && userGroup.FunctionType is { } naturalType
+            && naturalType.ParameterTypes.Length == delegateArity)
+        {
+            var naturalParameters = new Type[delegateArity];
+            for (var i = 0; i < naturalParameters.Length; i++)
+            {
+                if (projectType(naturalType.ParameterTypes[i]) is not { } projected)
+                {
+                    return null;
+                }
+
+                naturalParameters[i] = projected;
+            }
+
+            return projectType(naturalType.ReturnType) is { } naturalReturn
+                ? (naturalParameters, naturalReturn)
+                : null;
+        }
+
         FunctionSymbol? candidate = null;
         var userParameterOffset = 0;
         foreach (var possibleCandidate in userGroup.Candidates)
@@ -2545,6 +2565,14 @@ internal sealed partial class ExpressionBinder
         var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
             ? TypeMemberModel.ResolveStaticMemberOwner(userGroup.StaticOwnerType, declaredOwner)
             : null;
+        if (candidateOwner == null
+            && !candidate.IsExtension
+            && userGroup.Receiver?.Type is StructSymbol receiverStruct
+            && candidate.ReceiverType is StructSymbol declaredReceiver)
+        {
+            candidateOwner = TypeMemberModel.ResolveStaticMemberOwner(receiverStruct, declaredReceiver);
+        }
+
         var projectedParameters = new Type[delegateArity];
         for (var i = 0; i < projectedParameters.Length; i++)
         {
@@ -2556,6 +2584,11 @@ internal sealed partial class ExpressionBinder
             }
 
             projectedParameters[i] = projected;
+        }
+
+        if (candidate.IsAsyncOrSuspending && !candidate.IsAsyncVoid)
+        {
+            return null;
         }
 
         var returnType = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2348,6 +2348,14 @@ internal sealed partial class ExpressionBinder
         IReadOnlyList<Type> delegateParameterTypes,
         Func<TypeSymbol, Type?> projectType)
     {
+        if (delegateParameterTypes.Any(type => type.ContainsGenericParameters))
+        {
+            return ResolveSingleMethodGroupInferenceSignature(
+                argument,
+                delegateParameterTypes.Count,
+                projectType);
+        }
+
         if (argument is BoundClrMethodGroupExpression clrGroup)
         {
             var receiver = clrGroup.Receiver;
@@ -2466,6 +2474,94 @@ internal sealed partial class ExpressionBinder
                 !ReferenceEquals(candidate.Method, other.Method)
                 && IsBetterMethodGroupConversion(other.Conversions, candidate.Conversions))).ToList();
         return best.Count == 1 ? best[0].Signature : null;
+    }
+
+    private static (Type[] Parameters, Type Return)? ResolveSingleMethodGroupInferenceSignature(
+        BoundExpression argument,
+        int delegateArity,
+        Func<TypeSymbol, Type?> projectType)
+    {
+        if (argument is BoundClrMethodGroupExpression clrGroup)
+        {
+            MethodInfo? method = null;
+            var parameterOffset = 0;
+            foreach (var possibleMethod in clrGroup.Candidates)
+            {
+                var candidateOffset = clrGroup.Receiver != null && possibleMethod.IsStatic ? 1 : 0;
+                if (possibleMethod.GetParameters().Length - candidateOffset != delegateArity)
+                {
+                    continue;
+                }
+
+                if (method != null)
+                {
+                    return null;
+                }
+
+                method = possibleMethod;
+                parameterOffset = candidateOffset;
+            }
+
+            if (method == null || method.ContainsGenericParameters)
+            {
+                return null;
+            }
+
+            var parameters = method.GetParameters();
+            return (
+                parameters.Skip(parameterOffset).Select(parameter => parameter.ParameterType).ToArray(),
+                method.ReturnType);
+        }
+
+        if (argument is not BoundMethodGroupExpression userGroup)
+        {
+            return null;
+        }
+
+        FunctionSymbol? candidate = null;
+        var userParameterOffset = 0;
+        foreach (var possibleCandidate in userGroup.Candidates)
+        {
+            var candidateOffset = possibleCandidate.IsExtension && userGroup.Receiver != null ? 1 : 0;
+            if (possibleCandidate.Parameters.Length - candidateOffset != delegateArity)
+            {
+                continue;
+            }
+
+            if (candidate != null)
+            {
+                return null;
+            }
+
+            candidate = possibleCandidate;
+            userParameterOffset = candidateOffset;
+        }
+
+        if (candidate == null || candidate.IsGeneric)
+        {
+            return null;
+        }
+
+        var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
+            ? TypeMemberModel.ResolveStaticMemberOwner(userGroup.StaticOwnerType, declaredOwner)
+            : null;
+        var projectedParameters = new Type[delegateArity];
+        for (var i = 0; i < projectedParameters.Length; i++)
+        {
+            var parameter = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + userParameterOffset].Type)
+                ?? candidate.Parameters[i + userParameterOffset].Type;
+            if (projectType(parameter) is not { } projected)
+            {
+                return null;
+            }
+
+            projectedParameters[i] = projected;
+        }
+
+        var returnType = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
+        return projectType(returnType) is { } projectedReturn
+            ? (projectedParameters, projectedReturn)
+            : null;
     }
 
     internal static bool TryCloseMethodGroupCandidate(

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -2508,9 +2508,13 @@ internal sealed partial class ExpressionBinder
             }
 
             var parameters = method.GetParameters();
-            return (
-                parameters.Skip(parameterOffset).Select(parameter => parameter.ParameterType).ToArray(),
-                method.ReturnType);
+            var signatureParameters = new Type[delegateArity];
+            for (var i = 0; i < signatureParameters.Length; i++)
+            {
+                signatureParameters[i] = parameters[i + parameterOffset].ParameterType;
+            }
+
+            return (signatureParameters, method.ReturnType);
         }
 
         if (argument is not BoundMethodGroupExpression userGroup)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -1533,18 +1533,25 @@ internal static class ClrOverloadResolution
         }
 
         var closedInputs = new Type[delegateParameters.Length];
+        var inputsClosed = true;
         for (var i = 0; i < delegateParameters.Length; i++)
         {
             if (!TryCloseInferredType(delegateParameters[i], bounds, out var closedInput)
                 || closedInput is null)
             {
-                return false;
+                inputsClosed = false;
+                break;
             }
 
             closedInputs[i] = closedInput;
         }
 
-        var signature = methodGroupInference(argumentIndex, closedInputs);
+        // Issue #3766: an open delegate input cannot drive overload
+        // resolution, but a single arity-matching candidate is unambiguous and
+        // can supply the missing input bounds.
+        var signature = methodGroupInference(
+            argumentIndex,
+            inputsClosed ? closedInputs : delegateParameters);
         if (!signature.HasValue
             || signature.Value.Parameters.Length != delegateParameters.Length
             || signature.Value.Return is null)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -10,6 +10,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using GSharp.Core.CodeAnalysis.Documentation;
@@ -65,15 +66,12 @@ internal sealed partial class OverloadResolver
     }
 
     /// <summary>
-    /// Issue #3760: the user-generic counterpart of
+    /// Issues #3760/#3766: the user-generic counterpart of
     /// <c>ClrOverloadResolution.TryInferMethodGroupArgument</c>. A method group
     /// argument carries no type, so a type parameter reachable only through
-    /// the target delegate's RETURN position never receives a bound from the
-    /// positional pass. Close the delegate's input types from the bounds
-    /// gathered so far, resolve the group against that closed input list, and
-    /// unify the selected candidate's return type back into
-    /// <paramref name="substitution"/>. A group that stays ambiguous under the
-    /// closed inputs contributes nothing, leaving the established GS0151.
+    /// the target delegate never receives a bound from the positional pass.
+    /// Closed inputs drive normal overload resolution; otherwise a single
+    /// arity-matching candidate can supply parameter and return bounds.
     /// </summary>
     private void InferFromUserMethodGroupArgument(
         TypeSymbol parameterType,
@@ -82,11 +80,13 @@ internal sealed partial class OverloadResolver
     {
         if (argument is not BoundMethodGroupExpression and not BoundClrMethodGroupExpression
             || !MemberLookup.TryGetLambdaTargetFunctionTypeFromSymbol(parameterType, out var target)
-            || !TypeSymbol.ContainsTypeParameter(target.ReturnType))
+            || (!TypeSymbol.ContainsTypeParameter(target.ReturnType)
+                && !target.ParameterTypes.Any(TypeSymbol.ContainsTypeParameter)))
         {
             return;
         }
 
+        var hasUnboundInput = false;
         var closedInputs = new TypeSymbol[target.ParameterTypes.Length];
         for (var i = 0; i < closedInputs.Length; i++)
         {
@@ -95,22 +95,134 @@ internal sealed partial class OverloadResolver
                 || closedInput == TypeSymbol.Error
                 || TypeSymbol.ContainsTypeParameter(closedInput))
             {
-                // An input the first pass could not close gives the group no
-                // signature to resolve against.
-                return;
+                hasUnboundInput = true;
+                break;
             }
 
             closedInputs[i] = closedInput;
         }
 
-        var selectedReturn = argument is BoundClrMethodGroupExpression clrGroup
-            ? ResolveClrMethodGroupReturn(clrGroup, closedInputs)
-            : ResolveUserMethodGroupReturn((BoundMethodGroupExpression)argument, closedInputs);
-
-        if (selectedReturn != null)
+        if (!hasUnboundInput)
         {
-            inferTypeArguments(target.ReturnType, selectedReturn, substitution);
+            var selectedReturn = argument is BoundClrMethodGroupExpression clrGroup
+                ? ResolveClrMethodGroupReturn(clrGroup, closedInputs)
+                : ResolveUserMethodGroupReturn((BoundMethodGroupExpression)argument, closedInputs);
+            if (selectedReturn != null)
+            {
+                inferTypeArguments(target.ReturnType, selectedReturn, substitution);
+            }
+
+            return;
         }
+
+        if (!TryGetSingleMethodGroupSignature(
+                argument,
+                target.ParameterTypes.Length,
+                out var candidateParameters,
+                out var candidateReturn))
+        {
+            return;
+        }
+
+        for (var i = 0; i < target.ParameterTypes.Length; i++)
+        {
+            inferTypeArguments(target.ParameterTypes[i], candidateParameters[i], substitution);
+        }
+
+        inferTypeArguments(target.ReturnType, candidateReturn, substitution);
+    }
+
+    private bool TryGetSingleMethodGroupSignature(
+        BoundExpression argument,
+        int delegateArity,
+        [NotNullWhen(true)] out TypeSymbol[]? parameters,
+        [NotNullWhen(true)] out TypeSymbol? returnType)
+    {
+        parameters = null;
+        returnType = null;
+
+        if (argument is BoundClrMethodGroupExpression clrGroup)
+        {
+            MethodInfo? method = null;
+            var parameterOffset = 0;
+            foreach (var possibleMethod in clrGroup.Candidates)
+            {
+                var candidateOffset = clrGroup.Receiver != null && possibleMethod.IsStatic ? 1 : 0;
+                if (possibleMethod.GetParameters().Length - candidateOffset != delegateArity)
+                {
+                    continue;
+                }
+
+                if (method != null)
+                {
+                    return false;
+                }
+
+                method = possibleMethod;
+                parameterOffset = candidateOffset;
+            }
+
+            if (method == null || method.ContainsGenericParameters)
+            {
+                return false;
+            }
+
+            var methodParameters = method.GetParameters();
+            parameters = new TypeSymbol[delegateArity];
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                parameters[i] = TypeSymbol.FromClrType(
+                    binderCtx.References.MapClrTypeToReferences(
+                        methodParameters[i + parameterOffset].ParameterType));
+            }
+
+            returnType = method.ReturnType.IsSameAs(typeof(void))
+                ? TypeSymbol.Void
+                : TypeSymbol.FromClrType(binderCtx.References.MapClrTypeToReferences(method.ReturnType));
+            return true;
+        }
+
+        if (argument is not BoundMethodGroupExpression userGroup)
+        {
+            return false;
+        }
+
+        FunctionSymbol? candidate = null;
+        var parameterOffsetForUser = 0;
+        foreach (var possibleCandidate in userGroup.Candidates)
+        {
+            var candidateOffset = possibleCandidate.IsExtension && userGroup.Receiver != null ? 1 : 0;
+            if (possibleCandidate.Parameters.Length - candidateOffset != delegateArity)
+            {
+                continue;
+            }
+
+            if (candidate != null)
+            {
+                return false;
+            }
+
+            candidate = possibleCandidate;
+            parameterOffsetForUser = candidateOffset;
+        }
+
+        if (candidate == null || candidate.IsGeneric)
+        {
+            return false;
+        }
+
+        var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
+            ? TypeMemberModel.ResolveStaticMemberOwner(userGroup.StaticOwnerType, declaredOwner)
+            : null;
+        parameters = new TypeSymbol[delegateArity];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            parameters[i] = candidateOwner?.SubstituteMemberType(candidate.Parameters[i + parameterOffsetForUser].Type)
+                ?? candidate.Parameters[i + parameterOffsetForUser].Type;
+        }
+
+        returnType = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
+        return true;
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.CallBinding.cs
@@ -187,6 +187,15 @@ internal sealed partial class OverloadResolver
             return false;
         }
 
+        if (userGroup.Candidates.Length == 1
+            && userGroup.FunctionType is { } naturalType
+            && naturalType.ParameterTypes.Length == delegateArity)
+        {
+            parameters = naturalType.ParameterTypes.ToArray();
+            returnType = naturalType.ReturnType;
+            return true;
+        }
+
         FunctionSymbol? candidate = null;
         var parameterOffsetForUser = 0;
         foreach (var possibleCandidate in userGroup.Candidates)
@@ -214,6 +223,14 @@ internal sealed partial class OverloadResolver
         var candidateOwner = userGroup.StaticOwnerType != null && candidate.StaticOwnerType is StructSymbol declaredOwner
             ? TypeMemberModel.ResolveStaticMemberOwner(userGroup.StaticOwnerType, declaredOwner)
             : null;
+        if (candidateOwner == null
+            && !candidate.IsExtension
+            && userGroup.Receiver?.Type is StructSymbol receiverStruct
+            && candidate.ReceiverType is StructSymbol declaredReceiver)
+        {
+            candidateOwner = TypeMemberModel.ResolveStaticMemberOwner(receiverStruct, declaredReceiver);
+        }
+
         parameters = new TypeSymbol[delegateArity];
         for (var i = 0; i < parameters.Length; i++)
         {
@@ -221,7 +238,15 @@ internal sealed partial class OverloadResolver
                 ?? candidate.Parameters[i + parameterOffsetForUser].Type;
         }
 
-        returnType = candidateOwner?.SubstituteMemberType(candidate.Type) ?? candidate.Type ?? TypeSymbol.Void;
+        var observableReturn = candidate.Type ?? TypeSymbol.Void;
+        if (candidate.IsAsyncOrSuspending
+            && !candidate.IsAsyncVoid
+            && !isAsyncIteratorReturnType(observableReturn))
+        {
+            observableReturn = wrapAsTask(observableReturn, candidate.AsyncReturnsValueTask);
+        }
+
+        returnType = candidateOwner?.SubstituteMemberType(observableReturn) ?? observableReturn;
         return true;
     }
 

--- a/test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs
@@ -64,8 +64,23 @@ public class Issue3760UserGenericMethodGroupEmitTests
 
         func Map[TOut](value int32, f Func[int32, TOut]) TOut { return f(value) }
         func RunG[TIn](value TIn, a Action[TIn]) { a(value) }
+        func RunOnly[TIn](a Action[TIn]) { }
 
         """;
+
+    /// <summary>
+    /// Issue #3766: a type parameter reachable only through a single-candidate
+    /// method group's parameter positions is inferred from that candidate.
+    /// </summary>
+    [Fact]
+    public void FreeGenericFunction_InfersTIn_FromSingleCandidateMethodGroup()
+    {
+        string output = CompileAndRun(Preamble + """
+            RunOnly(Helper.Emit)
+            """);
+
+        Assert.Equal(string.Empty, output);
+    }
 
     /// <summary>
     /// The issue's headline repro (free function, inferred type argument).
@@ -241,9 +256,9 @@ public class Issue3760UserGenericMethodGroupEmitTests
     /// <summary>
     /// The new inference step is a RETRY on the failure path only, and it must
     /// stay a diagnostic — never a crash — when the group genuinely cannot be
-    /// resolved. Here the delegate's INPUT type is itself an un-inferable type
-    /// parameter, so there is no closed signature to resolve the group
-    /// against: GS0151 stands, and no GS9998 follows it.
+    /// resolved. Here both overloads have the target arity and the delegate's
+    /// INPUT type is itself unbound, so choosing either candidate would be
+    /// unsound: GS0151 stands, and no GS9998 follows it.
     /// <para>
     /// ANTI-VACUITY GUARD RAIL — this also passed on origin/main; it pins that
     /// the retry did not turn an honest diagnostic into a crash or a wrong
@@ -256,7 +271,7 @@ public class Issue3760UserGenericMethodGroupEmitTests
         (int exitCode, string output) = Compile(Preamble + """
             func Both[TIn, TOut](f Func[TIn, TOut]) TOut { return f(default) }
 
-            Console.WriteLine(Both(Helper.ToText))
+            Console.WriteLine(Both(Helper.Show))
             """);
 
         Assert.True(exitCode != 0, "expected the un-inferable call to be rejected:\n" + output);

--- a/test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3760UserGenericMethodGroupEmitTests.cs
@@ -62,9 +62,16 @@ public class Issue3760UserGenericMethodGroupEmitTests
             func Map[TOut](value int32, f Func[int32, TOut]) TOut { return f(value) }
         }
 
+        class Holder[T] {
+            func Accept(value T) { }
+            func Accept(value T, extra int32) { }
+        }
+
+        async func AsyncText(value int32) string { return value.ToString() }
         func Map[TOut](value int32, f Func[int32, TOut]) TOut { return f(value) }
         func RunG[TIn](value TIn, a Action[TIn]) { a(value) }
         func RunOnly[TIn](a Action[TIn]) { }
+        func Accept[TIn, TOut](f Func[TIn, TOut]) { }
 
         """;
 
@@ -77,6 +84,26 @@ public class Issue3760UserGenericMethodGroupEmitTests
     {
         string output = CompileAndRun(Preamble + """
             RunOnly(Helper.Emit)
+            """);
+
+        Assert.Equal(string.Empty, output);
+    }
+
+    [Fact]
+    public void FreeGenericFunction_UsesObservableAsyncMethodGroupReturn()
+    {
+        string output = CompileAndRun(Preamble + """
+            Accept(AsyncText)
+            """);
+
+        Assert.Equal(string.Empty, output);
+    }
+
+    [Fact]
+    public void FreeGenericFunction_SubstitutesConstructedMethodGroupReceiver()
+    {
+        string output = CompileAndRun(Preamble + """
+            RunOnly(Holder[int32]().Accept)
             """);
 
         Assert.Equal(string.Empty, output);

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -932,6 +932,41 @@ public class ImportedMemberMatrixTests
     }
 
     [Fact]
+    public void ImportedGenericFunction_InfersTypeFromSingleCandidateMethodGroupParameters()
+    {
+        const string csSource = """
+            using System;
+
+            namespace ImportedSingleMethodGroupInference.CSharp
+            {
+                public static class Api
+                {
+                    public static void RunOnly<T>(Action<T> action) => action(default!);
+                    public static void Emit(int value) => Console.WriteLine("emit" + value);
+                }
+            }
+            """;
+
+        const string source = """
+            package ImportedSingleMethodGroupInference.Probe
+            import System
+            import ImportedSingleMethodGroupInference.CSharp
+
+            func EmitSource(value int32) { Console.WriteLine("source" + value.ToString()) }
+
+            Api.RunOnly(Api.Emit)
+            Api.RunOnly(EmitSource)
+            """;
+
+        Assert.Equal(
+            $"emit0{Environment.NewLine}source0{Environment.NewLine}",
+            CompileAndRunWithSiblingCs(
+                csSource,
+                source,
+                "ImportedSingleMethodGroupInference.CSharp"));
+    }
+
+    [Fact]
     public void SourceAndImportedMethodGroups_RefKindMismatchesStayDiagnosed()
     {
         const string sourceDefined = """

--- a/test/Compiler.Tests/ImportedMemberMatrixTests.cs
+++ b/test/Compiler.Tests/ImportedMemberMatrixTests.cs
@@ -942,6 +942,7 @@ public class ImportedMemberMatrixTests
                 public static class Api
                 {
                     public static void RunOnly<T>(Action<T> action) => action(default!);
+                    public static void Accept<TIn, TOut>(Func<TIn, TOut> function) { }
                     public static void Emit(int value) => Console.WriteLine("emit" + value);
                 }
             }
@@ -953,9 +954,11 @@ public class ImportedMemberMatrixTests
             import ImportedSingleMethodGroupInference.CSharp
 
             func EmitSource(value int32) { Console.WriteLine("source" + value.ToString()) }
+            async func AsyncText(value int32) string { return value.ToString() }
 
             Api.RunOnly(Api.Emit)
             Api.RunOnly(EmitSource)
+            Api.Accept(AsyncText)
             """;
 
         Assert.Equal(


### PR DESCRIPTION
Closes #3766

## Fix
- when delegate inputs remain open, infer from the sole method-group candidate whose effective arity matches
- apply the fallback to both imported generic calls and user-declared generic calls
- retain normal closed-input overload resolution and leave multiple matching candidates un-inferable

## Tests
- reported `RunOnly(Helper.Emit)` repro
- imported generic callee with both CLR and source method groups
- same-arity overloaded method group remains GS0151
- existing #3760 method-group regression suite
- related Core inference suites (79 tests)
- full solution build (0 warnings, 0 errors)