### PR TITLE
gsc: support delegate combination operators (#3792)

### DIFF
--- a/docs/adr/0059-named-delegate-types.md
+++ b/docs/adr/0059-named-delegate-types.md
@@ -82,6 +82,21 @@ For `public delegate ClickHandler(sender Object, e EventArgs) `:;
 2. Two *distinct* named delegates do **not** silently convert into each other, even when their shapes match. This mirrors CLR rules: `Action` and `ThreadStart` are unrelated even though both are `void()`. Going from one named delegate to another requires extracting the underlying function value (`var f func() = a; var b OtherDelegate = f`).
 3. Any named-delegate value widens implicitly to `System.Delegate` and `System.MulticastDelegate`, identical to the existing rule for `Action`/`Func` (`Conversion.cs:IsSystemDelegateBaseType`).
 
+### Delegate combination
+
+Issue #3792 adds the CLR/C# delegate `+`, `-`, `+=`, and `-=` operators outside
+event-subscription sites. Two operands of the same concrete delegate type
+(including structural function types and user-declared or imported named
+delegates) lower to `System.Delegate.Combine` / `System.Delegate.Remove`, then
+`castclass` back to that concrete delegate type. A compatible method group or
+structural function value is target-typed to the concrete delegate first.
+
+Both operands are nil-tolerant, matching the CLR helpers. Addition is nullable
+only when both operands may be nil; removal is always nullable because removing
+the last matching invocation yields nil. `System.Delegate` and
+`System.MulticastDelegate` themselves do not gain these operators, nor do
+different named delegate types merely because their signatures match.
+
 ### Why a separate `delegate` keyword
 
 `type Name = func(…) R` could in principle re-mean "emit a CLR delegate." It does not, because the existing `type Name = SomeOtherName` alias surface is *erased* at bind time (ADR-0058's words: "Aliases are not emitted into CIL"). Adding emit semantics to plain `type Name = func(…)` would silently change the meaning of existing code and conflict with users who rely on alias erasure to give a domain-specific name to a function shape without paying for a TypeDef. The `delegate` keyword keeps the two cases visually and semantically distinct:

--- a/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundBinaryOperator.cs
@@ -45,7 +45,8 @@ public sealed record BoundBinaryOperator
         TypeSymbol leftType,
         TypeSymbol rightType,
         TypeSymbol resultType,
-        bool isReferenceEquality = false)
+        bool isReferenceEquality = false,
+        bool isDelegateCombination = false)
     {
         SyntaxKind = syntaxKind;
         Kind = kind;
@@ -53,6 +54,7 @@ public sealed record BoundBinaryOperator
         RightType = rightType;
         Type = resultType;
         IsReferenceEquality = isReferenceEquality;
+        IsDelegateCombination = isDelegateCombination;
     }
 
     /// <summary>
@@ -82,6 +84,9 @@ public sealed record BoundBinaryOperator
 
     /// <summary>Gets a value indicating whether equality compares reference identity.</summary>
     internal bool IsReferenceEquality { get; }
+
+    /// <summary>Gets a value indicating whether this operator combines or removes delegates.</summary>
+    internal bool IsDelegateCombination { get; }
 
     /// <summary>
     /// Binds a syntax kind and a type symbol to the corresponding bound binary operator, or
@@ -396,6 +401,30 @@ public sealed record BoundBinaryOperator
             ? BoundBinaryOperatorKind.Equals
             : BoundBinaryOperatorKind.NotEquals;
         return new BoundBinaryOperator(syntaxKind, kind, leftType, rightType, TypeSymbol.Bool, isReferenceEquality: true);
