### PR TITLE
gsc: inherited CLR probes share visibility and nullability (#3705)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -489,16 +489,30 @@ internal sealed partial class ExpressionBinder
                     if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
                     {
                         var memberName = ne.IdentifierToken.ValueText;
-                        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, memberName);
-                        if (clrProp != null && clrProp.CanRead)
+                        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+                            inheritedBaseClr,
+                            memberName,
+                            CanAccessInternalsOf);
+                        if (clrProp != null && GetVisibleGetter(clrProp, fromDerivedType: true) != null)
                         {
-                            return new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
+                            return new BoundClrPropertyAccessExpression(
+                                null,
+                                receiver,
+                                clrProp,
+                                GetInheritedClrMemberType(receiver.Type, clrProp));
                         }
 
-                        var clrFld = ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
+                        var clrFld = ClrTypeUtilities.SafeGetInheritedInstanceField(
+                            inheritedBaseClr,
+                            memberName,
+                            CanAccessInternalsOf);
                         if (clrFld != null)
                         {
-                            return new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
+                            return new BoundClrPropertyAccessExpression(
+                                null,
+                                receiver,
+                                clrFld,
+                                GetInheritedClrMemberType(receiver.Type, clrFld));
                         }
                     }
 
@@ -624,13 +638,21 @@ internal sealed partial class ExpressionBinder
                         var clrProp = ClrTypeUtilities.SafeGetProperty(clrBaseIface, ifaceMemberName, BindingFlags.Public | BindingFlags.Instance);
                         if (clrProp != null && clrProp.GetIndexParameters().Length == 0 && clrProp.CanRead)
                         {
-                            return new BoundClrPropertyAccessExpression(null, receiver, clrProp, TypeSymbol.FromClrType(clrProp.PropertyType));
+                            return new BoundClrPropertyAccessExpression(
+                                null,
+                                receiver,
+                                clrProp,
+                                GetInheritedClrMemberType(receiver.Type, clrProp));
                         }
 
                         var clrFld = ClrTypeUtilities.SafeGetField(clrBaseIface, ifaceMemberName, BindingFlags.Public | BindingFlags.Instance);
                         if (clrFld != null)
                         {
-                            return new BoundClrPropertyAccessExpression(null, receiver, clrFld, TypeSymbol.FromClrType(clrFld.FieldType));
+                            return new BoundClrPropertyAccessExpression(
+                                null,
+                                receiver,
+                                clrFld,
+                                GetInheritedClrMemberType(receiver.Type, clrFld));
                         }
                     }
 

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -583,8 +583,14 @@ internal sealed partial class ExpressionBinder
             // protected members.
             if (GetInheritedClrBaseType(structSymbol) is Type inheritedBaseClr)
             {
-                MemberInfo? inhMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, propertyName);
-                inhMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, propertyName);
+                MemberInfo? inhMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+                    inheritedBaseClr,
+                    propertyName,
+                    CanAccessInternalsOf);
+                inhMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(
+                    inheritedBaseClr,
+                    propertyName,
+                    CanAccessInternalsOf);
                 if (inhMember != null)
                 {
                     // Issue #3815: project the inherited member through the
@@ -1093,8 +1099,14 @@ internal sealed partial class ExpressionBinder
             if (GetInheritedClrBaseType(structSymbol) is System.Type inheritedBaseClr)
             {
                 var memberName = syntax.FieldIdentifier.ValueText;
-                MemberInfo? clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, memberName);
-                clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, memberName);
+                MemberInfo? clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+                    inheritedBaseClr,
+                    memberName,
+                    CanAccessInternalsOf);
+                clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(
+                    inheritedBaseClr,
+                    memberName,
+                    CanAccessInternalsOf);
                 if (clrMember != null)
                 {
                     // Issue #3815: project the inherited member through the
@@ -1966,8 +1978,14 @@ internal sealed partial class ExpressionBinder
         {
             // Issue #1582: the receiver is a derived G# type reaching into its
             // metadata base — surface inherited protected/public members.
-            instanceMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrReceiverType, memberName);
-            instanceMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(clrReceiverType, memberName);
+            instanceMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+                clrReceiverType,
+                memberName,
+                CanAccessInternalsOf);
+            instanceMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(
+                clrReceiverType,
+                memberName,
+                CanAccessInternalsOf);
         }
         else
         {
@@ -2828,8 +2846,14 @@ internal sealed partial class ExpressionBinder
             // base chain and include inherited protected members).
             if (GetInheritedClrBaseType(structSym) is System.Type inheritedBaseClr)
             {
-                MemberInfo? clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(inheritedBaseClr, fieldName);
-                clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(inheritedBaseClr, fieldName);
+                MemberInfo? clrMember = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+                    inheritedBaseClr,
+                    fieldName,
+                    CanAccessInternalsOf);
+                clrMember ??= ClrTypeUtilities.SafeGetInheritedInstanceField(
+                    inheritedBaseClr,
+                    fieldName,
+                    CanAccessInternalsOf);
                 if (clrMember != null)
                 {
                     // Issue #3815: project the inherited member through the

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -1526,7 +1526,8 @@ internal sealed partial class ExpressionBinder
                 // from outside its declaring/derived type, instead of
                 // silently binding it.
                 if (!allowProtectedInherited && !nonVirtualBaseCall
-                    && !best.IsPublic && (best.IsFamily || best.IsFamilyOrAssembly))
+                    && !best.IsPublic
+                    && (best.IsFamily || best.IsFamilyOrAssembly || best.IsFamilyAndAssembly))
                 {
                     Diagnostics.ReportProtectedMemberInaccessible(ce.Identifier.Location, methodName, ClrTypeDisplayName(best.DeclaringType ?? importedBaseClr));
                     result = new BoundErrorExpression(null);
@@ -3153,7 +3154,7 @@ internal sealed partial class ExpressionBinder
     /// <param name="clrBase">The CLR base type to search (its base chain is walked by reflection).</param>
     /// <param name="methodName">The invoked method name.</param>
     /// <returns>The deduplicated candidate methods (most-derived signature wins).</returns>
-    private static IReadOnlyList<MethodInfo> CollectBaseClrMethodCandidates(System.Type? clrBase, string methodName)
+    private IReadOnlyList<MethodInfo> CollectBaseClrMethodCandidates(System.Type? clrBase, string methodName)
     {
         var result = new List<MethodInfo>();
         if (clrBase == null)
@@ -3168,10 +3169,9 @@ internal sealed partial class ExpressionBinder
                 continue;
             }
 
-            // Accessible to a derived type via `base`: public, protected
-            // (Family), or protected-internal (FamilyOrAssembly). Exclude
-            // private and (cross-assembly) internal members.
-            if (!(m.IsPublic || m.IsFamily || m.IsFamilyOrAssembly))
+            if (!ClrMemberVisibility.IsVisibleFromDerived(
+                    m,
+                    CanAccessInternalsOf(m.DeclaringType)))
             {
                 continue;
             }
@@ -3507,13 +3507,16 @@ internal sealed partial class ExpressionBinder
         }
 
         var memberName = member.IdentifierToken.ValueText;
-        var clrProp = ClrTypeUtilities.SafeGetProperty(clrBase, memberName, BindingFlags.Public | BindingFlags.Instance);
-        if (clrProp == null || clrProp.GetIndexParameters().Length != 0 || !clrProp.CanRead)
+        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+            clrBase,
+            memberName,
+            CanAccessInternalsOf);
+        if (clrProp == null)
         {
             return false;
         }
 
