### PR TITLE
gsc: lower interpolation without host-only handler

### DIFF
--- a/src/Core/CodeAnalysis/Compilation/Compilation.cs
+++ b/src/Core/CodeAnalysis/Compilation/Compilation.cs
@@ -355,10 +355,9 @@ public class Compilation
             References ?? Symbols.ReferenceResolver.Default());
 
         // Issue #3730: the lowering above resolves the handler surface from the
-        // compilation's reference closure and reports GS0545 when the target
-        // framework does not provide it. That is a hard stop — continuing would
-        // emit calls the target's runtime cannot resolve — and the trailing
-        // result path filters errors out of `allWarnings`, so gate explicitly.
+        // compilation's reference closure. Keep its targeted GS0545 safety gate
+        // for an unusable resolved handler shape; a missing handler now takes
+        // #3769's target-compatible String.Format fallback.
         // Deliberately scoped to GS0545: GS0519's surfacing is long-established
         // and tested, and widening this to "any error" would change it.
         if (program.Diagnostics.Any(d => d.Id == DiagnosticDescriptors.InterpolatedStringHandlerUnavailable.Id))
@@ -505,10 +504,9 @@ public class Compilation
             References ?? Symbols.ReferenceResolver.Default());
 
         // Issue #3730: the lowering above resolves the handler surface from the
-        // compilation's reference closure and reports GS0545 when the target
-        // framework does not provide it. That is a hard stop — continuing would
-        // emit calls the target's runtime cannot resolve — and the trailing
-        // result path filters errors out of `allWarnings`, so gate explicitly.
+        // compilation's reference closure. Keep its targeted GS0545 safety gate
+        // for an unusable resolved handler shape; a missing handler now takes
+        // #3769's target-compatible String.Format fallback.
         // Deliberately scoped to GS0545: GS0519's surfacing is long-established
         // and tested, and widening this to "any error" would change it.
         if (program.Diagnostics.Any(d => d.Id == DiagnosticDescriptors.InterpolatedStringHandlerUnavailable.Id))

--- a/src/Core/CodeAnalysis/Lowering/DefaultInterpolatedStringHandlerShape.cs
+++ b/src/Core/CodeAnalysis/Lowering/DefaultInterpolatedStringHandlerShape.cs
@@ -102,8 +102,8 @@ internal sealed class DefaultInterpolatedStringHandlerShape
     /// Resolves the handler surface from <paramref name="references"/>. Returns
     /// <see langword="false"/> — naming the missing member in
     /// <paramref name="missingMember"/> — when the target framework does not
-    /// declare the shape the lowering needs, so the caller can report a
-    /// diagnostic instead of emitting a reference the target cannot resolve.
+    /// declare the shape the lowering needs, so the caller can select a
+    /// target-compatible non-handler lowering.
     /// </summary>
     /// <param name="references">The compilation's reference closure.</param>
     /// <param name="shape">The resolved handler surface.</param>
@@ -117,7 +117,8 @@ internal sealed class DefaultInterpolatedStringHandlerShape
         shape = null;
         missingMember = null;
 