+    }
+
+    /// <summary>Creates the built-in delegate <c>+</c> or <c>-</c> operator.</summary>
+    /// <param name="syntaxKind">The <c>+</c> or <c>-</c> token.</param>
+    /// <param name="leftType">The left operand type.</param>
+    /// <param name="rightType">The right operand type.</param>
+    /// <param name="resultType">The concrete, optionally nullable delegate result type.</param>
+    /// <returns>The delegate-combination operator.</returns>
+    internal static BoundBinaryOperator MakeDelegateCombination(
+        SyntaxKind syntaxKind,
+        TypeSymbol leftType,
+        TypeSymbol rightType,
+        TypeSymbol resultType)
+    {
+        var kind = syntaxKind == SyntaxKind.PlusToken
+            ? BoundBinaryOperatorKind.Sum
+            : BoundBinaryOperatorKind.Difference;
+        return new BoundBinaryOperator(
+            syntaxKind,
+            kind,
+            leftType,
+            rightType,
+            resultType,
+            isDelegateCombination: true);
     }
 
     /// <summary>

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Assignments.cs
@@ -1408,7 +1408,15 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var convertedResult = conversions.BindConversion(syntax.Value.Location, binaryResult, leftType);
+        // Issue #3792: a preceding assignment may smart-cast a nullable
+        // delegate read to its non-nullable underlying type. Compound
+        // assignment still stores into the variable's declared slot type;
+        // Delegate.Remove can produce nil, so converting through the narrowed
+        // read type would incorrectly reject a valid `D? -= handler`.
+        var storeType = binaryResult is BoundBinaryExpression { Op.IsDelegateCombination: true }
+            ? GetAssignmentTargetType(variable) ?? leftType
+            : leftType;
+        var convertedResult = conversions.BindConversion(syntax.Value.Location, binaryResult, storeType);
 
         // Route through the correct assignment path depending on variable kind.
         if (variable is ImplicitFieldVariableSymbol implicitField)

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Operators.cs
@@ -1780,6 +1780,21 @@ internal sealed partial class ExpressionBinder
 
         if (boundLeft.Type == TypeSymbol.Error || boundRight.Type == TypeSymbol.Error)
         {
+            if (TryBindDelegateCombinationOperator(
+                syntax.OperatorToken.Kind,
+                ref boundLeft,
+                ref boundRight,
+                syntax.Left.Location,
+                syntax.Right.Location,
+                out var delegateOperator))
+            {
+                return new BoundBinaryExpression(
+                    null,
+                    boundLeft,
+                    Invariant.Required(delegateOperator, "a successful delegate bind produces an operator"),
+                    boundRight);
+            }
+
             return new BoundErrorExpression(null);
         }
 
@@ -2533,12 +2548,13 @@ internal sealed partial class ExpressionBinder
     }
 
     /// <summary>
-    /// Issue #1246: shared numeric-operand adaptation for binding a binary
-    /// operator. Attempts an exact per-type bind first, then — when that fails —
-    /// applies, in order, the same adaptations <c>BindBinaryExpression</c>
-    /// performs: constant-integer-literal adaptation (#1144), directional
-    /// implicit integer widening (#1150), the value-type and heterogeneous
-    /// nullable mixed-mode lifts, and lifted (nullable) numeric widening (#1236).
+    /// Issue #1246: shared operand adaptation for binding a binary operator.
+    /// Attempts an exact per-type bind first, then — when that fails — applies
+    /// the same adaptations <c>BindBinaryExpression</c> performs, including
+    /// delegate target typing (#3792), constant-integer-literal adaptation
+    /// (#1144), directional implicit integer widening (#1150), the value-type
+    /// and heterogeneous nullable mixed-mode lifts, and lifted (nullable)
+    /// numeric widening (#1236).
     /// Any inserted conversions mutate <paramref name="boundLeft"/> /
     /// <paramref name="boundRight"/> in place. This is factored out so compound
     /// assignment (<c>a op= b</c>) widens its right operand exactly like the
@@ -2555,6 +2571,18 @@ internal sealed partial class ExpressionBinder
         TextLocation rightLocation)
     {
         var boundOperator = BoundBinaryOperator.Bind(operatorKind, boundLeft.Type, boundRight.Type);
+
+        if (boundOperator == null
+            && TryBindDelegateCombinationOperator(
+                operatorKind,
+                ref boundLeft,
+                ref boundRight,
+                leftLocation,
+                rightLocation,
+                out var delegateOperator))
+        {
+            return delegateOperator;
+        }
 
         // Issue #3463: C# defines string concatenation with char operands in
         // either order. Keep char-to-string adaptation local to `+` rather
@@ -2875,6 +2903,118 @@ internal sealed partial class ExpressionBinder
 
         return boundOperator;
     }