-        var getter = GetVisibleGetter(clrProp);
+        var getter = GetVisibleGetter(clrProp, fromDerivedType: true);
         if (getter == null)
         {
             return false;
@@ -3532,11 +3535,12 @@ internal sealed partial class ExpressionBinder
         }
 
         var receiver = new BoundVariableExpression(null, thisParameter);
+        var propertyType = GetInheritedClrMemberType(thisParameter.Type, clrProp);
         result = new BoundImportedInstanceCallExpression(
             member,
             receiver,
             getter,
-            TypeSymbol.FromClrType(clrProp.PropertyType),
+            propertyType,
             ImmutableArray<BoundExpression>.Empty,
             isNonVirtualBaseCall: true);
         return true;
@@ -3572,8 +3576,11 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        var clrProp = ClrTypeUtilities.SafeGetProperty(clrBase, memberName, BindingFlags.Public | BindingFlags.Instance);
-        if (clrProp == null || clrProp.GetIndexParameters().Length != 0)
+        var clrProp = ClrTypeUtilities.SafeGetInheritedInstanceProperty(
+            clrBase,
+            memberName,
+            CanAccessInternalsOf);
+        if (clrProp == null)
         {
             return false;
         }
@@ -3585,7 +3592,7 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        var setter = GetVisibleSetter(clrProp);
+        var setter = GetVisibleSetter(clrProp, fromDerivedType: true);
         if (setter == null)
         {
             Diagnostics.ReportCannotAssign(equalsLocation, memberName);
@@ -3600,12 +3607,13 @@ internal sealed partial class ExpressionBinder
             return true;
         }
 
-        var converted = conversions.BindConversion(valueLocation, value, TypeSymbol.FromClrType(clrProp.PropertyType));
         if (function?.ThisParameter is not { } thisParameter)
         {
             return false;
         }
 
+        var propertyType = GetInheritedClrMemberType(thisParameter.Type, clrProp);
+        var converted = conversions.BindConversion(valueLocation, value, propertyType);
         var receiver = new BoundVariableExpression(null, thisParameter);
         result = new BoundImportedInstanceCallExpression(
             value.Syntax,

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.cs
@@ -1375,8 +1375,13 @@ internal sealed partial class ExpressionBinder
     private MethodInfo? GetVisibleGetter(PropertyInfo property)
         => ClrMemberVisibility.GetVisibleGetter(property, CanAccessInternalsOf(property.DeclaringType));
 
+    private MethodInfo? GetVisibleGetter(PropertyInfo property, bool fromDerivedType)
+        => fromDerivedType
+            ? ClrMemberVisibility.GetDerivedVisibleGetter(property, CanAccessInternalsOf(property.DeclaringType))
+            : ClrMemberVisibility.GetVisibleGetter(property, CanAccessInternalsOf(property.DeclaringType));
+
     /// <summary>
-    /// Issue #3705: the setter sibling of <see cref="GetVisibleGetter"/>.
+    /// Issue #3705: the setter sibling of <see cref="GetVisibleGetter(PropertyInfo)"/>.
     /// </summary>
     /// <param name="property">The imported CLR property.</param>
     /// <returns>The callable setter, or <see langword="null"/>.</returns>
@@ -2790,19 +2795,19 @@ internal sealed partial class ExpressionBinder
 
         switch (member)
         {
-            case PropertyInfo clrProp when clrProp.CanRead:
+            case PropertyInfo clrProp when GetVisibleGetter(clrProp, fromDerivedType: true) != null:
                 bound = new BoundClrPropertyAccessExpression(
                     null,
                     receiver,
                     clrProp,
-                    GetInheritedClrMemberType(receiver.Type, clrProp, clrProp.PropertyType));
+                    GetInheritedClrMemberType(receiver.Type, clrProp));
                 return true;
             case FieldInfo clrFld:
                 bound = new BoundClrPropertyAccessExpression(
                     null,
                     receiver,
                     clrFld,
-                    GetInheritedClrMemberType(receiver.Type, clrFld, clrFld.FieldType));
+                    GetInheritedClrMemberType(receiver.Type, clrFld));
                 return true;
             default:
                 return false;
@@ -2879,52 +2884,24 @@ internal sealed partial class ExpressionBinder
         return true;
     }
 
