### PR TITLE
gsc: report the missing segment in qualified static access

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -981,8 +981,20 @@ public sealed class Binder
                 packagesInOrder.Add(packageSymbol);
                 AttachDocumentation(packageSymbol, packageSyntax);
             }
+            else if (packageSyntax != null)
+            {
+                packageSymbol.MarkExplicitlyDeclared();
+            }
 
             packageByTree[tree] = packageSymbol;
+        }
+
+        foreach (var packageSymbol in packagesInOrder)
+        {
+            if (packageSymbol.IsExplicitlyDeclared)
+            {
+                binder.scope.RegisterSourcePackage(packageSymbol.Name);
+            }
         }
 
         // Issue #2342: runs `action` with `pkg`'s name set as the ambient
@@ -3323,6 +3335,14 @@ public sealed class Binder
             previous = stack.Pop();
             var scope = new BoundScope(parent);
             var preserveImportSyntaxTrees = preserveLatestImportSyntaxTrees && stack.Count == 0;
+
+            foreach (var package in previous.Packages)
+            {
+                if (package.IsExplicitlyDeclared)
+                {
+                    scope.RegisterSourcePackage(package.Name);
+                }
+            }
 
             foreach (var i in previous.Imports)
             {

--- a/src/Core/CodeAnalysis/Binding/BoundScope.cs
+++ b/src/Core/CodeAnalysis/Binding/BoundScope.cs
@@ -24,6 +24,7 @@ public sealed class BoundScope
     private ImmutableArray<string>.Builder? functionKeys;
     private ImmutableArray<ImportSymbol>.Builder? imports;
     private ImmutableDictionary<string, TypeSymbol>.Builder? typeAliases;
+    private ImmutableDictionary<string, bool>.Builder? sourcePackagePrefixes;
 
     // ADR-0156 Phase 2: registered on the root scope of an interactive
     // submission's scope chain; exposed via SubmissionImports.
@@ -1717,6 +1718,57 @@ public sealed class BoundScope
     /// </summary>
     /// <param name="imports">The submission import set; may be <see langword="null"/>.</param>
     internal void SetSubmissionImports(SubmissionImports? imports) => submissionImports = imports;
+
+    /// <summary>
+    /// Records a package declared by the source compilation.
+    /// </summary>
+    /// <param name="packageName">The package's dotted name.</param>
+    internal void RegisterSourcePackage(string packageName)
+    {
+        sourcePackagePrefixes ??= ImmutableDictionary.CreateBuilder<string, bool>(StringComparer.Ordinal);
+        for (var end = packageName.Length; end > 0; end = packageName.LastIndexOf('.', end - 1))
+        {
+            var prefix = packageName.Substring(0, end);
+            var exact = end == packageName.Length;
+            if (!sourcePackagePrefixes.TryGetValue(prefix, out var existingExact) || (exact && !existingExact))
+            {
+                sourcePackagePrefixes[prefix] = exact;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns whether a source package exactly matches, or descends from, the
+    /// specified dotted prefix.
+    /// </summary>
+    /// <param name="packagePrefix">The package prefix to probe.</param>
+    /// <param name="exactMatch">Whether an exact package match was found.</param>
+    /// <returns>Whether the prefix belongs to the source package hierarchy.</returns>
+    internal bool TryMatchSourcePackagePrefix(string packagePrefix, out bool exactMatch)
+    {
+        exactMatch = false;
+        if (string.IsNullOrEmpty(packagePrefix))
+        {
+            return false;
+        }
+
+        var matched = false;
+        for (var current = this; current != null; current = current.Parent)
+        {
+            if (current.sourcePackagePrefixes?.TryGetValue(packagePrefix, out var isExact) == true)
+            {
+                if (isExact)
+                {
+                    exactMatch = true;
+                    return true;
+                }
+
+                matched = true;
+            }
+        }
+
+        return matched;
+    }
 
     /// <summary>
     /// Gets the per-compile-pass anonymous-class-literal type cache (issue

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -42,6 +42,13 @@ internal sealed partial class ExpressionBinder
             return BindNullConditionalAccessExpression(syntax);
         }
 
+        SyntaxToken? missingQualifiedType = null;
+        SyntaxToken? invalidQualifiedGenericType = null;
+        ExpressionSyntax? invalidQualifiedTypeArgument = null;
+        string? resolvedPrefix = null;
+        var resolvedPrefixIsPackage = false;
+        var qualifiedClrFailureHandled = false;
+
         // Issue #293: a fully-qualified imported-type constructor
         // (`System.Text.StringBuilder()`, `System.Collections.Generic.List[int]()`)
         // parses as an accessor chain whose terminal segment is the call, so it
@@ -72,7 +79,15 @@ internal sealed partial class ExpressionBinder
         {
             ExpressionSyntax qualifiedClrMember = syntax.RightPart;
             if (TryBindFullyQualifiedClrStaticAccess(
-                qualifiedClrRoot, ref qualifiedClrMember, out var qualifiedClrType))
+                qualifiedClrRoot,
+                ref qualifiedClrMember,
+                out var qualifiedClrType,
+                out missingQualifiedType,
+                out resolvedPrefix,
+                out resolvedPrefixIsPackage,
+                out qualifiedClrFailureHandled,
+                out invalidQualifiedGenericType,
+                out invalidQualifiedTypeArgument))
             {
                 return BindAccessorStep(null, qualifiedClrType, qualifiedClrMember);
             }
@@ -634,6 +649,40 @@ internal sealed partial class ExpressionBinder
             }
             else
             {
+                if (qualifiedClrFailureHandled)
+                {
+                    return new BoundErrorExpression(syntax);
+                }
+
+                if (invalidQualifiedTypeArgument != null)
+                {
+                    var invalidArgumentLocation = invalidQualifiedTypeArgument.Location;
+                    Diagnostics.ReportUnableToFindType(
+                        invalidArgumentLocation,
+                        invalidArgumentLocation.Text?.ToString(invalidArgumentLocation.Span) ?? string.Empty);
+                    return new BoundErrorExpression(syntax);
+                }
+
+                if (invalidQualifiedGenericType != null)
+                {
+                    Diagnostics.ReportTypeNotGeneric(
+                        invalidQualifiedGenericType.Location,
+                        invalidQualifiedGenericType.ValueText);
+                    return new BoundErrorExpression(syntax);
+                }
+
+                if (missingQualifiedType != null && resolvedPrefix != null)
+                {
+                    // Issue #3842: report the deepest verified namespace/package
+                    // boundary after every existing receiver path has failed.
+                    Diagnostics.ReportUnableToFindQualifiedType(
+                        missingQualifiedType.Location,
+                        missingQualifiedType.ValueText,
+                        resolvedPrefix,
+                        resolvedPrefixIsPackage);
+                    return new BoundErrorExpression(syntax);
+                }
+
                 Diagnostics.ReportUnableToFindType(leftName.Location, name);
                 return new BoundErrorExpression(null);
             }
@@ -1652,6 +1701,27 @@ internal sealed partial class ExpressionBinder
         [NotNullWhen(true)] out ImportedClassSymbol? importedClass)
         => TryWalkQualifiedClrTypePath(leftName.IdentifierToken.ValueText, ref rightPart, out importedClass);
 
