### PR TITLE
build: validate test documentation parameter names

### DIFF
--- a/build/gsharp.build.props
+++ b/build/gsharp.build.props
@@ -84,6 +84,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <HighEntropyVA>true</HighEntropyVA>
     <Deterministic>true</Deterministic>
+    <!-- Validate test documentation without publishing test-only XML files.
+         The suppressed IDs are the measured pre-existing test backlog from
+         issue #3860; CS1572 and CS1573 intentionally remain build-breaking. -->
+    <GenerateDocumentationFile Condition="'$(IsTestProject)' == 'true'">true</GenerateDocumentationFile>
+    <CopyDocumentationFileToOutputDirectory Condition="'$(IsTestProject)' == 'true'">false</CopyDocumentationFileToOutputDirectory>
+    <NoWarn Condition="'$(IsTestProject)' == 'true'">$(NoWarn);CS0419;CS1570;CS1574;CS1580;CS1591;CS1734</NoWarn>
     <DocumentationFile Condition="'$(IsTestProject)' != 'true'">$(OutputPath)/$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 

--- a/test/Sdk.Tests/Issue3860TestDocumentationPolicyTests.cs
+++ b/test/Sdk.Tests/Issue3860TestDocumentationPolicyTests.cs
@@ -90,7 +90,18 @@ public sealed class Issue3860TestDocumentationPolicyTests : IDisposable
             ?? throw new InvalidOperationException("Could not start dotnet build.");
         Task<string> standardOutput = process.StandardOutput.ReadToEndAsync();
         Task<string> standardError = process.StandardError.ReadToEndAsync();
-        Assert.True(process.WaitForExit(120_000), "dotnet build timed out.");
+        if (!process.WaitForExit(120_000))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            Task.WaitAll(standardOutput, standardError);
+            throw new TimeoutException(
+                "dotnet build timed out."
+                + Environment.NewLine
+                + standardOutput.Result
+                + standardError.Result);
+        }
+
         Task.WaitAll(standardOutput, standardError);
         return (process.ExitCode, standardOutput.Result + standardError.Result);
     }

