### PR TITLE
cs2gs: widen expanded params element nullability (#3888)

### DIFF
--- a/test/Compiler.Tests/Emit/VariadicEmitTests.cs
+++ b/test/Compiler.Tests/Emit/VariadicEmitTests.cs
@@ -70,6 +70,24 @@ public class VariadicEmitTests
     }
 
     [Fact]
+    public void VariadicNullableReference_PacksNilAndRuns()
+    {
+        var source = """
+            package P
+            import System
+
+            func count(values ...string?) int32 {
+              return values.Length
+            }
+
+            Console.WriteLine(count(nil, "x"))
+            """;
+
+        var output = CompileAndRun(source);
+        Assert.Equal($"2{Environment.NewLine}", output);
+    }
+
+    [Fact]
     public void VariadicWithFixedPrefix()
     {
         var source = """

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3886VariadicCarrierSinkContractTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3886VariadicCarrierSinkContractTests.cs
@@ -18,14 +18,10 @@ namespace Cs2Gs.Tests;
 /// <c>!!</c> bridge must agree with the signature the DECLARATION side
 /// actually emits.
 /// <para>
-/// <c>TranslateParameter</c> gates issue #1072 promotion on <c>!variadic</c> —
-/// "variadic params are never null-compared as a whole" — so an ADR-0173
-/// variadic carrier is always emitted <c>...T</c> however much null evidence
-/// (<c>if (paths is null) throw</c>) the oblivious-nullability fixpoint
-/// recorded against that parameter. The call side asked
-/// <c>ShouldPromoteToNullableReference</c> about the same parameter anyway,
-/// concluded the sink had widened to <c>...T?</c>, and dropped the bridge —
-/// so a promoted <c>string?</c> reached a non-null <c>...string</c> slot bare.
+/// Carrier evidence (<c>if (paths is null) throw</c>) never widens a variadic
+/// declaration, so a direct nullable-array argument still needs <c>!!</c>.
+/// Issue #3888 separately lets expanded-element evidence widen <c>...T</c> to
+/// <c>...T?</c>; that element call then stays bare.
 /// </para>
 /// <para>
 /// That is the whole migrated <c>test/Compiler.Tests</c> compile wall:
@@ -40,12 +36,11 @@ namespace Cs2Gs.Tests;
 public class Issue3886VariadicCarrierSinkContractTests
 {
     /// <summary>
-    /// The wall shape: an argument in the EXPANDED tail of a null-guarded
-    /// source-declared <c>params T[]</c> must still be bridged, and the
-    /// bridged program must run.
+    /// Issue #3888 refinement: expanded nullable evidence widens the element
+    /// position, while the carrier's null guard remains irrelevant to it.
     /// </summary>
     [Fact]
-    public void ExpandedArgument_NullGuardedSourceParams_AssertsNonNullAndRuns()
+    public void ExpandedArgument_NullGuardedSourceParams_WidensElementAndRuns()
     {
         string printed = TranslateOblivious("""
             using System;
@@ -87,14 +82,13 @@ public class Issue3886VariadicCarrierSinkContractTests
             }
             """);
 
-        // The evidence that the sink really is non-null: the declaration is a
-        // bare `...string` carrier, so the promoted `string?` argument needs
-        // the bridge.
-        Assert.Contains("func Join(parts ...string)", printed, StringComparison.Ordinal);
+        Assert.Contains("func Join(parts ...string?)", printed, StringComparison.Ordinal);
         Assert.Contains("prop First string?", printed, StringComparison.Ordinal);
-        Assert.Contains("Fixture.Join(result.First!!, \"b\")", printed, StringComparison.Ordinal);
+        Assert.Contains("Fixture.Join(result.First, \"b\")", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("result.First!!", printed, StringComparison.Ordinal);
 
         AssertEvaluates(printed, "Caller.Go(true)", "a|b");
+        AssertEvaluates(printed, "Caller.Go(false)", "|b");
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3888ExpandedParamsElementNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3888ExpandedParamsElementNullabilityTests.cs
@@ -1,0 +1,192 @@
+// <copyright file="Issue3888ExpandedParamsElementNullabilityTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using GSharp.Tests;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #3888: nullable evidence in an expanded <c>params T[]</c> argument
+/// belongs to the emitted <c>...T</c> element position, not to the array carrier.
+/// </summary>
+public class Issue3888ExpandedParamsElementNullabilityTests
+{
+    [Fact]
+    public void ExpandedEvidence_IsAssociatedWithItsParameterAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static int LiteralCount(params string[] values) => values.Length;
+                    public static int ExpressionCount(params string[] values) => values.Length;
+                    public static int StrictCount(params string[] values) => values.Length;
+                    public static int Ordinary(string value) => 1;
+                }
+
+                public static class Caller
+                {
+                    public static int Literal() => Fixture.LiteralCount(null, "tail");
+
+                    public static int Expression(bool useNull)
+                    {
+                        string maybe = useNull ? null : "x";
+                        return Fixture.ExpressionCount("head", maybe);
+                    }
+
+                    public static int Zero() => Fixture.StrictCount();
+                    public static int Multiple() => Fixture.StrictCount("a", "b");
+                    public static int OrdinaryNull() => Fixture.Ordinary(null);
+                }
+            }
+            """);
+
+        Assert.Contains("func LiteralCount(values ...string?)", printed, StringComparison.Ordinal);
+        Assert.Contains("func ExpressionCount(values ...string?)", printed, StringComparison.Ordinal);
+        Assert.Contains("func StrictCount(values ...string)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("func StrictCount(values ...string?)", printed, StringComparison.Ordinal);
+        Assert.Contains("func Ordinary(value string?)", printed, StringComparison.Ordinal);
+        Assert.Contains("LiteralCount(nil, \"tail\")", printed, StringComparison.Ordinal);
+        Assert.Contains("ExpressionCount(\"head\", maybe)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("nil!!", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("maybe!!", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Literal()", 2);
+        AssertEvaluates(printed, "Caller.Expression(true)", 2);
+        AssertEvaluates(printed, "Caller.Zero()", 0);
+        AssertEvaluates(printed, "Caller.Multiple()", 2);
+        AssertEvaluates(printed, "Caller.OrdinaryNull()", 1);
+    }
+
+    [Fact]
+    public void NormalFormNullableArray_DoesNotWidenElementOrCarrierAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static int Count(params string[] values)
+                    {
+                        if (values is null)
+                        {
+                            return -1;
+                        }
+
+                        return values.Length;
+                    }
+                }
+
+                public static class Caller
+                {
+                    public static int Go(bool present)
+                    {
+                        string[] values = present ? new[] { "x" } : null;
+                        return Fixture.Count(values);
+                    }
+                }
+            }
+            """);
+
+        Assert.Contains("func Count(values ...string)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("func Count(values ...string?)", printed, StringComparison.Ordinal);
+        Assert.Contains("Fixture.Count(values!!)", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go(true)", 1);
+    }
+
+    [Fact]
+    public void GenericReferenceParams_PromotesExpandedElementAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static int Count<T>(params T[] values)
+                        where T : class => values.Length;
+                }
+
+                public static class Caller
+                {
+                    public static int Go() => Fixture.Count<string>(null, "x");
+                }
+            }
+            """);
+
+        Assert.Contains("values ...T?", printed, StringComparison.Ordinal);
+        Assert.Contains("Count[string](nil, \"x\")", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("nil!!", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go()", 2);
+    }
+
+    [Fact]
+    public void AnnotatedNullableParamsElement_RemainsNullableAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            #nullable enable
+
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static int Count(params string?[] values) => values.Length;
+                }
+
+                public static class Caller
+                {
+                    public static int Go() => Fixture.Count(null, "x");
+                }
+            }
+            """);
+
+        Assert.Contains("func Count(values ...string?)", printed, StringComparison.Ordinal);
+        Assert.Contains("Fixture.Count(nil, \"x\")", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go()", 2);
+    }
+
+    private static void AssertEvaluates(string printed, string expression, object expected)
+    {
+        EmittedOracleResult result = EmittedOracle.Evaluate(
+            printed + Environment.NewLine + expression);
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(expected, result.Value);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3888ExpandedParamsElementNullabilityTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3888ExpandedParamsElementNullabilityTests.cs
@@ -3,6 +3,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cs2Gs.CodeModel.Ast;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
@@ -10,6 +12,7 @@ using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
 using GSharp.Tests;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -132,6 +135,31 @@ public class Issue3888ExpandedParamsElementNullabilityTests
     }
 
     [Fact]
+    public void CarrierShapedArrayElement_PromotesNestedElementAndRuns()
+    {
+        string printed = TranslateOblivious("""
+            namespace Demo
+            {
+                public static class Fixture
+                {
+                    public static int Count(params string[][] values) => values.Length;
+                }
+
+                public static class Caller
+                {
+                    public static int Go() => Fixture.Count(null, new[] { "x" });
+                }
+            }
+            """);
+
+        Assert.Contains("func Count(values ...[][]?string)", printed, StringComparison.Ordinal);
+        Assert.Contains("Fixture.Count(nil, []string{\"x\"})", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("nil!!", printed, StringComparison.Ordinal);
+
+        AssertEvaluates(printed, "Caller.Go()", 2);
+    }
+
+    [Fact]
     public void AnnotatedNullableParamsElement_RemainsNullableAndRuns()
     {
         string printed = TranslateOblivious("""
