### PR TITLE
runtime: a timer selectable arms only after its own fields are assigned (#4001)

### DIFF
--- a/src/Sdk/Gsharp.Runtime.Channels/Timers.cs
+++ b/src/Sdk/Gsharp.Runtime.Channels/Timers.cs
@@ -38,7 +38,13 @@ public sealed class AfterTimer : ISelectable<DateTime>, ISelectableCore<DateTime
     internal AfterTimer(TimeSpan due)
     {
         Order = SelectOrder.Next();
-        timer = new Timer(static state => ((AfterTimer)state!).OnFire(), this, due, Timeout.InfiniteTimeSpan); // state is `this`.
+
+        // Issue #4001: `new Timer(cb, state, due, period)` arms the timer before
+        // it returns, so a short `due` lets `OnFire` run on a thread-pool thread
+        // while `timer` is still unassigned — and `OnFire` ends in
+        // `timer.Dispose()`. Construct disarmed, assign, then arm.
+        timer = new Timer(static state => ((AfterTimer)state!).OnFire(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); // state is `this`.
+        timer.Change(due, Timeout.InfiniteTimeSpan);
     }
 
     /// <summary>Gets a value indicating whether the delay has elapsed (a snapshot).</summary>
@@ -184,7 +190,13 @@ public sealed class TickTimer : ISelectable<DateTime>, ISelectableCore<DateTime>
         }
 
         Order = SelectOrder.Next();
-        timer = new Timer(static state => ((TickTimer)state!).OnTick(), this, period, period); // state is `this`.
+
+        // Issue #4001: armed only once the field is assigned, as in `AfterTimer`.
+        // This constructor was *not* the crashing one — `OnTick` never touches
+        // `timer` — but the two shapes stay identical so that adding a `timer.…`
+        // to `OnTick` cannot quietly reintroduce that race.
+        timer = new Timer(static state => ((TickTimer)state!).OnTick(), this, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan); // state is `this`.
+        timer.Change(period, period);
     }
 
     /// <inheritdoc/>