-        if (!references.TryResolveType(HandlerTypeFullName, out var handlerType))
+        if (!references.TryResolveType(HandlerTypeFullName, out var handlerType)
+            || references.IsHostFallback(handlerType))
         {
             missingMember = HandlerTypeFullName;
             return false;

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -4,9 +4,11 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using GSharp.Core.CodeAnalysis.Binding;
 using GSharp.Core.CodeAnalysis.Symbols;
 using GSharp.Core.CodeAnalysis.Syntax;
@@ -15,7 +17,9 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 
 /// <summary>
 /// Emit-time (IL-only) lowering of <see cref="BoundInterpolatedStringExpression"/>
-/// to the C# 10 interpolated-string-handler pattern (issue #368, ADR-0055).
+/// to the C# 10 interpolated-string-handler pattern, or to composite formatting
+/// when the target framework does not provide that handler (issues #368/#3769,
+/// ADR-0055).
 /// </summary>
 /// <remarks>
 /// Each interpolation node is rewritten into a <see cref="BoundBlockExpression"/>
@@ -43,27 +47,22 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewriter
 {
     private readonly DiagnosticBag diagnostics = new();
+    private readonly ReferenceResolver references;
 
-    // Issue #3730: the DefaultInterpolatedStringHandler surface resolved from
-    // the compilation's reference closure. Null when the target framework does
-    // not declare the required shape; `missingHandlerMember` then names the
-    // first member it failed to provide, and the first interpolation site
-    // reports GS0545 rather than silently lowering onto the host SDK's handler.
+    // Issue #3730/#3769: the DefaultInterpolatedStringHandler surface resolved
+    // from the target reference closure. Null when the target does not declare
+    // the required shape; ordinary string interpolation then uses String.Format.
     private readonly DefaultInterpolatedStringHandlerShape? handler;
-    private readonly string? missingHandlerMember;
 
     private int counter;
-    private bool reportedMissingHandler;
+    private MethodInfo? stringFormat;
 
     private InterpolatedStringHandlerLowerer(ReferenceResolver references)
     {
-        if (DefaultInterpolatedStringHandlerShape.TryResolve(references, out var shape, out var missing))
+        this.references = references;
+        if (DefaultInterpolatedStringHandlerShape.TryResolve(references, out var shape, out _))
         {
             this.handler = shape;
-        }
-        else
-        {
-            this.missingHandlerMember = missing;
         }
     }
 
@@ -171,24 +170,14 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
             return this.RewriteUserHandler(node, node.Handler, literalLength, formattedCount);
         }
 
-        // Issue #3730: the target framework does not provide the handler surface
-        // this lowering emits calls against. Report it at the interpolation
-        // instead of lowering onto the host SDK's handler, which produced an
-        // assembly whose TypeRef pointed at the host's System.Private.CoreLib.
-        if (this.handler == null)
+        // Issue #3769: a handler supplied only by ReferenceResolver's host
+        // fallback is not part of the target framework. Use the pre-C# 10
+        // composite-format lowering instead of leaking System.Private.CoreLib
+        // into the emitted assembly. The same fallback covers older handler
+        // shapes that lack the overload required by this interpolation.
+        if (this.handler == null || !this.HasRequiredAppendFormatted(node))
         {
-            // The condition is compilation-wide, and `Lower` walks the same
-            // interpolation through both the function bodies and the top-level
-            // statement, so report it once rather than once per visit.
-            if (!this.reportedMissingHandler)
-            {
-                this.reportedMissingHandler = true;
-                this.diagnostics.ReportInterpolatedStringHandlerUnavailable(
-                    node.Syntax?.Location ?? default,
-                    Invariant.Required(this.missingHandlerMember, "a null handler shape always records the member it could not resolve"));
-            }
-
-            return node;
+            return this.RewriteStringFormat(node);
         }
 
         foreach (var part in node.Parts)
@@ -291,6 +280,131 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
             ImmutableArray<BoundExpression>.Empty);
 
         return new BoundBlockExpression(node.Syntax, statements.ToImmutable(), result);