@@ -155,6 +183,52 @@ public class Issue3888ExpandedParamsElementNullabilityTests
         Assert.Contains("Fixture.Count(nil, \"x\")", printed, StringComparison.Ordinal);
 
         AssertEvaluates(printed, "Caller.Go()", 2);
+    }
+
+    [Fact]
+    public void CrossProjectSameArityOverloads_KeepEvidenceOnSelectedParamsPosition()
+    {
+        const string libSource = """
+            namespace Lib
+            {
+                public static class Fixture
+                {
+                    public static int Count(params string[] values) => values.Length;
+                    public static int Count(params object[] values) => values.Length;
+                }
+            }
+            """;
+        const string appSource = """
+            using Lib;
+
+            namespace App
+            {
+                public static class Caller
+                {
+                    public static int Go()
+                    {
+                        string maybe = null;
+                        return Fixture.Count(maybe, "x");
+                    }
+                }
+            }
+            """;
+
+        LoadedCSharpProject library = LoadOblivious(libSource, "Lib");
+        LoadedCSharpProject app = LoadOblivious(
+            appSource,
+            "App",
+            new[] { library.Compilation.ToMetadataReference() });
+        var siblings = new[] { library.Compilation, app.Compilation };
+
+        string printedLibrary = TranslateProject(library, siblings);
+        string printedApp = TranslateProject(app, siblings);
+        TranslationTestValidation.AssertBinds(printedLibrary, printedApp);
+
+        Assert.Contains("func Count(values ...string?)", printedLibrary, StringComparison.Ordinal);
+        Assert.Contains("func Count(values ...object)", printedLibrary, StringComparison.Ordinal);
+        Assert.DoesNotContain("func Count(values ...object?)", printedLibrary, StringComparison.Ordinal);
+        Assert.DoesNotContain("maybe!!", printedApp, StringComparison.Ordinal);
     }
 
     private static void AssertEvaluates(string printed, string expression, object expected)