+    private bool TryBindFullyQualifiedClrStaticAccess(
+        NameExpressionSyntax leftName,
+        ref ExpressionSyntax rightPart,
+        [NotNullWhen(true)] out ImportedClassSymbol? importedClass,
+        out SyntaxToken? missingType,
+        out string? resolvedPrefix,
+        out bool resolvedPrefixIsPackage,
+        out bool failureHandled,
+        out SyntaxToken? invalidGenericType,
+        out ExpressionSyntax? invalidTypeArgument)
+        => TryWalkQualifiedClrTypePath(
+            leftName.IdentifierToken.ValueText,
+            ref rightPart,
+            out importedClass,
+            out missingType,
+            out resolvedPrefix,
+            out resolvedPrefixIsPackage,
+            out failureHandled,
+            out invalidGenericType,
+            out invalidTypeArgument);
+
     /// <summary>
     /// Walks a dotted accessor chain, extending a namespace prefix segment by
     /// segment until a prefix resolves to a referenced CLR type. On success the
@@ -1659,15 +1729,42 @@ internal sealed partial class ExpressionBinder
     /// <paramref name="rightPart"/> is advanced to the remaining (post-type)
     /// member-access chain. Shared by <see cref="TryBindImportAccessor"/> (which
     /// starts from a registered import target) and
