### PR TITLE
selfmig: fingerprint parity failures by failing tests

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/Fingerprint.cs
@@ -3,6 +3,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -20,6 +22,9 @@ namespace Cs2Gs.Pipeline;
 /// rendered as <c>"sha256:" + lowercase-hex</c>. It deliberately excludes
 /// <c>runId</c>, <c>corpusAppId</c>, <c>gscVersion</c>, and concrete source
 /// positions so the same defect dedups regardless of where/when it surfaced.
+/// Test-run failures use <see cref="ComputeTestParityFailure"/> because their
+/// stable evidence is a set of failing test identities rather than a source
+/// construct shape.
 /// </summary>
 public static class Fingerprint
 {
@@ -98,8 +103,63 @@ public static class Fingerprint
             constructKind ?? string.Empty,
             shape);
 
-        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
-        return "sha256:" + Convert.ToHexString(hash).ToLowerInvariant();
+        return "sha256:" + Hash(payload);
+    }
+
+    /// <summary>
+    /// Computes a stage-4 fingerprint from the complete set of failing test
+    /// method identities. Identity order, duplicate result lines, theory data,
+    /// durations, warnings, paths, and the rest of the process output do not
+    /// participate.
+    /// </summary>
+    /// <remarks>
+    /// When a completed run does not expose a complete per-test identity set,
+    /// the result is explicitly marked <c>unclassified-test-parity</c> and
+    /// scoped to one corpus app. Such a value is deterministic, but is not a
+    /// cross-app shared-cause signal.
+    /// </remarks>
+    /// <param name="category">The schema category.</param>
+    /// <param name="stage">The schema stage.</param>
+    /// <param name="diagnosticId">The diagnostic id.</param>
+    /// <param name="failingTestNames">The complete reported failing-test name set, or an empty set.</param>
+    /// <param name="fallbackScope">The stable corpus-app scope used only when the set is empty.</param>
+    /// <returns>A classified <c>sha256:</c> fingerprint or an explicit unclassified fingerprint.</returns>
+    public static string ComputeTestParityFailure(
+        string category,
+        string stage,
+        string diagnosticId,
+        IReadOnlyList<string> failingTestNames,
+        string fallbackScope)
+    {
+        string[] identities = (failingTestNames ?? Array.Empty<string>())
+            .Select(TestParityAllowList.NormalizeTestName)
+            .Select(name => WhitespacePattern.Replace(name, " ").Trim())
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        if (identities.Length == 0)
+        {
+            string scope = (fallbackScope ?? string.Empty).Trim().Replace('\\', '/');
+            string fallbackPayload = string.Join(
+                "|",
+                category ?? string.Empty,
+                stage ?? string.Empty,
+                diagnosticId ?? string.Empty,
+                "unclassified-app-scope",
+                scope);
+            return "unclassified-test-parity:sha256:" + Hash(fallbackPayload);
+        }
+
+        string payload = string.Join(
+            "|",
+            category ?? string.Empty,
+            stage ?? string.Empty,
+            diagnosticId ?? string.Empty,
+            "failing-test-identities",
+            string.Join("\n", identities));
+        return "sha256:" + Hash(payload);
     }
 
     /// <summary>
@@ -165,5 +225,11 @@ public static class Fingerprint
         }
 
         return shape.Substring(0, ShapeMaxLength) + "…";
+    }
+
+    private static string Hash(string payload)
+    {
+        byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash).ToLowerInvariant();
     }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TriageBuilder.cs
@@ -572,7 +572,11 @@ public sealed class TriageBuilder
     /// translator/emitter ("a real regression, not translation pending") when
     /// the actual signal is a runtime test failure, and is the same class of
     /// misleading degradation as #2842. The diagnostic id is
-    /// <c>LIBRARY-TESTS-FAILED</c>.
+    /// <c>LIBRARY-TESTS-FAILED</c>. Its fingerprint uses the complete,
+    /// normalized failing-test identity set. If the console output does not
+    /// contain every identity reported by the run summary, the artifact says
+    /// so and uses an explicit app-scoped unclassified fingerprint instead of
+    /// pretending the failure shares a root cause with another app.
     /// </summary>
     /// <param name="output">The captured <c>dotnet test</c> output.</param>
     /// <param name="gsFile">The emitted G# library file (relative path), or null.</param>
