### PR TITLE
docs: what to do when the PR translation guard is red

### DIFF
--- a/build/run-cs2gs-selfmig-pr-guard.sh
+++ b/build/run-cs2gs-selfmig-pr-guard.sh
@@ -39,6 +39,31 @@
 # all three of the incidents above rather than two — see the note under
 # guard_apps.
 #
+# IF THIS GUARD IS RED
+#
+# It blocks the PR. It is never advisory: it is the only check that asks the
+# self-hosting question, and it runs in minutes precisely so the answer is not
+# paid for overnight.
+#
+# FIX THE DEFECT IN cs2gs OR gsc, AND PROCEED WITHOUT ASKING. A red guard is a
+# found bug, and finding bugs is a goal of #3501 in its own right -- the C#
+# compiler is being used as a fuzzer, and a defect surfaced this way affects
+# every G# user, not just the migration. Translate into the SIMPLEST G# that
+# expresses the C# input; if the natural translation is ugly, that is a defect
+# report about cs2gs, not a reason to accept the ugliness.
+#
+# Do NOT:
+#   - exclude the file or app to get green. That turns a visible failure into
+#     an invisible one. --exclude means "not a migration target", never "dodge
+#     a defect".
+#   - raise a ratchet ceiling or lower a floor to absorb it.
+#
+# ASK FIRST only for: (a) syntax design changes, and (b) breaking changes to
+# the semantics of already-supported constructs. Adding G# language surface
+# purely to accommodate the translator is case (a) and wants an ADR.
+#
+# See docs/self-migration-policy.md.
+#
 # Usage: run-cs2gs-selfmig-pr-guard.sh
 # Environment:
 #   SELFMIG_PR_GUARD_ROOT  work root (default ${TMPDIR:-/tmp}/gsharp-cs2gs-pr-guard)