+    /// <summary>
+    /// Resolves an inherited imported property or field through the same
+    /// receiver-substitution and declaration-nullability readers as direct CLR
+    /// member access. This is the shared read-side sibling of
+    /// <see cref="TryGetWritableClrMember(MemberInfo?, TypeSymbol?, out Type?, out TypeSymbol?, out bool, bool)"/>.
+    /// </summary>
     private static TypeSymbol GetInheritedClrMemberType(
         TypeSymbol receiverType,
-        MemberInfo member,
-        Type reflectedMemberType)
-    {
-        if (receiverType is StructSymbol receiverStruct)
+        MemberInfo member)
+        => member switch
         {
-            for (StructSymbol? current = receiverStruct; current != null; current = current.BaseClass)
-            {
-                if (current.ImportedBaseType is not ImportedTypeSymbol importedBase
-                    || importedBase.OpenDefinition is not { } openDefinition
-                    || importedBase.TypeArguments.IsDefaultOrEmpty
-                    || member.DeclaringType == null
-                    || !member.DeclaringType.IsConstructedGenericType
-                    || member.DeclaringType.GetGenericTypeDefinition() != openDefinition)
-                {
-                    continue;
-                }
-
-                MemberInfo? openMember = openDefinition
-                    .GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                    .FirstOrDefault(candidate =>
-                        candidate.MetadataToken == member.MetadataToken
-                        && candidate.Module == member.Module);
-                Type? openMemberType = openMember switch
-                {
-                    PropertyInfo property => property.PropertyType,
-                    FieldInfo field => field.FieldType,
-                    _ => null,
-                };
-                if (openMemberType != null)
-                {
-                    var symbolic = MemberLookup.MapOpenClrTypeToSymbolic(
-                        openMemberType,
-                        openDefinition,
-                        importedBase.TypeArguments);
-                    if (symbolic != TypeSymbol.Error)
-                    {
-                        return symbolic;
-                    }
-                }
-            }
-        }
-
-        return TypeSymbol.FromClrType(reflectedMemberType);
-    }
+            PropertyInfo property => MemberLookup.GetClrPropertyTypeSymbol(
+                receiverType,
+                property,
+                projectOnlyWhenSymbolicallyRequired: true),
+            FieldInfo field => MemberLookup.GetClrFieldTypeSymbol(receiverType, field),
+            _ => TypeSymbol.Error,
+        };
 
     /// <summary>
     /// Issue #1584: resolves a bare (unqualified) identifier inside an instance
@@ -2957,8 +2934,8 @@ internal sealed partial class ExpressionBinder
             return false;
         }
 
-        member = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrBase, name);
-        member ??= ClrTypeUtilities.SafeGetInheritedInstanceField(clrBase, name);
+        member = ClrTypeUtilities.SafeGetInheritedInstanceProperty(clrBase, name, CanAccessInternalsOf);
+        member ??= ClrTypeUtilities.SafeGetInheritedInstanceField(clrBase, name, CanAccessInternalsOf);
         if (member == null)
         {
             return false;

--- a/src/Core/CodeAnalysis/Symbols/ClrMemberVisibility.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrMemberVisibility.cs
@@ -23,11 +23,10 @@ namespace GSharp.Core.CodeAnalysis.Symbols;
 /// for the declaring assembly.
 /// </para>
 /// <para>
-/// Only metadata <c>assembly</c> accessibility is ever admitted:
-/// <c>private</c>, <c>protected</c>, <c>protected internal</c> and
-/// <c>private protected</c> members stay invisible however the friendship is
-/// declared, and a consumer that was not named in an
-/// <c>InternalsVisibleTo</c> sees none of them.
+/// General member lookup admits only <c>public</c> and friend-visible
+/// <c>assembly</c> members. The explicitly derived-type helpers additionally
+/// admit the CLR family accessibilities available from a subclass; private
+/// members remain invisible.
 /// </para>
 /// </summary>
 public static class ClrMemberVisibility
@@ -52,12 +51,34 @@ public static class ClrMemberVisibility
     public static bool IsVisible(MethodBase? method, bool includeInternal)
         => method != null && (method.IsPublic || (includeInternal && method.IsAssembly));
 
+    /// <summary>Whether a method or accessor is visible from a derived type.</summary>
+    /// <param name="method">The candidate method, or <see langword="null"/>.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns><see langword="true"/> when the method may be called from the derived type.</returns>
+    public static bool IsVisibleFromDerived(MethodBase? method, bool includeInternal)
+        => method != null
+            && (method.IsPublic
+                || method.IsFamily
+                || method.IsFamilyOrAssembly
+                || (includeInternal && method.IsAssembly));
+
     /// <summary>Whether a field is visible to the consuming compilation.</summary>
     /// <param name="field">The candidate field, or <see langword="null"/>.</param>
     /// <param name="includeInternal">Whether friend internals are visible.</param>
     /// <returns><see langword="true"/> when the field may be bound here.</returns>
     public static bool IsVisible(FieldInfo? field, bool includeInternal)
         => field != null && (field.IsPublic || (includeInternal && field.IsAssembly));
+
+    /// <summary>Whether a field is visible from a derived type.</summary>
+    /// <param name="field">The candidate field, or <see langword="null"/>.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns><see langword="true"/> when the field may be accessed from the derived type.</returns>
+    public static bool IsVisibleFromDerived(FieldInfo? field, bool includeInternal)
+        => field != null
+            && (field.IsPublic
+                || field.IsFamily
+                || field.IsFamilyOrAssembly
+                || (includeInternal && field.IsAssembly));
 
     /// <summary>
     /// Whether a property is visible — i.e. at least one of its accessors is.
@@ -94,6 +115,13 @@ public static class ClrMemberVisibility
     public static MethodInfo? GetVisibleSetter(PropertyInfo property, bool includeInternal)
         => Visible(property.GetSetMethod(nonPublic: true), includeInternal);
 
+    /// <summary>Returns the property's getter when callable from a derived type.</summary>
+    /// <param name="property">The imported CLR property.</param>
+    /// <param name="includeInternal">Whether friend internals are visible.</param>
+    /// <returns>The callable getter, or <see langword="null"/>.</returns>
+    public static MethodInfo? GetDerivedVisibleGetter(PropertyInfo property, bool includeInternal)
+        => VisibleFromDerived(property.GetGetMethod(nonPublic: true), includeInternal);
+
     /// <summary>
     /// Issue #3813: the setter as seen from <b>inside a type that derives from
     /// the property's declaring type</b>, where CLR <c>family</c> accessibility
@@ -114,21 +142,7 @@ public static class ClrMemberVisibility
     /// <param name="includeInternal">Whether friend internals are visible.</param>
     /// <returns>The setter callable from a derived type, or <see langword="null"/>.</returns>
     public static MethodInfo? GetDerivedVisibleSetter(PropertyInfo property, bool includeInternal)
-    {
-        var setter = property.GetSetMethod(nonPublic: true);
-        if (setter == null)
-        {
-            return null;
-        }
-
-        // `family` (protected) and `famorassem` (protected internal) are always
-        // reachable from a derived type; `famandassem` (private protected) only
-        // adds the same-assembly/friend requirement on top.
-        var reachable = setter.IsFamily
-            || setter.IsFamilyOrAssembly
-            || (includeInternal && setter.IsFamilyAndAssembly);
-        return reachable ? setter : Visible(setter, includeInternal);
-    }
+        => VisibleFromDerived(property.GetSetMethod(nonPublic: true), includeInternal);
 
     /// <summary>Returns the event's <c>add</c> accessor when it is visible here.</summary>
     /// <param name="eventInfo">The event to inspect.</param>
@@ -146,4 +160,7 @@ public static class ClrMemberVisibility
 
     private static MethodInfo? Visible(MethodInfo? accessor, bool includeInternal)
         => IsVisible(accessor, includeInternal) ? accessor : null;
+
+    private static MethodInfo? VisibleFromDerived(MethodInfo? accessor, bool includeInternal)
+        => IsVisibleFromDerived(accessor, includeInternal) ? accessor : null;
 }