@@ -580,12 +584,27 @@ public sealed class TriageBuilder
     public TriageArtifact TestParityLibraryTestFailure(string output, string gsFile = null)
     {
         string message = string.IsNullOrWhiteSpace(output) ? "(no test output captured)" : output.Trim();
+        IReadOnlyList<string> failingTests = TestParityAllowList.ParseFailedTestNames(message);
+        int reportedFailures = TestParityAllowList.ReportedFailureCount(message);
+        bool hasCompleteFailureIdentities =
+            reportedFailures > 0 && failingTests.Count == reportedFailures;
+        string fingerprintNotice = null;
+        if (!hasCompleteFailureIdentities)
+        {
+            fingerprintNotice =
+                $"Fingerprint evidence unavailable: captured {failingTests.Count} of " +
+                $"{reportedFailures} reported failing test identities. The fingerprint is " +
+                $"unclassified and scoped only to '{this.CorpusAppId}'; equality with another " +
+                "fingerprint does not imply a shared cause.";
+        }
 
         var artifact = this.NewArtifact(MigrationStageKind.TestParity, TriageCategory.TestParityFailure);
         artifact.Diagnostic = new TriageDiagnostic
         {
             Id = "LIBRARY-TESTS-FAILED",
-            Message = message,
+            Message = fingerprintNotice is null
+                ? message
+                : fingerprintNotice + Environment.NewLine + message,
             Severity = "error",
         };
         artifact.SourceLocation = new TriageSourceLocation
@@ -602,12 +621,12 @@ public sealed class TriageBuilder
             Kind = "LibraryTestRun",
             Snippet = Truncate(message),
         };
