### PR TITLE
gsc: diagnose cross-context generic method closure (#3834)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -4404,6 +4404,15 @@ internal static class ClrOverloadResolution
                 continue;
             }
 
+            // G# does not admit by-ref-like values as generic arguments
+            // (issue #367). Live reflection rejects them even on an otherwise
+            // unconstrained parameter, so this is ordinary inapplicability,
+            // not a compiler identity/context failure.
+            if (ClrTypeUtilities.IsByRefLike(arg))
+            {
+                return false;
+            }
+
             GenericParameterAttributes attrs;
             try
             {
@@ -4498,13 +4507,10 @@ internal static class ClrOverloadResolution
                 }
             }
 
-            // Type-bound constraints — `where T : SomeBase` or
-            // `where T : ISomething`. Constraints that reference another
-            // method type parameter (e.g. `where TResult : T`) are skipped:
-            // resolving them requires substitution and is rare on the
-            // surfaces that motivated this work (ADR-0084). The dominant
-            // class/struct cases above already disambiguate the
-            // Optional/Sequences overload sets.
+            // Type-bound constraints — `where T : SomeBase`,
+            // `where T : ISomething`, or a dependent bound such as
+            // `where TResult : T`. Substitute the complete type-argument
+            // vector before testing the constraint.
             Type[] typeConstraints;
             try
             {
@@ -4632,10 +4638,20 @@ internal static class ClrOverloadResolution
         ImmutableArray<TypeSymbol?> typeArgSymbols,
         ArgumentException failure)
     {
-        if (!SatisfiesGenericConstraints(openMethod, typeArgs, typeArgSymbols)
-            || (!typeArgSymbols.IsDefaultOrEmpty
-                && typeArgSymbols.Any(static symbol => symbol is not null && symbol.ClrType is null)))
+        if (!SatisfiesGenericConstraints(openMethod, typeArgs, typeArgSymbols))
         {
+            return;
+        }
+
+        var hasErasedSymbol = !typeArgSymbols.IsDefaultOrEmpty
+            && typeArgSymbols.Any(static symbol => symbol is not null && symbol.ClrType is null);
+        if (hasErasedSymbol
+            && !HasConcreteReflectionContextMismatch(openMethod, typeArgs, typeArgSymbols))
+        {
+            // Placeholder closure is deliberately best-effort for
+            // same-compilation symbols with no CLR Type. Preserve their
+            // established silent rejection, but do not let one erased slot
+            // hide a mismatch in another concrete slot.
             return;
         }
 
@@ -4649,6 +4665,146 @@ internal static class ClrOverloadResolution
             "compiler-supplied type arguments after their generic constraints were satisfied. The method " +
             "and type arguments have incompatible reflection/load contexts or inconsistent CLR identities. " +
             $"Type arguments: {arguments}. Reflection reported: {failure.Message}");