--- a/docs/self-migration-policy.md
+++ b/docs/self-migration-policy.md
@@ -1,0 +1,89 @@
+# Self-migration policy: what to do when the PR translation guard is red
+
+Applies to the C# → G# self-migration effort ([#3501](https://github.com/DavidObando/gsharp/issues/3501)) and to
+the `cs2gs-pr-guard` check (`build/run-cs2gs-selfmig-pr-guard.sh`).
+
+## Why the migration exists
+
+Three goals, and they are not ranked — a change that serves one at the cost of
+another is usually the wrong change:
+
+1. **Move the repository entirely to G#.**
+2. **Find and fix as many compiler defects as possible.** The C# compiler is
+   being used as a fuzzer of sorts: every construct Roslyn accepts becomes a
+   test case gsc has to answer correctly. A defect found this way is worth more
+   than the migration step it blocked, because it affects every G# user.
+3. **Raise cs2gs to the quality bar G# needs for serious adoption** — readable,
+   maintainable, correct output. Not merely output that compiles.
+
+Goal 2 is why a red guard is good news rather than an obstacle: **the guard
+found a real defect**, and the migration is the mechanism that surfaced it.
+
+## The rule
+
+**A red translation guard blocks the PR. It is never advisory.**
+
+It is the only check that asks the self-hosting question. CI *compiles* the
+repository's C# sources; the guard *translates* them and compiles the result.
+Those are different questions, and a source file can answer the first perfectly
+while failing the second — which is how a fully CI-green PR takes the nightly
+gate down purely by existing, hours later, attributed to whatever else landed
+nearby (#3831, #3896, #3905, #3915).
+
+## What to do, in order
+
+1. **Fix the defect in cs2gs or gsc.** This is the default and it needs no
+   approval — proceed. A guard failure is a found bug, and finding bugs is the
+   point (goal 2). Classify it first: gsc defect, cs2gs translation defect, or
+   a source shape that is simply not worth translating.
+2. **Prefer the simplest possible G# for a given C# input.** cs2gs should
+   translate into ordinary, readable G# — not into clever G#, and not into a
+   shape that merely satisfies the compiler. If the natural translation is
+   ugly, that is usually a defect report about cs2gs, not a reason to accept
+   the ugliness.
+3. **Rewrite new C# into shapes G# already supports** when the construct has no
+   G# equivalent and adding one is not justified on its own merits.
+4. **Never exclude a file or app from migration to get green.** That converts a
+   visible failure into an invisible one — the same trade the test-parity
+   allow-list exists to prevent. An `--exclude` is a statement that a project
+   is *not a migration target*, never a way to dodge a defect.
+5. **Never raise a ratchet ceiling to absorb a regression.** Ceilings move when
+   a metric improves, in the same PR that improves it. Lowering a floor or
+   raising a ceiling to match a regression is how a gate stops meaning
+   anything.
+
+## When to stop and ask
+
+Only two categories need sign-off before proceeding:
+
+- **Syntax design changes** — new surface syntax, or a change to how an
+  existing construct is spelled. These are ADR-scale decisions.
+- **Breaking changes to the semantics of already-supported constructs.**
+  Changing what existing, working G# code means is not a migration fix.
+
+Adding G# language surface *purely to accommodate the translator* falls under
+the first category. It is the tail wagging the dog unless independently
+justified, and it deserves an ADR rather than a PR comment.
+
+Everything else — fixing a binder bug, an emit bug, a translation infidelity,
+a diagnostic that fires wrongly, a construct cs2gs mangles — proceeds without
+asking.
+
+## If the guard is red for an unrelated reason
+
+Say so explicitly, with evidence and a link to the run, and do not merge past
+it silently. "Unrelated" is a claim that needs the same standard of proof as
+any other — infrastructure flakes and real regressions look identical from the
+summary line.
+
+## Related
+
+- `build/run-cs2gs-selfmig-pr-guard.sh` — what the guard covers, and
+  deliberately does not.
+- `tools/cs2gs/selfmig-baseline.json` — the ratchet, and the discipline for
+  moving its numbers.
+- `tools/cs2gs/selfmig-test-allowlist.json` — the policy register for tests
+  whose premise stops holding after migration. An empty list is its healthiest
+  state.
+- ADR-0115 §B — the canonical G# output contract cs2gs must satisfy.
+- ADR-0179 — `gsfmt`, which takes over layout decisions from the printer.


### PR DESCRIPTION
The guard has documented the **hazard** thoroughly since #3836 and says nothing about **what to do when it fires**. People hitting a red guard have been improvising, and the tempting improvisations are all bad: exclude the file, add G# surface to accommodate one construct, or shrug because CI is green.

This states the policy where someone hitting the failure will actually read it — the guard's own header — with the longer form in `docs/self-migration-policy.md`.

## The rule

**A red guard blocks the PR. It is never advisory.** Fix the defect in cs2gs or gsc and **proceed without asking.**

That last clause is the substantive change. A red guard is a **found bug**, and finding bugs is a goal of #3501 in its own right rather than a side effect — the C# compiler is being used as a fuzzer, so every construct Roslyn accepts becomes a test case gsc has to answer correctly, and a defect surfaced this way is worth more than the migration step it blocked because **it affects every G# user**. Requiring sign-off on each one converts the effort's best feature into its bottleneck.

## Approval now required for exactly two things

- **Syntax design changes**
- **Breaking changes to the semantics of already-supported constructs**

Adding G# language surface *purely to accommodate the translator* is the first category and wants an ADR, not a PR comment.

## Two prohibitions, written down because both have been reached for

- **Never exclude a file or app from migration to get green.** `--exclude` means *"not a migration target"*, never *"dodge a defect"*. It turns a visible failure into an invisible one — the same trade the test-parity allow-list exists to prevent.
- **Never raise a ceiling or lower a floor to absorb a regression.** Ceilings move when a metric improves, in the PR that improves it.

## Also recorded

The three goals, unranked, since a change serving one at the cost of another is usually wrong: move fully to G#; find and fix compiler defects; **raise cs2gs to output that is readable and maintainable, not merely compilable.** cs2gs should emit the *simplest* G# that expresses a given C# input — if the natural translation is ugly, that is a defect report about cs2gs, not something to accept.

Context worth noting: the guard existed in code well before it became a required check, so a PR could go red on it and merge anyway. That gap is what run 33998090623 may have exercised — currently under investigation.

No behaviour change; comments and one new doc.

Refs #3501, #3836, #3831, #3896, #3905, #3915.