-        artifact.Fingerprint = Fingerprint.Compute(
+        artifact.Fingerprint = Fingerprint.ComputeTestParityFailure(
             artifact.Category,
             artifact.Stage,
             artifact.Diagnostic.Id,
-            artifact.OffendingCSharpConstruct.Kind,
-            message);
+            hasCompleteFailureIdentities ? failingTests : Array.Empty<string>(),
+            this.CorpusAppId);
         artifact.SuggestedIssue = this.TestParityIssue(artifact);
         return artifact;
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3853TestParityFingerprintTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3853TestParityFingerprintTests.cs
@@ -1,0 +1,120 @@
+// <copyright file="Issue3853TestParityFingerprintTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3853: completed mirrored-test failures fingerprint on stable failing
+/// test identities, not the shared stage/id or noisy process output.
+/// </summary>
+public class Issue3853TestParityFingerprintTests
+{
+    [Fact]
+    public void UnrelatedFailingTestsProduceDifferentFingerprints()
+    {
+        TriageArtifact first = Artifact(
+            "test/First.Tests/First.Tests.csproj",
+            Output("First.Tests.ParserTests.RejectsInvalidToken"));
+        TriageArtifact second = Artifact(
+            "test/Second.Tests/Second.Tests.csproj",
+            Output("Second.Tests.RuntimeTests.PreservesNullableValue"));
+
+        Assert.NotEqual(first.Fingerprint, second.Fingerprint);
+    }
+
+    [Fact]
+    public void ReorderedEquivalentFailuresProduceTheSameFingerprint()
+    {
+        TriageArtifact first = Artifact(
+            "test/Sample.Tests/Sample.Tests.csproj",
+            Output("Sample.Tests.A", "Sample.Tests.B"));
+        TriageArtifact reordered = Artifact(
+            "test/Sample.Tests/Sample.Tests.csproj",
+            Output("Sample.Tests.B", "Sample.Tests.A"));
+
+        Assert.Equal(first.Fingerprint, reordered.Fingerprint);
+    }
+
+    [Fact]
+    public void AmbientWarningsAndRunNoiseDoNotAffectTheFingerprint()
+    {
+        const string Test = "Sample.Tests.RuntimeTests.ReturnsExpectedValue";
+        string first =
+            "warning: token abc123 in /Users/runner/work/run-1/build.props\n" +
+            OutputWithDuration(Test, "14 ms");
+        string second =
+            "warning: a different advisory in C:\\agent\\run-99\\build.props\n" +
+            OutputWithDuration(Test, "8 s");
+
+        Assert.Equal(
+            Artifact("test/Sample.Tests/Sample.Tests.csproj", first).Fingerprint,
+            Artifact("test/Sample.Tests/Sample.Tests.csproj", second).Fingerprint);
+    }
+
+    [Fact]
+    public void FailureIdentityNormalizationIsDeterministic()
+    {
+        TriageArtifact first = Artifact(
+            "test/Sample.Tests/Sample.Tests.csproj",
+            OutputWithDuration("Sample.Tests.Theory(value: 1, secret: \"alpha\")", "1 ms"));
+        TriageArtifact second = Artifact(
+            "test/Sample.Tests/Sample.Tests.csproj",
+            OutputWithDuration("  Sample.Tests.Theory(value: 999, secret: \"beta\")  ", "9 s"));
+
+        Assert.Equal(first.Fingerprint, second.Fingerprint);
+        Assert.StartsWith("sha256:", first.Fingerprint, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MissingStructuredFailuresUsesExplicitAppScopedFallback()
+    {
+        const string OutputWithoutNames =
+            "Failed!  - Failed: 2, Passed: 0, Skipped: 0, Total: 2, Duration: 1 s";
+
+        TriageArtifact first = Artifact(
+            "test/First.Tests/First.Tests.csproj",
+            OutputWithoutNames);
+        TriageArtifact sameApp = Artifact(
+            "test/First.Tests/First.Tests.csproj",
+            OutputWithoutNames + "\nwarning: unrelated noise");
+        TriageArtifact otherApp = Artifact(
+            "test/Second.Tests/Second.Tests.csproj",
+            OutputWithoutNames);
+
+        Assert.StartsWith(
+            "unclassified-test-parity:sha256:",
+            first.Fingerprint,
+            StringComparison.Ordinal);
+        Assert.Equal(first.Fingerprint, sameApp.Fingerprint);
+        Assert.NotEqual(first.Fingerprint, otherApp.Fingerprint);
+        Assert.Contains(
+            "equality with another fingerprint does not imply a shared cause",
+            first.Diagnostic.Message,
+            StringComparison.Ordinal);
+    }
+
+    private static TriageArtifact Artifact(string appId, string output) =>
+        new TriageBuilder("run-1", "2026-09-06T00:00:00Z", "0.0.0", appId)
+            .TestParityLibraryTestFailure(output);
+
+    private static string Output(params string[] failingTests) =>
+        Output(failingTests, "1 ms");
+
+    private static string OutputWithDuration(string failingTest, string duration) =>
+        Output(new[] { failingTest }, duration);
+
+    private static string Output(string[] failingTests, string duration)
+    {
+        string failures = string.Join(
+            Environment.NewLine,
+            Array.ConvertAll(failingTests, test => $"  Failed {test} [{duration}]"));
+        return failures + Environment.NewLine +
+            $"Failed!  - Failed: {failingTests.Length}, Passed: 0, Skipped: 0, " +
+            $"Total: {failingTests.Length}, Duration: {duration}";
+    }
+}


### PR DESCRIPTION
Fixes #3853

## Summary

- fingerprint completed mirrored-test failures from the sorted, deduplicated failing test method identities
- exclude warning text, paths, durations, output order, theory values, and full process output from the hash
- emit an explicit app-scoped `unclassified-test-parity` fallback when the run summary cannot be matched to a complete identity set
- preserve the existing compile/ILVerify/stdout fingerprint path and report schema consumption

## Verification

- pre-fix witness: new issue tests failed 3/5 against `origin/main`; fixed code passes 5/5
- focused gate/report/fingerprint tests: 90/90 passed
- full `Cs2Gs.Tests`: 2,845/2,845 passed
- `dotnet build GSharp.sln -c Release --no-restore`: 0 warnings, 0 errors
- `python3 build/nullable_hygiene.py --base origin/main`: OK; no `!`, guards, escapes, null-bang, or suppressions added
- hot-core self-migration guard: exit 0; 8/8 apps passed translate, compile, ILVerify, and test parity

## Checklist

- [x] Behavioral tests carry a pre-fix RED witness and pass with the fix.
- [x] Self-review: MERGEABLE; no residual findings.