--- a/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
+++ b/src/Core/CodeAnalysis/Symbols/ClrTypeUtilities.cs
@@ -747,17 +747,26 @@ public static class ClrTypeUtilities
     /// walking the CLR base chain and including non-public members whose
     /// accessibility is visible to a derived type — <c>public</c>,
     /// <c>protected</c> (Family), or <c>protected internal</c>
-    /// (FamilyOrAssembly). Private and (cross-assembly) internal fields are
-    /// excluded, mirroring the accessibility rule used for inherited CLR
-    /// methods in <c>CollectBaseClrMethodCandidates</c>. Reflection's
+    /// (FamilyOrAssembly), plus friend-visible <c>internal</c> and
+    /// <c>internal</c> when requested. Private and <c>private protected</c>
+    /// fields are excluded,
+    /// mirroring the accessibility rule used for inherited CLR methods in
+    /// <c>CollectBaseClrMethodCandidates</c>. Reflection's
     /// <see cref="Type.GetField(string, BindingFlags)"/> already surfaces
     /// inherited (non-<c>DeclaredOnly</c>) members, so a single tolerant probe
     /// covers the whole chain.
     /// </summary>
     /// <param name="type">The CLR base type to search (its base chain is walked by reflection).</param>
     /// <param name="name">The field name.</param>
+    /// <param name="canAccessInternalsOf">
+    /// Optional predicate that decides friend-internal access for the returned
+    /// field's declaring type.
+    /// </param>
     /// <returns>The matching visible inherited field, or <c>null</c> when none is found.</returns>
