### PR TITLE
cs2gs: evaluate expression-based project references

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Cs2Gs.Translator.Loading;
 
@@ -75,8 +77,7 @@ internal static class DeclaredProjectItems
                 {
                     string include = item.Attribute("Include")?.Value;
                     if (!string.IsNullOrEmpty(include)
-                        && !include.Contains("$(", StringComparison.Ordinal)
-                        && !include.Contains("@(", StringComparison.Ordinal))
+                        && !IsMsbuildExpression(include))
                     {
                         string normalizedInclude = include
                             .Replace('\\', Path.DirectorySeparatorChar)
@@ -92,11 +93,37 @@ internal static class DeclaredProjectItems
         return items;
     }
 
-    internal static IReadOnlyList<string> ProjectReferencePaths(string projectPath) =>
-        Read(projectPath, "ProjectReference")
+    internal static IReadOnlyList<string> ProjectReferencePaths(
+        string projectPath,
+        IReadOnlyList<string> evaluatedProjectReferencePaths = null)
+    {
+        IReadOnlyList<DeclaredProjectItem> items = Read(projectPath, "ProjectReference");
+        return items
             .Select(item => item.SourceInclude)
             .Where(path => !string.IsNullOrEmpty(path))
+            .Concat(RequireEvaluatedProjectReferencePaths(
+                projectPath,
+                items,
+                evaluatedProjectReferencePaths))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    internal static async Task<IReadOnlyList<string>> EvaluateCompileProjectReferencePathsAsync(
+        string projectPath,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<LoadedCSharpProject> loaded =
+            await CSharpProjectLoader.LoadProjectWithReferencesAsync(projectPath, cancellationToken)
+                .ConfigureAwait(false);
+        return loaded
+            .Skip(1)
+            .Select(project => project.ProjectPath)
+            .Where(path => !string.IsNullOrEmpty(path))
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
 
     /// <summary>
     /// Collects the absolute project paths that any of the given projects
@@ -106,14 +133,20 @@ internal static class DeclaredProjectItems
     /// target's types), so it is excluded.
     /// </summary>
     /// <param name="projectPaths">The referencing projects' <c>.csproj</c> paths.</param>
+    /// <param name="evaluatedProjectReferences">
+    /// Evaluated compile-reference paths keyed by referencing project. Required
+    /// for projects declaring an MSBuild expression include.
+    /// </param>
     /// <returns>The referenced projects' absolute paths (case-insensitive set).</returns>
     internal static IReadOnlyCollection<string> CollectCompileReferencedProjectPaths(
-        IEnumerable<string> projectPaths)
+        IEnumerable<string> projectPaths,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> evaluatedProjectReferences = null)
     {
         var referenced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (string projectPath in projectPaths ?? Array.Empty<string>())
         {
-            foreach (DeclaredProjectItem item in Read(projectPath, "ProjectReference"))
+            IReadOnlyList<DeclaredProjectItem> items = Read(projectPath, "ProjectReference");
+            foreach (DeclaredProjectItem item in items)
             {
                 if (string.IsNullOrEmpty(item.SourceInclude))
                 {
@@ -133,6 +166,15 @@ internal static class DeclaredProjectItems
 
                 referenced.Add(item.SourceInclude);
             }
+
+            IReadOnlyList<string> evaluatedPaths = null;
+            evaluatedProjectReferences?.TryGetValue(
+                Path.GetFullPath(projectPath),
+                out evaluatedPaths);
+            referenced.UnionWith(RequireEvaluatedProjectReferencePaths(
+                projectPath,
+                items,
+                evaluatedPaths));
         }
 
         return referenced;
@@ -242,6 +284,33 @@ internal static class DeclaredProjectItems
     internal static bool HasMsbuildExpressionInclude(DeclaredProjectItem item) =>
         item is not null
         && IsMsbuildExpression(item.Element.Attribute("Include")?.Value);
+
+    private static IReadOnlyList<string> RequireEvaluatedProjectReferencePaths(
+        string projectPath,
+        IReadOnlyList<DeclaredProjectItem> items,
+        IReadOnlyList<string> evaluatedProjectReferencePaths)
+    {
+        string[] expressions = items
+            .Where(HasMsbuildExpressionInclude)
+            .Select(item => item.Element.Attribute("Include")?.Value)
+            .Where(include => !string.IsNullOrEmpty(include))
+            .OrderBy(include => include, StringComparer.Ordinal)
+            .ToArray();
+        if (expressions.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        if (evaluatedProjectReferencePaths is not null)
+        {
+            return evaluatedProjectReferencePaths;
+        }
+
+        throw new InvalidOperationException(
+            $"Project '{Path.GetFullPath(projectPath)}' declares ProjectReference Include " +
+            $"expressions that require MSBuild evaluation: {string.Join(", ", expressions.Select(
+                expression => $"'{expression}'"))}.");
+    }
 
     private static bool IsMsbuildExpression(string value) =>
         !string.IsNullOrEmpty(value)

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -171,13 +171,20 @@ public sealed class MigrationPipeline
         }
 
         Directory.CreateDirectory(runDir);
+        IReadOnlyDictionary<string, IReadOnlyList<string>> evaluatedProjectReferences =
+            await this.LoadEvaluatedProjectReferencesAsync(
+                apps,
+                includeBuildOrdering: true,
+                cancellationToken)
+                .ConfigureAwait(false);
 
         // Issue #3645: an executable app that another app in this run compiles
         // against must keep its entry-point class as a real G# class (see
         // PipelineOptions.ProjectsReferencedByOtherApps).
         this.options.ProjectsReferencedByOtherApps =
             DeclaredProjectItems.CollectCompileReferencedProjectPaths(
-                apps.Select(app => app.ProjectPath));
+                apps.Select(app => app.ProjectPath),
+                evaluatedProjectReferences);
 
         this.options.GeneratedProjectPaths = apps.ToDictionary(
             app => Path.GetFullPath(app.ProjectPath),
@@ -278,9 +285,8 @@ public sealed class MigrationPipeline
         };
 
         var appResults = new Dictionary<string, AppResult>(StringComparer.OrdinalIgnoreCase);