@@ -188,5 +262,39 @@ public class Issue3888ExpandedParamsElementNullabilityTests
             "Translated G# must round-trip. Errors:\n" +
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
         return printed;
+    }
+
+    private static LoadedCSharpProject LoadOblivious(
+        string source,
+        string assemblyName,
+        IReadOnlyList<MetadataReference> extraReferences = null)
+    {
+        IReadOnlyList<MetadataReference> references = extraReferences is null
+            ? CSharpProjectLoader.RuntimeReferences()
+            : CSharpProjectLoader.RuntimeReferences().Concat(extraReferences).ToList();
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { (assemblyName + ".cs", source) },
+            references,
+            assemblyName);
+        Assert.True(
+            project.BoundWithoutErrors,
+            $"{assemblyName} should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(NullableContextOptions.Disable, project.Compilation.Options.NullableContextOptions);
+        return project;
+    }
+
+    private static string TranslateProject(
+        LoadedCSharpProject project,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(
+            project.Compilation,
+            document.SemanticModel,
+            document.FilePath,
+            siblingCompilations,
+            repositoryCompilations: siblingCompilations);
+        return GSharpPrinter.Print(new CSharpToGSharpTranslator().TranslateDocument(document, context));
     }
 }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -995,11 +995,13 @@ public sealed partial class CSharpToGSharpTranslator
             bool variadic = symbol.IsParams
                 && (symbol.Type is IArrayTypeSymbol || IsSupportedParamsCollectionType(symbol.Type));
             ITypeSymbol parameterType = symbol.Type;
+            ITypeSymbol variadicElementType = null;
             if (variadic && parameterType is IArrayTypeSymbol arrayType
                 && arrayType.ElementType is not IArrayTypeSymbol
                 && !IsSupportedParamsCollectionType(arrayType.ElementType))
             {
                 parameterType = arrayType.ElementType;
+                variadicElementType = parameterType;
             }
 
             // An array params whose ELEMENT is itself carrier-shaped (e.g.
@@ -1015,11 +1017,18 @@ public sealed partial class CSharpToGSharpTranslator
 
             GTypeReference type = this.typeMapper.Map(parameterType, this.context, symbol.Locations.FirstOrDefault());
 