-    public static FieldInfo? SafeGetInheritedInstanceField(Type type, string name)
+    public static FieldInfo? SafeGetInheritedInstanceField(
+        Type type,
+        string name,
+        Func<Type?, bool>? canAccessInternalsOf = null)
     {
         if (type is null)
         {
@@ -765,7 +774,8 @@ public static class ClrTypeUtilities
         }
 
         var field = SafeGetField(type, name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        if (field != null && (field.IsPublic || field.IsFamily || field.IsFamilyOrAssembly))
+        var includeInternal = canAccessInternalsOf?.Invoke(field?.DeclaringType) == true;
+        if (ClrMemberVisibility.IsVisibleFromDerived(field, includeInternal))
         {
             return field;
         }
@@ -777,15 +787,24 @@ public static class ClrTypeUtilities
     /// Issue #1582: looks up a non-indexer instance PROPERTY named
     /// <paramref name="name"/> inherited from <paramref name="type"/> (a
     /// CLR/metadata base class), walking the CLR base chain and including
-    /// members with a non-public accessor whose accessibility is visible to a
+    /// members with at least one accessor whose accessibility is visible to a
     /// derived type (<c>public</c>, <c>protected</c>, or
-    /// <c>protected internal</c>). See
+    /// <c>protected internal</c>), plus friend-visible <c>internal</c> and
+    /// <c>internal</c> when requested. Private and <c>private protected</c>
+    /// accessors are excluded. See
     /// <see cref="SafeGetInheritedInstanceField"/> for the accessibility rule.
     /// </summary>
     /// <param name="type">The CLR base type to search (its base chain is walked by reflection).</param>
     /// <param name="name">The property name.</param>
+    /// <param name="canAccessInternalsOf">
+    /// Optional predicate that decides friend-internal access for the returned
+    /// property's declaring type.
+    /// </param>
     /// <returns>The matching visible inherited property, or <c>null</c> when none is found.</returns>
-    public static PropertyInfo? SafeGetInheritedInstanceProperty(Type type, string name)
+    public static PropertyInfo? SafeGetInheritedInstanceProperty(
+        Type type,
+        string name,
+        Func<Type?, bool>? canAccessInternalsOf = null)
     {
         if (type is null)
         {
@@ -798,8 +817,9 @@ public static class ClrTypeUtilities
             return null;
         }
 
-        var accessor = property.GetGetMethod(nonPublic: true) ?? property.GetSetMethod(nonPublic: true);
-        if (accessor != null && (accessor.IsPublic || accessor.IsFamily || accessor.IsFamilyOrAssembly))
+        var includeInternal = canAccessInternalsOf?.Invoke(property.DeclaringType) == true;
+        if (ClrMemberVisibility.GetDerivedVisibleGetter(property, includeInternal) != null
+            || ClrMemberVisibility.GetDerivedVisibleSetter(property, includeInternal) != null)
         {
             return property;
         }

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1582MetadataBaseInheritedMemberTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1582MetadataBaseInheritedMemberTests.cs
@@ -58,7 +58,7 @@ import System.Security.Cryptography
 open class A : HashAlgorithm {
     func Initialize() { }
     protected func HashCore(a []uint8, s int32, c int32) { }
-    protected func HashFinal() []uint8 { return HashValue }
+    protected func HashFinal() []uint8 { return HashValue ?? []uint8{} }
 }
 ";
         AssertNoErrors(source, withReferences);
@@ -78,7 +78,7 @@ open class A : HashAlgorithm {
     protected func HashCore(a []uint8, s int32, c int32) { }
     protected func HashFinal() []uint8 {
         this.HashValue = []uint8{}
-        return this.HashValue
+        return this.HashValue ?? []uint8{}
     }
 }
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue1584InheritedMemberBareWriteTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue1584InheritedMemberBareWriteTests.cs
@@ -168,7 +168,7 @@ open class A : HashAlgorithm {
     protected func HashCore(a []uint8, s int32, c int32) { }
     protected func HashFinal() []uint8 {
         this.HashValue = []uint8{}
-        return this.HashValue
+        return this.HashValue ?? []uint8{}
     }
 }
 ";

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindAccessibilityDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindAccessibilityDifferentialTests.cs
@@ -39,9 +39,10 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// while passing for the method and property/field-read rows.
 /// </para>
 /// <para>
-/// The guard rails are half the point: <c>private</c> and <c>protected</c>
-/// must stay invisible to a friend, and a non-friend must see neither those
-/// nor <c>internal</c>.
+/// The guard rails are half the point: outside a derived type,
+/// <c>private</c> and <c>protected</c> stay invisible to a friend, and a
+/// non-friend sees neither those nor <c>internal</c>. Derived-type probes below
+/// separately assert the CLR family-access rules.
 /// </para>
 /// </summary>
 public sealed class Issue3705MemberKindAccessibilityDifferentialTests
@@ -69,6 +70,8 @@ public sealed class Issue3705MemberKindAccessibilityDifferentialTests
             internal int InternalField;
             private int PrivateField;
             protected int ProtectedField;
+            protected internal int ProtectedInternalField;
+            private protected int PrivateProtectedField;
 
             public event Action PublicEvent;
             internal event Action InternalEvent;
@@ -79,11 +82,16 @@ public sealed class Issue3705MemberKindAccessibilityDifferentialTests
             internal int InternalProperty { get; set; }
             private int PrivateProperty { get; set; }
             protected int ProtectedProperty { get; set; }
+            protected internal int ProtectedInternalProperty { get; set; }
+            private protected int PrivateProtectedProperty { get; set; }
+            public int PublicSetterPrivateGetter { private get; set; }
 
             public int PublicMethod() => 1;
             internal int InternalMethod() => 1;
             private int PrivateMethod() => 1;
             protected int ProtectedMethod() => 1;
+            protected internal int ProtectedInternalMethod() => 1;
+            private protected int PrivateProtectedMethod() => 1;
 
             public int this[int index] { get => 0; set { } }
             internal int this[string index] { get => 0; set { } }
@@ -165,6 +173,186 @@ public sealed class Issue3705MemberKindAccessibilityDifferentialTests
         }
     }
 
+    /// <summary>
+    /// Inherited-property lookup must test the accessor used by the operation,
+    /// not whichever accessor reflection happens to return first.
+    /// </summary>
+    /// <returns>The derived-member probe cases.</returns>
+    public static IEnumerable<object[]> DerivedMemberCases()
+    {
+        yield return new object[] { "this-protected-read", "let value = this.ProtectedProperty", StrangerAssemblyName, true };
+        yield return new object[] { "bare-protected-read", "let value = ProtectedProperty", StrangerAssemblyName, true };
+        yield return new object[] { "base-protected-read", "let value = base.ProtectedProperty", StrangerAssemblyName, true };
+        yield return new object[] { "this-protected-write", "this.ProtectedProperty = 7", StrangerAssemblyName, true };
+        yield return new object[] { "bare-protected-write", "ProtectedProperty = 7", StrangerAssemblyName, true };
+        yield return new object[] { "base-protected-write", "base.ProtectedProperty = 7", StrangerAssemblyName, true };
+        yield return new object[] { "this-protected-method", "let value = this.ProtectedMethod()", StrangerAssemblyName, true };
+        yield return new object[] { "bare-protected-method", "let value = ProtectedMethod()", StrangerAssemblyName, true };
+        yield return new object[] { "base-protected-method", "let value = base.ProtectedMethod()", StrangerAssemblyName, true };
+        yield return new object[] { "protected-internal-property", "let value = this.ProtectedInternalProperty", StrangerAssemblyName, true };
+        yield return new object[] { "protected-internal-field", "let value = this.ProtectedInternalField", StrangerAssemblyName, true };
+        yield return new object[] { "protected-internal-method", "let value = this.ProtectedInternalMethod()", StrangerAssemblyName, true };
+        yield return new object[] { "this-private-getter-read", "let value = this.PublicSetterPrivateGetter", StrangerAssemblyName, false };
+        yield return new object[] { "bare-private-getter-read", "let value = PublicSetterPrivateGetter", StrangerAssemblyName, false };
+        yield return new object[] { "base-private-getter-read", "let value = base.PublicSetterPrivateGetter", StrangerAssemblyName, false };
+        yield return new object[] { "this-public-setter-write", "this.PublicSetterPrivateGetter = 7", StrangerAssemblyName, true };
+        yield return new object[] { "bare-public-setter-write", "PublicSetterPrivateGetter = 7", StrangerAssemblyName, true };
+        yield return new object[] { "base-public-setter-write", "base.PublicSetterPrivateGetter = 7", StrangerAssemblyName, true };
+
+        yield return new object[] { "this-friend-internal-property-read", "let value = this.InternalProperty", FriendAssemblyName, true };
+        yield return new object[] { "bare-friend-internal-property-read", "let value = InternalProperty", FriendAssemblyName, true };
+        yield return new object[] { "base-friend-internal-property-read", "let value = base.InternalProperty", FriendAssemblyName, true };
+        yield return new object[] { "this-friend-internal-property-write", "this.InternalProperty = 7", FriendAssemblyName, true };
+        yield return new object[] { "bare-friend-internal-property-write", "InternalProperty = 7", FriendAssemblyName, true };
+        yield return new object[] { "base-friend-internal-property-write", "base.InternalProperty = 7", FriendAssemblyName, true };
+        yield return new object[] { "this-friend-internal-field-read", "let value = this.InternalField", FriendAssemblyName, true };
+        yield return new object[] { "bare-friend-internal-field-read", "let value = InternalField", FriendAssemblyName, true };
+        yield return new object[] { "this-friend-internal-field-write", "this.InternalField = 7", FriendAssemblyName, true };
+        yield return new object[] { "bare-friend-internal-field-write", "InternalField = 7", FriendAssemblyName, true };
+        yield return new object[] { "this-friend-internal-method", "let value = this.InternalMethod()", FriendAssemblyName, true };
+        yield return new object[] { "bare-friend-internal-method", "let value = InternalMethod()", FriendAssemblyName, true };
+        yield return new object[] { "base-friend-internal-method", "let value = base.InternalMethod()", FriendAssemblyName, true };
+        yield return new object[] { "friend-private-protected-property", "let value = this.PrivateProtectedProperty", FriendAssemblyName, false };
+        yield return new object[] { "friend-private-protected-field", "let value = this.PrivateProtectedField", FriendAssemblyName, false };
+        yield return new object[] { "friend-private-protected-method", "let value = this.PrivateProtectedMethod()", FriendAssemblyName, false };
+
+        yield return new object[] { "nonfriend-internal-property-read", "let value = this.InternalProperty", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-internal-property-write", "this.InternalProperty = 7", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-internal-field-read", "let value = this.InternalField", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-internal-field-write", "this.InternalField = 7", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-internal-method", "let value = this.InternalMethod()", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-private-protected-property", "let value = this.PrivateProtectedProperty", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-private-protected-field", "let value = this.PrivateProtectedField", StrangerAssemblyName, false };
+        yield return new object[] { "nonfriend-private-protected-method", "let value = this.PrivateProtectedMethod()", StrangerAssemblyName, false };
+        yield return new object[] { "private-method", "let value = this.PrivateMethod()", StrangerAssemblyName, false };
+    }
+
+    /// <param name="name">The probe name.</param>
+    /// <param name="body">The derived method body.</param>
+    /// <param name="consumer">The consuming assembly name.</param>
+    /// <param name="expectedVisible">Whether the selected member operation is visible.</param>
+    [Theory]
+    [MemberData(nameof(DerivedMemberCases))]
+    public void InheritedMember_Uses_OperationSpecific_Visibility(
+        string name,
+        string body,
+        string consumer,
+        bool expectedVisible)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+            var result = CompileGSharp(
+                $$"""
+                package {{consumer}}
+                import Issue3705.Library
+
+                class Derived : Surface {
+                    func Probe() {
+                        {{body}}
+                    }
+                }
+                """,
+                consumer,
+                libraryPath);
+
+            Assert.True(
+                result.Success == expectedVisible,
+                $"{name}: expected visible={expectedVisible}: {Describe(result)}");
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// Friendship belongs to the member's declaring assembly, not the
+    /// immediate imported base through which reflection found it.
+    /// </summary>
+    [Fact]
+    public void InheritedInternalVisibility_Uses_The_DeclaringAssembly()
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var friendAncestor = EmitCSharpLibrary(
+                directory,
+                "Issue3705.FriendAncestor",
+                """
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("Issue3705.Friend")]
+                namespace Issue3705.FriendAncestor;
+                public class Ancestor
+                {
+                    internal int ValueField = 1;
+                    internal int ValueProperty => 2;
+                }
+                """);
+            var neutralMiddle = EmitCSharpLibrary(
+                directory,
+                "Issue3705.NeutralMiddle",
+                """
+                namespace Issue3705.NeutralMiddle;
+                public class Middle : Issue3705.FriendAncestor.Ancestor { }
+                """,
+                friendAncestor);
+
+            var visible = CompileGSharp(
+                """
+                package Issue3705.Friend
+                import Issue3705.NeutralMiddle
+                class Derived : Middle {
+                    func Read() int32 -> this.ValueField + this.ValueProperty
+                }
+                """,
+                FriendAssemblyName,
+                friendAncestor,
+                neutralMiddle);
+            Assert.True(visible.Success, Describe(visible));
+
+            var noFriendAncestor = EmitCSharpLibrary(
+                directory,
+                "Issue3705.NoFriendAncestor",
+                """
+                namespace Issue3705.NoFriendAncestor;
+                public class Ancestor
+                {
+                    internal int ValueField = 1;
+                    internal int ValueProperty => 2;
+                }
+                """);
+            var friendlyMiddle = EmitCSharpLibrary(
+                directory,
+                "Issue3705.FriendlyMiddle",
+                """
+                using System.Runtime.CompilerServices;
+                [assembly: InternalsVisibleTo("Issue3705.Friend")]
+                namespace Issue3705.FriendlyMiddle;
+                public class Middle : Issue3705.NoFriendAncestor.Ancestor { }
+                """,
+                noFriendAncestor);
+
+            var hidden = CompileGSharp(
+                """
+                package Issue3705.Friend
+                import Issue3705.FriendlyMiddle
+                class Derived : Middle {
+                    func Read() int32 -> this.ValueField + this.ValueProperty
+                }
+                """,
+                FriendAssemblyName,
+                noFriendAncestor,
+                friendlyMiddle);
+            Assert.False(hidden.Success);
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
     private static string BuildSource(string kind, string accessibility, string consumer)
     {
         // The index argument selects the overload whose accessibility is under
@@ -230,12 +418,18 @@ public sealed class Issue3705MemberKindAccessibilityDifferentialTests
             emit.Diagnostics.Select(d => new DiagnosticInfo(d.Id, d.Message)).ToArray());
     }
 