-        IReadOnlyList<CorpusApp> orderedApps = repositoryLayout
-            ? await this.OrderForSdkBuildAsync(apps, cancellationToken).ConfigureAwait(false)
-            : this.OrderForSdkBuild(apps);
+        IReadOnlyList<CorpusApp> orderedApps =
+            this.OrderForSdkBuild(apps, evaluatedProjectReferences);
         foreach (CorpusApp app in orderedApps)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -450,9 +456,16 @@ public sealed class MigrationPipeline
                     app.RelativeProjectPath ?? Path.GetRelativePath(this.options.SourceRoot, app.ProjectPath),
                     ".gsproj")),
             StringComparer.OrdinalIgnoreCase);
+        IReadOnlyDictionary<string, IReadOnlyList<string>> evaluatedProjectReferences =
+            await this.LoadEvaluatedProjectReferencesAsync(
+                allApps,
+                includeBuildOrdering: false,
+                cancellationToken)
+                .ConfigureAwait(false);
         this.options.ProjectsReferencedByOtherApps =
             DeclaredProjectItems.CollectCompileReferencedProjectPaths(
-                allApps.Select(app => app.ProjectPath));
+                allApps.Select(app => app.ProjectPath),
+                evaluatedProjectReferences);
 
         IReadOnlyDictionary<string, List<TriageRetryEntry>> priorHistory =
             LoadPriorRetryEntries(outputRoot, runId);
@@ -519,7 +532,9 @@ public sealed class MigrationPipeline
         return runResult;
     }
 