-    /// <see cref="TryBindFullyQualifiedClrStaticAccess"/> (which starts from a
+    /// <c>TryBindFullyQualifiedClrStaticAccess</c> (which starts from a
     /// bare leading namespace name).
     /// </summary>
     private bool TryWalkQualifiedClrTypePath(
         string startPath,
         ref ExpressionSyntax rightPart,
         [NotNullWhen(true)] out ImportedClassSymbol? importedClass)
+        => TryWalkQualifiedClrTypePath(
+            startPath,
+            ref rightPart,
+            out importedClass,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _,
+            out _);
+
+    private bool TryWalkQualifiedClrTypePath(
+        string startPath,
+        ref ExpressionSyntax rightPart,
+        [NotNullWhen(true)] out ImportedClassSymbol? importedClass,
+        out SyntaxToken? missingType,
+        out string? resolvedPrefix,
+        out bool resolvedPrefixIsPackage,
+        out bool failureHandled,
+        out SyntaxToken? invalidGenericType,
+        out ExpressionSyntax? invalidTypeArgument)
     {
         importedClass = null;
+        missingType = null;
+        resolvedPrefix = null;
+        resolvedPrefixIsPackage = false;
+        failureHandled = false;
+        invalidGenericType = null;
+        invalidTypeArgument = null;
 
         var currentPath = startPath;
         var currentRight = rightPart;
@@ -1686,21 +1783,71 @@ internal sealed partial class ExpressionBinder
             // (mirroring the non-generic branch just below) and hand the
             // remaining chain back as the static-member access on the closed type.
             if (currentRight is AccessorExpressionSyntax genericSegment
-                && TryGetGenericSegmentNameAndArity(genericSegment.LeftPart, out var genericSegmentName, out var genericArity))
+                && TryGetGenericSegmentNameAndArity(genericSegment.LeftPart, out var genericIdentifier, out var genericArity))
             {
-                var mangledName = currentPath + "." + genericSegmentName + "`" + genericArity;
-                if (scope.References.TryResolveType(mangledName, out var openGenericType)
-                    && TryBindGenericImportSegmentTypeArguments(genericSegment.LeftPart, genericArity, out var segmentTypeArgs)
-                    && TryCloseImportedGenericTypeReceiver(openGenericType, segmentTypeArgs, genericSegment.LeftPart, out var closedGenericImported))
+                var mangledName = currentPath + "." + genericIdentifier.ValueText + "`" + genericArity;
+                if (scope.References.TryResolveType(mangledName, out var openGenericType))
                 {
-                    importedClass = closedGenericImported;
-                    rightPart = genericSegment.RightPart;
-                    return true;
+                    var diagnosticCount = Diagnostics.Count;
+                    if (!TryBindGenericImportSegmentTypeArguments(genericSegment.LeftPart, genericArity, out var segmentTypeArgs))
+                    {
+                        if (Diagnostics.Count > diagnosticCount)
+                        {
+                            failureHandled = true;
+                        }
+                        else
+                        {
+                            invalidTypeArgument = genericSegment.LeftPart is IndexExpressionSyntax index
+                                ? index.Indices.FirstOrDefault(
+                                    argument => !TryBuildTypeClauseFromExpression(argument, out _))
+                                : genericSegment.LeftPart;
+                            invalidTypeArgument ??= genericSegment.LeftPart;
+                        }
+
+                        return false;
+                    }
+
+                    if (TryCloseImportedGenericTypeReceiver(openGenericType, segmentTypeArgs, genericSegment.LeftPart, out var closedGenericImported))
+                    {
+                        importedClass = closedGenericImported;
+                        rightPart = genericSegment.RightPart;
+                        return true;
+                    }
+
+                    if (!scope.TryLookupSourceTypeInPackage(
+                            currentPath,
+                            genericIdentifier.ValueText,
+                            genericArity,
+                            out _))
+                    {
+                        invalidGenericType = genericIdentifier;
+                    }
+
+                    return false;
+                }
+
+                if (scope.References.TryResolveType(
+                        currentPath + "." + genericIdentifier.ValueText,
+                        out _)
+                    || scope.TryLookupSourceTypeInPackage(
+                        currentPath,
+                        genericIdentifier.ValueText,
+                        preferredArity: 0,
+                        out _))
+                {
+                    invalidGenericType = genericIdentifier;
+                    return false;
                 }
 
                 // A generic instantiation can never be a further namespace
                 // level, so a failed resolution here ends the walk instead of
                 // falling through to the plain-segment cases below.
+                if (TryClassifyQualifiedNamespaceOrPackage(currentPath, out resolvedPrefixIsPackage))
+                {
+                    missingType = genericIdentifier;
+                    resolvedPrefix = currentPath;
+                }
+
                 return false;
             }
 