+    }
+
+    private static bool HasConcreteReflectionContextMismatch(
+        MethodInfo openMethod,
+        Type[] typeArgs,
+        ImmutableArray<TypeSymbol?> typeArgSymbols)
+    {
+        Type[] typeParameters;
+        try
+        {
+            typeParameters = openMethod.GetGenericArguments();
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return false;
+        }
+
+        for (var i = 0; i < typeParameters.Length && i < typeArgs.Length; i++)
+        {
+            if (!typeArgSymbols.IsDefaultOrEmpty
+                && i < typeArgSymbols.Length
+                && typeArgSymbols[i] is { ClrType: null })
+            {
+                continue;
+            }
+
+            var argument = typeArgs[i];
+            if (!CanConstructGenericContextProbe(typeParameters[i], argument))
+            {
+                return true;
+            }
+
+            Type[] constraints;
+            try
+            {
+                constraints = typeParameters[i].GetGenericParameterConstraints();
+            }
+            catch (Exception ex) when (IsMetadataLoadFailure(ex))
+            {
+                continue;
+            }
+
+            foreach (var originalConstraint in constraints)
+            {
+                if (DependsOnErasedTypeParameter(
+                    originalConstraint,
+                    typeParameters,
+                    typeArgSymbols))
+                {
+                    continue;
+                }
+
+                var constraint = originalConstraint;
+                try
+                {
+                    for (var p = 0; p < typeParameters.Length; p++)
+                    {
+                        constraint = SubstituteClrType(constraint, typeParameters[p], typeArgs[p]);
+                    }
+
+                    if (!constraint.ContainsGenericParameters
+                        && ClrTypeUtilities.IsAssignableByName(constraint, argument)
+                        && !constraint.IsAssignableFrom(argument))
+                    {
+                        return true;
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    return true;
+                }
+                catch (Exception ex) when (IsMetadataLoadFailure(ex))
+                {
+                    continue;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool DependsOnErasedTypeParameter(
+        Type type,
+        Type[] typeParameters,
+        ImmutableArray<TypeSymbol?> typeArgSymbols)
+    {
+        if (type.IsGenericParameter)
+        {
+            for (var i = 0; i < typeParameters.Length && i < typeArgSymbols.Length; i++)
+            {
+                if (ReferenceEquals(type, typeParameters[i])
+                    && typeArgSymbols[i] is { ClrType: null })
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (type.HasElementType && type.GetElementType() is { } element)
+        {
+            return DependsOnErasedTypeParameter(element, typeParameters, typeArgSymbols);
+        }
+
+        return type.IsGenericType
+            && type.GetGenericArguments().Any(
+                argument => DependsOnErasedTypeParameter(
+                    argument,
+                    typeParameters,
+                    typeArgSymbols));
+    }
+
+    private static bool CanConstructGenericContextProbe(Type genericParameter, Type argument)
+    {
+        try
+        {
+            Type? root = genericParameter.BaseType;
+            while (root?.BaseType is { } baseType)
+            {
+                root = baseType;
+            }
+
+            Type? listDefinition = root?.Assembly.GetType("System.Collections.Generic.List`1");
+            if (listDefinition is null)
+            {
+                return true;
+            }
+
+            _ = listDefinition.MakeGenericType(argument);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (Exception ex) when (IsMetadataLoadFailure(ex))
+        {
+            return true;
+        }
     }
 
     private static bool ErasedSymbolSatisfiesInterfaceConstraint(TypeSymbol symbol, Type constraint)

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/ClrOverloadResolution.cs
@@ -2448,7 +2448,7 @@ internal static class ClrOverloadResolution
                             }
                         }
                     }
-                    catch (ArgumentException)
+                    catch (ArgumentException ex)
                     {
                         var recoveredSymbols = recoverTypeArgSymbols?.Invoke(gmi, false) ?? default;
 
@@ -2462,7 +2462,11 @@ internal static class ClrOverloadResolution
                         }
                         else if (!TryCloseOverUserReferenceTypePlaceholders(gmi, explicitTypeArgsArray, recoveredSymbols, out closed))
                         {
-                            // Generic constraints not satisfied — drop this candidate.
+                            RejectConstraintFailureOrThrowCompilerInvariant(
+                                gmi,
+                                explicitTypeArgsArray,
+                                recoveredSymbols,
+                                ex);
                             return;
                         }
                     }
@@ -2632,7 +2636,7 @@ internal static class ClrOverloadResolution
                 {
                     closed = mi.MakeGenericMethod(typeArgs);
                 }
-                catch (ArgumentException)
+                catch (ArgumentException ex)
                 {
                     var recoveredSymbols = recoverTypeArgSymbols?.Invoke(mi, false) ?? default;
 
@@ -2646,7 +2650,11 @@ internal static class ClrOverloadResolution
                     }
                     else if (!TryCloseOverUserReferenceTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
                     {
-                        // Generic constraints not satisfied — drop this candidate.
+                        RejectConstraintFailureOrThrowCompilerInvariant(
+                            mi,
+                            typeArgs,
+                            recoveredSymbols,
+                            ex);
                         return;
                     }
                 }
@@ -2899,7 +2907,7 @@ internal static class ClrOverloadResolution
                 {
                     closed = gmi.MakeGenericMethod(explicitTypeArgs.ToArray());
                 }
-                catch (ArgumentException)
+                catch (ArgumentException ex)
                 {
                     recoveredSymbols = recoverTypeArgSymbols?.Invoke(gmi, true) ?? default;
                     var explicitTypeArgsArray = explicitTypeArgs.ToArray();
@@ -2909,6 +2917,11 @@ internal static class ClrOverloadResolution
                     }
                     else if (!TryCloseOverUserReferenceTypePlaceholders(gmi, explicitTypeArgsArray, recoveredSymbols, out closed))
                     {
+                        RejectConstraintFailureOrThrowCompilerInvariant(
+                            gmi,
+                            explicitTypeArgsArray,
+                            recoveredSymbols,
+                            ex);
                         return;
                     }
                 }
@@ -2961,7 +2974,7 @@ internal static class ClrOverloadResolution
             {
                 closed = mi.MakeGenericMethod(typeArgs);
             }
-            catch (ArgumentException)
+            catch (ArgumentException ex)
             {
                 recoveredSymbols = recoverTypeArgSymbols?.Invoke(mi, true) ?? default;
                 if (TryCloseOverUserValueTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
@@ -2970,6 +2983,11 @@ internal static class ClrOverloadResolution
                 }
                 else if (!TryCloseOverUserReferenceTypePlaceholders(mi, typeArgs, recoveredSymbols, out closed))
                 {
+                    RejectConstraintFailureOrThrowCompilerInvariant(
+                        mi,
+                        typeArgs,
+                        recoveredSymbols,
+                        ex);
                     return;
                 }
             }
@@ -4500,7 +4518,30 @@ internal static class ClrOverloadResolution
             for (var c = 0; c < typeConstraints.Length; c++)
             {
                 var constraint = typeConstraints[c];
-                if (constraint is null || constraint.IsGenericParameter || constraint.ContainsGenericParameters)
+                if (constraint is null)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    for (var p = 0; p < typeParams.Length; p++)
+                    {
+                        constraint = SubstituteClrType(constraint, typeParams[p], typeArgs[p]);
+                    }
+                }
+                catch (ArgumentException)
+                {
+                    // A cross-context type argument can make the substitution
+                    // itself fail. It did not disprove the language constraint;
+                    // the MakeGenericMethod failure is classified below.
+                }
+                catch (Exception ex) when (IsMetadataLoadFailure(ex))
+                {
+                    continue;
+                }
+
+                if (constraint.IsGenericParameter || constraint.ContainsGenericParameters)
                 {
                     continue;
                 }
@@ -4583,6 +4624,31 @@ internal static class ClrOverloadResolution
         }
 
         return true;
+    }
+
+    private static void RejectConstraintFailureOrThrowCompilerInvariant(
+        MethodInfo openMethod,
+        Type[] typeArgs,
+        ImmutableArray<TypeSymbol?> typeArgSymbols,
+        ArgumentException failure)
+    {
+        if (!SatisfiesGenericConstraints(openMethod, typeArgs, typeArgSymbols)
+            || (!typeArgSymbols.IsDefaultOrEmpty
+                && typeArgSymbols.Any(static symbol => symbol is not null && symbol.ClrType is null)))
+        {
+            return;
+        }
+
+        var methodName = $"{openMethod.DeclaringType?.FullName ?? "<unknown>"}.{openMethod.Name}";
+        var arguments = string.Join(
+            ", ",
+            typeArgs.Select(type => $"{type.FullName ?? type.Name} [{type.Assembly.GetName().Name}]"));
+
+        throw new InvalidOperationException(
+            $"Generic method closure invariant violated for '{methodName}': MakeGenericMethod rejected " +
+            "compiler-supplied type arguments after their generic constraints were satisfied. The method " +
+            "and type arguments have incompatible reflection/load contexts or inconsistent CLR identities. " +
+            $"Type arguments: {arguments}. Reflection reported: {failure.Message}");
     }
 
     private static bool ErasedSymbolSatisfiesInterfaceConstraint(TypeSymbol symbol, Type constraint)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3834GenericMethodClosureDiagnosticsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3834GenericMethodClosureDiagnosticsTests.cs
@@ -1,0 +1,159 @@
+// <copyright file="Issue3834GenericMethodClosureDiagnosticsTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+using GSharp.Core.CodeAnalysis.Binding.OverloadResolution;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3834: <see cref="MethodInfo.MakeGenericMethod(Type[])"/> failures
+/// caused by mixed reflection contexts are compiler invariant violations, not
+/// ordinary generic-constraint inapplicability.
+/// </summary>
+public class Issue3834GenericMethodClosureDiagnosticsTests
+{
+    [Fact]
+    public void RuntimeConstraintFailure_RemainsOrdinaryCandidateRejection()
+    {
+        MethodInfo open = typeof(ConstraintFixture).GetMethod(
+            nameof(ConstraintFixture.Dependent),
+            BindingFlags.Public | BindingFlags.Static);
+
+        var result = ClrOverloadResolution.Resolve(
+            new[] { open },
+            Array.Empty<Type>(),
+            explicitTypeArgs: new[] { typeof(string), typeof(object) });
+
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+    }
+
+    [Fact]
+    public void RuntimeCrossContextTypeArgument_ProducesInternalDiagnostic()
+    {
+        byte[] image = File.ReadAllBytes(typeof(SyntaxNode).Assembly.Location);
+        var firstContext = new IsolatedLoadContext("issue3834-first");
+        var secondContext = new IsolatedLoadContext("issue3834-second");
+
+        try
+        {
+            Assembly firstAssembly = Load(firstContext, image);
+            Assembly secondAssembly = Load(secondContext, image);
+            Type firstNode = GetRequiredType(
+                firstAssembly,
+                "GSharp.Core.CodeAnalysis.Syntax.SyntaxNode");
+            Type secondFunction = GetRequiredType(
+                secondAssembly,
+                "GSharp.Core.CodeAnalysis.Syntax.FunctionDeclarationSyntax");
+            MethodInfo open = firstNode.GetMethods()
+                .Single(method =>
+                    method.Name == nameof(SyntaxNode.FirstAncestorOrSelf)
+                    && method.IsGenericMethodDefinition);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => ClrOverloadResolution.Resolve(
+                    new[] { open },
+                    Array.Empty<Type>(),
+                    explicitTypeArgs: new[] { secondFunction }));
+
+            AssertInternalDiagnostic(exception, nameof(SyntaxNode.FirstAncestorOrSelf));
+        }
+        finally
+        {
+            firstContext.Unload();
+            secondContext.Unload();
+        }
+    }
+
+    [Fact]
+    public void MetadataLoadContextConstraintFailure_RemainsOrdinaryCandidateRejection()
+    {
+        using ReferenceResolver resolver = CreateMetadataLoadContextResolver();
+        Assert.True(resolver.TryResolveType("System.Nullable", out Type nullable));
+        MethodInfo open = nullable.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == nameof(Nullable.Compare) && method.IsGenericMethodDefinition);
+        Type stringType = resolver.MapClrTypeToReferences(typeof(string));
+
+        var result = ClrOverloadResolution.Resolve(
+            new[] { open },
+            Array.Empty<Type>(),
+            explicitTypeArgs: new[] { stringType });
+
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+    }
+
+    [Fact]
+    public void MetadataLoadContextRuntimeInference_ProducesInternalDiagnostic()
+    {
+        using ReferenceResolver resolver = CreateMetadataLoadContextResolver();
+        Assert.True(resolver.TryResolveType("System.Linq.Enumerable", out Type enumerable));
+        MethodInfo open = enumerable.GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method =>
+                method.Name == nameof(Enumerable.Repeat)
+                && method.IsGenericMethodDefinition);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => ClrOverloadResolution.Resolve(
+                new[] { open },
+                new[] { typeof(string), typeof(int) }));
+
+        AssertInternalDiagnostic(exception, nameof(Enumerable.Repeat));
+    }
+
+    private static void AssertInternalDiagnostic(
+        InvalidOperationException exception,
+        string methodName)
+    {
+        var diagnostic = Compilation.CreateInternalErrorDiagnostic(exception);
+
+        Assert.Equal("GS9998", diagnostic.Id);
+        Assert.Contains("generic method closure invariant", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("incompatible reflection/load contexts", diagnostic.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(methodName, diagnostic.Message, StringComparison.Ordinal);
+    }
+
+    private static Assembly Load(AssemblyLoadContext context, byte[] image)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        return context.LoadFromStream(stream);
+    }
+
+    private static Type GetRequiredType(Assembly assembly, string fullName)
+        => assembly.GetType(fullName, throwOnError: true)
+            ?? throw new InvalidOperationException($"Assembly does not declare '{fullName}'.");
+
+    private static ReferenceResolver CreateMetadataLoadContextResolver()
+        => ReferenceResolver.WithReferences(
+            Directory.EnumerateFiles(
+                RuntimeEnvironment.GetRuntimeDirectory(),
+                "*.dll",
+                SearchOption.TopDirectoryOnly));
+
+    private sealed class IsolatedLoadContext : AssemblyLoadContext
+    {
+        public IsolatedLoadContext(string name)
+            : base(name, isCollectible: true)
+        {
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName) => null;
+    }
+
+    public static class ConstraintFixture
+    {
+        public static void Dependent<TBase, TDerived>()
+            where TDerived : TBase
+        {
+        }
+    }
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3834GenericMethodClosureDiagnosticsTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3834GenericMethodClosureDiagnosticsTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -34,6 +35,20 @@ public class Issue3834GenericMethodClosureDiagnosticsTests
             new[] { open },
             Array.Empty<Type>(),
             explicitTypeArgs: new[] { typeof(string), typeof(object) });
