### PR TITLE
gsc: an `out var` inside a `?.` call binds in the enclosing scope (#3978)

### DIFF
--- a/build/run-cs2gs-selfmig-pr-guard.sh
+++ b/build/run-cs2gs-selfmig-pr-guard.sh
@@ -17,6 +17,12 @@
 #          16 apps red, gate 44 -> 28.
 #   #3905  #3882's src/Sdk/Gsharp.Runtime.Channels crashed gsc with a stack
 #          overflow, blinding 11 apps behind "no parseable diagnostics".
+#   #3978  #3972's new `out var` inside a `?.` call in
+#          tools/cs2gs/Cs2Gs.Pipeline did not translate; 3 banked apps red,
+#          and the `!!` ceiling breached as a knock-on because an app that
+#          fails to compile never reaches CompileStage's polish pass. THIS
+#          GUARD RAN AND PASSED on that PR — Pipeline was not in the guarded
+#          set. See the note above guard_apps.
 #
 # All three are the same shape: a *hot-core* project — one that most of the
 # corpus transitively references — stopped surviving its own migration, and
@@ -70,6 +76,10 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 #   src/Sdk/Gsharp.Runtime.Channels  #3905's root, and a ProjectReference
 #                                 leaf, so it costs this job only a couple of
 #                                 minutes. ADDED BY #3933, see below.
+#   tools/cs2gs/Cs2Gs.Pipeline    the OTHER cs2gs hub: Cli, Report and Tests
+#                                 all reference it. ADDED BY #3978, see below.
+#   tools/cs2gs/Cs2Gs.ProjectLoading  Pipeline's ProjectReference; here to keep
+#                                 the set closed, not because it is hot.
 #
 # ADDED BY #3933. Channels was deliberately absent through five PRs because
 # this guard runs translate -> compile -> ilverify -> test-parity and the app
@@ -83,16 +93,39 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # hazard has now fired four times (#3831, #3896, #3905, and #3915's rewrite
 # adding four unseen artifacts between #3916's base and its merge).
 #
+# ADDED BY #3978, and this one is a COVERAGE HOLE the guard had rather than a
+# deliberate omission. PR #3972 added an inline `out var` inside a `?.` call to
+# tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs. This guard ran on that PR and
+# reported 6/6 PASSED — correctly, because every app it guards still migrated.
+# The modified project simply was not one of them, and the nightly gate then
+# went red with migrated Cs2Gs.Pipeline failing GS0125, taking Cs2Gs.Cli,
+# Cs2Gs.Report and Cs2Gs.Tests down as dependents (three banked greenApps) and
+# breaching the `!!` ceiling as a second-order effect, because
+# NullAssertionPolishPass lives in CompileStage and never runs for an app that
+# fails to compile.
+#
+# The lesson generalises past this one project: the set was closed DOWNWARD
+# from Cs2Gs.Translator (its reference closure) when the hazard is really "a
+# project many corpus apps reference". Pipeline is the second cs2gs hub —
+# Cs2Gs.Cli, Cs2Gs.Report and Cs2Gs.Tests all reference it — and it was
+# translate/compile/ilverify/test-parity green in gate run 33943018295, so it
+# is not a red-from-day-one addition. Cs2Gs.ProjectLoading comes with it only
+# to keep the set closed under ProjectReference (verify_closure below would
+# otherwise fail the run). The two add roughly one more app's worth of
+# translate + compile to a ~30-minute job.
+#
 # STILL DELIBERATELY ABSENT: tools/cs2gs/Cs2Gs.Tests, which #3836 names as the
 # natural next step. It has ~9 known migration failures and would be red by
 # construction until those clear — the same reasoning that kept Channels out
-# until today.
+# until #3933.
 guard_apps=(
   src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj
   src/Core/Core.csproj
   src/Formatting/GSharp.Formatting/GSharp.Formatting.csproj
   src/Sdk/Gsharp.Runtime.Channels/Gsharp.Runtime.Channels.csproj
   tools/cs2gs/Cs2Gs.CodeModel/Cs2Gs.CodeModel.csproj
+  tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj
+  tools/cs2gs/Cs2Gs.ProjectLoading/Cs2Gs.ProjectLoading.csproj
   tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj
 )
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -1515,6 +1515,39 @@ internal sealed partial class ExpressionBinder
         var captureRef = new BoundVariableExpression(null, capture);
         var whenNotNull = BindAccessorStep(captureRef, null, rightPart);
 
+        // Issue #3978: the temp scope above exists only to hold the synthetic
+        // capture, but binding the right part can DECLARE user-visible names
+        // in it — an inline `out var` argument is the one that matters:
+        //
+        //     if map?.TryGetValue(key, out var found) == true { use(found) }
+        //
+        // An `out var` binds in the scope enclosing the call, exactly as it
+        // does when the receiver is spelled `map!!.`. Popping this scope
+        // wholesale discarded those declarations, so every later reference
+        // reported GS0125 "Variable 'found' doesn't exist": a `?.` receiver
+        // silently changed where an `out var` landed. Promote whatever the
+        // right part declared — everything except the capture itself, which is
+        // synthetic and must stay invisible — into the enclosing scope.
+        //
+        // Spelled without `?.` and without a discarded call result on purpose:
+        // this file is inside the self-migration corpus, and the defect being
+        // fixed here is precisely a construct that C# accepted and the
+        // migrated G# did not.
+        var enclosingScope = scope.Parent;
+        if (enclosingScope != null)
+        {
+            foreach (var declared in scope.GetDeclaredVariables())
+            {
+                if (!ReferenceEquals(declared, capture))
+                {
+                    // A name already declared in the enclosing scope loses the
+                    // race and keeps its existing binding, which is the same
+                    // shadowing outcome the non-`?.` spelling produces.
+                    enclosingScope.TryDeclareVariable(declared);
+                }
+            }
+        }
+
         scope = scope.Pop();
 
         // Issue #1213: a null-conditional invocation whose access produces no

--- a/test/Compiler.Tests/Emit/Issue3978NullConditionalOutVarScopeEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue3978NullConditionalOutVarScopeEmitTests.cs
@@ -1,0 +1,204 @@
+// <copyright file="Issue3978NullConditionalOutVarScopeEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+
+namespace GSharp.Compiler.Tests.Emit;
+
+/// <summary>
+/// Issue #3978: an inline <c>out var</c> argument inside a NULL-CONDITIONAL
+/// access must bind in the scope enclosing the call, exactly as it does when
+/// the receiver is spelled <c>receiver!!.</c>.
+/// <para>
+/// <c>BindNullConditionalAccessExpressionCore</c> pushes a temporary scope to
+/// hold the synthetic <c>$ncap_N</c> capture local and popped it wholesale
+/// after binding the right part, which threw away every declaration the right
+/// part had made. <c>lookup?.TryGetValue(k, out var found) == true</c>
+/// therefore reported <c>GS0125 Variable 'found' doesn't exist</c> at every
+/// later reference, while the <c>!!</c> spelling of the same call compiled.
+/// </para>
+/// <para>
+/// These tests EXECUTE the emitted assembly rather than only binding it: the
+/// risk of hoisting a declaration out of a scope is that the local is emitted
+/// but never assigned on the short-circuit path, which binds clean and then
+/// reads garbage (or fails ilverify) at run time. The nil-receiver case below
+/// is the one that pins that down.
+/// </para>
+/// </summary>
+public class Issue3978NullConditionalOutVarScopeEmitTests
+{
+    [Fact]
+    public void ConditionalAccess_InlineOutVar_IsVisibleAfterTheCall()
+    {
+        // Hit, miss-on-empty and nil-receiver in one program. The nil case
+        // proves `?.` still short-circuits: the call never runs, so the
+        // condition is nil (not `true`) and the binding is simply not taken.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func probe(lookup Dictionary[string, int32]?) string {
+                if lookup?.TryGetValue("k", out var found) == true {
+                    return "hit:" + found.ToString()
+                }
+                return "miss"
+            }
+
+            let live = Dictionary[string, int32]()
+            live["k"] = 7
+            Console.WriteLine(probe(live))
+            Console.WriteLine(probe(Dictionary[string, int32]()))
+            Console.WriteLine(probe(nil))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            $"hit:7{Environment.NewLine}miss{Environment.NewLine}miss{Environment.NewLine}",
+            output);
+    }
+
+    [Fact]
+    public void ConditionalAccess_InlineOutVar_MatchesTheBangBangSpelling()
+    {
+        // The whole defect was that the RECEIVER SPELLING moved the binding.
+        // Both spellings of the same call must produce the same result.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let d = Dictionary[string, string]()
+            d["a"] = "alpha"
+
+            let viaAssertion = d!!.TryGetValue("a", out var asserted)
+            Console.WriteLine(viaAssertion)
+            Console.WriteLine(asserted)
+
+            let nullable Dictionary[string, string]? = d
+            if nullable?.TryGetValue("a", out var conditional) == true {
+                Console.WriteLine(conditional)
+            }
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            $"True{Environment.NewLine}alpha{Environment.NewLine}alpha{Environment.NewLine}",
+            output);
+    }
+
+    [Fact]
+    public void ConditionalAccess_InlineOutVar_SurvivesTheTranslatedSelfMigrationShape()
+    {
+        // The exact shape cs2gs emitted for tools/cs2gs/Cs2Gs.Pipeline's
+        // TranslateStage after #3972: an `out var` inside a `?.` call that is
+        // the last conjunct of an `&&` chain, consumed twice in the body.
+        var source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            func transform(
+                enabled bool,
+                moniker string,
+                paths Dictionary[string, string]?,
+                key string) string {
+                if enabled &&
+                    !string.IsNullOrEmpty(moniker) &&
+                    paths?.TryGetValue(key, out var generatedProjectPath) == true {
+                    return generatedProjectPath + "|" + generatedProjectPath
+                }
+                return "skipped"
+            }
+
+            let paths = Dictionary[string, string]()
+            paths["p"] = "gen"
+            Console.WriteLine(transform(true, "sdk", paths, "p"))
+            Console.WriteLine(transform(true, "sdk", paths, "absent"))
+            Console.WriteLine(transform(false, "sdk", paths, "p"))
+            Console.WriteLine(transform(true, "", paths, "p"))
+            Console.WriteLine(transform(true, "sdk", nil, "p"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal(
+            $"gen|gen{Environment.NewLine}skipped{Environment.NewLine}skipped{Environment.NewLine}" +
+            $"skipped{Environment.NewLine}skipped{Environment.NewLine}",
+            output);
+    }
+
+    private static string CompileAndRun(string source)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_issue3978_emit_").FullName;
+        try
+        {
+            var srcPath = Path.Combine(tempDir, "test.gs");
+            var outPath = Path.Combine(tempDir, "test.dll");
+            File.WriteAllText(srcPath, source);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var prevOut = Console.Out;
+            var prevErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(new[]
+                {
+                    "/out:" + outPath,
+                    "/target:exe",
+                    "/targetframework:net10.0",
+                    srcPath,
+                });
+            }
+            finally
+            {
+                Console.SetOut(prevOut);
+                Console.SetError(prevErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed:\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+            IlVerifier.Verify(outPath);
+
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                WorkingDirectory = tempDir,
+            };
+            psi.ArgumentList.Add("exec");
+            psi.ArgumentList.Add("--runtimeconfig");
+            psi.ArgumentList.Add(Path.ChangeExtension(outPath, ".runtimeconfig.json"));
+            psi.ArgumentList.Add(outPath);
+
+            using var proc = Process.Start(psi);
+            var stdout = proc.StandardOutput.ReadToEnd();
+            var stderr = proc.StandardError.ReadToEnd();
+            Assert.True(proc.WaitForExit(30_000), "dotnet exec timed out");
+            Assert.True(
+                proc.ExitCode == 0,
+                $"exited {proc.ExitCode}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            return stdout.ReplaceLineEndings(Environment.NewLine);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3978.

## What broke

Self-migration gate run [33998090623](https://github.com/DavidObando/gsharp/actions/runs/33998090623) failed with two symptoms that turn out to be **one cause**:

```
GATE: !! null-assertion count 17194 exceeded ceiling 11500.
GATE: app(s) listed in greenApps are no longer green:
  - tools/cs2gs/Cs2Gs.Cli/Cs2Gs.Cli.csproj
  - tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj
  - tools/cs2gs/Cs2Gs.Report/Cs2Gs.Report.csproj
```

PR #3972 added this to `tools/cs2gs/Cs2Gs.Pipeline/TranslateStage.cs`:

```csharp
&& context.Options.GeneratedProjectPaths?.TryGetValue(
       Path.GetFullPath(context.App.ProjectPath),
       out string generatedProjectPath) == true)
```

cs2gs translated it faithfully. **gsc rejected the result** — `GS0125 Variable 'generatedProjectPath' doesn't exist`, twice, in migrated `TranslateStage.gs` (257,83) and (258,26). Migrated `Cs2Gs.Pipeline` stopped compiling and `Cs2Gs.Cli`, `Cs2Gs.Report` and `Cs2Gs.Tests` failed behind it with the identical two diagnostic fingerprints, pointing at `Cs2Gs.Pipeline.gsproj`.

## The compiler bug

`BindNullConditionalAccessExpressionCore` pushes a temporary `BoundScope` for the synthetic `$ncap_N` capture and pops it wholesale, discarding everything the right part declared. So:

```gs
if lookup?.TryGetValue(k, out var found) == true { use(found) }   // GS0125
if lookup!!.TryGetValue(k, out var found)        { use(found) }   // fine
```

The **receiver spelling** decided where the `out var` landed. Fixed by promoting the right part's declarations (all but the capture) into the enclosing scope before popping.

## Why the `!!` ceiling moved — same cause, second order

`NullAssertionPolishPass` runs from `CompileStage`, so an app that fails to compile never polishes. Reconstructing both gate trees (migrated tree + every shard's `polished.tar.gz` replayed, i.e. exactly what `run-cs2gs-selfmig-gate.sh` measures) reproduces both published totals exactly and attributes the delta:

| app | gate-scale `!!` prev (33943018295) | gate-scale `!!` now | fresh (migrate-scale) prev → now |
|---|---|---|---|
| `Cs2Gs.Tests` | 759 | **6630** | 6582 → 6630 |
| `Cs2Gs.Cli` | 28 | **165** | 165 → 165 |
| `Cs2Gs.Report` | 26 | **88** | 88 → 88 |
| `Cs2Gs.Pipeline` | 241 | **252** | 664 → 688 |
| everything else | — | — | — |
| **total** | **11053** | **17194** | 22040 → 22201 |

`Cs2Gs.Cli` and `Cs2Gs.Report` have **byte-identical fresh counts** in both runs and their gate numbers are exactly their fresh numbers now: they were not translated differently, they were not polished. +6070 of the +6141 delta is these four apps; the residual +71 is ordinary drift plus the three new `src/Formatting` apps entering the corpus (denominator 53 → 56). `Cs2Gs.Tests`' `sdk.build.log` for this run contains **zero GS0536** — the polish loop's entry condition — because the strict build stops on Pipeline's GS0125/GS0159.

**No baseline number is touched.** The projection once Pipeline compiles again is 17194 − 6070 ≈ 11124, back under the 11500 ceiling, which is where 11053 sat.

## The guard hole

`build/run-cs2gs-selfmig-pr-guard.sh` **ran on #3972 and reported `6/6 apps green; run PASSED`** ([job](https://github.com/DavidObando/gsharp/actions/runs/33992094049)). It was not a trigger or enforcement failure — it was coverage. `guard_apps` was closed *downward* from `Cs2Gs.Translator`, and `Cs2Gs.Pipeline` — the project #3972 modified, and the one `Cs2Gs.Cli`, `Cs2Gs.Report` and `Cs2Gs.Tests` all reference — was not in it. Added here, with `Cs2Gs.ProjectLoading` to keep the set closed under `ProjectReference`. Both were four-stage green in gate run 33943018295, so neither is a red-from-day-one addition.

## Tests

Three tests in `test/Compiler.Tests/Emit/Issue3978NullConditionalOutVarScopeEmitTests.cs`. They **compile, ilverify and EXECUTE** the emitted assembly — the hazard of hoisting a declaration out of a scope is a local that binds but is never assigned on the short-circuit path, which only a run catches. Coverage: hit / miss-on-empty / nil receiver; `?.` vs `!!` spellings agreeing; and the exact `&&`-chained shape cs2gs emitted for `TranslateStage`. All three fail with `GS0125` on the parent commit and pass here.

`src/Core` is inside the migration corpus, so the fix is spelled without `?.` and without a discarded call result. A local hot-core guard run confirms migrated `src/Core` is translate + compile + ilverify green with this change (`All Classes and Methods in GSharp.Core.dll Verified.`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nng28yiBdPVdeML7mSZphs