-    private static string EmitCSharpLibrary(string directory, string assemblyName, string source)
+    private static string EmitCSharpLibrary(
+        string directory,
+        string assemblyName,
+        string source,
+        params string[] additionalReferences)
     {
         var references = ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string)
                 ?.Split(Path.PathSeparator)
                 ?? Array.Empty<string>())
             .Where(File.Exists)
+            .Concat(additionalReferences)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path));
         var compilation = CSharpCompilation.Create(
             assemblyName,

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindNullabilityDifferentialTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3705MemberKindNullabilityDifferentialTests.cs
@@ -32,9 +32,9 @@ namespace GSharp.Core.Tests.CodeAnalysis.Binding;
 /// So rather than one test per site, this fixture asserts the INVARIANT: for a
 /// reference-typed signature position on an imported member, whether the bound
 /// type is nullable depends only on the DECLARATION's annotation state, and
-/// never on the member kind through which the position was reached. The member
-/// kind never appears on the right-hand side of either expectation; the table
-/// IS the invariant.
+/// never on the member kind or receiver shape through which the position was
+/// reached. Neither appears on the right-hand side of either expectation; the
+/// table IS the invariant.
 /// </para>
 /// <para>
 /// There are FOUR annotation states, not three, and the fourth is the one the
@@ -161,6 +161,16 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             public string this[int index] => "V";
 
             public string? this[long index] => null;
+        }
+
+        public interface INonNullInherited
+        {
+            string Value { get; }
+        }
+
+        public interface INullableInherited
+        {
+            string? Value { get; }
         }
 
         // ObliviousZero: a `[NullableContext(1)]` type whose `#nullable disable`
