### PR TITLE
gsc: object satisfies reference-type constraints (#3684)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -6650,7 +6650,7 @@ public sealed class Binder
             return true;
         }
 
-        if (type == TypeSymbol.String)
+        if (type == TypeSymbol.String || type == TypeSymbol.Object)
         {
             return true;
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue775ClassStructConstraintTests.cs
@@ -36,6 +36,19 @@ First[string](""hi"")
     }
 
     [Fact]
+    public void ClassConstraint_ObjectArgument_Accepted()
+    {
+        var source = @"
+func Required[T class](x T?) T -> x!!
+let value object? = ""ok""
+Required(value).ToString()
+";
+        var result = Evaluate(source);
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal("ok", result.Value);
+    }
+
+    [Fact]
     public void ClassConstraint_ValueTypeArgument_Diagnoses()
     {
         var source = @"


### PR DESCRIPTION
Closes #3684.

## Scope re-check

Every family originally listed in #3684 is already fixed on current `main`:

- F8/F9/F11/F14: #3699
- F7: #3702
- F12/F15/F16: #3751
- F13: #3753
- F1b: #3759
- F10: #3819
- F18: confirmed as a cascade removed by #3687

I re-ran the issue's whole-repository migration plus the `test/Core.Tests` dependency-chain validation rather than duplicating any of those changes. Current `main` had one newly introduced residual compile family from #3975's test fixture:

```text
GS0152 Type argument 'object' ... does not satisfy the 'class' constraint
GS0159 Cannot find function Invoke
```

The second diagnostic was a cascade from the first: the failed `Required(Activator.CreateInstance(...))` call left its result error-typed before `MethodInfo.Invoke` consumed it.

## Root cause and fix

`Binder.IsReferenceTypeForConstraint` explicitly recognized the canonical `string` symbol, but omitted the canonical `object` symbol. Consequently an inferred `T = object` was rejected for `[T class]`, although `object` is the root reference type.

The fix adds `TypeSymbol.Object` to that existing canonical-reference branch. The focused regression infers `object` through a nullable `[T class]` parameter, uses the returned value, and executes it; this pins both constraint acceptance and the absence of the downstream member-lookup cascade.

## Verification

- focused/relevant Core.Tests: 138 passed
- related Compiler.Tests: 15 passed
- related Cs2Gs.Tests: 45 passed
- rebased focused check (`Issue775` + `Issue3730`): 37 passed
- `python3 build/nullable_hygiene.py --base origin/main`: OK
- `dotnet build GSharp.sln -c Release --no-restore`: 0 warnings, 0 errors
- whole-repository `run-cs2gs-selfmig-migrate.sh`: 55/56 translated; only the pre-existing `test/Interpreter.Tests` unsupported sites remain
- exact migrated validation at `gsc 0.4.502+97d566e4ae`:
  - `src/Core`: compile / ILVerify / parity PASS
  - `GSharp.CodeAnalysis.Analyzers.Testing`: compile / ILVerify / parity PASS
  - `test/Core.Tests`: **compile PASS, ILVerify PASS**

`test/Core.Tests` now reaches test parity, where 261 existing migrated-runtime assertion failures remain. Those are outside #3684's compile-error family scope, so this PR does not alter the parity allow-list or claim the app fully green.