-            // Issue #1072: a non-nullable reference/array parameter that is
-            // null-checked or null-assigned in the method body is really nullable;
-            // render it `T?` so the `== nil` guard type-checks (variadic params are
-            // never null-compared as a whole, so they are excluded).
-            if (!variadic && promoteNullability)
+            // Issue #1072/#3888: promote the declaration position that actually
+            // receives null. Ordinary parameters use their carrier symbol; a
+            // variadic array uses the separately tracked expanded-ELEMENT
+            // evidence, never nullable evidence about the array itself.
+            if (promoteNullability && variadicElementType != null)
+            {
+                type = this.PromoteParamsElementIfUsedAsNullable(
+                    type,
+                    symbol,
+                    variadicElementType);
+            }
+            else if (!variadic && promoteNullability)
             {
                 type = this.PromoteIfUsedAsNullable(type, symbol);
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -995,13 +995,20 @@ public sealed partial class CSharpToGSharpTranslator
             bool variadic = symbol.IsParams
                 && (symbol.Type is IArrayTypeSymbol || IsSupportedParamsCollectionType(symbol.Type));
             ITypeSymbol parameterType = symbol.Type;
-            ITypeSymbol variadicElementType = null;
+            ITypeSymbol variadicElementType =
+                variadic && symbol.Type is IArrayTypeSymbol paramsArray
+                    ? paramsArray.ElementType
+                    : null;
+            bool variadicElementNestedInArrayType = false;
             if (variadic && parameterType is IArrayTypeSymbol arrayType
                 && arrayType.ElementType is not IArrayTypeSymbol
                 && !IsSupportedParamsCollectionType(arrayType.ElementType))
             {
                 parameterType = arrayType.ElementType;
-                variadicElementType = parameterType;
+            }
+            else if (variadicElementType != null)
+            {
+                variadicElementNestedInArrayType = true;
             }
 
             // An array params whose ELEMENT is itself carrier-shaped (e.g.
@@ -1026,7 +1033,8 @@ public sealed partial class CSharpToGSharpTranslator
                 type = this.PromoteParamsElementIfUsedAsNullable(
                     type,
                     symbol,
-                    variadicElementType);
+                    variadicElementType,
+                    variadicElementNestedInArrayType);
             }
             else if (!variadic && promoteNullability)
             {

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -283,6 +283,32 @@ public sealed partial class CSharpToGSharpTranslator
             return this.ShouldPromoteToNullableReference(symbol) ? MakeNullable(type) : type;
         }
 
+        // Issue #3888: a `params T[]` declaration has two distinct nullable
+        // positions. The variadic G# spelling drops the array envelope and emits
+        // only `...T`, so direct null evidence from EXPANDED arguments must widen
+        // that element position without treating a nullable array/carrier as
+        // element evidence.
+        private GTypeReference PromoteParamsElementIfUsedAsNullable(
+            GTypeReference type,
+            IParameterSymbol parameter,
+            ITypeSymbol elementType)
+        {
+            if (type == null
+                || type.IsNullable
+                || elementType is not { IsReferenceType: true }
+                || elementType.NullableAnnotation == NullableAnnotation.Annotated)
+            {
+                return type;
+            }
+
+            return ObliviousNullabilityAnalyzer.IsParamsElementTainted(
+                this.context.Compilation,
+                parameter,
+                this.context.RepositoryCompilations ?? this.context.SiblingCompilations)
+                    ? MakeNullable(type)
+                    : type;
+        }
+
         // Issue #2113/#914: method/local-function returns are just another
         // symbol-position declaration sink, so their promote/not-promote answer
         // must come from the shared decision table.
@@ -1453,10 +1479,18 @@ public sealed partial class CSharpToGSharpTranslator
             // errors on the error-typed result).
             //
             // Mirror the declaration rule: a variadic carrier's contract is
-            // whatever its own annotation says, never a promoted one.
+            // whatever its own annotation says, never a promoted one. Issue
+            // #3888 adds one deliberately separate exception: when this query
+            // is for the expanded ELEMENT position and that position's own
+            // evidence widened `...T` to `...T?`, no bridge is needed.
             if (IsVariadicCarrierParameter(targetSymbol))
             {
-                return true;
+                return targetSymbol is not IParameterSymbol { Type: IArrayTypeSymbol array } paramsParameter
+                    || !SymbolEqualityComparer.Default.Equals(targetType, array.ElementType)
+                    || !ObliviousNullabilityAnalyzer.IsParamsElementTainted(
+                        this.context.Compilation,
+                        paramsParameter,
+                        this.context.RepositoryCompilations ?? this.context.SiblingCompilations);
             }
 
             bool targetDeclaredInThisCompilation = targetSymbol?.DeclaringSyntaxReferences

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Nullability.cs
@@ -291,7 +291,8 @@ public sealed partial class CSharpToGSharpTranslator
         private GTypeReference PromoteParamsElementIfUsedAsNullable(
             GTypeReference type,
             IParameterSymbol parameter,
-            ITypeSymbol elementType)
+            ITypeSymbol elementType,
+            bool elementNestedInArrayType)
         {
             if (type == null
                 || type.IsNullable
@@ -301,12 +302,20 @@ public sealed partial class CSharpToGSharpTranslator
                 return type;
             }
 
-            return ObliviousNullabilityAnalyzer.IsParamsElementTainted(
+            if (!ObliviousNullabilityAnalyzer.IsParamsElementTainted(
                 this.context.Compilation,
                 parameter,
-                this.context.RepositoryCompilations ?? this.context.SiblingCompilations)
-                    ? MakeNullable(type)
-                    : type;
+                this.context.RepositoryCompilations ?? this.context.SiblingCompilations))
+            {
+                return type;
+            }
+
+            return elementNestedInArrayType && type is ArrayTypeReference array
+                ? new ArrayTypeReference(MakeNullable(array.ElementType), array.Rank)
+                {
+                    IsNullable = array.IsNullable,
+                }
+                : MakeNullable(type);
         }
 
         // Issue #2113/#914: method/local-function returns are just another

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -719,6 +719,61 @@ internal static class ObliviousNullabilityAnalyzer
     }
 
     /// <summary>