@@ -1727,6 +1874,15 @@ internal sealed partial class ExpressionBinder
                     hasMoreChain = false;
                     break;
 
+                case CallExpressionSyntax call when !call.Identifier.IsMissing:
+                    if (TryClassifyQualifiedNamespaceOrPackage(currentPath, out resolvedPrefixIsPackage))
+                    {
+                        missingType = call.Identifier;
+                        resolvedPrefix = currentPath;
+                    }
+
+                    return false;
+
                 default:
                     return false;
             }
@@ -1743,12 +1899,50 @@ internal sealed partial class ExpressionBinder
             // as another namespace level and keep walking. Otherwise, give up.
             if (!hasMoreChain)
             {
+                if (TryClassifyQualifiedNamespaceOrPackage(currentPath, out resolvedPrefixIsPackage))
+                {
+                    missingType = typeNameSyntax.IdentifierToken;
+                    resolvedPrefix = currentPath;
+                }
+
+                return false;
+            }
+
+            if (TryClassifyQualifiedNamespaceOrPackage(fullTypeName, out _))
+            {
+                currentPath = fullTypeName;
+                currentRight = remainder;
+                continue;
+            }
+
+            if (TryClassifyQualifiedNamespaceOrPackage(currentPath, out resolvedPrefixIsPackage))
+            {
+                missingType = typeNameSyntax.IdentifierToken;
+                resolvedPrefix = currentPath;
                 return false;
             }
 
             currentPath = fullTypeName;
             currentRight = remainder;
         }
+    }
+
+    private bool TryClassifyQualifiedNamespaceOrPackage(string prefix, out bool isPackage)
+    {
+        if (scope.TryMatchSourcePackagePrefix(prefix, out var exactPackage))
+        {
+            isPackage = exactPackage;
+            return true;
+        }
+
+        if (scope.References.ContainsNamespace(prefix))
+        {
+            isPackage = false;
+            return true;
+        }
+
+        isPackage = false;
+        return false;
     }
 
     /// <summary>
@@ -1762,7 +1956,7 @@ internal sealed partial class ExpressionBinder
     /// </summary>
     private static bool TryGetGenericSegmentNameAndArity(
         ExpressionSyntax segment,
-        [NotNullWhen(true)] out string? name,
+        [NotNullWhen(true)] out SyntaxToken? identifier,
         out int arity)
     {
         switch (segment)
@@ -1770,22 +1964,22 @@ internal sealed partial class ExpressionBinder
             case IndexExpressionSyntax index:
                 if (index.IsNullConditional || index.Target is not NameExpressionSyntax indexName)
                 {
-                    name = string.Empty;
+                    identifier = null;
                     arity = 0;
                     return false;
                 }
 
-                name = indexName.IdentifierToken.ValueText;
+                identifier = indexName.IdentifierToken;
                 arity = index.Indices.Count;
                 return true;
 
             case GenericNameExpressionSyntax generic:
-                name = generic.Identifier.ValueText;
+                identifier = generic.Identifier;
                 arity = generic.TypeArgumentList.Arguments.Count;
                 return true;
 
             default:
-                name = null;
+                identifier = null;
                 arity = 0;
                 return false;
         }