+    }
+
+    private bool HasRequiredAppendFormatted(BoundInterpolatedStringExpression node)
+    {
+        var shape = Invariant.Required(this.handler, "the handler shape is resolved before its overloads are inspected");
+        foreach (var part in node.Parts)
+        {
+            if (part.IsHole
+                && shape.GetAppendFormatted(part.Alignment.HasValue, part.Format != null).Method == null)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private BoundExpression RewriteStringFormat(BoundInterpolatedStringExpression node)
+    {
+        var (parts, leading) = this.PrepareParts(node);
+        var format = new StringBuilder();
+        var arguments = ImmutableArray.CreateBuilder<BoundExpression>();
+
+        foreach (var part in parts)
+        {
+            if (part.IsLiteral)
+            {
+                AppendEscapedFormatLiteral(
+                    format,
+                    Invariant.Required(
+                        part.Literal,
+                        "a literal part is created by BoundInterpolatedStringPart.FromLiteral, which stores string.Empty rather than null"));
+                continue;
+            }
+
+            var value = Invariant.Required(part.Value, "a formatted interpolated-string part has a bound value");
+            if (TypeSymbol.IsByRefLike(value.Type))
+            {
+                var toString = FindByRefLikeToString(value.Type);
+                if (toString == null)
+                {
+                    this.diagnostics.ReportByRefLikeInterpolationUnsupported(
+                        part.HoleSyntax?.Location ?? value.Syntax?.Location ?? node.Syntax?.Location ?? default,
+                        value.Type);
+                    return node;
+                }
+
+                value = new BoundImportedInstanceCallExpression(
+                    node.Syntax,
+                    value,
+                    toString,
+                    TypeSymbol.String,
+                    ImmutableArray<BoundExpression>.Empty);
+            }
+
+            var index = arguments.Count;
+            arguments.Add(value.Type == TypeSymbol.Object
+                ? value
+                : new BoundConversionExpression(null, TypeSymbol.Object, value));
+
+            format.Append('{').Append(index.ToString(CultureInfo.InvariantCulture));
+            if (part.Alignment.HasValue)
+            {
+                format.Append(',').Append(part.Alignment.Value.ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (part.Format != null)
+            {
+                format.Append(':').Append(part.Format);
+            }
+
+            format.Append('}');
+        }
+
+        var argumentArray = new BoundArrayCreationExpression(
+            null,
+            ArrayTypeSymbol.Get(TypeSymbol.Object, arguments.Count),
+            arguments.ToImmutable());
+        var result = new BoundClrStaticCallExpression(
+            node.Syntax,
+            this.GetStringFormatMethod(),
+            TypeSymbol.String,
+            ImmutableArray.Create<BoundExpression>(
+                new BoundLiteralExpression(null, format.ToString()),
+                argumentArray));
+
+        return leading.IsEmpty
+            ? result
+            : new BoundBlockExpression(node.Syntax, leading, result);
+    }
+
+    private MethodInfo GetStringFormatMethod()
+    {
+        if (this.stringFormat != null)
+        {
+            return this.stringFormat;
+        }
+
+        if (!this.references.TryResolveType("System.String", requireExternalVisibility: false, out var stringType)
+            || !this.references.TryResolveType("System.Object", requireExternalVisibility: false, out var objectType))
+        {
+            throw new InvalidOperationException("String.Format cannot be resolved from the target reference set.");
+        }
+
+        this.stringFormat = stringType.GetMethod(
+            nameof(string.Format),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: new[] { stringType, objectType.MakeArrayType() },
+            modifiers: null)
+            ?? throw new InvalidOperationException("String.Format(string, object[]) cannot be resolved from the target reference set.");
+        return this.stringFormat;
+    }
+
+    private static void AppendEscapedFormatLiteral(StringBuilder builder, string text)
+    {
+        foreach (var character in text)
+        {
+            if (character is '{' or '}')
+            {
+                builder.Append(character);
+            }
+
+            builder.Append(character);
+        }
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
+++ b/src/Core/CodeAnalysis/Lowering/InterpolatedStringHandlerLowerer.cs
@@ -22,8 +22,8 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 /// ADR-0055).
 /// </summary>
 /// <remarks>
-/// Each interpolation node is rewritten into a <see cref="BoundBlockExpression"/>
-/// that does the following.
+/// When the target provides the default handler, each interpolation node is
+/// rewritten into a <see cref="BoundBlockExpression"/> that does the following.
 /// <list type="number">
 /// <item>declares a <c>System.Runtime.CompilerServices.DefaultInterpolatedStringHandler</c>
 /// value-type local and constructs it with <c>(literalLength, formattedCount)</c>.</item>
@@ -40,6 +40,13 @@ namespace GSharp.Core.CodeAnalysis.Lowering;
 /// reflection <see cref="System.Type"/>, over an <c>object</c> placeholder while
 /// the real type-argument symbol is encoded into the emitted MethodSpec), so the
 /// hole value is passed by its natural representation.
+/// </para>
+/// <para>
+/// When the target does not provide the default handler, ordinary string
+/// interpolation instead lowers to <c>String.Format(string, object[])</c>.
+/// That target-compatible path boxes value-type holes and preserves composite
+/// formatting, alignment, evaluation order, and literal-brace escaping.
+/// User-defined interpolated-string handlers are unaffected.
 /// </para>
 /// This rewrite is applied only on the emit path; the tree-walk interpreter
 /// renders <see cref="BoundInterpolatedStringExpression"/> directly.
@@ -173,9 +180,8 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
         // Issue #3769: a handler supplied only by ReferenceResolver's host
         // fallback is not part of the target framework. Use the pre-C# 10
         // composite-format lowering instead of leaking System.Private.CoreLib
-        // into the emitted assembly. The same fallback covers older handler
-        // shapes that lack the overload required by this interpolation.
-        if (this.handler == null || !this.HasRequiredAppendFormatted(node))
+        // into the emitted assembly.
+        if (this.handler == null)
         {
             return this.RewriteStringFormat(node);
         }
@@ -280,21 +286,6 @@ internal sealed class InterpolatedStringHandlerLowerer : NestedFunctionBodyRewri
             ImmutableArray<BoundExpression>.Empty);
 
         return new BoundBlockExpression(node.Syntax, statements.ToImmutable(), result);
-    }
-
-    private bool HasRequiredAppendFormatted(BoundInterpolatedStringExpression node)
-    {
-        var shape = Invariant.Required(this.handler, "the handler shape is resolved before its overloads are inspected");
-        foreach (var part in node.Parts)
-        {
-            if (part.IsHole
-                && shape.GetAppendFormatted(part.Alignment.HasValue, part.Format != null).Method == null)
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private BoundExpression RewriteStringFormat(BoundInterpolatedStringExpression node)

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -65,6 +65,7 @@ public sealed class ReferenceResolver : IDisposable
     private readonly MetadataLoadContext? metadataContext;
     private readonly AssemblyLoadContext? runtimeContext;
     private readonly ImmutableArray<string> missingTransitiveReferences;
+    private readonly ImmutableHashSet<string> hostFallbackAssemblyNames;
 
     // Process-wide registry of original on-disk paths for assemblies loaded
     // via LoadFromByteArray (whose Assembly.Location is empty). Populated by
@@ -179,12 +180,15 @@ public sealed class ReferenceResolver : IDisposable
         MetadataLoadContext? metadataContext,
         ImmutableArray<string> missingTransitiveReferences,
         AssemblyLoadContext? runtimeContext = null,
-        Lazy<Dictionary<string, Type>>? typeNameIndex = null)
+        Lazy<Dictionary<string, Type>>? typeNameIndex = null,
+        ImmutableHashSet<string>? hostFallbackAssemblyNames = null)
     {
         this.assemblies = assemblies;
         this.metadataContext = metadataContext;
         this.runtimeContext = runtimeContext;
         this.missingTransitiveReferences = missingTransitiveReferences;
+        this.hostFallbackAssemblyNames = hostFallbackAssemblyNames
+            ?? ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
         this.typeNameIndex = typeNameIndex ?? CreateTypeNameIndex(assemblies);
         this.emittedTypeNameIndex = new Lazy<Dictionary<string, string>>(
             () => BuildEmittedTypeNameIndex(
@@ -691,7 +695,14 @@ public sealed class ReferenceResolver : IDisposable
         var loaded = builder.ToImmutable();
         var missing = ComputeMissingTransitiveReferences(loaded, mlc, resolver);
 
-        return new ReferenceResolver(loaded, mlc, missing);
+        return new ReferenceResolver(
+            loaded,
+            mlc,
+            missing,
+            hostFallbackAssemblyNames: fallbackHostPaths
+                .Select(Path.GetFileNameWithoutExtension)
+                .OfType<string>()
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -815,6 +826,20 @@ public sealed class ReferenceResolver : IDisposable
 
         type = resolved;
         return true;
+    }
+
+    /// <summary>
+    /// Returns whether <paramref name="type"/> was resolved from the host
+    /// runtime assemblies that <see cref="WithReferences"/> appends as a
+    /// transitive-dependency fallback rather than from the supplied target
+    /// reference set.
+    /// </summary>
+    /// <param name="type">The resolved type to classify.</param>
+    /// <returns><see langword="true"/> when the type came from the host fallback.</returns>
+    public bool IsHostFallback(Type type)
+    {
+        var assemblyName = type.Assembly.GetName().Name;
+        return assemblyName != null && this.hostFallbackAssemblyNames.Contains(assemblyName);
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Emit/Issue3764CrossContextValueTypeCallShapeTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3764CrossContextValueTypeCallShapeTests.cs
@@ -7,11 +7,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
 using Xunit;
 
@@ -44,9 +43,10 @@ namespace GSharp.Compiler.Tests.Emit;
 /// reported success; only ILVerify caught it.
 /// </para>
 /// <para>
-/// These tests pin the <em>emitted call shape</em> and execute the result.
-/// Asserting that the handler merely resolves — which is what #3754's own
-/// fixture asserted — passes on the bug.
+/// Issue #3769 subsequently removed this handler from the emit path entirely:
+/// the resolver fallback remains observable, while interpolation lowers to
+/// target-compatible composite formatting and executes without referencing the
+/// host core library.
 /// </para>
 /// </summary>
 public class Issue3764CrossContextValueTypeCallShapeTests
@@ -58,7 +58,7 @@ public class Issue3764CrossContextValueTypeCallShapeTests
 
         class Formatter {
             func Describe(name string, count int32) string {
-                return "name=${name} count=${count}!"
+                return "name=${name} count=${count,4:D2}!"
             }
         }
         """;
@@ -104,6 +104,8 @@ public class Issue3764CrossContextValueTypeCallShapeTests
         // one, this fixture no longer reproduces #3764 and must be re-aimed
         // rather than silently passing.
         Assert.Equal("System.Private.CoreLib", handler.Assembly.GetName().Name);
+        Assert.True(resolver.IsHostFallback(handler));
+        Assert.False(DefaultInterpolatedStringHandlerShape.TryResolve(resolver, out _, out _));
 
         // Only a value type can be by-ref-like. Both answers must agree.
         Assert.True(ClrTypeUtilities.IsByRefLike(handler));
@@ -111,31 +113,38 @@ public class Issue3764CrossContextValueTypeCallShapeTests
     }
 
     /// <summary>
-    /// The emitted shape. A struct's instance method takes <c>this</c> as a
-    /// managed pointer: the receiver must be loaded by address and the call
-    /// must be a non-virtual <c>call</c>. On the bug every one of these was a
-    /// <c>callvirt</c> over the handler value.
+    /// The resolver can see the host handler, but the emitted target must not.
+    /// The interpolation uses <c>String.Format</c> from the target closure.
     /// </summary>
     [Fact]
-    public void InterpolationAgainstANetStandardTarget_CallsTheHandlerByAddress()
+    public void InterpolationAgainstANetStandardTarget_DoesNotReferenceTheHostHandler()
     {
         using var workspace = new Workspace();
         var probe = workspace.CompileProbe();
 
-        var (calls, loadsAddress) = ReadHandlerCallShape(probe, "Formatter", "Describe");
+        using var stream = File.OpenRead(probe);
+        using var pe = new PEReader(stream);
+        var metadata = pe.GetMetadataReader();
 
-        // Anti-vacuity: the method really did lower onto the handler.
-        Assert.NotEmpty(calls);
-        Assert.All(calls, call => Assert.Equal(OpCodes.Call, call.OpCode));
-        Assert.DoesNotContain(calls, call => call.OpCode == OpCodes.Callvirt);
-        Assert.True(loadsAddress, "the handler local was never loaded by address (ldloca)");
+        Assert.DoesNotContain(
+            metadata.TypeReferences.Select(metadata.GetTypeReference),
+            type => metadata.GetString(type.Name) == HandlerTypeName);
+        var format = Assert.Single(
+            metadata.MemberReferences.Select(metadata.GetMemberReference),
+            member => metadata.GetString(member.Name) == "Format"
+                && member.Parent.Kind == HandleKind.TypeReference
+                && metadata.GetString(metadata.GetTypeReference((TypeReferenceHandle)member.Parent).Name) == "String");
+        var stringType = metadata.GetTypeReference((TypeReferenceHandle)format.Parent);
+        Assert.Equal(HandleKind.AssemblyReference, stringType.ResolutionScope.Kind);
+        Assert.NotEqual(
+            "System.Private.CoreLib",
+            metadata.GetString(metadata.GetAssemblyReference((AssemblyReferenceHandle)stringType.ResolutionScope).Name));
     }
 
     /// <summary>
-    /// Verification and execution, because "it compiled" is exactly the signal
-    /// that failed here. ILVerify rejects the bug's IL
-    /// (<c>CallVirtOnValueType</c>); running it proves the handler is actually
-    /// driven through a managed pointer rather than a reinterpreted value.
+    /// Verification and execution, because "it compiled" was not sufficient to
+    /// catch the original leak. Running proves the target-compatible fallback
+    /// preserves interpolation output.
     /// </summary>
     [Fact]
     public void InterpolationAgainstANetStandardTarget_VerifiesAndRuns()
@@ -155,98 +164,13 @@ public class Issue3764CrossContextValueTypeCallShapeTests
             Assert.NotNull(describe);
 
             Assert.Equal(
-                "name=widget count=7!",
+                "name=widget count=  07!",
                 describe.Invoke(instance, new object[] { "widget", 7 }));
         }
         finally
         {
             context.Unload();
         }
-    }
-
-    /// <summary>
-    /// Returns every call instruction in the named method that targets a
-    /// <c>DefaultInterpolatedStringHandler</c> member, plus whether the body
-    /// ever loads a local's address (the receiver form a struct's instance call
-    /// requires).
-    /// </summary>
-    /// <param name="assemblyPath">The emitted assembly.</param>
-    /// <param name="typeName">The declaring type's simple name.</param>
-    /// <param name="methodName">The method to decode.</param>
-    /// <returns>The handler-targeting call instructions and the address-load flag.</returns>
-    private static (IReadOnlyList<IlInstruction> Calls, bool LoadsAddress) ReadHandlerCallShape(
-        string assemblyPath,
-        string typeName,
-        string methodName)
-    {
-        using var stream = File.OpenRead(assemblyPath);
-        using var pe = new PEReader(stream);
-        var metadata = pe.GetMetadataReader();
-
-        var method = metadata.TypeDefinitions
-            .Select(metadata.GetTypeDefinition)
-            .Where(type => metadata.GetString(type.Name) == typeName)
-            .SelectMany(type => type.GetMethods())
-            .Select(metadata.GetMethodDefinition)
-            .Single(candidate => metadata.GetString(candidate.Name) == methodName);
-
-        var il = pe.GetMethodBody(method.RelativeVirtualAddress).GetILBytes();
-        Assert.NotNull(il);
-
-        var handlerTokens = HandlerMemberTokens(metadata);
-        var instructions = IlInstructionReader.Read(il);
-
-        var calls = instructions
-            .Where(instruction =>
-                (instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Callvirt)
-                && instruction.MetadataToken is { } token
-                && handlerTokens.Contains(token))
-            .ToList();
-
-        var loadsAddress = instructions.Any(instruction =>
-            instruction.OpCode == OpCodes.Ldloca || instruction.OpCode == OpCodes.Ldloca_S);
-
-        return (calls, loadsAddress);
-    }
-
-    /// <summary>
-    /// The metadata tokens of every member reference (and generic
-    /// instantiation of one) whose parent type is the interpolated-string
-    /// handler.
-    /// </summary>
-    /// <param name="metadata">The emitted assembly's metadata.</param>
-    /// <returns>The handler member tokens.</returns>
-    private static HashSet<int> HandlerMemberTokens(MetadataReader metadata)
-    {
-        var tokens = new HashSet<int>();
-
-        foreach (var handle in metadata.MemberReferences)
-        {
-            var member = metadata.GetMemberReference(handle);
-            if (member.Parent.Kind != HandleKind.TypeReference)
-            {
-                continue;
-            }
-
-            var parent = metadata.GetTypeReference((TypeReferenceHandle)member.Parent);
-            if (metadata.GetString(parent.Name) == HandlerTypeName)
-            {
-                tokens.Add(MetadataTokens.GetToken(handle));
-            }
-        }
-
-        var methodSpecCount = metadata.GetTableRowCount(TableIndex.MethodSpec);
-        for (var row = 1; row <= methodSpecCount; row++)
-        {
-            var handle = MetadataTokens.MethodSpecificationHandle(row);
-            var parent = metadata.GetMethodSpecification(handle).Method;
-            if (tokens.Contains(MetadataTokens.GetToken(parent)))
-            {
-                tokens.Add(MetadataTokens.GetToken(handle));
-            }
-        }
-
-        return tokens;
     }
 
     /// <summary>

--- a/test/Core.Tests/CodeAnalysis/Lowering/Issue3730InterpolatedStringHandlerTargetFrameworkTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Lowering/Issue3730InterpolatedStringHandlerTargetFrameworkTests.cs
@@ -8,8 +8,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.Loader;
 using GSharp.Core.CodeAnalysis.Compilation;
 using GSharp.Core.CodeAnalysis.Lowering;
 using GSharp.Core.CodeAnalysis.Symbols;
@@ -52,6 +54,12 @@ public class Issue3730InterpolatedStringHandlerTargetFrameworkTests
 let count = 3
 let label = ""value""
 let text = ""$label = $count""
+
+class Formatter {
+    func Describe(label string, count int32) string {
+        return ""$label = $count""
+    }
+}
 ";
 
     /// <summary>
@@ -186,7 +194,7 @@ let text = ""$label = $count""
     /// handler must produce a <c>TypeRef</c> scoped to <em>that closure's</em>
     /// <c>System.Runtime</c> and must never mention the host's
     /// <c>System.Private.CoreLib</c>; a closure that declares no handler must
-    /// produce GS0545 rather than an assembly.
+    /// fall back to target-compatible composite formatting.
     /// </summary>
     [Fact]
     public void EmitTargetsTheReferencedFrameworksHandler()
@@ -215,18 +223,17 @@ let text = ""$label = $count""
 
         Assert.True(packs >= 1, "no Microsoft.NETCore.App.Ref targeting pack was available");
 
-        // The handler-less target. On main this compiled successfully and the
-        // emitted assembly carried a TypeRef into the host's
-        // System.Private.CoreLib.
+        // The handler-less target uses String.Format rather than failing or
+        // lowering onto the host's handler.
         using var netStandard = NetStandardClosure();
         var (netStandardDiagnostics, netStandardImage) = Compile(netStandard);
 
-        var reported = Assert.Single(netStandardDiagnostics, d => d.Id == "GS0545");
-        Assert.Contains(
-            DefaultInterpolatedStringHandlerShape.HandlerTypeFullName,
-            reported.Message,
-            StringComparison.Ordinal);
-        Assert.Null(netStandardImage);
+        Assert.DoesNotContain(netStandardDiagnostics, d => d.Id == "GS0545");
+        var netStandardBytes = Required(netStandardImage, "an emitted assembly for netstandard");
+        var (_, netStandardHandlerScopes) = ReadHandlerReferences(netStandardBytes);
+        Assert.Empty(netStandardHandlerScopes);
+        Assert.NotEqual("System.Private.CoreLib", Assert.Single(ReadStringFormatScopes(netStandardBytes)));
+        Assert.Equal("value = 3", ExecuteDescribe(netStandardBytes));
     }
 
     /// <summary>
@@ -236,12 +243,15 @@ let text = ""$label = $count""
     /// probe can tell the two apart.
     /// </summary>
     [Fact]
-    public void HostDeclaresTheHandler_ButTheNetStandardTargetDoesNot()
+    public void HostFallbackHandler_IsObservableAndNotATargetHandler()
     {
         Assert.NotNull(Type.GetType(DefaultInterpolatedStringHandlerShape.HandlerTypeFullName));
 
         using var netStandard = NetStandardClosure();
-        Assert.False(netStandard.TryResolveType(DefaultInterpolatedStringHandlerShape.HandlerTypeFullName, out _));
+        Assert.True(netStandard.TryResolveType(DefaultInterpolatedStringHandlerShape.HandlerTypeFullName, out var handler));
+        Assert.True(
+            netStandard.IsHostFallback(handler),
+            $"resolved from unexpected assembly '{handler.Assembly.FullName}'");
         Assert.False(DefaultInterpolatedStringHandlerShape.TryResolve(netStandard, out _, out var missing));
         Assert.Equal(DefaultInterpolatedStringHandlerShape.HandlerTypeFullName, missing);
     }
@@ -342,6 +352,55 @@ let text = ""$label = $count""
         return (assemblyRefs, handlerScopes);
     }
 
+    private static IReadOnlyList<string> ReadStringFormatScopes(byte[] image)
+    {
+        using var peReader = new PEReader(System.Collections.Immutable.ImmutableArray.Create(image));
+        var metadata = PEReaderExtensions.GetMetadataReader(peReader);
+        var scopes = new List<string>();
+        foreach (var handle in metadata.MemberReferences)
+        {
+            var member = metadata.GetMemberReference(handle);
+            if (metadata.GetString(member.Name) != "Format" || member.Parent.Kind != HandleKind.TypeReference)
+            {
+                continue;
+            }
+
+            var parent = metadata.GetTypeReference((TypeReferenceHandle)member.Parent);
+            if (metadata.GetString(parent.Namespace) != "System" || metadata.GetString(parent.Name) != "String")
+            {
+                continue;
+            }
+
+            scopes.Add(parent.ResolutionScope.Kind == HandleKind.AssemblyReference
+                ? metadata.GetString(metadata.GetAssemblyReference((AssemblyReferenceHandle)parent.ResolutionScope).Name)
+                : parent.ResolutionScope.Kind.ToString());
+        }
+
+        return scopes;
+    }
+
+    private static string ExecuteDescribe(byte[] image)
+    {
+        var context = new AssemblyLoadContext($"gs3769-{Guid.NewGuid():N}", isCollectible: true);
+        try
+        {
+            using var stream = new MemoryStream(image);
+            var assembly = context.LoadFromStream(stream);
+            var formatter = Required(
+                assembly.GetType("Issue3730.Formatter", throwOnError: true),
+                "the emitted Formatter type");
+            var instance = Required(Activator.CreateInstance(formatter), "a Formatter instance");
+            var describe = Required(
+                formatter.GetMethod("Describe", BindingFlags.Public | BindingFlags.Instance),
+                "Formatter.Describe");
+            return Assert.IsType<string>(describe.Invoke(instance, new object[] { "value", 3 }));
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
     /// <summary>
     /// The host runtime plus every installed targeting pack — every closure that
     /// is expected to declare a handler.
@@ -389,19 +448,15 @@ let text = ""$label = $count""
     /// <returns>The netstandard reference closure.</returns>
     private static ReferenceResolver NetStandardClosure()
     {
-        var packRoot = Path.Combine(DotnetRoot(), "packs", "NETStandard.Library.Ref");
-        var refDirectory = Directory.Exists(packRoot)
-            ? Directory
-                .EnumerateDirectories(packRoot)
-                .OrderBy(d => d, StringComparer.Ordinal)
-                .Select(version => Directory.EnumerateDirectories(Path.Combine(version, "ref")).OrderBy(d => d, StringComparer.Ordinal).LastOrDefault())
-                .LastOrDefault(d => d != null)
-            : null;
+        var refDirectory = typeof(Issue3730InterpolatedStringHandlerTargetFrameworkTests).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "NetStandard20ReferenceDirectory")
+            .Value;
 
-        if (refDirectory == null)
+        if (string.IsNullOrEmpty(refDirectory) || !Directory.Exists(refDirectory))
         {
             throw new Xunit.Sdk.XunitException(
-                $"prerequisite missing: no NETStandard.Library.Ref targeting pack under '{packRoot}'");
+                $"prerequisite missing: netstandard2.0 reference directory '{refDirectory}'");
         }
 
         return ReferenceResolver.WithReferences(Directory.EnumerateFiles(refDirectory, "*.dll"));


### PR DESCRIPTION
Closes #3769.

## Root cause

`ReferenceResolver.WithReferences` intentionally makes host runtime assemblies available as a transitive-dependency fallback. A target such as netstandard2.0 does not provide `DefaultInterpolatedStringHandler`, but the fallback can still satisfy that type lookup from the host `System.Private.CoreLib`. The default interpolation lowerer therefore treated a host-only type as target API and emitted an invalid handler reference.

## Fix

- Record the simple names of assemblies supplied only by the host fallback and expose `ReferenceResolver.IsHostFallback(Type)` so compiler features can distinguish target API from fallback API without banning the fallback globally.
- Reject a fallback-only `DefaultInterpolatedStringHandler` shape.
- Lower ordinary interpolation to target-resolved `String.Format(string, object[])` when the target handler is unavailable. Composite-format escaping, alignment, format clauses, evaluation order, await preparation, boxing, and supported byref-like `ToString` conversion are preserved.
- Keep user-defined handlers, target-provided default handlers, and the existing diagnostic for an incomplete target-provided handler unchanged.

This deliberately avoids a blanket fallback error, which would regress netstandard consumers and unrelated transitive-reference behavior.

## Tests

- Exact NETStandard.Library 2.0 reference closure: compile succeeds, no handler TypeRef is emitted, `String.Format` is scoped outside `System.Private.CoreLib`, and the emitted method executes with the expected result.
- Host-fallback closure with an ordinary dependency: fallback origin is observable, the host handler is rejected for lowering, formatted/aligned output verifies and runs, and no handler TypeRef is emitted.
- Full `Core.Tests`: 8,910 passed.
- Related `Compiler.Tests`: 20 passed; focused host-fallback fixture: 3 passed.
- Release build of `src/Core`: succeeded with 0 warnings/errors.
- `python3 build/nullable_hygiene.py --base origin/main`: OK.

## Nullable-hygiene classification

All behavior-capable hunks are intentional: `ReferenceResolver` records fallback provenance; the handler shape excludes fallback-only types; the lowerer selects and constructs the compatible formatting path; the two test fixtures assert metadata and execution. Added guards implement those runtime decisions rather than suppressing nullable warnings.