+
+    private bool TryBindDelegateCombinationOperator(
+        SyntaxKind operatorKind,
+        ref BoundExpression left,
+        ref BoundExpression right,
+        TextLocation leftLocation,
+        TextLocation rightLocation,
+        out BoundBinaryOperator? op)
+    {
+        op = null;
+        if (operatorKind is not SyntaxKind.PlusToken and not SyntaxKind.MinusToken)
+        {
+            return false;
+        }
+
+        var leftDelegate = GetConcreteDelegateType(left.Type);
+        var rightDelegate = GetConcreteDelegateType(right.Type);
+        TypeSymbol? target = null;
+
+        if (leftDelegate != null && IsUnresolvedMethodGroup(right))
+        {
+            right = conversions.BindConversion(rightLocation, right, leftDelegate);
+            if (right is BoundErrorExpression)
+            {
+                return false;
+            }
+
+            rightDelegate = GetConcreteDelegateType(right.Type);
+        }
+        else if (rightDelegate != null && IsUnresolvedMethodGroup(left))
+        {
+            left = conversions.BindConversion(leftLocation, left, rightDelegate);
+            if (left is BoundErrorExpression)
+            {
+                return false;
+            }
+
+            leftDelegate = GetConcreteDelegateType(left.Type);
+        }
+
+        if (leftDelegate != null && rightDelegate != null)
+        {
+            if (TypeSymbol.AreRuntimeEquivalentIgnoringReferenceNullability(leftDelegate, rightDelegate))
+            {
+                target = leftDelegate;
+            }
+            else if (rightDelegate is FunctionTypeSymbol
+                && leftDelegate is not FunctionTypeSymbol
+                && Conversion.Classify(right.Type, leftDelegate).IsImplicit)
+            {
+                target = leftDelegate;
+                right = conversions.BindConversion(rightLocation, right, target);
+            }
+            else if (leftDelegate is FunctionTypeSymbol
+                && rightDelegate is not FunctionTypeSymbol
+                && Conversion.Classify(left.Type, rightDelegate).IsImplicit)
+            {
+                target = rightDelegate;
+                left = conversions.BindConversion(leftLocation, left, target);
+            }
+        }
+        else if (leftDelegate != null && right.Type == TypeSymbol.Null)
+        {
+            target = leftDelegate;
+        }
+        else if (rightDelegate != null && left.Type == TypeSymbol.Null)
+        {
+            target = rightDelegate;
+        }
+
+        if (target == null)
+        {
+            return false;
+        }
+
+        var resultType = operatorKind == SyntaxKind.MinusToken
+            || (MayBeNilDelegateOperand(left.Type) && MayBeNilDelegateOperand(right.Type))
+            ? NullableTypeSymbol.Get(target)
+            : target;
+        op = BoundBinaryOperator.MakeDelegateCombination(
+            operatorKind,
+            left.Type,
+            right.Type,
+            resultType);
+        return true;
+    }
+
+    private static TypeSymbol? GetConcreteDelegateType(TypeSymbol type)
+    {
+        var candidate = type is NullableTypeSymbol nullable ? nullable.UnderlyingType : type;
+        if (candidate is FunctionTypeSymbol or DelegateTypeSymbol)
+        {
+            return candidate;
+        }
+
+        var clrType = candidate.ClrType;
+        if (!ClrTypeUtilities.IsDelegateType(clrType))
+        {
+            return null;
+        }
+
+        return clrType?.FullName is "System.Delegate" or "System.MulticastDelegate"
+            ? null
+            : candidate;
+    }
+
+    private static bool MayBeNilDelegateOperand(TypeSymbol type)
+        => type == TypeSymbol.Null || type is NullableTypeSymbol;
+
+    private static bool IsUnresolvedMethodGroup(BoundExpression expression)
+        => expression is BoundMethodGroupExpression
+            or BoundClrMethodGroupExpression { ResolvedMethod: null };
 
     private BoundExpression ConvertStringConcatCharOperand(BoundExpression expression, TextLocation location)
     {

--- a/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionTreeRestrictionValidator.cs
@@ -182,7 +182,11 @@ internal static class ExpressionTreeRestrictionValidator
                 return;
 
             case BoundBinaryExpression binary:
-                if (binary.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
+                if (binary.Op.IsDelegateCombination)
+                {
+                    diagnostics.ReportExpressionTreeUnsupported(LocationOf(binary.Syntax), "a delegate combination operator");
+                }
+                else if (binary.Op.Kind == BoundBinaryOperatorKind.NullCoalesce
                     && binary.Left is BoundLiteralExpression { Value: null } or BoundDefaultExpression)
                 {
                     diagnostics.ReportExpressionTreeUnsupported(LocationOf(binary.Syntax), "a coalescing operator with a null/default left operand");

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Operators.cs
@@ -694,6 +694,23 @@ internal sealed partial class MethodBodyEmitter
             return;
         }
 
+        if (b.Op.IsDelegateCombination)
+        {
+            this.EmitExpression(b.Left);
+            this.EmitExpression(b.Right);
+            this.il.OpCode(ILOpCode.Call);
+            this.il.Token(
+                b.Op.Kind == BoundBinaryOperatorKind.Sum
+                    ? this.outer.wellKnown.GetDelegateCombineRef()
+                    : this.outer.wellKnown.GetDelegateRemoveRef());
+            this.il.OpCode(ILOpCode.Castclass);
+            var resultType = b.Type is NullableTypeSymbol nullableResult
+                ? nullableResult.UnderlyingType
+                : b.Type;
+            this.il.Token(this.outer.memberRefs.GetElementTypeToken(resultType));
+            return;
+        }
+
         // Issue #1298: lifted equality / inequality over a nullable
         // user-defined enum (`E? == E?`, `E? == E`, `E? == nil`, …). A
         // user EnumSymbol has no static CLR type, so the value-type

--- a/test/Compiler.Tests/Issue3792DelegateCombinationTests.cs
+++ b/test/Compiler.Tests/Issue3792DelegateCombinationTests.cs
@@ -1,0 +1,246 @@
+// <copyright file="Issue3792DelegateCombinationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using GSharp.Compiler;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>Issue #3792: delegate combination lowers through Delegate.Combine/Remove.</summary>
+public class Issue3792DelegateCombinationTests
+{
+    /// <summary>Gets executable delegate-combination cases.</summary>
+    public static IEnumerable<object[]> Cases()
+    {
+        yield return new object[]
+        {
+            "imported-local-and-expression",
+            """
+            package P
+            import System
+
+            func First() { Console.WriteLine("first") }
+            func Second() { Console.WriteLine("second") }
+
+            let first Action = First
+            let second Action = Second
+            let pair = first + second
+            pair()
+            let removed = pair - first
+            removed?()
+
+            let leftNil = nil + first
+            leftNil()
+            let rightNil = first + nil
+            rightNil()
+
+            var callbacks Action? = nil
+            callbacks += nil
+            callbacks += first
+            callbacks += second
+            callbacks -= nil
+            callbacks -= first
+            callbacks?()
+            callbacks -= second
+            Console.WriteLine(callbacks == nil)
+            """,
+            new[] { "first", "second", "second", "first", "first", "second", "True" },
+        };
+
+        yield return new object[]
+        {
+            "structural-local",
+            """
+            package P
+            import System
+
+            let first (() -> void) = () -> Console.WriteLine("structural-first")
+            let second (() -> void) = () -> Console.WriteLine("structural-second")
+            var callbacks (() -> void)? = nil
+            callbacks = callbacks + first
+            callbacks += second
+            callbacks?()
+            callbacks -= first
+            callbacks?()
+            callbacks = callbacks - second
+            Console.WriteLine(callbacks == nil)
+            """,
+            new[] { "structural-first", "structural-second", "structural-second", "True" },
+        };
+
+        yield return new object[]
+        {
+            "named-field-and-property",
+            """
+            package P
+            import System
+
+            delegate Handler(value string);
+
+            func First(value string) { Console.WriteLine("first:" + value) }
+            func Second(value string) { Console.WriteLine("second:" + value) }
+
+            class Box {
+                var Field Handler? = nil
+                prop Property Handler? { get; set; }
+
+                func Add(value Handler) {
+                    Field += value
+                    Property += value
+                }
+
+                func Remove(value Handler) {
+                    Field -= value
+                    Property -= value
+                }
+            }
+
+            let first Handler = First
+            let second Handler = Second
+            let box = Box()
+            box.Add(first)
+            box.Add(second)
+            box.Field?("field")
+            box.Property?("property")
+            box.Remove(first)
+            box.Field?("field-removed")
+            box.Property?("property-removed")
+            """,
+            new[]
+            {
+                "first:field",
+                "second:field",
+                "first:property",
+                "second:property",
+                "second:field-removed",
+                "second:property-removed",
+            },
+        };
+
+        yield return new object[]
+        {
+            "source-and-clr-method-groups",
+            """
+            package P
+            import System
+
+            func Print(value string) { Console.WriteLine("source:" + value) }
+            func Print(value int32) { Console.WriteLine(value) }
+
+            let seed Action[string] = (value string) -> Console.WriteLine("seed:" + value)
+            let source = seed + Print
+            let clr = source + Console.WriteLine
+            clr("value")
+            var callbacks Action[string]? = seed
+            callbacks += Print
+            callbacks += Console.WriteLine
+            callbacks -= Print
+            callbacks?("compound")
+            """,
+            new[]
+            {
+                "seed:value",
+                "source:value",
+                "value",
+                "seed:compound",
+                "compound",
+            },
+        };
+    }
+
+    /// <summary>Compiles, IL-verifies, executes, and checks each case.</summary>
+    [Theory]
+    [MemberData(nameof(Cases))]
+    public void DelegateCombination_CompilesVerifiesAndRuns(string name, string source, string[] expectedLines)
+    {
+        var tempDir = Directory.CreateTempSubdirectory("gs_3792_").FullName;
+        try
+        {
+            var sourcePath = Path.Combine(tempDir, "Program.gs");
+            var outputPath = Path.Combine(tempDir, name + ".dll");
+            File.WriteAllText(sourcePath, source);
+
+            var args = new List<string>
+            {
+                "/out:" + outputPath,
+                "/target:exe",
+                "/targetframework:net10.0",
+            };
+            foreach (var reference in TrustedPlatformAssemblies())
+            {
+                args.Add("/reference:" + reference);
+            }
+
+            args.Add(sourcePath);
+
+            using var compileOut = new StringWriter();
+            using var compileErr = new StringWriter();
+            var previousOut = Console.Out;
+            var previousErr = Console.Error;
+            Console.SetOut(compileOut);
+            Console.SetError(compileErr);
+            int compileExit;
+            try
+            {
+                compileExit = Program.Main(args.ToArray());
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+                Console.SetError(previousErr);
+            }
+
+            Assert.True(
+                compileExit == 0,
+                $"gsc failed for '{name}':\nstdout:\n{compileOut}\nstderr:\n{compileErr}");
+
+            IlVerifier.Verify(outputPath);
+
+            var (exitCode, output) = RunDotnet(outputPath);
+            Assert.True(exitCode == 0, $"'{name}' exited {exitCode}:\n{output}");
+            var lines = output
+                .Split('\n')
+                .Select(line => line.TrimEnd('\r'))
+                .Where(line => line.Length > 0)
+                .ToArray();
+            Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    private static (int ExitCode, string Output) RunDotnet(string assemblyPath)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"\"{assemblyPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath) ?? ".",
+        };
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("could not start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        return string.IsNullOrEmpty(tpa)
+            ? Enumerable.Empty<string>()
+            : tpa.Split(Path.PathSeparator).Where(File.Exists);
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue2130ExpressionTreeBindingTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue2130ExpressionTreeBindingTests.cs
@@ -252,6 +252,21 @@ let expr Expression[Func[int32?, int32]] = (value int32?) -> value!!
         Assert.Contains(diagnostics, d => d.Id == "GS0473");
     }
 
+    [Fact]
+    public void DelegateCombination_IsRejectedInsideExpressionTree()
+    {
+        var diagnostics = GetDiagnostics(@"
+import System
+import System.Linq.Expressions
+
+let expr Expression[Func[Action, Action, Action]] = (left Action, right Action) -> left + right
+");
+
+        Assert.Contains(
+            diagnostics,
+            d => d.Id == "GS0473" && d.Message.Contains("delegate combination operator"));
+    }
+
     private static System.Collections.Immutable.ImmutableArray<Diagnostic> GetDiagnostics(string source)
     {
         var tree = SyntaxTree.Parse(SourceText.From(source));

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3792DelegateCombinationTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3792DelegateCombinationTests.cs
@@ -1,0 +1,131 @@
+// <copyright file="Issue3792DelegateCombinationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>Issue #3792: delegate combination outside event subscription sites.</summary>
+public class Issue3792DelegateCombinationTests
+{
+    [Theory]
+    [InlineData("Action")]
+    [InlineData("(() -> void)")]
+    [InlineData("Handler")]
+    public void DelegateBinaryAndCompoundOperators_Bind(string delegateType)
+    {
+        var declaration = delegateType == "Handler" ? "delegate Handler();\n" : string.Empty;
+        var source = $$"""
+            package P
+            import System
+
+            {{declaration}}
+            func Tick() {}
+
+            class Box {
+                var Field {{delegateType}}? = nil
+                prop Property {{delegateType}}? { get; set; }
+
+                func Update(value {{delegateType}}) {
+                    Field += value
+                    Property += value
+                    Field -= value
+                    Property -= value
+                }
+            }
+
+            func Run() {
+                let value {{delegateType}} = Tick
+                let sum = value + value
+                let removed = sum - value
+                let leftNil = nil + value
+                let rightNil = value + nil
+                var local {{delegateType}}? = nil
+                local += value
+                local += nil
+                local -= nil
+                local -= value
+                let box = Box()
+                box.Update(value)
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    [Fact]
+    public void DelegateOperators_DoNotBroadenToDelegateBaseOrDifferentNamedTypes()
+    {
+        const string source = """
+            package P
+            import System
+
+            delegate First();
+            delegate Second();
+
+            func Run(
+                a Delegate,
+                b Delegate,
+                first First,
+                second Second,
+                objects Action[object],
+                strings Action[string]) {
+                let badBase = a + b
+                let badNamed = first - second
+                let badVariant = objects + strings
+            }
+            """;
+
+        var diagnostics = Bind(source);
+        Assert.Equal(3, diagnostics.Count(d => d.Id == "GS0129"));
+    }
+
+    [Fact]
+    public void DelegateOperators_TargetTypeSourceAndClrMethodGroups()
+    {
+        const string source = """
+            package P
+            import System
+
+            func Print(value string) {}
+            func Print(value int32) {}
+
+            func Run() {
+                let seed Action[string] = (value string) -> {}
+                let source = seed + Print
+                let clr = seed + Console.WriteLine
+                var callbacks Action[string]? = seed
+                callbacks += Print
+                callbacks += Console.WriteLine
+                callbacks -= Print
+                callbacks -= Console.WriteLine
+            }
+            """;
+
+        Assert.Empty(Bind(source));
+    }
+
+    private static ImmutableArray<Diagnostic> Bind(string source)
+    {
+        var tree = SyntaxTree.Parse(SourceText.From(source));
+        if (tree.Diagnostics.Any())
+        {
+            return tree.Diagnostics;
+        }
+
+        var globalScope = Binder.BindGlobalScope(previous: null, ImmutableArray.Create(tree));
+        if (globalScope.Diagnostics.Any())
+        {
+            return globalScope.Diagnostics;
+        }
+
+        return Binder.BindProgram(globalScope).Diagnostics.ToImmutableArray();
+    }
+}


### PR DESCRIPTION
Closes #3792.

## Implementation

- binds `+` / `-` for the same concrete delegate type through the shared binary-operator path
- reuses that path for `+=` / `-=` on locals, fields, and properties
- supports structural function types plus source and imported named delegates
- lowers to `System.Delegate.Combine` / `System.Delegate.Remove`, then casts back to the concrete delegate type
- preserves CLR nil behavior; removal and all-nil addition produce nullable results
- does not add operators to `System.Delegate` / `System.MulticastDelegate`, different named delegate types, or variance-only delegate pairs

## Tests

- binding regressions: imported, structural, and named delegate expressions/compound assignments; unrelated-operator guard rails
- executing + ILVerify regressions: local, field, property, expression, nil operands, multicast ordering, and removal
- targeted Core suites: 21 passed
- targeted Compiler suites: 14 passed
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`: passed, 0 warnings
- `python3 build/nullable_hygiene.py --base origin/main`: passed
- `./build/run-ilverify.sh`: 135/135 verified
- self-migration PR guard: all 8 guarded apps passed translate, compile, ILVerify, and test parity