@@ -321,9 +331,9 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
         """;
 
     /// <summary>
-    /// Gets the signature-position kinds under test. Each names a distinct
-    /// reader inside the compiler; the invariant is that they all give the
-    /// same answer for the same declaration.
+    /// Gets the signature-position kinds and receiver shapes under test. Each
+    /// names a distinct reader inside the compiler; the invariant is that they
+    /// all give the same answer for the same declaration.
     /// </summary>
     private static string[] Kinds => new[]
     {
@@ -335,6 +345,11 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
         "ConstrainedProperty",
         "ConstrainedIndexer",
         "DeconstructOut",
+        "InheritedField",
+        "InheritedProperty",
+        "BareInheritedField",
+        "BareInheritedProperty",
+        "BaseProperty",
     };
 
     /// <summary>
@@ -351,7 +366,7 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
     };
 
     /// <summary>
-    /// Gets the differential matrix: signature-position kind × annotation
+    /// Gets the differential matrix: signature-position path × annotation
     /// state. Both expectations — "does this bind as non-null?" and "what does
     /// the emitted program print?" — are computed from the annotation state
     /// ALONE. The kind never appears on the right-hand side.
@@ -371,19 +386,16 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
     /// <summary>
     /// The family-2 invariant, over all four annotation states.
     /// <para>
-    /// Rows that pass on <c>origin/main</c> and are here as guard rails: every
-    /// <c>NonNull</c> and <c>Nullable</c> row (#3741 landed those), and the
-    /// <c>Oblivious*</c> rows for <c>Property</c>, <c>MethodReturn</c> and
-    /// <c>IndexerElement</c>, which already took the plain
-    /// <c>ClrNullability</c> readers.
+    /// Existing rows pass on the current <c>origin/main</c> and remain as guard
+    /// rails. The inherited-class and explicit-<c>base</c> rows added for the
+    /// remaining #3705 base-member group fail there for every nullable state:
+    /// those paths used bare <c>TypeSymbol.FromClrType</c> instead of the same
+    /// nullability-aware readers as direct imported member access.
     /// </para>
     /// <para>
-    /// Rows that FAIL on <c>origin/main</c>: the <c>Oblivious*</c> rows for
-    /// <c>Field</c>, <c>ConstrainedMethodReturn</c> and <c>DeconstructOut</c>,
-    /// the three kinds that route through
-    /// <c>NullableFlagsBuilder.MergeDeclarationNullability</c>. On main they
-    /// bind an unannotated imported reference position as non-null, which is
-    /// the pre-#1354 answer.
+    /// The <c>NonNull</c> rows are the negative controls: routing these paths
+    /// through <c>ClrNullability</c> must not widen an explicitly non-null
+    /// declaration.
     /// </para>
     /// </summary>
     /// <param name="kind">The signature-position kind.</param>
@@ -436,6 +448,123 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             Assert.Equal(
                 expectedMarker,
                 RunGSharp(lenient, libraryPath, $"{kind}-{state}").Trim());
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// The write-side sibling of the inherited/base property reads in
+    /// <see cref="SignaturePositions_Agree_On_DeclarationNullability"/>.
+    /// </summary>
+    /// <param name="state">The declaration's annotation state.</param>
+    /// <param name="acceptsNil">Whether assigning <c>nil</c> must compile.</param>
+    [Theory]
+    [InlineData("NonNull", false)]
+    [InlineData("Nullable", true)]
+    [InlineData("ObliviousAbsent", true)]
+    [InlineData("ObliviousZero", true)]
+    public void BasePropertyWrite_Uses_DeclarationNullability(string state, bool acceptsNil)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+            var baseType = state.StartsWith("Oblivious", StringComparison.Ordinal)
+                ? state + "Surface"
+                : "Surface";
+            var compiled = CompileGSharp(
+                $$"""
+                package {{ConsumerAssemblyName}}
+                import Issue3705.NullabilityLibrary
+
+                class Derived : {{baseType}} {
+                    func Clear() {
+                        base.{{state}}Property = nil
+                    }
+                }
+
+                func Main() {
+                    Derived().Clear()
+                }
+                """,
+                libraryPath);
+
+            Assert.True(
+                compiled.Success == acceptsNil,
+                $"{state}: expected acceptsNil={acceptsNil}: {Describe(compiled)}");
+            if (!acceptsNil)
+            {
+                Assert.Contains(compiled.Diagnostics, diagnostic => diagnostic.Id == "GS0155");
+            }
+        }
+        finally
+        {
+            DeleteOutputDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// A user interface that extends an imported interface must read the
+    /// inherited property's declaration nullability, just like a user class
+    /// that extends an imported base class.
+    /// </summary>
+    /// <param name="nullable">Whether the imported property is nullable.</param>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ImportedBaseInterfaceProperty_Uses_DeclarationNullability(bool nullable)
+    {
+        var directory = CreateOutputDirectory();
+        try
+        {
+            var libraryPath = EmitCSharpLibrary(directory, LibraryAssemblyName, CSharpLibrarySource);
+            var suffix = nullable ? "Nullable" : "NonNull";
+            var propertyType = nullable ? "string?" : "string";
+            var value = nullable ? "nil" : "\"V\"";
+            string BuildSource(string target)
+            {
+                var report = target == "string?"
+                ? """
+                      if probe == nil {
+                          Console.WriteLine("nil")
+                      } else {
+                          Console.WriteLine("value")
+                      }
+                  """
+                : "    Console.WriteLine(probe)";
+
+                return $$"""
+                    package {{ConsumerAssemblyName}}
+                    import Issue3705.NullabilityLibrary
+
+                    interface Local : I{{suffix}}Inherited {}
+
+                    class Impl : Local {
+                        prop Value {{propertyType}} {
+                            get { return {{value}} }
+                        }
+                    }
+
+                    func Read(receiver Local) {{target}} {
+                        return receiver.Value
+                    }
+
+                    func Main() {
+                        let probe {{target}} = Read(Impl())
+                    {{report}}
+                    }
+                    """;
+            }
+
+            var strict = CompileGSharp(BuildSource("string"), libraryPath);
+            var lenient = CompileGSharp(BuildSource("string?"), libraryPath);
+
+            Assert.Equal(!nullable, strict.Success);
+            Assert.True(lenient.Success, Describe(lenient));
+            Assert.Equal(nullable ? "nil" : "value", RunGSharp(lenient, libraryPath, suffix).Trim());
         }
         finally
         {
@@ -651,6 +780,7 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
         var indexArgument = state == "Nullable" ? "1L" : "1";
         var constrainedInterface = isOblivious ? "I" + state + "Constrained" : "IConstrained";
         var constrainedImpl = isOblivious ? state + "Constrained" : "Constrained";
+        var inheritedBase = isOblivious ? state + "Surface" : "Surface";
         var deconstructReceiver = state switch
         {
             "NonNull" => "Surface",
@@ -683,6 +813,9 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
             "DeconstructOut" => $"    let receiver = {deconstructReceiver}()\n"
                 + "    let (first, second) = receiver\n"
                 + $"    let probe {target} = first",
+            "InheritedField" or "InheritedProperty" or "BareInheritedField"
+                or "BareInheritedProperty" or "BaseProperty"
+                => $"    let probe {target} = Derived().Read()",
             _ => throw new ArgumentOutOfRangeException(nameof(kind)),
         };
 
@@ -720,6 +853,27 @@ public sealed class Issue3705MemberKindNullabilityDifferentialTests
                     return {{constrainedRead}}
                 }
                 """;