+
+        Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
+    }
+
+    [Fact]
+    public void RuntimeByRefLikeArgument_RemainsOrdinaryCandidateRejection()
+    {
+        MethodInfo open = typeof(ConstraintFixture).GetMethod(
+            nameof(ConstraintFixture.Identity),
+            BindingFlags.Public | BindingFlags.Static);
+
+        var result = ClrOverloadResolution.Resolve(
+            new[] { open },
+            new[] { typeof(Span<int>) });
 
         Assert.Equal(ClrOverloadResolution.ResolutionOutcome.NoneApplicable, result.Outcome);
     }
@@ -110,6 +125,47 @@ public class Issue3834GenericMethodClosureDiagnosticsTests
         AssertInternalDiagnostic(exception, nameof(Enumerable.Repeat));
     }
 
+    [Fact]
+    public void ErasedSymbol_DoesNotHideCrossContextConcreteArgument()
+    {
+        byte[] image = File.ReadAllBytes(typeof(Issue3834GenericMethodClosureDiagnosticsTests).Assembly.Location);
+        var firstContext = new IsolatedLoadContext("issue3834-mixed-first");
+        var secondContext = new IsolatedLoadContext("issue3834-mixed-second");
+
+        try
+        {
+            Assembly firstAssembly = Load(firstContext, image);
+            Assembly secondAssembly = Load(secondContext, image);
+            Type firstFixture = GetRequiredType(firstAssembly, typeof(ConstraintFixture).FullName);
+            Type secondDerived = GetRequiredType(secondAssembly, typeof(CrossContextDerived).FullName);
+            MethodInfo open = firstFixture.GetMethod(
+                nameof(ConstraintFixture.Mixed),
+                BindingFlags.Public | BindingFlags.Static);
+            var erased = new TypeParameterSymbol(
+                "TErased",
+                0,
+                TypeParameterConstraint.Any,
+                TypeParameterVariance.None);
+            ImmutableArray<TypeSymbol> recovered = ImmutableArray.Create<TypeSymbol>(
+                erased,
+                TypeSymbol.FromClrType(secondDerived));
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => ClrOverloadResolution.Resolve(
+                    new[] { open },
+                    Array.Empty<Type>(),
+                    explicitTypeArgs: new[] { typeof(object), secondDerived },
+                    recoverTypeArgSymbols: (_, _) => recovered));
+
+            AssertInternalDiagnostic(exception, nameof(ConstraintFixture.Mixed));
+        }
+        finally
+        {
+            firstContext.Unload();
+            secondContext.Unload();
+        }
+    }
+
     private static void AssertInternalDiagnostic(
         InvalidOperationException exception,
         string methodName)