+    /// Issue #3888: whether a <c>params T[]</c> parameter's expanded ELEMENT
+    /// position receives direct or transitive null evidence. This is deliberately
+    /// separate from <see cref="IsTainted(CSharpCompilation, ISymbol, IReadOnlyList{CSharpCompilation})"/>,
+    /// which describes the nullable array/carrier position.
+    /// </summary>
+    /// <param name="compilation">The compilation containing the declaration or call evidence.</param>
+    /// <param name="parameter">The params-array declaration whose element position is queried.</param>
+    /// <param name="siblingCompilations">Other compilations loaded in the same translation run.</param>
+    /// <returns><see langword="true"/> when an expanded element can be null.</returns>
+    public static bool IsParamsElementTainted(
+        CSharpCompilation compilation,
+        IParameterSymbol parameter,
+        IReadOnlyList<CSharpCompilation> siblingCompilations)
+    {
+        if (parameter == null
+            || compilation == null
+            || compilation.Options.NullableContextOptions != NullableContextOptions.Disable)
+        {
+            return false;
+        }
+
+        RegisterSourceAssemblies(compilation, siblingCompilations);
+        IEnumerable<CSharpCompilation> candidates =
+            new[] { compilation }.Concat(siblingCompilations ?? Enumerable.Empty<CSharpCompilation>());
+        foreach (CSharpCompilation candidateCompilation in candidates.Distinct())
+        {
+            if (candidateCompilation == null
+                || candidateCompilation.Options.NullableContextOptions != NullableContextOptions.Disable)
+            {
+                continue;
+            }
+
+            ISymbol candidate = ReferenceEquals(candidateCompilation, compilation)
+                ? Canonical(parameter)
+                : RemapToCompilation(candidateCompilation, parameter);
+            if (candidate == null)
+            {
+                continue;
+            }
+
+            TaintResult result = Cache.GetValue(candidateCompilation, Compute);
+            candidate = Canonical(candidate);
+            if (result.ParamsElementTainted.Contains(candidate)
+                || result.ParamsElementEdges.Any(edge =>
+                    SymbolEqualityComparer.Default.Equals(edge.Target, candidate)
+                    && IsTainted(candidateCompilation, edge.Source, siblingCompilations)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Whether one reference-typed leaf inside a tuple-valued declaration is
     /// null-tainted. Tuple leaves are tracked independently so evidence for
     /// one element never widens its siblings.
@@ -1795,6 +1850,8 @@ internal static class ObliviousNullabilityAnalyzer
         var tupleScalarEdges = new List<(TupleElementKey Target, ISymbol Source)>();
         var scalarTupleEdges = new List<(ISymbol Target, TupleElementKey Source)>();
         var delegateReturnEdges = new List<(ISymbol Target, ISymbol Source)>();
+        var paramsElementTainted = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var paramsElementEdges = new List<(ISymbol Target, ISymbol Source)>();
 
         foreach (SyntaxTree tree in compilation.SyntaxTrees)
         {
@@ -1804,7 +1861,14 @@ internal static class ObliviousNullabilityAnalyzer
             foreach (SyntaxNode node in root.DescendantNodes())
             {
                 SeedDirectTaint(node, model, tainted);
-                CollectEdges(node, model, tainted, edges, scalarTupleEdges);
+                CollectEdges(
+                    node,
+                    model,
+                    tainted,
+                    edges,
+                    scalarTupleEdges,
+                    paramsElementTainted,
+                    paramsElementEdges);
             }
 
             // Method / accessor / local-function RETURN taint: a `return null`,
@@ -1895,7 +1959,9 @@ internal static class ObliviousNullabilityAnalyzer
             tupleEdges,
             tupleScalarEdges,
             scalarTupleEdges,
-            delegateReturnEdges);
+            delegateReturnEdges,
+            paramsElementTainted,
+            paramsElementEdges);
     }
 
     private static void SeedEfEntityPropertyTaint(
@@ -2005,7 +2071,9 @@ internal static class ObliviousNullabilityAnalyzer
         SemanticModel model,
         HashSet<ISymbol> tainted,
         List<(ISymbol Target, ISymbol Source)> edges,
-        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges)
+        List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
+        HashSet<ISymbol> paramsElementTainted,
+        List<(ISymbol Target, ISymbol Source)> paramsElementEdges)
     {
         // Interprocedural parameter taint: an argument that is directly null or
         // reads a (possibly tainted) declaration flows to the bound parameter, so
@@ -2036,6 +2104,11 @@ internal static class ObliviousNullabilityAnalyzer
             or ElementBindingExpressionSyntax)
         {
             CollectArgumentEdges(node, model, tainted, edges, scalarTupleEdges);
+            CollectExpandedParamsElementEdges(
+                node,
+                model,
+                paramsElementTainted,
+                paramsElementEdges);
         }
 
         switch (node)
@@ -2094,6 +2167,72 @@ internal static class ObliviousNullabilityAnalyzer
                 }
 
                 break;
