### PR TITLE
cs2gs: preserve erased null-forgiving semantics (#3775)

### DIFF
--- a/docs/adr/0036-event-subscription.md
+++ b/docs/adr/0036-event-subscription.md
@@ -29,6 +29,14 @@ Key shape decisions:
 
    The relaxation is deliberately *not* a general "nilable is assignable to non-nilable" hole: it is scoped to the subscription argument, where the CLR contract itself is nil-tolerant.
 
+   The single handler-binding seam also owns structural-arrow conversion.
+   A nilable `((object, DataReceivedEventArgs) -> void)?` value — the form
+   cs2gs emits for a C# `DataReceivedEventHandler` declaration — converts once
+   to the event's nilable named delegate target. The CLR-event caller must not
+   then reconvert that result to the event's bare delegate type, which would
+   recreate `GS0155` after the nil-tolerant conversion had already succeeded
+   (issue #3775).
+
 ## Alternatives considered
 
 - **Extend `FieldAssignmentExpressionSyntax` with an operator token.** Rejected: the existing node models a single `Receiver: SyntaxToken`, so multi-segment LHS would still require a parallel shape. A dedicated node keeps both paths clean.

--- a/docs/adr/0115-csharp-to-gsharp-migration-tool.md
+++ b/docs/adr/0115-csharp-to-gsharp-migration-tool.md
@@ -577,12 +577,36 @@ empirically (gsc **0.2.137+31ced6cfb7**) before adoption.
   has **no range operator** (gsc gap, §G OD-1); a `RangeExpression` index over a
   `Span`/`Memory`/`ReadOnlySpan` lowers to a `.Slice` call: `s[i..j]` →
   `s.Slice(i, j - i)`, `s[i..]` → `s.Slice(i)`, `s[..j]` → `s.Slice(0, j)`.
-- **Null-forgiving `expr!` → non-null assertion `expr!!` when still needed.**
-  G#'s postfix `!!` asserts non-null (spec: "Postfix `!!` asserts non-null"),
-  but cs2gs omits it when native pattern bindings, G# smart-cast flow, or
-  non-null conditional/coalesce arms already give the translated value a
-  non-null type. Assertion insertion is idempotent, so an existing `!!` is
-  never wrapped in another one.
+- **Null-forgiving `expr!` is erased whenever the sink accepts nil; otherwise it
+  maps to `expr!!` (issue #3775).** C#'s `!` is compile-time-only, while G#'s
+  postfix `!!` is a checked operation that throws on nil. cs2gs therefore omits
+  the assertion when the contextual return, initializer, assignment, argument,
+  conditional arm, or switch arm remains nullable, as well as when native
+  pattern bindings, G# smart-cast flow, or non-null conditional/coalesce arms
+  already give the translated value a non-null type. When the emitted sink
+  remains non-nullable, G# has no erased equivalent: cs2gs retains `!!` as the
+  smallest compiling representation of the author's `!`, accepting that a
+  genuinely nil value throws earlier than in C#. Assertion insertion is
+  idempotent, so an existing `!!` is never wrapped in another one. An inferred
+  local whose C# type became non-null through `!` also retains the assertion:
+  erasing it only at the initializer would infer nullable G# storage while
+  Roslyn still reports every later use as non-null, losing the downstream
+  bridge the program needs.
+
+  The same explicit policy governs translator-added bridges in
+  nullable-oblivious code. A sink whose declaration can be widened is widened;
+  a sink with no declaration to widen (an element/indexer write), or whose
+  emitted contract deliberately remains non-nullable, receives `!!`. This
+  preserves the emitted contract but can turn a C# null store into an immediate
+  throw; broad contract widening is rejected because it changes unrelated
+  reads and callers.
+
+  Two construct-specific rules take precedence. Event subscription accepts a
+  nilable handler directly because `Delegate.Combine`/`Remove` define
+  `e += null` and `e -= null` as no-ops (ADR-0036); cs2gs must never add `!!` at
+  that site. `Nullable<T>.Value` still maps to `!!`; G# recognizes the
+  value-nullable operand and emits `Nullable<T>.Value`, so an empty value throws
+  `InvalidOperationException` just as it does in C#.
 - **Post/pre-increment/decrement as an expression.** G# now models `++`/`--`
   both as statements *and* as value-producing expressions (issue #1027). A
   `PostIncrementExpression`/`PostDecrementExpression` used as a **value** in a

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Async.cs
@@ -297,29 +297,11 @@ internal sealed partial class ExpressionBinder
                     BindingFlags.Public | BindingFlags.Instance);
                 if (constrainedEvent != null)
                 {
-                    var constrainedHandlerType = Invariant.Required(
-                        constrainedEvent.EventHandlerType,
-                        "a reflected event has a handler type");
                     var constrainedHandlerTypeSymbol = MemberLookup.GetClrEventHandlerTypeSymbol(
                         clrInterfaceConstraint,
                         constrainedEvent);
-                    var constrainedBoundHandler = BindEventSubscriptionHandler(syntax.Value, constrainedHandlerTypeSymbol);
-                    BoundExpression constrainedConvertedHandler;
-                    if (constrainedBoundHandler is BoundFunctionLiteralExpression
-                        || constrainedBoundHandler is BoundMethodGroupExpression
-                        || constrainedBoundHandler is BoundClrMethodGroupExpression
-                        || (constrainedBoundHandler.Type is FunctionTypeSymbol constrainedFunction
-                            && IsSignatureCompatibleWithDelegate(constrainedFunction, constrainedHandlerType)))
-                    {
-                        constrainedConvertedHandler = constrainedBoundHandler;
-                    }
-                    else
-                    {
-                        constrainedConvertedHandler = conversions.BindConversion(
-                            syntax.Value.Location,
-                            constrainedBoundHandler,
-                            constrainedHandlerTypeSymbol);
-                    }
+                    var constrainedConvertedHandler =
+                        BindEventSubscriptionHandler(syntax.Value, constrainedHandlerTypeSymbol);
 
                     return new BoundClrEventSubscriptionExpression(
                         null,
@@ -446,32 +428,16 @@ internal sealed partial class ExpressionBinder
             return new BoundErrorExpression(null);
         }
 
-        var handlerType = Invariant.Required(eventInfo.EventHandlerType, "a CLR event has an event-handler type");
         var handlerTypeSymbol = importedEventTarget != null
             ? MemberLookup.GetClrEventHandlerTypeSymbol(importedEventTarget, eventInfo)
             : MemberLookup.GetClrEventHandlerTypeSymbol(eventInfo);
-        var boundHandler = BindEventSubscriptionHandler(syntax.Value, handlerTypeSymbol);
 
-        // The handler is most useful when expressed as a function literal of
-        // matching signature. For that path we skip BindConversion (which has
-        // no generic fn → custom-delegate rule) and rely on the evaluator /
-        // emitter to materialize the right delegate type. Otherwise fall back
-        // to the standard conversion (covers null, already-typed delegate
-        // variables, etc.). Method-group handlers were already routed through
-        // BindEventSubscriptionHandler above and arrive here resolved.
-        BoundExpression convertedHandler;
-        if (boundHandler is BoundFunctionLiteralExpression
-            || boundHandler is BoundMethodGroupExpression
-            || boundHandler is BoundClrMethodGroupExpression
-            || (boundHandler.Type is FunctionTypeSymbol fn
-                && IsSignatureCompatibleWithDelegate(fn, handlerType)))
-        {
-            convertedHandler = boundHandler;
-        }
-        else
-        {
-            convertedHandler = conversions.BindConversion(syntax.Value.Location, boundHandler, handlerTypeSymbol);
-        }
+        // BindEventSubscriptionHandler is the single conversion seam. In
+        // particular, a nilable structural arrow is converted to the event's
+        // nilable named delegate target there; converting that result again to
+        // the event's bare delegate would reject the nil that this site
+        // deliberately accepts (issue #3775).
+        var convertedHandler = BindEventSubscriptionHandler(syntax.Value, handlerTypeSymbol);
 
         var eventContainingType = importedEventTarget == null
             ? null
@@ -585,7 +551,10 @@ internal sealed partial class ExpressionBinder
             // already-bound LeftPart. The fast path is `recv.MemberName`
             // where the rebind is cheap; the slower path materializes the
             // bound receiver into a synthetic local so it isn't re-evaluated.
-            return BindEventSubscriptionHandlerFromBoundAccessor(memberAccess, boundReceiver, targetDelegateType);
+            return ConvertEventSubscriptionHandler(
+                handlerSyntax,
+                BindEventSubscriptionHandlerFromBoundAccessor(memberAccess, boundReceiver, targetDelegateType),
+                targetDelegateType);
         }
 
         // Issue #2389: an untyped arrow lambda handler (`Ticked += (count) ->
@@ -627,15 +596,20 @@ internal sealed partial class ExpressionBinder
         // `TickHandler`) is expected, producing invalid IL. Route it (and any
         // other not-yet-matching handler shape) through the same conversion
         // the method-group branches above already apply.
-        if (bound.Type != targetDelegateType && bound is not BoundErrorExpression)
-        {
-            return conversions.BindConversion(
-                handlerSyntax.Location,
-                bound,
-                NilTolerantHandlerTarget(bound, targetDelegateType));
-        }
+        return ConvertEventSubscriptionHandler(handlerSyntax, bound, targetDelegateType);
+    }
 
-        return bound;
+    private BoundExpression ConvertEventSubscriptionHandler(
+        ExpressionSyntax handlerSyntax,
+        BoundExpression handler,
+        TypeSymbol targetDelegateType)
+    {
+        return handler.Type != targetDelegateType && handler is not BoundErrorExpression
+            ? conversions.BindConversion(
+                handlerSyntax.Location,
+                handler,
+                NilTolerantHandlerTarget(handler, targetDelegateType))
+            : handler;
     }
 
     /// <summary>

--- a/test/Compiler.Tests/Issue3775NilEventHandlerTests.cs
+++ b/test/Compiler.Tests/Issue3775NilEventHandlerTests.cs
@@ -109,6 +109,57 @@ Run()
             new[] { "clr-added", "clr-removed", "literal-nil" },
         };
 
+        // cs2gs maps a C# named delegate declaration/reference to a structural
+        // arrow type. The nullable arrow must receive the same nil-tolerant
+        // event-site conversion as a nullable named delegate.
+        yield return new object[]
+        {
+            "clr-event-nilable-arrow-handler",
+            @"
+package P
+import System
+import System.Diagnostics
+
+func Run() {
+    let p = Process()
+    let h ((object, DataReceivedEventArgs) -> void)? = nil
+    p.OutputDataReceived += h
+    Console.WriteLine(""arrow-added"")
+    p.OutputDataReceived -= h
+    Console.WriteLine(""arrow-removed"")
+}
+
+Run()
+",
+            new[] { "arrow-added", "arrow-removed" },
+        };
+
+        yield return new object[]
+        {
+            "clr-event-nilable-arrow-member",
+            @"
+package P
+import System
+import System.Diagnostics
+
+class Holder {
+    var Handler ((object, DataReceivedEventArgs) -> void)? = nil
+}
+
+func Run() {
+    let p = Process()
+    let holder = Holder()
+    p.OutputDataReceived += holder.Handler
+    Console.WriteLine(""member-added"")
+    p.OutputDataReceived -= holder.Handler
+    Console.WriteLine(""member-removed"")
+}
+
+Run()
+",
+            new[] { "member-added", "member-removed" },
+        };
+
         // ANTI-VACUITY: accepting the nil subscription must not disturb the
         // real one. A nil `+=` before and after a genuine handler leaves
         // exactly one subscriber; the nil `-=` removes nothing; the real `-=`

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2427ObliviousExternalAssignmentForgivenessTranslationTests.cs
@@ -29,7 +29,7 @@ namespace Cs2Gs.Tests;
 /// assignment STATEMENT: `TranslateExpressionStatement`'s
 /// <c>AssignmentExpressionSyntax</c> case computes its RHS via
 /// <c>CoerceConstantToUnsigned</c> / <c>CoerceCompoundAssignmentRhs</c> /
-/// <c>CoercePointerConversion</c> / <c>ForgiveEventSubscriptionRhs</c> /
+/// <c>CoercePointerConversion</c> /
 /// <c>ForgiveElementAccessAssignmentRhs</c>, none of which apply
 /// <c>IsObliviousExternalNullableMember</c> forgiveness. This is exactly the
 /// real-world `Oahu.Core` `BookLibrary.gs:469` shape surfaced by #2426:

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3770SilentRuntimeDivergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3770SilentRuntimeDivergenceTests.cs
@@ -38,6 +38,12 @@ namespace Cs2Gs.Tests;
 /// with it 6 of the 13 migrated <c>GSharp.GeneratorHost.Tests</c> failures.
 /// </para>
 /// <para>
+/// #3775 completes the policy: an event handler is passed through because G#
+/// now models C#'s nil-tolerant subscription contract, and an explicit C#
+/// null-forgiving operator is erased when its sink already accepts nil. A
+/// non-null sink still receives <c>!!</c>, because G# has no erased equivalent.
+/// </para>
+/// <para>
 /// Both are invisible to a binding-only assertion, so each is asserted by
 /// EXECUTING the translated G#.
 /// </para>
@@ -72,6 +78,74 @@ public sealed class Issue3770SilentRuntimeDivergenceTests
 
             return d;
         }