@@ -155,5 +211,20 @@ public class Issue3834GenericMethodClosureDiagnosticsTests
             where TDerived : TBase
         {
         }
+
+        public static T Identity<T>(T value) => value;
+
+        public static void Mixed<TErased, TConcrete>()
+            where TConcrete : CrossContextBase
+        {
+        }
+    }
+
+    public class CrossContextBase
+    {
+    }
+
+    public sealed class CrossContextDerived : CrossContextBase
+    {
     }
 }


### PR DESCRIPTION
Fixes #3834
Part of #3705

## Summary

- classify `MakeGenericMethod` `ArgumentException` by rechecking the method's actual generic constraints, without exception-message sniffing
- keep genuine language-level constraint failures as silent candidate rejection, including dependent constraints such as `where TDerived : TBase`
- surface a concrete reflection-context/identity mismatch through the existing `InvalidOperationException` → `GS9998` internal-error path, naming the method and operands instead of degrading to `GS0159`; symbolic placeholder and by-ref-like rejection remain ordinary
- cover runtime/private-ALC and `MetadataLoadContext` mismatches, with runtime and MLC controls proving valid constraint failures stay ordinary

## Verification

- `dotnet restore GSharp.sln --locked-mode`
- `dotnet build GSharp.sln --configuration Release --no-restore -graph` — 0 warnings, 0 errors
- focused overload/load-context/#3705 plus review-regression filters — 118/118
- `Core.Tests` — 9000/9000 (after rebasing onto #3999 and #4003)
- `build/run-cs2gs-selfmig-pr-guard.sh` — 8/8 guarded apps pass translate, compile, ILVerify, and test parity; wrapper exits 0. It reproduces current-main #3993 (`unexpected test/Shared/GoldenFile.gs`, report says `run FAILED`, wrapper says `PR guard PASSED`).
- `python3 build/nullable_hygiene.py` — OK; no forgiving operators, suppressions, nullable directives, or annotation changes added. The reported null guard is the pre-existing loop check split from a compound condition so substituted dependent constraints can be evaluated.
- ADR-0154 witness: with the production hunk reverted, the six new tests are 3 passed / 3 failed; all three cross-context diagnostic tests fail because no exception is surfaced. With the fix, 6/6 pass. The three passing pre-fix rows are the constraint and by-ref-like negative controls.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): cross-context rows fail on pre-change code and pass with the fix; genuine constraint-failure controls pass in both states.
- [x] Self-review verdict: **MERGEABLE**. The independent nested-generic call-site signature defect remains tracked in #3940.