+        }
+    }
+
+    // Issue #3888: Roslyn represents an expanded params tail as one synthesized
+    // array argument, so the ordinary argument→parameter pass above sees only
+    // the carrier. Walk the source arguments positionally and record evidence
+    // against the distinct element position. A normal-form array argument is
+    // excluded by its conversion to the full carrier type.
+    private static void CollectExpandedParamsElementEdges(
+        SyntaxNode call,
+        SemanticModel model,
+        HashSet<ISymbol> paramsElementTainted,
+        List<(ISymbol Target, ISymbol Source)> paramsElementEdges)
+    {
+        BaseArgumentListSyntax argumentList = call switch
+        {
+            InvocationExpressionSyntax invocation => invocation.ArgumentList,
+            BaseObjectCreationExpressionSyntax creation => creation.ArgumentList,
+            ConstructorInitializerSyntax initializer => initializer.ArgumentList,
+            ElementAccessExpressionSyntax elementAccess => elementAccess.ArgumentList,
+            ElementBindingExpressionSyntax elementBinding => elementBinding.ArgumentList,
+            _ => null,
+        };
+        ISymbol callable = model.GetSymbolInfo(call).Symbol;
+        ImmutableArray<IParameterSymbol> parameters = callable switch
+        {
+            IMethodSymbol method => method.Parameters,
+            IPropertySymbol property => property.Parameters,
+            _ => default,
+        };
+        if (argumentList == null
+            || parameters.IsDefaultOrEmpty
+            || parameters[^1] is not { IsParams: true, Type: IArrayTypeSymbol array } parameter
+            || array.ElementType is not { IsReferenceType: true }
+            || array.ElementType.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return;
+        }
+
+        ISymbol target = Canonical(parameter);
+        int firstExpandedPosition = parameters.Length - 1;
+        for (int i = firstExpandedPosition; i < argumentList.Arguments.Count; i++)
+        {
+            ArgumentSyntax argument = argumentList.Arguments[i];
+            if (argument.NameColon != null)
+            {
+                continue;
+            }
+
+            ITypeSymbol convertedType = model.GetTypeInfo(argument.Expression).ConvertedType;
+            if (convertedType != null
+                && SymbolEqualityComparer.Default.Equals(convertedType, parameter.Type))
+            {
+                continue;
+            }
+
+            if (IsDirectlyNullable(argument.Expression, model))
+            {
+                paramsElementTainted.Add(target);
+                continue;
+            }
+
+            foreach (ISymbol source in ResolveSources(argument.Expression, model))
+            {
+                paramsElementEdges.Add((target, source));
+            }
         }
     }
 
@@ -5082,7 +5221,9 @@ internal static class ObliviousNullabilityAnalyzer
             List<(TupleElementKey Target, TupleElementKey Source)> tupleEdges,
             List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges,
             List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
