### PR TITLE
ci: make the hot-core translation guard report on every PR so it can be required

### DIFF
--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -33,38 +33,55 @@ name: cs2gs-pr-guard
 # src/Formatting/GSharp.Formatting in addition to the original hot core. See
 # build/run-cs2gs-selfmig-pr-guard.sh for the closed ProjectReference set.
 #
-# THE paths FILTER
+# THE TRIGGER: every PR to `main`, no `paths:` filter
 #
-# Scoped to exactly what the job can actually judge: the sources of the
-# guarded projects, plus the compiler and translator machinery that decides
-# how they translate, plus this job's own definition. #3836 suggested
-# `tools/cs2gs/**` alone — but #3896, the most expensive of the three
-# incidents, was a src/Core change, and src/Core is already inside the guarded
-# closure, so including it costs nothing extra to run and catches strictly
-# more.
+# Matching build.yml, and deliberately so. The reason is REQUIRED-CHECK
+# ELIGIBILITY, not cost.
 #
-# Note: `tools/cs2gs/**` is included in full even though only Cs2Gs.CodeModel
-# and Cs2Gs.Translator are guarded — a change to any part of cs2gs changes how
-# the guarded sources translate, which is the thing being measured.
+# A `paths:`-filtered workflow does not report a neutral status when the
+# filter misses: GitHub skips the workflow and the check never appears at all.
+# A required check in that state parks every docs-only or website-only PR
+# forever on "Expected — waiting for status to be reported". So a top-level
+# `paths:` filter and "required" are mutually exclusive, and this guard is
+# worth more as a required check than as a cheap one — #3831, #3896 and #3905
+# each reached `main` with CI fully green, which is precisely the situation an
+# advisory check does not survive.
+#
+# WHAT THAT COSTS
+#
+# The job takes ~30-45 minutes (five consecutive runs measured 29, 41, 44, 44
+# and 45 minutes), and it is now paid on PRs that cannot possibly affect
+# translation. build.yml's entire matrix finishes in ~21-25 minutes, so on a
+# docs-only PR this guard becomes the critical path and roughly doubles the
+# time to green. That is the price of the check being reportable on every PR.
+#
+# WHAT THE OLD FILTER SAID, AND WHERE THAT KNOWLEDGE LIVES NOW
+#
+# It was scoped to what this job can actually judge: the guarded projects'
+# sources (src/Core, src/Analyzers/InternalAnalyzers,
+# src/Formatting/GSharp.Formatting, src/Sdk/Gsharp.Runtime.Channels), the
+# whole tools/cs2gs tree — which decides how those sources translate, not just
+# the two guarded projects in it — plus src/Compiler and src/Sdk/Gsharp.NET.Sdk,
+# which decide whether the translated result compiles (#3905 was a gsc crash,
+# not a translation defect), and this job's own definition.
+#
+# That set is still the honest answer to "which changes can turn this job
+# red". It is simply no longer the answer to "when does this job run". If the
+# cost above stops being acceptable, the shape to reach for is a changed-paths
+# step INSIDE the job that short-circuits the expensive steps with `if:`, so
+# the check still reports on every PR. Do not reintroduce a top-level `paths:`
+# filter while this check is required — that is the failure this trigger
+# exists to avoid.
+#
+# `push:` on `main` is deliberately absent, and `tags:` more so. This is a
+# PR-time instrument (see the concurrency group, keyed on the PR number); the
+# nightly cs2gs-selfmig gate is the `main`-branch one, and `workflow_dispatch`
+# covers an on-demand run.
 
 on:
   pull_request:
-    paths:
-      # The guarded projects' own sources: a new file here is the #3831 /
-      # #3896 / #3905 hazard directly.
-      - 'src/Core/**'
-      - 'src/Analyzers/InternalAnalyzers/**'
-      - 'src/Formatting/GSharp.Formatting/**'
-      - 'src/Sdk/Gsharp.Runtime.Channels/**'
-      # The translator: it decides what the guarded sources become.
-      - 'tools/cs2gs/**'
-      # The compiler and the SDK: they decide whether what it produces
-      # compiles. #3905 was a gsc crash, not a translation defect.
-      - 'src/Compiler/**'
-      - 'src/Sdk/Gsharp.NET.Sdk/**'
-      # The guard itself, so changes to it are exercised by it.
-      - 'build/run-cs2gs-selfmig-pr-guard.sh'
-      - '.github/workflows/cs2gs-pr-guard.yml'
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What this fixes

The `hot-core translation guard` job could not be a **required** status check on PRs. The reason was not its event list — it already triggers on `pull_request`. It was the `paths:` filter: when a PR touches none of the filtered paths, GitHub **skips the workflow entirely and no status is ever reported**. A required check in that state leaves the PR stuck forever on *"Expected — waiting for status to be reported."*

So the fix is the trigger, as asked: align it with `build.yml`.

```yaml
on:
  pull_request:
    branches:
      - main
  workflow_dispatch:
```