--- a/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
+++ b/src/Core/CodeAnalysis/DiagnosticBag.Reports.Expressions.cs
@@ -425,6 +425,23 @@ public sealed partial class DiagnosticBag
     => Report(location, DiagnosticDescriptors.UnableToFindType, text);
 
     /// <summary>
+    /// Reports that a qualified namespace/package path resolved, but its next
+    /// segment did not name a type.
+    /// </summary>
+    /// <param name="location">The missing type segment's location.</param>
+    /// <param name="typeName">The missing simple type name.</param>
+    /// <param name="prefix">The longest resolvable namespace/package prefix.</param>
+    /// <param name="isPackage">Whether <paramref name="prefix"/> is a source package.</param>
+    public void ReportUnableToFindQualifiedType(
+        TextLocation location,
+        string typeName,
+        string prefix,
+        bool isPackage)
+    => ReportUnableToFindType(
+        location,
+        $"'{typeName}' in {(isPackage ? "package" : "namespace")} '{prefix}'");
+
+    /// <summary>
     /// Reports that we couldn't find the specified member.
     /// </summary>
     /// <param name="location">The text location where the error was found.</param>

--- a/src/Core/CodeAnalysis/Symbols/PackageSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/PackageSymbol.cs
@@ -20,6 +20,7 @@ public sealed class PackageSymbol : Symbol
         : base(name)
     {
         Declaration = declaration;
+        IsExplicitlyDeclared = declaration != null;
     }
 
     /// <inheritdoc/>
@@ -29,4 +30,15 @@ public sealed class PackageSymbol : Symbol
     /// Gets the declaration of the package, or <see langword="null"/> for synthesized package symbols.
     /// </summary>
     public PackageSyntax? Declaration { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether any syntax tree explicitly declared this
+    /// package name.
+    /// </summary>
+    internal bool IsExplicitlyDeclared { get; private set; }
+
+    /// <summary>
+    /// Records that a later syntax tree explicitly declared this package.
+    /// </summary>
+    internal void MarkExplicitlyDeclared() => IsExplicitlyDeclared = true;
 }

--- a/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
+++ b/src/Core/CodeAnalysis/Symbols/ReferenceResolver.cs
@@ -129,6 +129,7 @@ public sealed class ReferenceResolver : IDisposable
     // and the binder already constructs (e.g. "Ns.Type`1").
     private readonly Lazy<Dictionary<string, Type>> typeNameIndex;
     private readonly Lazy<Dictionary<string, string>> emittedTypeNameIndex;
+    private readonly Lazy<ImmutableHashSet<string>> namespaceIndex;
 
     // ADR-0107 (cold-start cache): an optional, externally-supplied
     // full-name -> declaring-assembly-index map that stands in for the eager
@@ -190,6 +191,9 @@ public sealed class ReferenceResolver : IDisposable
         this.hostFallbackAssemblyNames = hostFallbackAssemblyNames
             ?? ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
         this.typeNameIndex = typeNameIndex ?? CreateTypeNameIndex(assemblies);