--- a/test/Sdk.Tests/Issue3860TestDocumentationPolicyTests.cs
+++ b/test/Sdk.Tests/Issue3860TestDocumentationPolicyTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue3860TestDocumentationPolicyTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Xunit;
+
+namespace GSharp.Sdk.Tests;
+
+/// <summary>
+/// Regression coverage for the test-project documentation policy from issue #3860.
+/// </summary>
+public sealed class Issue3860TestDocumentationPolicyTests : IDisposable
+{
+    private readonly DirectoryInfo root = Directory.CreateDirectory(Path.Combine(
+        RepoRoot.Path,
+        "out",
+        "test",
+        nameof(Issue3860TestDocumentationPolicyTests),
+        Guid.NewGuid().ToString("N")));
+
+    [Fact]
+    public void InvalidParamNamesFailWithoutPublishingTestDocumentation()
+    {
+        this.WriteProject();
+
+        var survey = this.Build(treatWarningsAsErrors: false, rebuild: false);
+
+        Assert.Equal(0, survey.ExitCode);
+        Assert.Contains("warning CS1572", survey.Output);
+        Assert.Contains("warning CS1573", survey.Output);
+        Assert.DoesNotContain("CS1591", survey.Output);
+        Assert.Single(Directory.GetFiles(
+            Path.Combine(this.root.FullName, "obj"),
+            "GSharp.InvalidTestDocumentation.xml",
+            SearchOption.AllDirectories));
+        Assert.Empty(Directory.GetFiles(
+            Path.Combine(this.root.FullName, "bin"),
+            "GSharp.InvalidTestDocumentation.xml",
+            SearchOption.AllDirectories));
+
+        var strict = this.Build(treatWarningsAsErrors: true, rebuild: true);
+
+        Assert.NotEqual(0, strict.ExitCode);
+        Assert.Contains("error CS1572", strict.Output);
+        Assert.Contains("error CS1573", strict.Output);
+        Assert.DoesNotContain("CS1591", strict.Output);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (this.root.Exists)
+        {
+            this.root.Delete(recursive: true);
+        }
+    }
+
+    private (int ExitCode, string Output) Build(bool treatWarningsAsErrors, bool rebuild)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = this.root.FullName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add("InvalidTestDocumentation.csproj");
+        startInfo.ArgumentList.Add("--configuration");
+        startInfo.ArgumentList.Add("Release");
+        startInfo.ArgumentList.Add("--nologo");
+        startInfo.ArgumentList.Add("--verbosity:minimal");
+        startInfo.ArgumentList.Add("-p:RestorePackagesWithLockFile=false");
+        startInfo.ArgumentList.Add($"-p:TreatWarningsAsErrors={treatWarningsAsErrors.ToString().ToLowerInvariant()}");
+        startInfo.ArgumentList.Add($"-p:BaseOutputPath={Path.Combine(this.root.FullName, "bin")}{Path.DirectorySeparatorChar}");
+        startInfo.ArgumentList.Add($"-p:BaseIntermediateOutputPath={Path.Combine(this.root.FullName, "obj")}{Path.DirectorySeparatorChar}");
+        if (rebuild)
+        {
+            startInfo.ArgumentList.Add("--no-restore");
+            startInfo.ArgumentList.Add("-t:Rebuild");
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start dotnet build.");
+        Task<string> standardOutput = process.StandardOutput.ReadToEndAsync();
+        Task<string> standardError = process.StandardError.ReadToEndAsync();
+        Assert.True(process.WaitForExit(120_000), "dotnet build timed out.");
+        Task.WaitAll(standardOutput, standardError);
+        return (process.ExitCode, standardOutput.Result + standardError.Result);
+    }
+
+    private void WriteProject()
+    {
+        new XDocument(
+            new XElement(
+                "Project",
+                new XElement(
+                    "PropertyGroup",
+                    new XElement("IsTestProject", "true")),
+                new XElement(
+                    "Import",
+                    new XAttribute("Project", Path.Combine(RepoRoot.Path, "Directory.Build.props")))))
+            .Save(Path.Combine(this.root.FullName, "Directory.Build.props"));
+
+        File.WriteAllText(
+            Path.Combine(this.root.FullName, "InvalidTestDocumentation.csproj"),
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <IsPackable>false</IsPackable>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Remove="@(PackageReference)" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        File.WriteAllText(
+            Path.Combine(this.root.FullName, "InvalidDocumentation.cs"),
+            """
+            public static class InvalidDocumentation
+            {
+                /// <summary>Deliberately stale parameter documentation.</summary>
+                /// <param name="stale">A parameter that does not exist.</param>
+                public static void Verify(int actual)
+                {
+                }
+
+                public static void Undocumented()
+                {
+                }
+            }
+            """);
+    }
+}


### PR DESCRIPTION
Fixes #3860

## Summary

- enable Roslyn documentation diagnostics for every `IsTestProject` project;
- rely on the SDK's intermediate `DocumentationFile` path and disable copying test documentation XML to `bin`;
- keep `CS1572` and `CS1573` build-breaking; the fresh-main census found **0 CS1572** and **0 CS1573**, so neither needs suppression;
- suppress only the measured unrelated test-doc backlog (`CS1591`, `CS1574`, `CS1570`, `CS0419`, `CS1580`, `CS1734`) rather than churning 15,744 diagnostics;
- add an end-to-end SDK regression that builds a synthetic test project and proves stale `<param>` names produce `CS1572`/`CS1573`, missing-comment `CS1591` remains intentionally quiet, and the XML stays under `obj`.

The five stale `scenario` tags identified in #3859 are already corrected on current `main` by merged PR #3859, so this PR does not duplicate that source edit.

## Census on fresh `origin/main`

Measured at `2a6a953c6` with the existing Release solution build plus `GenerateDocumentationFile=true` and `TreatWarningsAsErrors=false`:

| warning | count |
|---|---:|
| CS1572 | 0 |
| CS1573 | 0 |

The unrelated emitted backlog was 15,744 diagnostics: 15,635× CS1591, 88× CS1574, 10× CS1570, 7× CS0419, 2× CS1580, and 2× CS1734. Those categories are explicitly suppressed for test projects; parameter-name correctness and completeness remain enforced.

## Verification

- `dotnet test test/Sdk.Tests/Sdk.Tests.csproj -c Release --no-build --no-restore`: **93/93 passed**
- focused regression: **1/1 passed**
- ADR-0154 witness: changing test `GenerateDocumentationFile` back to `false` makes the regression fail because `warning CS1572` is absent
- `dotnet build GSharp.sln -c Release --no-restore -graph`: **0 warnings, 0 errors**
- post-clean build: **0 test-project documentation XML files in `out/bin/Release`**
- `python3 build/nullable_hygiene.py --base origin/main`: **OK**
- `build/run-cs2gs-selfmig-pr-guard.sh`: **8/8 guarded apps green, PASS**
- targeted self-migration including `test/Sdk.Tests` and its full project-reference closure: **8/8 apps passed translate, compile, ILVerify, and test parity**

## Checklist

- [x] Behavioral tests carry a witness of discrimination.
- [x] Self-review verdict: **MERGEABLE**.