--- a/test/Runtime.Channels.Tests/Issue4001TimerArmingTests.cs
+++ b/test/Runtime.Channels.Tests/Issue4001TimerArmingTests.cs
@@ -1,0 +1,139 @@
+// <copyright file="Issue4001TimerArmingTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Gsharp.Concurrency;
+using Xunit;
+
+namespace GSharp.Runtime.Channels.Tests;
+
+/// <summary>
+/// Issue #4001: a timer selectable must be armed only once its own fields are
+/// assigned. <c>new Timer(cb, state, due, period)</c> arms before it returns, so
+/// for a short <c>due</c> the callback can run on a thread-pool thread while the
+/// constructor is still executing — and <c>AfterTimer.OnFire</c> ends in
+/// <c>timer.Dispose()</c>, on a field that is not yet assigned.
+/// </summary>
+/// <remarks>
+/// The failure mode is a <see cref="NullReferenceException"/> on a thread-pool
+/// thread with nothing to catch it, so it kills the process rather than failing
+/// an assertion: on the defective code this file does not report a failed test,
+/// it aborts the whole test run ("Test host process crashed"). That is the only
+/// shape a regression here can take, and it is exactly the CI symptom the issue
+/// reports.
+/// <para>
+/// Discrimination witness (ADR-0154). Reverting
+/// <c>src/Sdk/Gsharp.Runtime.Channels/Timers.cs</c> to the single-expression
+/// <c>timer = new Timer(…, due, Timeout.InfiniteTimeSpan)</c> form kills
+/// <see cref="After_ZeroDelay_ConstructedConcurrently_ArmsOnlyAfterTheFieldIsAssigned"/>
+/// — measured on this machine at a median of ~35 000 constructions across four
+/// threads (five for five runs, range 28 239–39 513, all within 20 ms), against
+/// the 400 000 the test drives.
+/// </para>
+/// <para>
+/// <see cref="Tick_SubTickPeriod_ConstructedConcurrently_DoesNotFault"/> is
+/// <em>not</em> claimed as a killer of that mutant: <c>TickTimer.OnTick</c>
+/// never touches its <c>timer</c> field, so the identical constructor shape was
+/// measured to be harmless there (900 000 constructions across three runs, no
+/// fault). It pins that fact so a future <c>timer.…</c> in <c>OnTick</c> cannot
+/// quietly reintroduce the class.
+/// </para>
+/// </remarks>
+public class Issue4001TimerArmingTests
+{
+    /// <summary>Threads racing the constructor against its own callback.</summary>
+    private const int Threads = 4;
+
+    /// <summary>
+    /// Constructions per thread. The race reproduced within ~35 000 total on a
+    /// developer machine, so 100 000 per thread is an order of magnitude of
+    /// headroom for a slower CI runner while still costing well under a second.
+    /// </summary>
+    private const int PerThread = 100_000;
+
+    /// <summary>Timers held to prove the fix still arms them.</summary>
+    private const int ArmedSample = 512;
+
+    [Fact]
+    public void After_ZeroDelay_ConstructedConcurrently_ArmsOnlyAfterTheFieldIsAssigned()
+    {
+        Race(() => Timers.After(TimeSpan.Zero).Dispose());
+
+        // Survival alone is vacuous: a constructor that never arms the timer
+        // would also survive. Hold a sample and require every one of them to
+        // fire.
+        var sample = new AfterTimer[ArmedSample];
+        try
+        {
+            for (var i = 0; i < sample.Length; i++)
+            {
+                sample[i] = Timers.After(TimeSpan.Zero);
+            }
+
+            var deadline = Stopwatch.StartNew();
+            var fired = 0;
+            while (fired < sample.Length && deadline.Elapsed < TimeSpan.FromSeconds(10))
+            {
+                fired = 0;
+                foreach (var timer in sample)
+                {
+                    if (timer.HasFired)
+                    {
+                        fired++;
+                    }
+                }
+
+                if (fired < sample.Length)
+                {
+                    Thread.Sleep(5);
+                }
+            }
+
+            Assert.Equal(sample.Length, fired);
+        }
+        finally
+        {
+            foreach (var timer in sample)
+            {
+                timer?.Dispose();
+            }
+        }
+    }
+
+    [Fact]
+    public void Tick_SubTickPeriod_ConstructedConcurrently_DoesNotFault()
+    {
+        // The shortest period the constructor accepts, so the first tick is due
+        // immediately and races the constructor exactly as `after(0)` does.
+        Race(() => Timers.Tick(TimeSpan.FromTicks(1)).Dispose());
+    }
+
+    private static void Race(Action construct)
+    {
+        var start = new Barrier(Threads);
+        var workers = new Thread[Threads];
+        for (var t = 0; t < workers.Length; t++)
+        {
+            workers[t] = new Thread(() =>
+            {
+                start.SignalAndWait();
+                for (var i = 0; i < PerThread; i++)
+                {
+                    construct();
+                }
+            })
+            {
+                IsBackground = true,
+            };
+            workers[t].Start();
+        }
+
+        foreach (var worker in workers)
+        {
+            Assert.True(worker.Join(TimeSpan.FromMinutes(2)), "A constructing thread did not finish.");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4001

## Summary

- `AfterTimer`'s constructor armed its timer in the same expression that assigned the field. `new Timer(cb, state, due, period)` arms before it returns, so for a short `due` the callback ran on a thread-pool thread while the constructor was still executing — and `OnFire` ends in `timer.Dispose()`, on a field not yet assigned. The `NullReferenceException` had nothing to catch it, so it killed the process instead of failing a test. Both constructors now build the timer **disarmed** and arm it with `Change` once the field is assigned.
- `TickTimer` **did not share the defect**, contrary to the issue's "wants the same treatment". Its shape is identical, but `OnTick` never touches `timer` — see the measurement below. Its constructor is changed anyway, for symmetry, so that a future `timer.…` in `OnTick` cannot quietly reintroduce the class. The PR states plainly that it did not crash.
- New `test/Runtime.Channels.Tests/Issue4001TimerArmingTests.cs` drives the race.
- No `try`/`catch` around `OnFire` — reasoned below.

### Every other `new Timer(` in the repo

`rg 'new Timer\('` finds three more, none affected:

| Site | Why it is safe |
| --- | --- |
| `src/LanguageServer/Server/LspServer.cs:1395` | constructed with `Timeout.Infinite, Timeout.Infinite` — already disarmed |
| `src/Sdk/Gsharp.HotReload.Runtime/HotReloadAgent.cs:190` | constructed with `Timeout.Infinite, Timeout.Infinite` — already disarmed |
| `tools/cs2gs/Cs2Gs.Tests/Issue3554…Tests.cs:41` | armed at `0`, but the callback is `_ => { }` and touches nothing |

### The issue's diagnosis, checked

Correct on every point about `AfterTimer` — cause, line, fix — and the fix shape it proposes is the one applied. The one correction: `TickTimer` has the identical *shape* but does not share the *defect*. `OnTick` reads `gate` and `waiters` (both field initializers, so assigned before the constructor body runs), plus `disposed` / `pending` / `pendingAt`; it never dereferences `timer`. Measured, not asserted — see below.

## Verification

**Build:** `dotnet build GSharp.sln --configuration Release -graph` → **0 Warning(s), 0 Error(s)**.

**Suites:**

| Suite | Result |
| --- | --- |
| `test/Runtime.Channels.Tests` (whole project) | Passed! Failed: 0, **Passed: 190**, Skipped: 0, Total: 190 |
| `test/Compiler.Tests` `--filter "FullyQualifiedName~Adr0174\|FullyQualifiedName~Timer\|FullyQualifiedName~Select"` | Passed! Failed: 0, **Passed: 90**, Skipped: 0, Total: 90 |

Not run: the rest of the solution's suites, per the repo owner's standing instruction that PR CI does full validation. The change is confined to two constructors in `Gsharp.Runtime.Channels`.

### Witness of discrimination (ADR-0154)

The new tests were written and run **before** touching `src/`, on the parent commit `b6d2f60e`, with `--filter FullyQualifiedName~Issue4001`. The failure mode is a killed host, not an assertion — so the "red" is an aborted run, which is exactly the CI symptom being fixed:

```
Test run for .../GSharp.Runtime.Channels.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at Gsharp.Concurrency.AfterTimer.OnFire() in .../src/Sdk/Gsharp.Runtime.Channels/Timers.cs:line 163
   at Gsharp.Concurrency.AfterTimer.<>c.<.ctor>b__6_0(Object state) in .../src/Sdk/Gsharp.Runtime.Channels/Timers.cs:line 41
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.TimerQueueTimer.Fire(Boolean isThreadPool)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
...
Test Run Aborted.
```

Line for line the stack in the issue, and in [the failing job](https://github.com/DavidObando/gsharp/actions/runs/34017938878/job/101445037420). Exit code 1.

With the fix, same filter: `Passed! - Failed: 0, Passed: 2, Skipped: 0, Total: 2, Duration: 434 ms`.

### How many iterations make the race reproduce

Measured with a standalone console app referencing the built `Gsharp.Runtime.Channels.dll` (an aborted xunit host loses any counter it printed), four threads constructing `Timers.After(TimeSpan.Zero)` in a tight loop, count read from an `AppDomain.CurrentDomain.UnhandledException` handler. Five runs on the parent commit, five crashes:

| Run | Constructions before the crash | Elapsed |
| --- | --- | --- |
| 1 | 33 831 | 16 ms |
| 2 | 39 513 | 17 ms |
| 3 | 34 767 | 15 ms |
| 4 | 28 239 | 18 ms |
| 5 | 36 260 | 17 ms |

**Median 34 767, range 28 239–39 513, 5/5.** With the fix the same probe survived **3 × 2 000 000 = 6 000 000** constructions, no fault. The test drives 400 000 (4 threads × 100 000, ~11× the median) and costs 434 ms — headroom for a slower CI runner without hurting a 190-test shard.

**Second mutant, also measured.** The test does not stop at survival: a constructor that never armed its timer would also survive. It holds a 512-timer sample and requires every one to report `HasFired` within a bounded wait. Deleting `timer.Change(due, Timeout.InfiniteTimeSpan);` from `AfterTimer` and rerunning the filter:

```
  Failed After_ZeroDelay_ConstructedConcurrently_ArmsOnlyAfterTheFieldIsAssigned [10 s]
  Error Message:
   Assert.Equal() Failure: Values differ
Expected: 512
Actual:   0
```

Restored and re-verified green (`Passed: 2, Duration: 323 ms`).

**`TickTimer`, measured:** the same stress with `Timers.Tick(TimeSpan.FromTicks(1))` — the shortest period the guard accepts, so the first tick is due immediately — survived **3 × 300 000 = 900 000** constructions on the parent commit with no fault. 26× the count that reliably kills `AfterTimer`. That is the evidence for "identical shape, not the same defect". `Tick_SubTickPeriod_ConstructedConcurrently_DoesNotFault` pins it and is explicitly *not* claimed as a killer of the `AfterTimer` mutant.

## Decision: no `try`/`catch` in `OnFire`

The issue asks whether an unexpected failure in `OnFire` should route through `GsharpRuntime`'s diagnostics rather than kill the host. Declined, for three reasons:

1. **No hook fits.** The only fatal-path hook is `GoroutineRuntime.UnhandledGoroutineException`, whose payload is documented as "the free goroutine's failure" and whose `FreeGoroutineSink.Fail` message is about `go`/`scope` (ADR-0174 D5). A timer callback is not a goroutine; routing through it misnames the failure, and a host setting `Handled = true` for its own goroutines would then silently swallow a runtime-internal bug.
2. **`GsharpRuntime`'s events are for situations, not faults.** Its own remarks scope them to "two situations reportable rather than fatal" — a `defer` grace budget expiring (D7) and a scope join stalling. Both are documented semantics a host may observe. An internal-fault channel is a third, new piece of public API and belongs in an ADR, not in a CI fix.
3. **The catch would not own what it caught.** `OnFire` ends in `winner?.Publish()` → `SelectWaiter.PublishOutcome`, which sets `core.RunContinuationsAsynchronously = !inline` — so when the inline budget allows, the select's *continuation* runs on the timer thread inside the `try`. A catch there converts an exception from code the runtime does not own into a swallowed diagnostic. Async state machines capture their own exceptions into the task, so escapes are rare — but rare-and-swallowed is worse than rare-and-fatal.

What is left in `OnFire` after this change is runtime-internal work under its own gate. A throw from there is a bug in this file, and it should stay loud.

## Out of scope, filed

- **#4008** — `tick(d)` with a sub-millisecond `d` fires exactly once and then never again. `TickTimer`'s guard rejects only `period <= TimeSpan.Zero`, but `System.Threading.Timer` truncates to whole milliseconds and a zero period disables periodic signalling. Measured on `main`: periods of 0.1 / 0.5 / 0.9 ms produce **1** tick in 500 ms; 1.0 / 1.5 ms produce 437 / 439. Pre-existing and unchanged by this PR (re-measured after the fix: identical).

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154): written and run red on the parent commit `b6d2f60e` before `src/` was touched, exact abort text above; green with the fix.
- [x] Self-review verdict recorded: MERGEABLE. Residual filed as #4008 rather than dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVZ9GDN9g4NVF47GRNpWkL