-    private IReadOnlyList<CorpusApp> OrderForSdkBuild(IReadOnlyList<CorpusApp> apps)
+    internal IReadOnlyList<CorpusApp> OrderForSdkBuild(
+        IReadOnlyList<CorpusApp> apps,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> evaluatedProjectReferences)
     {
         if (!this.options.CompileViaSdk || apps.Count <= 1)
         {
@@ -546,7 +561,14 @@ public sealed class MigrationPipeline
                 return;
             }
 
-            foreach (string referencePath in DeclaredProjectItems.ProjectReferencePaths(path))
+            IReadOnlyList<string> evaluatedPaths = null;
+            evaluatedProjectReferences?.TryGetValue(path, out evaluatedPaths);
+
+            // Evaluated paths cover expression-based compile references; the
+            // declared paths retain analyzer-only ordering edges (#3617).
+            foreach (string referencePath in DeclaredProjectItems.ProjectReferencePaths(
+                path,
+                evaluatedPaths))
             {
                 if (byPath.TryGetValue(referencePath, out CorpusApp dependency))
                 {
@@ -566,72 +588,30 @@ public sealed class MigrationPipeline
         return ordered;
     }
 
-    private async Task<IReadOnlyList<CorpusApp>> OrderForSdkBuildAsync(
+    private async Task<IReadOnlyDictionary<string, IReadOnlyList<string>>> LoadEvaluatedProjectReferencesAsync(
         IReadOnlyList<CorpusApp> apps,
+        bool includeBuildOrdering,
         CancellationToken cancellationToken)
     {
-        if (!this.options.CompileViaSdk || apps.Count <= 1)
-        {
-            return apps;
-        }
-
-        var byPath = apps.ToDictionary(
-            app => Path.GetFullPath(app.ProjectPath),
-            StringComparer.OrdinalIgnoreCase);
         var references = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        bool loadAllForBuildOrdering =
+            includeBuildOrdering && this.options.CompileViaSdk && apps.Count > 1;
         foreach (CorpusApp app in apps)
-        {
-            IReadOnlyList<Cs2Gs.Translator.Loading.LoadedCSharpProject> loaded =
-                await Cs2Gs.Translator.Loading.CSharpProjectLoader
-                    .LoadProjectWithReferencesAsync(app.ProjectPath, cancellationToken)
-                    .ConfigureAwait(false);
-
-            // Issue #3617: the Roslyn loader follows compile references only,
-            // so an analyzer-shaped reference (`OutputItemType="Analyzer"
-            // ReferenceOutputAssembly="false"`, e.g. Core → InternalAnalyzers)
-            // never becomes an ordering edge. Union in the XML-declared
-            // ProjectReference paths so a dependent app cannot build before
-            // its analyzer dependency has translated its sources — building
-            // the dependency from a source-less mirror directory produces a
-            // two-file husk assembly that later fails analyzer discovery
-            // (GS9301).
-            references[Path.GetFullPath(app.ProjectPath)] = loaded
-                .Skip(1)
-                .Select(project => project.ProjectPath)
-                .Where(path => !string.IsNullOrEmpty(path))
-                .Select(Path.GetFullPath)
-                .Concat(DeclaredProjectItems.ProjectReferencePaths(app.ProjectPath))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-        }
-
-        var ordered = new List<CorpusApp>(apps.Count);
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        void Visit(CorpusApp app)
         {
             string path = Path.GetFullPath(app.ProjectPath);
-            if (!visited.Add(path))
+            bool hasExpression = DeclaredProjectItems.Read(path, "ProjectReference")
+                .Any(DeclaredProjectItems.HasMsbuildExpressionInclude);
+            if (!loadAllForBuildOrdering && !hasExpression)
             {
-                return;
+                continue;
             }
 
-            foreach (string reference in references[path])
-            {
-                if (byPath.TryGetValue(reference, out CorpusApp dependency))
-                {
-                    Visit(dependency);
-                }
-            }
-
-            ordered.Add(app);
+            references[path] = await DeclaredProjectItems
+                .EvaluateCompileProjectReferencePathsAsync(path, cancellationToken)
+                .ConfigureAwait(false);
         }
 
-        foreach (CorpusApp app in apps)
-        {
-            Visit(app);
-        }
-
-        return ordered;
+        return references;
     }
 
     private static string NewRunId(DateTime utc)

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryExcludedScope.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryExcludedScope.cs
@@ -68,8 +68,7 @@ internal sealed class RepositoryExcludedScope
             {
                 string include = item.Element.Attribute("Include")?.Value;
                 if (string.IsNullOrEmpty(include)
-                    || include.Contains("$(", StringComparison.Ordinal)
-                    || include.Contains("@(", StringComparison.Ordinal)
+                    || DeclaredProjectItems.HasMsbuildExpressionInclude(item)
                     || include.Contains('*', StringComparison.Ordinal))
                 {
                     continue;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3846EvaluatedProjectReferenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3846EvaluatedProjectReferenceTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="Issue3846EvaluatedProjectReferenceTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Regression coverage for issue #3846: raw project XML cannot resolve
+/// <c>@(Item)</c>/<c>$(Property)</c> ProjectReference includes, so consumers
+/// must use the evaluated MSBuild graph rather than silently treating them as
+/// no references.
+/// </summary>
+public sealed class Issue3846EvaluatedProjectReferenceTests : IDisposable
+{
+    private readonly string root;
+    private readonly string appProject;
+    private readonly string itemProject;
+    private readonly string propertyProject;
+
+    /// <summary>Creates a three-project graph whose two edges are MSBuild expressions.</summary>
+    public Issue3846EvaluatedProjectReferenceTests()
+    {
+        this.root = Path.Combine(
+            Path.GetTempPath(),
+            "cs2gs-issue3846-" + Guid.NewGuid().ToString("N"));
+        this.itemProject = this.WriteProject("ItemDependency", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        this.propertyProject = this.WriteProject("PropertyDependency", "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        this.appProject = this.WriteProject(
+            "App",
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <PropertyDependency>..\PropertyDependency\PropertyDependency.csproj</PropertyDependency>
+              </PropertyGroup>
+              <ItemGroup>
+                <ItemDependencies Include="..\ItemDependency\ItemDependency.csproj" />
+                <ProjectReference Include="@(ItemDependencies)" />
+                <ProjectReference Include="$(PropertyDependency)" />
+              </ItemGroup>
+            </Project>
+            """);
+    }
+
+    /// <summary>Deletes the isolated project graph.</summary>
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(this.root, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Both expression shapes remain observable in the declared items, and a
+    /// consumer that omits evaluated references receives a stable diagnostic
+    /// instead of an indistinguishable empty path list.
+    /// </summary>
+    [Fact]
+    public void DeclaredExpressionIncludes_AreObservableAndDiagnosed()
+    {
+        IReadOnlyList<DeclaredProjectItem> items =
+            DeclaredProjectItems.Read(this.appProject, "ProjectReference");
+
+        Assert.Equal(2, items.Count);
+        Assert.All(items, item => Assert.Null(item.SourceInclude));
+        Assert.All(items, item => Assert.True(
+            DeclaredProjectItems.HasMsbuildExpressionInclude(item)));
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => DeclaredProjectItems.ProjectReferencePaths(this.appProject));
+        Assert.Equal(
+            $"Project '{Path.GetFullPath(this.appProject)}' declares ProjectReference Include " +
+            "expressions that require MSBuild evaluation: '$(PropertyDependency)', '@(ItemDependencies)'.",
+            error.Message);
+    }
+
+    /// <summary>
+    /// Roslyn/MSBuildWorkspace supplies both concrete compile-reference paths,
+    /// and the compile-surface probe consumes that evaluated answer.
+    /// </summary>
+    [Fact]
+    public async Task CompileReferenceDiscovery_UsesEvaluatedItemAndPropertyIncludes()
+    {
+        IReadOnlyList<string> evaluated =
+            await DeclaredProjectItems.EvaluateCompileProjectReferencePathsAsync(this.appProject);
+        var graph = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Path.GetFullPath(this.appProject)] = evaluated,
+        };
+
+        IReadOnlyCollection<string> referenced =
+            DeclaredProjectItems.CollectCompileReferencedProjectPaths(
+                new[] { this.appProject },
+                graph);
+
+        Assert.Contains(Path.GetFullPath(this.itemProject), referenced);
+        Assert.Contains(Path.GetFullPath(this.propertyProject), referenced);
+    }
+
+    /// <summary>
+    /// The diagnostic-run build path uses the same evaluated edges as the
+    /// repository path, so both dependencies are deterministically ordered
+    /// before their consumer.
+    /// </summary>
+    [Fact]
+    public async Task SdkBuildOrdering_UsesEvaluatedItemAndPropertyIncludesDeterministically()
+    {
+        IReadOnlyList<string> evaluated =
+            await DeclaredProjectItems.EvaluateCompileProjectReferencePathsAsync(this.appProject);
+        var graph = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Path.GetFullPath(this.appProject)] = evaluated,
+            [Path.GetFullPath(this.itemProject)] = Array.Empty<string>(),
+            [Path.GetFullPath(this.propertyProject)] = Array.Empty<string>(),
+        };
+        var apps = new[]
+        {
+            App("App", this.appProject),
+            App("PropertyDependency", this.propertyProject),
+            App("ItemDependency", this.itemProject),
+        };
+        var pipeline = new MigrationPipeline(new PipelineOptions { CompileViaSdk = true });
+
+        string[] first = pipeline.OrderForSdkBuild(apps, graph).Select(app => app.Id).ToArray();
+        string[] second = pipeline.OrderForSdkBuild(apps, graph).Select(app => app.Id).ToArray();
+
+        Assert.Equal(first, second);
+        Assert.True(Array.IndexOf(first, "ItemDependency") < Array.IndexOf(first, "App"));
+        Assert.True(Array.IndexOf(first, "PropertyDependency") < Array.IndexOf(first, "App"));
+    }
+
+    private static CorpusApp App(string id, string projectPath) =>
+        new CorpusApp(id, projectPath, TargetKind.Library);
+
+    private string WriteProject(string name, string xml)
+    {
+        string directory = Path.Combine(this.root, name);
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, name + ".csproj");
+        File.WriteAllText(path, xml);
+        File.WriteAllText(Path.Combine(directory, name + ".cs"), $"public class {name} {{ }}");
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3846.

- make `ProjectReference` includes containing `@(Item)`/`$(Property)` observable instead of silently looking like no references
- evaluate compile references through the existing Roslyn/MSBuildWorkspace path once per run and reuse them for compile-reference discovery and both SDK build-ordering layouts
- keep XML-declared literal references in the ordering union for analyzer-only edges, centralize expression detection on `HasMsbuildExpressionInclude`, and leave `SdkCompileRunner` rewriting behavior unchanged

## Tests

- `Issue3846EvaluatedProjectReferenceTests`: `@(ItemDependencies)` and `$(PropertyDependency)` are observable, evaluated for compile-reference discovery, and deterministically ordered before their consumer
- focused reference/migration regressions: 33/33 passed
- full `Cs2Gs.Tests`: 2837/2840 passed in one parallel run; the three unrelated compile-stage failures all passed together on unmodified `origin/main`, confirming baseline test interference rather than this change
- `dotnet build GSharp.sln -c Release --no-restore`: 0 warnings, 0 errors
- `python3 build/nullable_hygiene.py --base origin/main`: OK; no new null-forgiving operators, guards, or suppressions
- `build/run-cs2gs-selfmig-pr-guard.sh`: 8/8 guarded apps passed translate, compile, ILVerify, and test parity; wrapper exited 0

## Nullable hygiene classification

All production hunks are behavior-capable and covered by the focused suites above. No null guards or nullable escapes were added.