+
+        var inheritedRead = kind switch
+        {
+            "InheritedField" => $"this.{memberPrefix}Field",
+            "InheritedProperty" => $"this.{memberPrefix}Property",
+            "BareInheritedField" => $"{memberPrefix}Field",
+            "BareInheritedProperty" => $"{memberPrefix}Property",
+            "BaseProperty" => $"base.{memberPrefix}Property",
+            _ => null,
+        };
+        if (inheritedRead != null)
+        {
+            helper = $$"""
+
+                class Derived : {{inheritedBase}} {
+                    func Read() {{target}} {
+                        return {{inheritedRead}}
+                    }
+                }
+                """;
+        }
 
         return $$"""
             package {{ConsumerAssemblyName}}


### PR DESCRIPTION
Part of #3705

## Summary

- finish the explicitly deferred inherited/base-member audit: route `this.Member`, bare `Member`, inherited imported-interface members, and `base.Property` through the existing declaration-nullability readers instead of bare `TypeSymbol.FromClrType`
- centralize derived-type CLR visibility in `ClrMemberVisibility`, including operation-specific getter/setter checks and friend-visible `internal` members and CLR derived-family access; use it for inherited fields, properties, and methods
- extend the existing #3705 differential gates from member-kind-only coverage to inherited receiver/access forms; repair old `HashAlgorithm.HashValue` tests to acknowledge its imported nullable declaration

## Findings / triage

Current `main` still had one coherent reachable family:

| site | sibling already right | consequence |
|---|---|---|
| inherited CLR property/field reads (`this.` and bare), imported-base-interface reads, `base.Property` read/write | direct imported member readers (`MemberLookup.GetClrPropertyTypeSymbol` / `GetClrFieldTypeSymbol`) | explicit `string?` and oblivious metadata bound as non-null; nullable base writes rejected |
| inherited property lookup | `ClrMemberVisibility` accessor helpers | lookup tested whichever accessor reflection returned first: valid public-setter/private-getter writes were hidden, while reads did not ask specifically for a visible getter |
| inherited fields/properties/methods in a friend-derived type | ordinary friend-member lookup and derived protected lookup | the two dimensions were handled separately, so friend `internal` members disappeared through `this`, bare, and `base` paths |

Post-funnel additions were classified. Channel runtime reflection probes are compiler-owned public runtime contracts; the delegate `Invoke` additions retain the open-definition fallback; no additional high-confidence reflection/load-context defect was found. Previously filed independent work (#3834 and #3940) is not duplicated here; #3876/#3986 landed while this branch was being rebased. The broader audit issue therefore remains open.

## Verification

- `dotnet restore GSharp.sln --locked-mode`
- `dotnet build GSharp.sln --configuration Release --no-restore -graph` — 0 warnings, 0 errors
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --no-build --no-restore` — 8987/8987
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --no-restore --filter 'FullyQualifiedName~Issue3705'` — 214/214
- related inherited/member suites (`Issue1582|Issue1584|Issue1181|Issue2642|Issue2809|Issue3415`) — 50/50
- related `Compiler.Tests` (`Issue3813|Issue3815|Issue1181|Issue2642|Issue2210|Issue2218|Issue1260`) — 20/20
- `python3 build/nullable_hygiene.py` — OK; no forgiving operators, suppressions, or nullable directives added
- `build/run-cs2gs-selfmig-pr-guard.sh` — 8/8 app rows PASS across translate, compile, ILVerify, and test-parity; wrapper exits 0. Its report also reproduces main's independent #3993 (`unexpected file test/Shared/GoldenFile.gs`, then contradictory `run FAILED` / `PR guard PASSED`).

ADR-0154 witness: with the production hunks exactly reverted and the new differential tests retained, **38/169 fail**; with the fix, all pass. The explicitly non-null, non-friend, private, and inaccessible-accessor rows are the negative controls.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): exact product-hunk revert is 38 failed / 131 passed; fixed tree is green.
- [x] Self-review verdict: **MERGEABLE**. Independent already-filed residuals are linked above rather than folded into this PR.