-            List<(ISymbol Target, ISymbol Source)> delegateReturnEdges)
+            List<(ISymbol Target, ISymbol Source)> delegateReturnEdges,
+            HashSet<ISymbol> paramsElementTainted,
+            List<(ISymbol Target, ISymbol Source)> paramsElementEdges)
         {
             this.Tainted = tainted;
             this.TupleTainted = tupleTainted;
@@ -5090,6 +5231,8 @@ internal static class ObliviousNullabilityAnalyzer
             this.TupleScalarEdges = tupleScalarEdges;
             this.ScalarTupleEdges = scalarTupleEdges;
             this.DelegateReturnEdges = delegateReturnEdges;
+            this.ParamsElementTainted = paramsElementTainted;
+            this.ParamsElementEdges = paramsElementEdges;
         }
 
         public HashSet<ISymbol> Tainted { get; }
@@ -5103,6 +5246,10 @@ internal static class ObliviousNullabilityAnalyzer
         public List<(ISymbol Target, TupleElementKey Source)> ScalarTupleEdges { get; }
 
         public List<(ISymbol Target, ISymbol Source)> DelegateReturnEdges { get; }
+
+        public HashSet<ISymbol> ParamsElementTainted { get; }
+
+        public List<(ISymbol Target, ISymbol Source)> ParamsElementEdges { get; }
     }
 
     private sealed class SourceAssemblySet

--- a/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ObliviousNullabilityAnalyzer.cs
@@ -740,6 +740,12 @@ internal static class ObliviousNullabilityAnalyzer
             return false;
         }
 
+        string parameterId = ParamsElementId(parameter);
+        if (parameterId == null)
+        {
+            return false;
+        }
+
         RegisterSourceAssemblies(compilation, siblingCompilations);
         IEnumerable<CSharpCompilation> candidates =
             new[] { compilation }.Concat(siblingCompilations ?? Enumerable.Empty<CSharpCompilation>());
@@ -751,19 +757,10 @@ internal static class ObliviousNullabilityAnalyzer
                 continue;
             }
 
-            ISymbol candidate = ReferenceEquals(candidateCompilation, compilation)
-                ? Canonical(parameter)
-                : RemapToCompilation(candidateCompilation, parameter);
-            if (candidate == null)
-            {
-                continue;
-            }
-
             TaintResult result = Cache.GetValue(candidateCompilation, Compute);
-            candidate = Canonical(candidate);
-            if (result.ParamsElementTainted.Contains(candidate)
+            if (result.ParamsElementTainted.Contains(parameterId)
                 || result.ParamsElementEdges.Any(edge =>
-                    SymbolEqualityComparer.Default.Equals(edge.Target, candidate)
+                    edge.Target == parameterId
                     && IsTainted(candidateCompilation, edge.Source, siblingCompilations)))
             {
                 return true;
@@ -1850,8 +1847,8 @@ internal static class ObliviousNullabilityAnalyzer
         var tupleScalarEdges = new List<(TupleElementKey Target, ISymbol Source)>();
         var scalarTupleEdges = new List<(ISymbol Target, TupleElementKey Source)>();
         var delegateReturnEdges = new List<(ISymbol Target, ISymbol Source)>();
-        var paramsElementTainted = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
-        var paramsElementEdges = new List<(ISymbol Target, ISymbol Source)>();
+        var paramsElementTainted = new HashSet<string>(System.StringComparer.Ordinal);
+        var paramsElementEdges = new List<(string Target, ISymbol Source)>();
 
         foreach (SyntaxTree tree in compilation.SyntaxTrees)
         {
@@ -2072,8 +2069,8 @@ internal static class ObliviousNullabilityAnalyzer
         HashSet<ISymbol> tainted,
         List<(ISymbol Target, ISymbol Source)> edges,
         List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
-        HashSet<ISymbol> paramsElementTainted,
-        List<(ISymbol Target, ISymbol Source)> paramsElementEdges)
+        HashSet<string> paramsElementTainted,
+        List<(string Target, ISymbol Source)> paramsElementEdges)
     {
         // Interprocedural parameter taint: an argument that is directly null or
         // reads a (possibly tainted) declaration flows to the bound parameter, so
@@ -2178,8 +2175,8 @@ internal static class ObliviousNullabilityAnalyzer
     private static void CollectExpandedParamsElementEdges(
         SyntaxNode call,
         SemanticModel model,
-        HashSet<ISymbol> paramsElementTainted,
-        List<(ISymbol Target, ISymbol Source)> paramsElementEdges)
+        HashSet<string> paramsElementTainted,
+        List<(string Target, ISymbol Source)> paramsElementEdges)
     {
         BaseArgumentListSyntax argumentList = call switch
         {
@@ -2206,7 +2203,12 @@ internal static class ObliviousNullabilityAnalyzer
             return;
         }
 
-        ISymbol target = Canonical(parameter);
+        string target = ParamsElementId(parameter);
+        if (target == null)
+        {
+            return;
+        }
+
         int firstExpandedPosition = parameters.Length - 1;
         for (int i = firstExpandedPosition; i < argumentList.Arguments.Count; i++)
         {
@@ -2235,6 +2237,15 @@ internal static class ObliviousNullabilityAnalyzer
             }
         }
     }