+    }
+";
+
+    private const string NilEventHandlerSource = @"
+    public class Clock
+    {
+        public event EventHandler Ticked;
+
+        public void Subscribe(EventHandler handler)
+        {
+            Ticked += handler;
+            Ticked -= handler;
+        }
+    }
+
+    public static class EventProbe
+    {
+        private static EventHandler Pick(bool present) =>
+            present ? (_, _) => { } : null;
+
+        public static void Run()
+        {
+            var clock = new Clock();
+            EventHandler handler = Pick(false);
+            clock.Subscribe(handler);
+            Console.WriteLine(""event-ok"");
+        }
+    }
+";
+
+    private const string NullForgivingSource = @"
+    public static class NullForgivingProbe
+    {
+        private static string? Pick(bool present) => present ? ""value"" : null;
+
+        public static object? NullableProperty { get; } = Pick(false)!;
+
+        public static object? NullableSink() => Pick(false)!;
+
+        public static int InferredNonNullLocal()
+        {
+            var value = Pick(true)!;
+            return value.Length;
+        }
+
+        public static bool NullableLocal()
+        {
+            string? value = Pick(false);
+            object? result = value!;
+            return result is null;
+        }
+
+        public static bool NullableConditional(bool flag)
+        {
+            string? value = Pick(false);
+            object? result = flag ? value! : null;
+            return result is null;
+        }
+
+        public static object NonNullSink()
+        {
+            string? value = Pick(false);
+            return value!;
+        }
+
+        public static int NullableValue(int? value) => value.Value;
+
+        public static T Generic<T>(T? value) => value!;
     }
 ";
 