The guard now reports on every PR to `main`, which is the precondition for making it required.

## Judgement calls

**1. `push: branches: [main]` — not mirrored.** Only the `pull_request` half is load-bearing for a required check. This job is a PR-time instrument: its `concurrency` group is keyed on the PR number, its output banner is written for a PR reviewer, and the `main`-branch question is already asked, far more thoroughly, by the nightly `cs2gs-selfmig` gate. A push run would mostly repeat the answer the PR run just gave, at ~40 minutes of runner time per merge. `workflow_dispatch` stays for on-demand runs. `tags: ['v*']` is not mirrored either — a PR guard has nothing to say about a release tag.

**2. Cost of running on every PR: ~30–45 minutes.** Measured from five consecutive real runs of the `hot-core translation guard` job (durations 29, 41, 44, 44 and 45 minutes; median ~44). The work is `build/run-cs2gs-selfmig-pr-guard.sh`: four `dotnet build`s (Cs2Gs.Cli Release, Compiler Debug, Gsharp.NET.Sdk Debug, Gsharp.NET.Sdk Release repack) followed by a `cs2gs migrate` over the eight guarded projects through translate → compile → ilverify → test-parity, on top of the job's own restore and tool-restore steps.

For context, `build.yml`'s entire matrix finishes in ~21–25 minutes. So on a docs-only or website-only PR — which previously skipped this job entirely — the guard is now the critical path and roughly doubles the time to green. That is the price of the check being reportable, and it is stated plainly in the workflow comment rather than left to be rediscovered.

## The alternative you may prefer (not implemented)

There is a third option that gets a required check **and** keeps the cost profile the old `paths:` filter was buying: keep the workflow always-triggering so it always reports, but make the expensive work conditional *inside* the job — either a `dorny/paths-filter` step, or a first step that computes the changed paths and later steps guarded by `if:`. On an irrelevant PR the job then reports success in well under a minute instead of being skipped, and the ~40 minutes is only spent when a guarded path actually changed.

Tradeoff: it is more machinery, the path list has to be maintained in a second place (a step input rather than the `on:` block), and a mistake in it fails *open* — the check goes green without doing the work, which is exactly the failure mode of #3978 where the guard passed on a PR whose project was outside the guarded set. The literal request was to match `build.yml`'s trigger, so that is what is implemented here. Say the word and I will convert it to the conditional-steps shape.

The workflow comment names this alternative as the thing to reach for if the cost stops being acceptable, and explicitly says not to reintroduce a top-level `paths:` filter while the check is required.

## Comment block

The comment block's `THE paths FILTER` section justified a filter that no longer exists, so it is rewritten rather than left stale. The replacement keeps everything that section actually knew — src/Core was in scope because #3896 was a src/Core change; all of `tools/cs2gs/**` counted even though only two projects there are guarded; src/Compiler and the SDK counted because #3905 was a gsc crash rather than a translation defect — but reframed as the answer to *"which changes can turn this job red"* instead of *"when does this job run"*. The `WHY THIS EXISTS` incident history (#3831, #3896, #3905) and the `WHAT IT IS NOT` scope disclaimer are untouched.

## Stale-reference sweep

`grep -rn "cs2gs-pr-guard" .` over `.github/`, `docs/` and `build/` turns up:

- `docs/self-migration-policy.md:4` — names the check and the script; says nothing about when it triggers. Not stale.
- `tools/cs2gs/README.md:157` — describes what the guard migrates; says nothing about path filtering or skip behaviour. Not stale from this change. (It *is* stale in a different way that predates this PR: it lists four guarded apps and says Channels is not covered, while the script now guards eight including Channels, Formatting, Pipeline and ProjectLoading. Out of scope here — flagging it rather than fixing it in a CI PR.)
- `docs/adr/0179-gsfmt-canonical-formatter.md:356` — refers to the script's `guard_apps`, not the trigger. Not stale.
- No other workflow references this one's path filtering. `pages.yml` is the only other workflow with a `paths:` filter and is unrelated.

So no other file needed updating.

## What you still have to do by hand

**This PR does not make the check required — it only makes it *eligible*.** Making it actually required is a repository-settings change you have to make in the GitHub UI: Settings → Branches → the `main` protection rule → *Require status checks to pass before merging* → add **`hot-core translation guard`** (the job's `name:`, which is what appears in the checks list — not the workflow name `cs2gs-pr-guard`). Until you do that, nothing about merge behaviour changes; the guard is still advisory.

Worth doing that only after this PR merges, so the check has reported on `main`-based PRs at least once and appears in the settings picker.

## Validation

- YAML parses; `on:` resolves to `{'pull_request': {'branches': ['main']}, 'workflow_dispatch': None}`.
- The `jobs.guard` body — steps, timeout, concurrency, artifact upload — is unchanged. The diff is the comment section and the `on:` block only.
- This PR touches `.github/workflows/cs2gs-pr-guard.yml` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ptr4sovcAwpgaUEM4rEin
