### PR TITLE
cs2gs: retarget project item paths in mirrored build files

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -161,10 +161,10 @@ internal static class GSharpProjectTransformer
         string destinationRoot,
         IReadOnlyDictionary<string, string> generatedProjectPaths)
     {
-        // Shared props/targets often anchor item paths at a repository-root
-        // property whose value is not available while mirroring. Treat only
-        // its literal suffix as root-relative, then require an exact hit in
-        // the source-to-generated project map before preserving the expression.
+        IReadOnlySet<string> repositoryRootExpressions = FindRepositoryRootExpressions(
+            document,
+            sourceFileDirectory,
+            sourceRoot);
         bool changed = false;
         foreach (XElement itemGroup in ElementsNamed(document, "ItemGroup"))
         {
@@ -182,7 +182,8 @@ internal static class GSharpProjectTransformer
                     destinationFileDirectory,
                     generatedProjectPaths,
                     sourceRoot,
-                    destinationRoot);
+                    destinationRoot,
+                    repositoryRootExpressions);
                 if (!string.Equals(rewritten, include.Value, StringComparison.Ordinal))
                 {
                     include.Value = rewritten;
@@ -192,6 +193,47 @@ internal static class GSharpProjectTransformer
         }
 
         return changed;
+    }
+
+    private static IReadOnlySet<string> FindRepositoryRootExpressions(
+        XDocument document,
+        string sourceFileDirectory,
+        string sourceRoot)
+    {
+        var expressions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (XElement propertyGroup in ElementsNamed(document, "PropertyGroup"))
+        {
+            foreach (XElement property in propertyGroup.Elements())
+            {
+                string value = property.Value.Trim();
+                const string anchor = "$(MSBuildThisFileDirectory)";
+                if (property.HasElements ||
+                    !value.StartsWith(anchor, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                string remainder = value.Substring(anchor.Length);
+                if (remainder.Contains("$(", StringComparison.Ordinal) ||
+                    remainder.Contains("@(", StringComparison.Ordinal) ||
+                    remainder.Contains('*'))
+                {
+                    continue;
+                }
+
+                string resolved = Path.GetFullPath(
+                    Path.Combine(sourceFileDirectory, NormalizeDirectorySeparators(remainder)));
+                if (string.Equals(
+                    Path.TrimEndingDirectorySeparator(resolved),
+                    Path.TrimEndingDirectorySeparator(sourceRoot),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    expressions.Add("$(" + property.Name.LocalName + ")");
+                }
+            }
+        }
+
+        return expressions;
     }
 
     private static void AddSourceSdkDefaults(XDocument document, string sourceSdk)
@@ -352,7 +394,8 @@ internal static class GSharpProjectTransformer
         string destinationProjectDirectory,
         IReadOnlyDictionary<string, string> generatedProjectPaths,
         string sourceRoot = null,
-        string destinationRoot = null)
+        string destinationRoot = null,
+        IReadOnlySet<string> repositoryRootExpressions = null)
     {
         if (value.IndexOf(".csproj", StringComparison.OrdinalIgnoreCase) < 0)
         {
@@ -370,6 +413,7 @@ internal static class GSharpProjectTransformer
                 generatedProjectPaths,
                 sourceRoot,
                 destinationRoot,
+                repositoryRootExpressions,
                 out string mapped))
             {
                 specs[i] = mapped;
@@ -393,6 +437,7 @@ internal static class GSharpProjectTransformer
         IReadOnlyDictionary<string, string> generatedProjectPaths,
         string sourceRoot,
         string destinationRoot,
+        IReadOnlySet<string> repositoryRootExpressions,
         out string mapped)
     {
         mapped = null;
@@ -423,9 +468,17 @@ internal static class GSharpProjectTransformer
             }
 
             prefix = value.Substring(0, close + 1);
+            if (prefix.Equals("$(MSBuildProjectDirectory)", StringComparison.OrdinalIgnoreCase)
+                && sourceRoot is not null)
+            {
+                return false;
+            }
+
             if (!IsAnchorExpression(prefix))
             {
-                if (string.IsNullOrEmpty(sourceRoot) || string.IsNullOrEmpty(destinationRoot))
+                if (string.IsNullOrEmpty(sourceRoot) ||
+                    string.IsNullOrEmpty(destinationRoot) ||
+                    repositoryRootExpressions?.Contains(prefix) != true)
                 {
                     return false;
                 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GSharpProjectTransformer.cs
@@ -153,6 +153,47 @@ internal static class GSharpProjectTransformer
         return resolved;
     }
 
+    internal static bool RewriteProjectItemPaths(
+        XDocument document,
+        string sourceFileDirectory,
+        string destinationFileDirectory,
+        string sourceRoot,
+        string destinationRoot,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
+    {
+        // Shared props/targets often anchor item paths at a repository-root
+        // property whose value is not available while mirroring. Treat only
+        // its literal suffix as root-relative, then require an exact hit in
+        // the source-to-generated project map before preserving the expression.
+        bool changed = false;
+        foreach (XElement itemGroup in ElementsNamed(document, "ItemGroup"))
+        {
+            foreach (XElement item in itemGroup.Elements())
+            {
+                XAttribute include = AttributeNamed(item, "Include");
+                if (include is null || string.IsNullOrWhiteSpace(include.Value))
+                {
+                    continue;
+                }
+
+                string rewritten = RewriteProjectPathList(
+                    include.Value,
+                    sourceFileDirectory,
+                    destinationFileDirectory,
+                    generatedProjectPaths,
+                    sourceRoot,
+                    destinationRoot);
+                if (!string.Equals(rewritten, include.Value, StringComparison.Ordinal))
+                {
+                    include.Value = rewritten;
+                    changed = true;
+                }
+            }
+        }
+
+        return changed;
+    }
+
     private static void AddSourceSdkDefaults(XDocument document, string sourceSdk)
     {
         bool isWeb = HasSdk(sourceSdk, "Microsoft.NET.Sdk.Web");
@@ -309,7 +350,9 @@ internal static class GSharpProjectTransformer
         string value,
         string sourceProjectDirectory,
         string destinationProjectDirectory,
-        IReadOnlyDictionary<string, string> generatedProjectPaths)
+        IReadOnlyDictionary<string, string> generatedProjectPaths,
+        string sourceRoot = null,
+        string destinationRoot = null)
     {
         if (value.IndexOf(".csproj", StringComparison.OrdinalIgnoreCase) < 0)
         {
@@ -325,6 +368,8 @@ internal static class GSharpProjectTransformer
                 sourceProjectDirectory,
                 destinationProjectDirectory,
                 generatedProjectPaths,
+                sourceRoot,
+                destinationRoot,
                 out string mapped))
             {
                 specs[i] = mapped;
@@ -336,15 +381,18 @@ internal static class GSharpProjectTransformer
     }
 
     // Maps one path spec to its generated counterpart, preserving the leading
-    // MSBuild directory expression (the only two that can be expanded without
-    // evaluating the project) and any surrounding whitespace. Returns false —
-    // leaving the spec untouched — for anything that cannot be resolved
-    // statically or that is not part of the migration set.
+    // MSBuild directory expression and any surrounding whitespace. Project
+    // transforms recognize only the two expressions that can be resolved from
+    // their location. Shared item files may additionally match an expression's
+    // literal suffix against the repository-rooted migration map. Returns false
+    // for anything unresolved or outside the migration set.
     private static bool TryMapProjectPathSpec(
         string spec,
         string sourceProjectDirectory,
         string destinationProjectDirectory,
         IReadOnlyDictionary<string, string> generatedProjectPaths,
+        string sourceRoot,
+        string destinationRoot,
         out string mapped)
     {
         mapped = null;
@@ -365,6 +413,7 @@ internal static class GSharpProjectTransformer
 
         string prefix = string.Empty;
         string remainder = value;
+        bool rootRelativeExpression = false;
         if (value.StartsWith("$(", StringComparison.Ordinal))
         {
             int close = value.IndexOf(')');
@@ -376,7 +425,12 @@ internal static class GSharpProjectTransformer
             prefix = value.Substring(0, close + 1);
             if (!IsAnchorExpression(prefix))
             {
-                return false;
+                if (string.IsNullOrEmpty(sourceRoot) || string.IsNullOrEmpty(destinationRoot))
+                {
+                    return false;
+                }
+
+                rootRelativeExpression = true;
             }
 
             remainder = value.Substring(close + 1).TrimStart('/', '\\');
@@ -393,10 +447,20 @@ internal static class GSharpProjectTransformer
         }
 
         string sourceReferencePath = Path.GetFullPath(
-            Path.Combine(sourceProjectDirectory, NormalizeDirectorySeparators(remainder)));
+            Path.Combine(
+                rootRelativeExpression ? sourceRoot : sourceProjectDirectory,
+                NormalizeDirectorySeparators(remainder)));
         if (!generatedProjectPaths.TryGetValue(sourceReferencePath, out string generatedProjectPath))
         {
             return false;
+        }
+
+        if (rootRelativeExpression)
+        {
+            string generatedRelative = Path.GetRelativePath(destinationRoot, generatedProjectPath)
+                .Replace('\\', '/');
+            mapped = leading + prefix + "/" + generatedRelative + trailing;
+            return true;
         }
 
         string relative = Path.GetRelativePath(

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -156,10 +156,26 @@ public sealed class MigrationPipeline
         }
 
         string runDir = Path.Combine(outputRoot, runId);
+        this.options.GeneratedProjectPaths = apps.ToDictionary(
+            app => Path.GetFullPath(app.ProjectPath),
+            app => repositoryLayout
+                ? Path.Combine(
+                    destinationRoot,
+                    Path.ChangeExtension(
+                        app.RelativeProjectPath ?? Path.GetRelativePath(this.options.SourceRoot, app.ProjectPath),
+                        ".gsproj"))
+                : Path.Combine(
+                    runDir,
+                    SanitizeAppId(app.Id),
+                    Path.GetFileNameWithoutExtension(app.ProjectPath) + ".gsproj"),
+            StringComparer.OrdinalIgnoreCase);
         IReadOnlyList<string> repositoryFiles = null;
         if (repositoryLayout)
         {
-            repositoryFiles = RepositoryMirror.Prepare(this.options.SourceRoot, destinationRoot);
+            repositoryFiles = RepositoryMirror.Prepare(
+                this.options.SourceRoot,
+                destinationRoot,
+                this.options.GeneratedProjectPaths);
             this.options.RepositorySourceFiles = repositoryFiles
                 .Where(path => Path.GetExtension(path).Equals(".cs", StringComparison.OrdinalIgnoreCase))
                 .Select(path => Path.GetFullPath(Path.Combine(this.options.SourceRoot, path)))
@@ -186,19 +202,6 @@ public sealed class MigrationPipeline
                 apps.Select(app => app.ProjectPath),
                 evaluatedProjectReferences);
 
-        this.options.GeneratedProjectPaths = apps.ToDictionary(
-            app => Path.GetFullPath(app.ProjectPath),
-            app => repositoryLayout
-                ? Path.Combine(
-                    destinationRoot,
-                    Path.ChangeExtension(
-                        app.RelativeProjectPath ?? Path.GetRelativePath(this.options.SourceRoot, app.ProjectPath),
-                        ".gsproj"))
-                : Path.Combine(
-                    runDir,
-                    SanitizeAppId(app.Id),
-                    Path.GetFileNameWithoutExtension(app.ProjectPath) + ".gsproj"),
-            StringComparer.OrdinalIgnoreCase);
         RepositoryExcludedScope excludedScope = repositoryLayout
             ? RepositoryExcludedScope.Compute(this.options.SourceRoot, this.options.ExcludedProjectPaths)
             : null;

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
@@ -14,7 +14,10 @@ namespace Cs2Gs.Pipeline;
 /// <summary>Creates the non-source portion of an exact repository mirror.</summary>
 internal static class RepositoryMirror
 {
-    internal static IReadOnlyList<string> Prepare(string sourceRoot, string destinationRoot)
+    internal static IReadOnlyList<string> Prepare(
+        string sourceRoot,
+        string destinationRoot,
+        IReadOnlyDictionary<string, string> generatedProjectPaths = null)
     {
         string source = Path.GetFullPath(sourceRoot);
         string destination = Path.GetFullPath(destinationRoot);
@@ -37,7 +40,12 @@ internal static class RepositoryMirror
 
             string target = Path.Combine(destination, relativePath);
             Directory.CreateDirectory(Path.GetDirectoryName(target));
-            CopyFile(Path.Combine(source, relativePath), target);
+            CopyFile(
+                Path.Combine(source, relativePath),
+                target,
+                source,
+                destination,
+                generatedProjectPaths);
         }
 
         return files;
@@ -335,18 +343,52 @@ internal static class RepositoryMirror
         }
     }
 
-    private static void CopyFile(string source, string destination)
+    private static void CopyFile(
+        string source,
+        string destination,
+        string sourceRoot,
+        string destinationRoot,
+        IReadOnlyDictionary<string, string> generatedProjectPaths)
     {
         string fileName = Path.GetFileName(source);
+        string extension = Path.GetExtension(source);
+        string content = null;
+        bool changed = false;
         if (fileName.Equals("Directory.Build.props", StringComparison.OrdinalIgnoreCase) ||
             fileName.Equals("Directory.Packages.props", StringComparison.OrdinalIgnoreCase))
         {
-            string content = File.ReadAllText(source);
+            content = File.ReadAllText(source);
             if (NerdbankGitVersioningPolicy.TryBumpProjectXml(content, out string bumped))
             {
-                File.WriteAllText(destination, bumped);
+                content = bumped;
+                changed = true;
+            }
+        }
+
+        if ((extension.Equals(".props", StringComparison.OrdinalIgnoreCase) ||
+            extension.Equals(".targets", StringComparison.OrdinalIgnoreCase)) &&
+            generatedProjectPaths is not null &&
+            generatedProjectPaths.Count != 0)
+        {
+            content ??= File.ReadAllText(source);
+            XDocument document = XDocument.Parse(content, LoadOptions.PreserveWhitespace);
+            if (GSharpProjectTransformer.RewriteProjectItemPaths(
+                document,
+                Path.GetDirectoryName(source),
+                Path.GetDirectoryName(destination),
+                sourceRoot,
+                destinationRoot,
+                generatedProjectPaths))
+            {
+                document.Save(destination, SaveOptions.DisableFormatting);
                 return;
             }
+        }
+
+        if (changed)
+        {
+            File.WriteAllText(destination, content);
+            return;
         }
 
         File.Copy(source, destination);

--- a/tools/cs2gs/Cs2Gs.Tests/RepositoryMirrorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/RepositoryMirrorTests.cs
@@ -3,8 +3,10 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using Cs2Gs.Pipeline;
 using Xunit;
 
@@ -80,6 +82,113 @@ public sealed class RepositoryMirrorTests
         string copied = File.ReadAllText(Path.Combine(destination, "Directory.Packages.props"));
         Assert.Contains("Version=\"3.11.13-beta\"", copied);
         Assert.DoesNotContain("3.7.115", copied);
+    }
+
+    [Fact]
+    public void Prepare_RetargetsGsharpPropsProjectHandlesInMigrationSet()
+    {
+        using var scratch = new ScratchDirectory();
+        string source = Path.Combine(scratch.Path, "source");
+        string destination = Path.Combine(scratch.Path, "destination");
+        string props = Path.Combine(source, "build", "gsharp.props");
+        Directory.CreateDirectory(Path.GetDirectoryName(props));
+        File.WriteAllText(
+            props,
+            """
+            <Project>
+              <ItemGroup>
+                <GsharpCore Include="$(GsharpRepoRoot)\src\Core\Core.csproj" />
+                <GsharpCompiler Include="$(GsharpRepoRoot)\src\Compiler\Compiler.csproj" />
+                <GsharpFormatting Include="$(GsharpRepoRoot)\src\Formatting\Formatting.csproj" />
+                <GsharpFormatterCli Include="$(GsharpRepoRoot)\src\Formatting\FormatterCli.csproj" />
+                <GsharpRepl Include="$(GsharpRepoRoot)\src\Repl\Repl.csproj" />
+                <GsharpLanguageServer Include="$(GsharpRepoRoot)\src\LanguageServer\LanguageServer.csproj" />
+                <GsharpAll Include="@(GsharpCore)" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        var generated = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string project in new[] { "Core", "Compiler", "Repl", "LanguageServer" })
+        {
+            generated[Path.Combine(source, "src", project, project + ".csproj")] =
+                Path.Combine(destination, "src", project, project + ".gsproj");
+        }
+
+        RepositoryMirror.Prepare(source, destination, generated);
+
+        XDocument mirrored = XDocument.Load(Path.Combine(destination, "build", "gsharp.props"));
+        Assert.Equal(
+            new[]
+            {
+                "$(GsharpRepoRoot)/src/Core/Core.gsproj",
+                "$(GsharpRepoRoot)/src/Compiler/Compiler.gsproj",
+                "$(GsharpRepoRoot)/src/Repl/Repl.gsproj",
+                "$(GsharpRepoRoot)/src/LanguageServer/LanguageServer.gsproj",
+            },
+            new[] { "GsharpCore", "GsharpCompiler", "GsharpRepl", "GsharpLanguageServer" }
+                .Select(name => mirrored.Descendants(name).Single().Attribute("Include")?.Value)
+                .ToArray());
+        Assert.Equal(
+            "$(GsharpRepoRoot)\\src\\Formatting\\Formatting.csproj",
+            mirrored.Descendants("GsharpFormatting").Single().Attribute("Include")?.Value);
+        Assert.Equal(
+            "$(GsharpRepoRoot)\\src\\Formatting\\FormatterCli.csproj",
+            mirrored.Descendants("GsharpFormatterCli").Single().Attribute("Include")?.Value);
+        Assert.Equal("@(GsharpCore)", mirrored.Descendants("GsharpAll").Single().Attribute("Include")?.Value);
+    }
+
+    [Theory]
+    [InlineData(".props")]
+    [InlineData(".targets")]
+    public void Prepare_RetargetsOnlyMigratedProjectItemPaths(string extension)
+    {
+        using var scratch = new ScratchDirectory();
+        string source = Path.Combine(scratch.Path, "source");
+        string destination = Path.Combine(scratch.Path, "destination");
+        string buildDirectory = Path.Combine(source, "build");
+        string sharedBuildFile = Path.Combine(buildDirectory, "shared" + extension);
+        string sourceProject = Path.Combine(source, "src", "Core", "Core.csproj");
+        string generatedProject = Path.Combine(destination, "src", "Core", "Core.gsproj");
+        Directory.CreateDirectory(buildDirectory);
+        File.WriteAllText(
+            sharedBuildFile,
+            """
+            <Project>
+              <ItemGroup>
+                <LiteralProject Include="../src/Core/Core.csproj" />
+                <PropertyProject Include="$(RepoRoot)\src\Core\Core.csproj" />
+                <ComputedProject Include="$(RepoRoot)\src\$(ProjectName)\Core.csproj" />
+                <ExternalProject Include="../external/External.csproj" />
+                <Compile Include="../src/Core/Core.cs" />
+              </ItemGroup>
+              <Target Name="Report">
+                <Message Text="src/Core/Core.csproj" />
+              </Target>
+            </Project>
+            """);
+
+        RepositoryMirror.Prepare(
+            source,
+            destination,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [sourceProject] = generatedProject,
+            });
+
+        XDocument mirrored = XDocument.Load(Path.Combine(destination, "build", "shared" + extension));
+        Assert.Equal("../src/Core/Core.gsproj", mirrored.Descendants("LiteralProject").Single().Attribute("Include")?.Value);
+        Assert.Equal(
+            "$(RepoRoot)/src/Core/Core.gsproj",
+            mirrored.Descendants("PropertyProject").Single().Attribute("Include")?.Value);
+        Assert.Equal(
+            "$(RepoRoot)\\src\\$(ProjectName)\\Core.csproj",
+            mirrored.Descendants("ComputedProject").Single().Attribute("Include")?.Value);
+        Assert.Equal(
+            "../external/External.csproj",
+            mirrored.Descendants("ExternalProject").Single().Attribute("Include")?.Value);
+        Assert.Equal("../src/Core/Core.cs", mirrored.Descendants("Compile").Single().Attribute("Include")?.Value);
+        Assert.Equal("src/Core/Core.csproj", mirrored.Descendants("Message").Single().Attribute("Text")?.Value);
     }
 
     [Fact]

--- a/tools/cs2gs/Cs2Gs.Tests/RepositoryMirrorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/RepositoryMirrorTests.cs
@@ -96,6 +96,9 @@ public sealed class RepositoryMirrorTests
             props,
             """
             <Project>
+              <PropertyGroup>
+                <GsharpRepoRoot>$(MSBuildThisFileDirectory)..</GsharpRepoRoot>
+              </PropertyGroup>
               <ItemGroup>
                 <GsharpCore Include="$(GsharpRepoRoot)\src\Core\Core.csproj" />
                 <GsharpCompiler Include="$(GsharpRepoRoot)\src\Compiler\Compiler.csproj" />
@@ -155,9 +158,14 @@ public sealed class RepositoryMirrorTests
             sharedBuildFile,
             """
             <Project>
+              <PropertyGroup>
+                <RepoRoot>$(MSBuildThisFileDirectory)..</RepoRoot>
+              </PropertyGroup>
               <ItemGroup>
                 <LiteralProject Include="../src/Core/Core.csproj" />
                 <PropertyProject Include="$(RepoRoot)\src\Core\Core.csproj" />
+                <UnknownPropertyProject Include="$(ExternalRoot)\src\Core\Core.csproj" />
+                <ImportingProjectPath Include="$(MSBuildProjectDirectory)\..\src\Core\Core.csproj" />
                 <ComputedProject Include="$(RepoRoot)\src\$(ProjectName)\Core.csproj" />
                 <ExternalProject Include="../external/External.csproj" />
                 <Compile Include="../src/Core/Core.cs" />
@@ -181,6 +189,12 @@ public sealed class RepositoryMirrorTests
         Assert.Equal(
             "$(RepoRoot)/src/Core/Core.gsproj",
             mirrored.Descendants("PropertyProject").Single().Attribute("Include")?.Value);
+        Assert.Equal(
+            "$(ExternalRoot)\\src\\Core\\Core.csproj",
+            mirrored.Descendants("UnknownPropertyProject").Single().Attribute("Include")?.Value);
+        Assert.Equal(
+            "$(MSBuildProjectDirectory)\\..\\src\\Core\\Core.csproj",
+            mirrored.Descendants("ImportingProjectPath").Single().Attribute("Include")?.Value);
         Assert.Equal(
             "$(RepoRoot)\\src\\$(ProjectName)\\Core.csproj",
             mirrored.Descendants("ComputedProject").Single().Attribute("Include")?.Value);


### PR DESCRIPTION
Closes #3850.

## Root cause

`RepositoryMirror.Prepare` copied `.props` and `.targets` before the source-to-generated project map was available, so custom item includes such as `$(GsharpRepoRoot)\src\Core\Core.csproj` survived unchanged even though the mirror contained `Core.gsproj`.

## Fix

- Build the existing `GeneratedProjectPaths` identity map before mirroring.
- Reuse `GSharpProjectTransformer`'s project-path mapping for `Include` attributes inside mirrored `.props`/`.targets` item groups.
- Resolve literal paths from the shared file and property-prefixed literal suffixes from the repository root, but rewrite only exact migration-map hits.
- Preserve unknown/computed expressions, non-project items, item-list expressions, and external/unmigrated projects.

## Tests

- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter 'FullyQualifiedName~RepositoryMirrorTests|FullyQualifiedName~GSharpProjectTransformerTests|FullyQualifiedName~Issue3772MirrorFidelityTests' --no-restore -p:GeneratePackageOnBuild=false` — 20/20 passed.
- `dotnet build GSharp.sln -c Release -graph` — succeeded, 0 warnings/errors.
- `python3 build/nullable_hygiene.py --base origin/main` — OK.
- Whole-repository translate-only self-migration — 55/56 translated; only the existing `test/Interpreter.Tests` translation gap remained.
- `run-cs2gs-selfmig-validate.sh issue3850 src/Repl/Repl.csproj` — compile/ILVerify/test parity all passed.
- Direct Release build of migrated `src/Repl/Repl.gsproj` — succeeded; Core, LanguageServer, Formatting, Channels, and Extensions references built/resolved; `Gsharp project does not exist` warning count was 0 (previously four issue-reported warnings).
- `run-cs2gs-selfmig-pr-guard.sh` — 8/8 guarded apps green.