+        this.namespaceIndex = new Lazy<ImmutableHashSet<string>>(
+            BuildNamespaceIndex,
+            LazyThreadSafetyMode.ExecutionAndPublication);
         this.emittedTypeNameIndex = new Lazy<Dictionary<string, string>>(
             () => BuildEmittedTypeNameIndex(
                 this.warmNameIndex is { } warm
@@ -1213,6 +1217,15 @@ public sealed class ReferenceResolver : IDisposable
         return true;
     }
 
+    /// <summary>
+    /// Returns whether the reference set contains at least one type below the
+    /// specified CLR namespace.
+    /// </summary>
+    /// <param name="namespaceName">The fully-qualified namespace name.</param>
+    /// <returns>Whether the namespace is present in the reference set.</returns>
+    internal bool ContainsNamespace(string namespaceName)
+        => !string.IsNullOrEmpty(namespaceName) && namespaceIndex.Value.Contains(namespaceName);
+
     internal static string? FindBundledExtensionPath(string baseDirectory)
     {
         // Compiler cannot ProjectReference Gsharp.Extensions because its bootstrap
@@ -1228,6 +1241,33 @@ public sealed class ReferenceResolver : IDisposable
         // layout has it under out/bin/<Config>/Gsharp.Runtime.Channels/, and
         // the SDK NuGet under tools/channels/.
         return FindBundledRuntimePath(baseDirectory, "Gsharp.Runtime.Channels.dll", "Gsharp.Runtime.Channels", "channels");
+    }
+
+    private ImmutableHashSet<string> BuildNamespaceIndex()
+    {
+        var builder = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        IEnumerable<string> indexedNames = warmNameIndex != null
+            ? warmNameIndex.Keys
+            : typeNameIndex.Value.Keys;
+        var names = indexedNames.ToArray();
+        var scopes = BuildTypeNameScopes(names);
+
+        foreach (var name in names)
+        {
+            AddNamespacePrefixes(name);
+            AddNamespacePrefixes(CanonicalTypeName(name, scopes));
+        }
+
+        return builder.ToImmutable();
+
+        void AddNamespacePrefixes(string typeName)
+        {
+            var topLevelName = typeName.Split('+')[0];
+            for (var separator = topLevelName.LastIndexOf('.'); separator > 0; separator = topLevelName.LastIndexOf('.', separator - 1))
+            {
+                builder.Add(topLevelName.Substring(0, separator));
+            }
+        }
     }
 
     private static void AppendBundledPath(List<string> paths, string? bundledPath)

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3842CanonicalNamespaceFixture.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3842CanonicalNamespaceFixture.cs
@@ -1,0 +1,12 @@
+// <copyright file="Issue3842CanonicalNamespaceFixture.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+namespace @package;
+
+/// <summary>
+/// Supplies a keyword-named CLR namespace for issue #3842 diagnostics.
+/// </summary>
+public sealed class Existing
+{
+}

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue3842QualifiedStaticAccessDiagnosticTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue3842QualifiedStaticAccessDiagnosticTests.cs
@@ -1,0 +1,462 @@
+// <copyright file="Issue3842QualifiedStaticAccessDiagnosticTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Binding;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Symbols;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #3842: a qualified static-member access whose type segment did not
+/// resolve blamed the first namespace/package segment instead of the missing
+/// type.
+/// </summary>
+public sealed class Issue3842QualifiedStaticAccessDiagnosticTests
+{
+    [Fact]
+    public void ChainedScope_ExactPackageOutranksNearerPrefixOnlyMatch()
+    {
+        var older = new BoundScope(parent: null);
+        older.RegisterSourcePackage("A.B");
+        var newer = new BoundScope(older);
+        newer.RegisterSourcePackage("A.B.C");
+
+        Assert.True(newer.TryMatchSourcePackagePrefix("A.B", out var exactMatch));
+        Assert.True(exactMatch);
+    }
+
+    [Fact]
+    public void SourcePackage_MissingType_ReportsLongestPackageAndMissingSegment()
+    {
+        var diagnostic = SingleError(
+            """
+            package A.B
+
+            func Existing() {}
+            """,
+            """
+            package Consumer
+
+            func Run() {
+                A.B.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in package 'A.B'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void NamespacePrefixEndingBeforeTerminalCall_ReportsTerminalType()
+    {
+        var diagnostic = SingleError(
+            """
+            package A.B.Missing.Sub
+
+            func Existing() {}
+            """,
+            """
+            package Consumer
+
+            func Run() {
+                A.B.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Call' in namespace 'A.B.Missing'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Call", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void ClrNamespace_MissingType_ReportsLongestNamespaceAndMissingSegment()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run() {
+                System.Text.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in namespace 'System.Text'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void CanonicalClrNamespace_MissingType_ReportsCanonicalPrefix()
+    {
+        using var resolver = ReferenceResolver.WithReferences(
+            new[] { typeof(global::@package.Existing).Assembly.Location });
+        var diagnostic = SingleError(
+            resolver,
+            """
+            package Consumer
+
+            func Run() {
+                package_.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in namespace 'package_'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void GenericMissingType_ReportsGenericIdentifier()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run() {
+                System.Collections.Generic.Missing[int32].Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in namespace 'System.Collections.Generic'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void ResolvedGenericTypeWithInvalidArgument_DoesNotReportMissingType()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run() {
+                let value = System.Nullable[string].Value
+            }
+            """);
+
+        Assert.Equal("GS0149", diagnostic.Id);
+        Assert.Equal("Type 'Nullable' is not generic.", diagnostic.Message);
+        Assert.Equal("Nullable", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void NonGenericQualifiedTypeWithTypeArguments_ReportsTypeNotGeneric()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run() {
+                let value = System.String[int32].Empty
+            }
+            """);
+
+        Assert.Equal("GS0149", diagnostic.Id);
+        Assert.Equal("Type 'String' is not generic.", diagnostic.Message);
+        Assert.Equal("String", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void NonTypeGenericArgument_StillReportsAnError()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run() {
+                let value = System.Collections.Generic.List[1].Count
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal("Cannot find type 1. Are you missing an import?", diagnostic.Message);
+        Assert.Equal("1", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void AliasOnlySourcePackage_IsRecognized()
+    {
+        var diagnostic = SingleError(
+            """
+            package A.B
+
+            type Existing = int32
+            """,
+            """
+            package Consumer
+
+            func Run() {
+                A.B.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in package 'A.B'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void UnrelatedSourceAlias_DoesNotHideQualifiedMissingType()
+    {
+        var diagnostic = SingleError(
+            """
+            package A.B
+
+            func Existing() {}
+            """,
+            """
+            package C
+
+            type Missing = int32
+            """,
+            """
+            package Consumer
+            import C
+
+            func Run() {
+                A.B.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in package 'A.B'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void UnresolvedImport_DoesNotPretendItsTargetIsAPackage()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+            import Foo.Bar
+
+            func Run() {
+                Foo.Bar.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal("Cannot find type Foo. Are you missing an import?", diagnostic.Message);
+        Assert.Equal("Foo", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void ImplicitDefaultPackage_IsNotQualifiedByItsSynthesizedName()
+    {
+        var diagnostic = SingleError(
+            """
+            class Present {}
+
+            func Run() {
+                Default.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal("Cannot find type Default. Are you missing an import?", diagnostic.Message);
+        Assert.Equal("Default", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ExplicitDefaultPackage_IsRecognizedRegardlessOfTreeOrder(bool implicitTreeFirst)
+    {
+        const string implicitSource = "class Present {}";
+        const string explicitSource = """
+            package Default
+
+            func Existing() {}
+            """;
+        const string consumer = """
+            package Consumer
+
+            func Run() {
+                Default.Missing.Call()
+            }
+            """;
+
+        var sources = implicitTreeFirst
+            ? new[] { implicitSource, explicitSource, consumer }
+            : new[] { explicitSource, implicitSource, consumer };
+        var diagnostic = SingleError(sources);
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in package 'Default'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void PackageNameCollidingWithSourceType_DoesNotPreemptNestedTypeBinding()
+    {
+        var diagnostics = Errors(
+            """
+            package Outer
+
+            func PackageMarker() {}
+            """,
+            """
+            package Consumer
+
+            class Outer {
+                class Inner {
+                    shared {
+                        func Member() int32 -> 1
+                    }
+                }
+            }
+
+            func Run() int32 -> Outer.Inner.Member()
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void PackageNameCollidingWithSourceType_DoesNotPreemptStaticMemberBinding()
+    {
+        var diagnostics = Errors(
+            """
+            package Outer
+
+            func PackageMarker() {}
+            """,
+            """
+            package Consumer
+
+            class Outer {
+                shared {
+                    prop Value string -> "x"
+                }
+            }
+
+            func Run() int32 -> Outer.Value.Length
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void NamespaceNameCollidingWithOutOfRegionPatternVariable_ReportsDefiniteAssignment()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run(value object) {
+                if value is string System {}
+                System.Text.Missing.Call()
+            }
+            """);
+
+        Assert.Equal("GS0532", diagnostic.Id);
+        Assert.Contains("not definitely assigned here", diagnostic.Message, System.StringComparison.Ordinal);
+        Assert.Equal("System", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void NamespaceNameCollidingWithDefaultInterfaceProperty_DoesNotPreemptReceiverBinding()
+    {
+        var diagnostics = Errors(
+            """
+            package Consumer
+
+            class Holder {
+                prop Text string -> "value"
+            }
+
+            interface IConsumer {
+                prop System Holder { get; }
+
+                func Run() int32 {
+                    return System.Text.Length
+                }
+            }
+            """);
+
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public void SourceType_MissingStaticMember_StillReportsMember()
+    {
+        var diagnostic = SingleError(
+            """
+            package A.B
+
+            class Present {}
+            """,
+            """
+            package Consumer
+
+            func Run() {
+                A.B.Present.Missing()
+            }
+            """);
+
+        Assert.Equal("GS0158", diagnostic.Id);
+        Assert.Equal("Cannot find member Missing.", diagnostic.Message);
+        Assert.Equal("Missing()", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void ClrType_MissingStaticMember_StillReportsMember()
+    {
+        var diagnostic = SingleError(
+            """
+            package Consumer
+
+            func Run() {
+                System.Text.StringBuilder.Missing()
+            }
+            """);
+
+        Assert.Equal("GS0159", diagnostic.Id);
+        Assert.Equal("Cannot find function Missing.", diagnostic.Message);
+        Assert.Equal("Missing()", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    private static Diagnostic SingleError(params string[] sources)
+        => Assert.Single(Errors(sources));
+
+    private static Diagnostic SingleError(ReferenceResolver resolver, params string[] sources)
+        => Assert.Single(Errors(resolver, sources));
+
+    private static Diagnostic[] Errors(params string[] sources)
+        => Errors(references: null, sources);
+
+    private static Diagnostic[] Errors(ReferenceResolver references, params string[] sources)
+    {
+        var trees = sources.Select(source => SyntaxTree.Parse(SourceText.From(source))).ToArray();
+        var compilation = new Compilation(references, trees) { IsLibrary = true };
+        return compilation.GlobalScope.Diagnostics
+            .Concat(compilation.BoundProgram.Diagnostics)
+            .Where(diagnostic => diagnostic.IsError)
+            .ToArray();
+    }
+}


### PR DESCRIPTION
Closes #3842.

## Cause

The fully-qualified static-access walker returned only success/failure. When it exhausted a real namespace/package prefix before finding a type, `BindAccessorExpression` fell through and rebound the original chain from its head, producing `GS0157 Cannot find type A` even though `A.B` resolved.

## Fix

- preserve the longest verified CLR namespace or registered source-package prefix while using the existing qualified-type walk;
- report GS0157 on the first missing type segment, e.g. `Cannot find type 'Missing' in package 'A.B'`;
- defer that diagnostic until the existing package-qualified and nested source-type fallbacks have had their second chance;
- carry the missing identifier token for both ordinary and generic type segments, without masking generic argument/closure failures;
- cache CLR namespace names for O(1) diagnostic-path lookup;
- leave successful type binding and established missing-member/function diagnostics unchanged.

The nullable-hygiene control-flow guards are intentional: one initializes the package-name set lazily; the other commits only when the shared walk returned both a missing token and a verified prefix.

## Tests

- focused #3842 namespace/package/generic/type/member/collision diagnostics: 21 passed
- related qualified/package/nested binding regressions (#3821, #2209, #2342, #2419, #2455, #2585, #1069): 96 passed
- full `Core.Tests`: 9010 passed
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`: passed, 0 warnings
- `python3 build/nullable_hygiene.py --base origin/main`: passed
- hot-core self-migration PR guard: 8/8 apps green
- pinned Oahu migration: 15/15 apps green, including the `Oahu.Aux.Extensions.JsonExtensions.Options` regression exposed by the first CI revision