@@ -144,10 +218,112 @@ public sealed class Issue3770SilentRuntimeDivergenceTests
         Assert.Equal("3", stdout.Trim());
     }
 
-    private static string Translate(string source)
+    /// <summary>
+    /// Once gsc accepts a nilable event-subscription handler, cs2gs must not
+    /// reintroduce the old run-time divergence by appending <c>!!</c>.
+    /// </summary>
+    [Fact]
+    public void NilEventHandler_DoesNotReceiveANonNullAssertion()
+    {
+        string printed = Translate(NilEventHandlerSource, nullableEnabled: false);
+
+        Assert.Contains("Ticked += handler", printed, StringComparison.Ordinal);
+        Assert.Contains("Ticked -= handler", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Ticked += handler!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Ticked -= handler!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The executing half of <see cref="NilEventHandler_DoesNotReceiveANonNullAssertion"/>.
+    /// The pre-fix translation threw at the first subscription.
+    /// </summary>
+    [Fact]
+    public void NilEventHandler_RemainsASilentNoOpAtRuntime()
+    {
+        string printed = Translate(NilEventHandlerSource, nullableEnabled: false);
+        string stdout = CompileAndRun(printed, "EventProbe.Run()");
+
+        Assert.Equal("event-ok", stdout.Trim());
+    }
+
+    /// <summary>
+    /// C#'s null-forgiving operator is erased when the contextual G# sink is
+    /// nullable, but remains a checked assertion when a non-null sink requires
+    /// it. <c>Nullable&lt;T&gt;.Value</c> keeps the same checked spelling under
+    /// the accepted exception-type compatibility limit recorded in ADR-0115.
+    /// </summary>
+    [Fact]
+    public void NullForgivingOperator_FollowsTheContextualSinkPolicy()
+    {
+        string printed = Translate(NullForgivingSource);
+
+        Assert.Contains("func NullableSink() object? -> Pick(false)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("func NullableSink() object? -> Pick(false)!!", printed, StringComparison.Ordinal);
+        Assert.Contains("prop NullableProperty object?", printed, StringComparison.Ordinal);
+        Assert.Contains("let value = Pick(true)!!", printed, StringComparison.Ordinal);
+        Assert.Contains("let result object? = value", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("let result object? = value!!", printed, StringComparison.Ordinal);
+        Assert.Contains("return value!!", printed, StringComparison.Ordinal);
+        Assert.Contains("func NullableValue(value int32?) int32 -> value!!", printed, StringComparison.Ordinal);
+        Assert.Contains("func Generic[T](value T?) T -> value!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A genuinely nil value reaches a nullable sink unchanged. This is the
+    /// run-time behavior that a text-only assertion cannot prove.
+    /// </summary>
+    [Fact]
+    public void NullForgivingOperator_AtNullableSink_RemainsNilAtRuntime()
+    {
+        string printed = Translate(NullForgivingSource);
+        string stdout = CompileAndRun(
+            printed,
+            "Console.WriteLine(if NullForgivingProbe.NullableProperty == nil && NullForgivingProbe.NullableSink() == nil && NullForgivingProbe.NullableLocal() && NullForgivingProbe.NullableConditional(true) { \"nil\" } else { \"value\" })");
+
+        Assert.Equal("nil", stdout.Trim());
+    }
+
+    /// <summary>
+    /// Pins the retained non-null-sink assertion and verifies that
+    /// <c>Nullable&lt;T&gt;.Value</c> now preserves C#'s
+    /// <see cref="InvalidOperationException"/> contract.
+    /// </summary>
+    [Fact]
+    public void RetainedAssertions_KeepTheirDocumentedRuntimeBehavior()
+    {
+        string printed = Translate(NullForgivingSource);
+        string stdout = CompileAndRun(
+            printed,
+            """
+            try {
+                NullForgivingProbe.NonNullSink()
+            } catch (NullReferenceException) {
+                Console.WriteLine("non-null-sink")
+            }
+            try {
+                NullForgivingProbe.NullableValue(nil)
+            } catch (InvalidOperationException) {
+                Console.WriteLine("nullable-value")
+            }
+            """);
+
+        Assert.Equal(
+            "non-null-sink" + Environment.NewLine + "nullable-value",
+            stdout.Trim());
+    }
+
+    private static string Translate(string source, bool nullableEnabled = true)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Snippet.cs", "#nullable enable\nusing System;\n\nnamespace Demo\n{\n" + source + "\n}\n") });
+            new[]
+            {
+                (
+                    "Snippet.cs",
+                    (nullableEnabled ? "#nullable enable\n" : string.Empty)
+                        + "using System;\n\nnamespace Demo\n{\n"
+                        + source
+                        + "\n}\n"),
+            });
         Assert.True(
             project.BoundWithoutErrors,
             "Snippet should bind with no C# errors: "

--- a/tools/cs2gs/Cs2Gs.Tests/Issue914FoundationSinkTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue914FoundationSinkTranslationTests.cs
@@ -111,12 +111,12 @@ namespace Demo
     }
 
     [Fact]
-    public void Oblivious_PromotedDelegateSubscribedToEvent_ForgivesRhsWithBang()
+    public void Oblivious_PromotedDelegateSubscribedToEvent_PreservesNilableHandler()
     {
         // `handler` is a delegate parameter defaulted to `null`, so it promotes to
-        // `((object, EventArgs) -> void)?`. Subscribing it to the named-delegate
-        // event `Fired` needs a `!!` so the promoted `T?` converts to the event's
-        // non-nullable delegate type (GS0155 otherwise).
+        // `((object, EventArgs) -> void)?`. Issue #3775 made event subscription
+        // itself nil-tolerant, matching Delegate.Combine/Remove, so cs2gs must
+        // preserve the handler instead of restoring the old throwing `!!` bridge.
         string printed = TranslateOblivious(@"
 using System;
 namespace Demo
@@ -137,7 +137,8 @@ namespace Demo
     }
 }");
 
-        Assert.Contains("s.Fired += handler!!", printed);
+        Assert.Contains("s.Fired += handler", printed);
+        Assert.DoesNotContain("s.Fired += handler!!", printed);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -167,8 +167,8 @@ namespace Demo
     }
 
     /// <summary>
-    /// The C# null-forgiving operator <c>expr!</c> maps to G#'s postfix non-null
-    /// assertion <c>expr!!</c> (ADR-0115 §B).
+    /// At a non-null sink, the C# null-forgiving operator <c>expr!</c> maps to
+    /// G#'s postfix non-null assertion <c>expr!!</c> (ADR-0115 §B).
     /// </summary>
     [Fact]
     public void SuppressNullableWarning_MapsToNonNullAssertion()

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -2092,6 +2092,36 @@ public sealed partial class CSharpToGSharpTranslator
             }
         }
 
+        private (ITypeSymbol Type, ISymbol Symbol) FindNullForgivingTarget(
+            PostfixUnaryExpressionSyntax value)
+        {
+            ISymbol sink = this.ResolveValueSink(value);
+            return sink switch
+            {
+                ILocalSymbol local when ExplicitLocalTypeIsNullable(local) =>
+                    (local.Type, local),
+                IFieldSymbol { Type.NullableAnnotation: NullableAnnotation.Annotated } field =>
+                    (field.Type, field),
+                IPropertySymbol { Type.NullableAnnotation: NullableAnnotation.Annotated } property =>
+                    (property.Type, property),
+                _ => this.FindContextualValueTarget(value),
+            };
+
+            static bool ExplicitLocalTypeIsNullable(ILocalSymbol local) =>
+                local.Type.NullableAnnotation == NullableAnnotation.Annotated
+                && local.DeclaringSyntaxReferences.Any(reference =>
+                    reference.GetSyntax() is VariableDeclaratorSyntax
+                    {
+                        Parent: VariableDeclarationSyntax { Type.IsVar: false },
+                    });
+        }
+
+        private bool NullForgivingTargetAcceptsNil(ITypeSymbol targetType, ISymbol targetSymbol) =>
+            targetType?.NullableAnnotation == NullableAnnotation.Annotated
+            || targetType?.OriginalDefinition?.SpecialType == SpecialType.System_Nullable_T
+            || (targetType is { IsReferenceType: true }
+                && !this.TargetWillRemainNonNullableReference(targetType, targetSymbol));
+
         // Issue #2511: element-access arguments are call-like value sinks too.
         // Apply the established forgiveness predicate only when Roslyn bound the
         // argument to a non-null reference parameter that cs2gs will keep

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -420,15 +420,37 @@ public sealed partial class CSharpToGSharpTranslator
         private ISymbol ResolveValueSink(ExpressionSyntax value)
         {
             SyntaxNode node = value;
-            while (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+            while (true)
             {
-                node = node.Parent;
+                if (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+                {
+                    node = node.Parent;
+                    continue;
+                }
+
+                if (node.Parent is ConditionalExpressionSyntax conditional
+                    && (conditional.WhenTrue == node || conditional.WhenFalse == node))
+                {
+                    node = conditional;
+                    continue;
+                }
+
+                if (node.Parent is SwitchExpressionArmSyntax arm && arm.Expression == node)
+                {
+                    node = arm.Parent;
+                    continue;
+                }
+
+                break;
             }
 
             switch (node.Parent)
             {
                 case EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax declarator }:
                     return this.context.GetDeclaredSymbol(declarator);
+
+                case EqualsValueClauseSyntax { Parent: PropertyDeclarationSyntax property }:
+                    return this.context.GetDeclaredSymbol(property);
 
                 case AssignmentExpressionSyntax assignment
                     when assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -498,9 +498,10 @@ public sealed partial class CSharpToGSharpTranslator
 
                 case PostfixUnaryExpressionSyntax suppressNullable
                     when suppressNullable.IsKind(SyntaxKind.SuppressNullableWarningExpression):
-                    // The C# null-forgiving operator `expr!` maps to G#'s postfix
-                    // non-null assertion `expr!!` when the translated operand
-                    // still has a nullable static type (ADR-0115 §B).
+                    // C# erases `expr!`; G# checks `expr!!` at run time. Preserve
+                    // the operand when its actual sink accepts nil, and use the
+                    // checked G# spelling only where the sink still requires a
+                    // non-null reference (ADR-0115 §B, issue #3775).
                     // A null literal is never forgivable: preserve `nil` so its
                     // target type accepts nullable sinks and rejects non-null ones.
                     if (IsNullOrSuppressedNull(suppressNullable.Operand))
@@ -509,11 +510,16 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     GExpression suppressed = this.TranslateExpression(suppressNullable.Operand);
+                    (ITypeSymbol suppressTargetType, ISymbol suppressTargetSymbol) =
+                        this.FindNullForgivingTarget(suppressNullable);
                     return this.GSharpExpressionIsStaticallyNonNull(
-                        suppressNullable.Operand,
-                        suppressed)
-                            ? suppressed
-                            : EnsureNonNullAssertion(suppressed);
+                            suppressNullable.Operand,
+                            suppressed)
+                            || this.NullForgivingTargetAcceptsNil(
+                            suppressTargetType,
+                            suppressTargetSymbol)
+                                ? suppressed
+                                : EnsureNonNullAssertion(suppressed);
 
                 case PostfixUnaryExpressionSyntax postfixValue
                     when postfixValue.IsKind(SyntaxKind.PostIncrementExpression)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -610,37 +610,6 @@ public sealed partial class CSharpToGSharpTranslator
             return this.context.GetTypeInfo(assignment.Left).Type?.TypeKind == TypeKind.Delegate;
         }
 
-        // Issue #914 (oblivious sink): a CLR event subscription `e += handler` /
-        // `e -= handler` whose right-hand side is an oblivious-promoted nullable
-        // function value (e.g. a `DataReceivedEventHandler eventHandler = null`
-        // parameter that promotes to `((object, DataReceivedEventArgs) -> void)?`)
-        // assigns a `T?` into the event's NAMED delegate type. gsc imports that
-        // delegate target as a non-nullable reference — even when the C# BCL event
-        // is annotated `DataReceivedEventHandler?`, the metadata annotation is not
-        // carried onto the arrow type gsc converts through — so the extra `?` on
-        // the promoted RHS is rejected (GS0155). Forgive it at the sink with `!!`,
-        // exactly like every other promoted-nullable-into-non-nullable sink
-        // (return/argument/tuple). Gated to a promoted RHS, so a nullable-enabled
-        // compilation (nothing is promoted) and every non-promoted RHS are
-        // byte-identical.
-        private GExpression ForgiveEventSubscriptionRhs(
-            AssignmentExpressionSyntax assignment, GExpression translatedRhs)
-        {
-            if ((!assignment.IsKind(SyntaxKind.AddAssignmentExpression)
-                    && !assignment.IsKind(SyntaxKind.SubtractAssignmentExpression))
-                || translatedRhs is NonNullAssertionExpression
-                || IsNullOrSuppressedNull(assignment.Right)
-                || this.context.GetSymbolInfo(assignment.Left).Symbol is not IEventSymbol eventSymbol
-                || eventSymbol.Type is not { IsReferenceType: true })
-            {
-                return translatedRhs;
-            }
-
-            return this.IsNullablePromotedValue(assignment.Right)
-                ? EnsureNonNullAssertion(translatedRhs)
-                : translatedRhs;
-        }
-
         // Issue #2259 (oblivious sink): an ELEMENT-access assignment target
         // (`arr[i] = …`, a `Dictionary`/user-indexer write, …) whose RHS is a
         // null-conditional access result (`x?[i]` / `x?.Member`) or any other
@@ -2037,7 +2006,6 @@ public sealed partial class CSharpToGSharpTranslator
             value = this.CoerceCovariantArrayConversion(
                 assignment.Right,
                 this.CoercePointerConversion(assignment.Right, value));
-            value = this.ForgiveEventSubscriptionRhs(assignment, value);
             value = this.ForgiveElementAccessAssignmentRhs(assignment, value);
             value = this.ForgiveObliviousExternalAssignmentRhs(assignment, value);
             if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))


### PR DESCRIPTION
Fixes #3775.

## Policy

C# `expr!` is erased; G# `expr!!` is a runtime check. cs2gs now erases `!` only when the emitted sink is explicitly nullable (including nullable returns and explicitly typed nullable storage). It retains `!!` where a non-null contract still needs a bridge, including inferred locals whose later Roslyn flow assumes the `!`. Oblivious non-null sinks keep the existing explicit bridge rather than widening unrelated contracts. `Nullable<T>.Value` remains `!!`; current gsc lowers value-nullable `!!` through `Nullable<T>.Value`, preserving `InvalidOperationException`.

## Fixes

- Removes the obsolete cs2gs event-subscription `!!` bridge now that event sites are nil-tolerant.
- Makes CLR event handler binding use its single conversion seam, so nullable structural arrows emitted by cs2gs convert once to nullable named delegates instead of being narrowed again.
- Drops source null-forgiving assertions at genuinely nullable return/local/field/property sinks without changing non-null and inferred-local behavior.
- Records the residual oblivious-sink policy and current `Nullable<T>.Value` behavior in ADR-0115; extends ADR-0036 for nullable arrow handlers.
- Leaves #3792's non-event delegate-combination work untouched.

## Verification

- Release solution build: 0 warnings, 0 errors.
- Focused cs2gs runtime/policy tests: 11 passed.
- Event compiler runtime tests: 11 passed.
- Nullable assertion hygiene tests: 7 passed.
- Nullable hygiene gate: OK.
- Pinned Oahu migration: 15/15 apps translate, compile, ILVerify, and pass parity; `!!` count 1057.
- ADR-0154 witness: reverting the three product files to `origin/main` made all four new event/null-forgiving regressions fail (two runtime NREs, two emitted-text failures).
- Hot-core self-migration guard and full CI: pending.