+
+    // Parameters do not have documentation IDs of their own. The owning
+    // method's ID includes its full parameter-type signature, and the ordinal
+    // selects this declaration position without the overload ambiguity of the
+    // general-purpose cross-compilation remapper.
+    private static string ParamsElementId(IParameterSymbol parameter) =>
+        parameter?.ContainingSymbol?.OriginalDefinition.GetDocumentationCommentId() is { } ownerId
+            ? ownerId + ":" + parameter.Ordinal
+            : null;
 
     // Interprocedural: map each call argument to its bound parameter and add a
     // taint edge (or a direct taint for a directly-null argument), so a parameter
@@ -5222,8 +5233,8 @@ internal static class ObliviousNullabilityAnalyzer
             List<(TupleElementKey Target, ISymbol Source)> tupleScalarEdges,
             List<(ISymbol Target, TupleElementKey Source)> scalarTupleEdges,
             List<(ISymbol Target, ISymbol Source)> delegateReturnEdges,
-            HashSet<ISymbol> paramsElementTainted,
-            List<(ISymbol Target, ISymbol Source)> paramsElementEdges)
+            HashSet<string> paramsElementTainted,
+            List<(string Target, ISymbol Source)> paramsElementEdges)
         {
             this.Tainted = tainted;
             this.TupleTainted = tupleTainted;
@@ -5247,9 +5258,9 @@ internal static class ObliviousNullabilityAnalyzer
 
         public List<(ISymbol Target, ISymbol Source)> DelegateReturnEdges { get; }
 
-        public HashSet<ISymbol> ParamsElementTainted { get; }
+        public HashSet<string> ParamsElementTainted { get; }
 
-        public List<(ISymbol Target, ISymbol Source)> ParamsElementEdges { get; }
+        public List<(string Target, ISymbol Source)> ParamsElementEdges { get; }
     }
 
     private sealed class SourceAssemblySet


### PR DESCRIPTION
Closes #3888.

## Root cause and fix

Roslyn represents an expanded `params T[]` tail as one synthesized array argument. The existing oblivious-nullability argument analysis therefore associated null evidence only with the array parameter/carrier. Declaration lowering intentionally ignores carrier promotion for variadics, so direct element evidence such as `Load(null, output)` could never widen the emitted `...T` element contract.

This change adds a separate, symbol-keyed params-element evidence set to the existing taint result. Expanded source arguments are mapped positionally to their selected params parameter; direct null/annotated expressions seed the element position, and ordinary symbol taint supplies transitive evidence across calls and sibling compilations. `MapParameter` reuses the declaration promotion path to emit `...T?` only for that element evidence. Normal-form array arguments remain carrier evidence and keep #3886's existing `!!` bridge; no `nil!!` bridge is introduced.

## Coverage

Translation + compile/execution regressions cover:

- literal `null` and nullable expressions in expanded element positions;
- zero and multiple expanded elements, with per-parameter/call-site isolation;
- normal-form nullable array arguments (carrier stays `...string`, existing bridge retained);
- reference-constrained generic `params T[]`;
- explicitly annotated nullable params elements;
- ordinary parameter promotion and non-null params controls;
- the #3886 expanded form updated to the widened element contract, while its direct carrier regression remains unchanged;
- compiler execution of `...string?` packing `nil`.

## Validation

- Focused cs2gs families (#3888/#3886/#3644/#1072): **26 passed**
- Focused compiler nullable-variadic execution: **1 passed**
- Full `Cs2Gs.Tests` (pre-final rebase, same change): **2852 passed**
- `dotnet build GSharp.sln -c Release`: **0 warnings, 0 errors**
- `python3 build/nullable_hygiene.py --base origin/main`: **OK**
- cs2gs PR self-migration guard: **8/8 guarded apps passed** translate/compile/ILVerify/test-parity
- `tools/cs2gs/selfmig-baseline.json` and `selfmig-test-allowlist.json`: unchanged

### Nullable-hygiene behavior-capable hunks

- `ObliviousNullabilityAnalyzer.cs`: records the missing expanded-element evidence position.
- `CSharpToGSharpTranslator.Constructors.cs`: promotes the emitted variadic element declaration from that evidence.
- `CSharpToGSharpTranslator.Nullability.cs`: makes sink forgiveness agree with the newly widened element declaration while preserving carrier semantics.
- `Issue3886VariadicCarrierSinkContractTests.cs`: updates the expanded-element expectation; retains the direct-carrier control.
- `VariadicEmitTests.cs`: executes nullable variadic packing in gsc.
