### PR TITLE
gsc: preserve CLR delegate identity after receiver substitution

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Arguments.cs
@@ -3025,7 +3025,13 @@ internal sealed partial class ExpressionBinder
         }
 
         var arguments = BindBaseCallArguments(ce);
-        var method = overloads.SelectInstanceOverloadOrReport(baseOverloads, arguments, ce, methodName, argumentNames);
+        var method = overloads.SelectInstanceOverloadOrReport(
+            baseOverloads,
+            arguments,
+            ce,
+            methodName,
+            argumentNames,
+            searchBase);
         if (method == null)
         {
             return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Calls.Invocation.cs
@@ -3348,7 +3348,13 @@ internal sealed partial class ExpressionBinder
                     var tpClassOverloads = MemberLookup.CollectSourceInstanceMethods(tpClassRecv, methodName);
                     if (tpClassOverloads.Length > 0)
                     {
-                        var tpClassMethod = overloads.SelectInstanceOverloadOrReport(tpClassOverloads, arguments, ce, methodName, argumentNames);
+                        var tpClassMethod = overloads.SelectInstanceOverloadOrReport(
+                            tpClassOverloads,
+                            arguments,
+                            ce,
+                            methodName,
+                            argumentNames,
+                            receiver.Type);
                         if (tpClassMethod == null)
                         {
                             return new BoundErrorExpression(null);
@@ -3376,7 +3382,13 @@ internal sealed partial class ExpressionBinder
                 var userOverloads = MemberLookup.CollectSourceInstanceMethods(userClass, methodName);
                 if (userOverloads.Length > 0)
                 {
-                    var userMethod = overloads.SelectInstanceOverloadOrReport(userOverloads, arguments, ce, methodName, argumentNames);
+                    var userMethod = overloads.SelectInstanceOverloadOrReport(
+                        userOverloads,
+                        arguments,
+                        ce,
+                        methodName,
+                        argumentNames,
+                        receiver.Type);
                     if (userMethod == null)
                     {
                         return new BoundErrorExpression(null);
@@ -3568,7 +3580,13 @@ internal sealed partial class ExpressionBinder
             var priorityOverloads = MemberLookup.CollectSourceInstanceMethods(userClassPriority, methodName);
             if (priorityOverloads.Length > 0)
             {
-                var userMethodPriority = overloads.SelectInstanceOverloadOrReport(priorityOverloads, arguments, ce, methodName, argumentNames);
+                var userMethodPriority = overloads.SelectInstanceOverloadOrReport(
+                    priorityOverloads,
+                    arguments,
+                    ce,
+                    methodName,
+                    argumentNames,
+                    receiver.Type);
                 if (userMethodPriority == null)
                 {
                     return new BoundErrorExpression(null);

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Candidates.cs
@@ -61,7 +61,8 @@ internal sealed partial class OverloadResolver
         ImmutableArray<BoundExpression> arguments,
         CallExpressionSyntax ce,
         string methodName,
-        ImmutableArray<string> argumentNames)
+        ImmutableArray<string> argumentNames,
+        TypeSymbol? receiverType = null)
     {
         if (overloads.Length <= 1)
         {
@@ -128,7 +129,8 @@ internal sealed partial class OverloadResolver
             out var nullSafetyFailure,
             explicitTypeArgCount,
             boundTypeArguments,
-            ce);
+            ce,
+            receiverType);
         if (selected != null)
         {
             return selected;
@@ -212,7 +214,7 @@ internal sealed partial class OverloadResolver
             return null;
         }
 
-        return SelectInstanceOverloadOrReport(unified, arguments, ce, methodName, argumentNames);
+        return SelectInstanceOverloadOrReport(unified, arguments, ce, methodName, argumentNames, structSym);
     }
 
     private FunctionSymbol? SelectBestUserOverload(
@@ -243,7 +245,8 @@ internal sealed partial class OverloadResolver
         out NullSafetyArgumentMismatch? nullSafetyFailure,
         int explicitTypeArgCount = 0,
         ImmutableArray<TypeSymbol> explicitTypeArguments = default,
-        CallExpressionSyntax? callSyntax = null)
+        CallExpressionSyntax? callSyntax = null,
+        TypeSymbol? receiverType = null)
     {
         ambiguous = false;
         nullSafetyFailure = null;
@@ -268,7 +271,8 @@ internal sealed partial class OverloadResolver
             out ambiguous,
             out nullSafetyFailure,
             explicitTypeArgCount,
-            explicitTypeArguments);
+            explicitTypeArguments,
+            receiverType);
     }
 
     private FunctionSymbol? SelectBestUserOverloadCore(
@@ -280,7 +284,8 @@ internal sealed partial class OverloadResolver
         out bool ambiguous,
         out NullSafetyArgumentMismatch? nullSafetyFailure,
         int explicitTypeArgCount = 0,
-        ImmutableArray<TypeSymbol> explicitTypeArguments = default)
+        ImmutableArray<TypeSymbol> explicitTypeArguments = default,
+        TypeSymbol? receiverType = null)
     {
         ambiguous = false;
         nullSafetyFailure = null;
@@ -291,24 +296,52 @@ internal sealed partial class OverloadResolver
         // inputs. Memoize per candidate for this call so unification runs once
         // instead of twice per generic candidate.
         var substitutionCache = new Dictionary<FunctionSymbol, (bool Ok, Dictionary<TypeParameterSymbol, TypeSymbol> Substitution)>();
+
+        // Issue #3874: constructed receivers expose their definition's open
+        // methods. Apply the receiver map during selection, not only after a
+        // winner is chosen, and compose it with any method-level type arguments.
+        var receiverSubstitution = receiverType != null
+            ? TryBuildReceiverSubstitution(receiverType)
+            : null;
         Dictionary<TypeParameterSymbol, TypeSymbol>? GetCandidateSubstitution(FunctionSymbol candidate)
         {
+            Dictionary<TypeParameterSymbol, TypeSymbol>? methodSubstitution = null;
             if (!explicitTypeArguments.IsDefaultOrEmpty
                 && candidate.TypeParameters.Length == explicitTypeArguments.Length)
             {
-                return candidate.TypeParameters
+                methodSubstitution = candidate.TypeParameters
                     .Select((parameter, index) => (parameter, argument: explicitTypeArguments[index]))
                     .ToDictionary(pair => pair.parameter, pair => pair.argument);
             }
+            else if (candidate.IsGeneric)
+            {
+                if (!GetCachedCandidateSubstitution(
+                        candidate,
+                        boundArguments,
+                        argumentCount,
+                        substitutionCache,
+                        out var inferred))
+                {
+                    return null;
+                }
 
-            return GetCachedCandidateSubstitution(
-                candidate,
-                boundArguments,
-                argumentCount,
-                substitutionCache,
-                out var inferred)
-                    ? inferred
-                    : null;
+                methodSubstitution = inferred;
+            }
+
+            if (receiverSubstitution == null)
+            {
+                return methodSubstitution;
+            }
+
+            var combined = methodSubstitution != null
+                ? new Dictionary<TypeParameterSymbol, TypeSymbol>(methodSubstitution)
+                : new Dictionary<TypeParameterSymbol, TypeSymbol>();
+            foreach (var pair in receiverSubstitution)
+            {
+                combined[pair.Key] = pair.Value;
+            }
+
+            return combined;
         }
 
         // Phase 1: applicability.
@@ -498,14 +531,9 @@ internal sealed partial class OverloadResolver
                 defaultsUsed = 0;
             }
 
-            // For generic candidates, compute the inferred method-type
-            // substitution so delegate parameter return types can be closed
-            // when classifying the value-return discard case below.
-            Dictionary<TypeParameterSymbol, TypeSymbol>? candSubstitution = null;
-            if (cand.IsGeneric)
-            {
-                candSubstitution = GetCandidateSubstitution(cand);
-            }
+            // Close both receiver- and method-level type parameters before
+            // classifying conversions and comparing their target types.
+            var candSubstitution = GetCandidateSubstitution(cand);
 
             // Classify each supplied argument's conversion to its ACTUAL
             // target slot. Issue #1628: boundArguments[i] is source order,
@@ -517,6 +545,7 @@ internal sealed partial class OverloadResolver
             // parameter type.
             var kinds = new ClrOverloadResolution.ImplicitConversionKind[boundArguments.Count];
             var paramTypes = new TypeSymbol[boundArguments.Count];
+            var openParamTypes = new TypeSymbol[boundArguments.Count];
             var isTailSlot = new bool[boundArguments.Count];
             var elementType = isVariadic
                 && VariadicCarriers.GetElementType(cand.Parameters[cand.Parameters.Length - 1].Type) is { } variadicElement
@@ -610,6 +639,7 @@ internal sealed partial class OverloadResolver
                             variadicCarrierType,
                             "a carrier pass-through candidate has a variadic carrier parameter");
                         paramTypes[i] = normalFormCarrier;
+                        openParamTypes[i] = cand.Parameters[cand.Parameters.Length - 1].Type;
                         kinds[i] = ClassifyUserArgumentConversionKind(tailArgType, normalFormCarrier);
                         continue;
                     }
@@ -639,18 +669,22 @@ internal sealed partial class OverloadResolver
                     }
 
                     paramTypes[i] = elementType;
+                    openParamTypes[i] = VariadicCarriers.GetElementType(
+                        cand.Parameters[cand.Parameters.Length - 1].Type) ?? elementType;
                     kinds[i] = ClassifyUserArgumentConversionKind(tailArgType, elementType);
                     continue;
                 }
 
                 var argType = boundArguments[i]?.Type;
                 var openParamType = cand.Parameters[slot + parameterOffset].Type;
-                paramTypes[i] = openParamType;
+                openParamTypes[i] = openParamType;
                 var paramType = openParamType;
                 if (candSubstitution != null)
                 {
                     paramType = Binder.SubstituteType(paramType, candSubstitution);
                 }
+
+                paramTypes[i] = paramType;
 
                 // Issue #1531 control: a value-returning delegate/method-group
                 // argument that maps onto a `(...)->void` delegate parameter
@@ -673,7 +707,7 @@ internal sealed partial class OverloadResolver
                             : ClassifyUserArgumentConversionKind(argType, paramType);
             }
 
-            data.Add(new UserCandidateRankData(cand, kinds, paramTypes, isTailSlot, defaultsUsed, isVariadic));
+            data.Add(new UserCandidateRankData(cand, kinds, paramTypes, openParamTypes, isTailSlot, defaultsUsed, isVariadic));
         }
 
         // Phase 2a: pairwise domination. A candidate survives when no other
@@ -812,7 +846,7 @@ internal sealed partial class OverloadResolver
             var bareTypeParam = false;
             foreach (var w in current)
             {
-                var openParam = argIndex < w.ParamTypes.Length ? w.ParamTypes[argIndex] : null;
+                var openParam = argIndex < w.OpenParamTypes.Length ? w.OpenParamTypes[argIndex] : null;
                 if (openParam is FunctionTypeSymbol paramFn)
                 {
                     if (IsTaskReturnTypeSymbol(paramFn.ReturnType))
@@ -884,11 +918,12 @@ internal sealed partial class OverloadResolver
     /// </summary>
     private readonly struct UserCandidateRankData
     {
-        public UserCandidateRankData(FunctionSymbol candidate, ClrOverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, bool[] isTailSlot, int defaultsUsed, bool isVariadic)
+        public UserCandidateRankData(FunctionSymbol candidate, ClrOverloadResolution.ImplicitConversionKind[] kinds, TypeSymbol[] paramTypes, TypeSymbol[] openParamTypes, bool[] isTailSlot, int defaultsUsed, bool isVariadic)
         {
             Candidate = candidate;
             Kinds = kinds;
             ParamTypes = paramTypes;
+            OpenParamTypes = openParamTypes;
             IsTailSlot = isTailSlot;
             DefaultsUsed = defaultsUsed;
             IsVariadic = isVariadic;
@@ -899,6 +934,8 @@ internal sealed partial class OverloadResolver
         public ClrOverloadResolution.ImplicitConversionKind[] Kinds { get; }
 
         public TypeSymbol[] ParamTypes { get; }
+
+        public TypeSymbol[] OpenParamTypes { get; }
 
         /// <summary>
         /// Gets per-argument flags set when the argument at that index bound

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Invocations.cs
@@ -1970,7 +1970,13 @@ internal sealed partial class OverloadResolver
 
     private static Dictionary<TypeParameterSymbol, TypeSymbol>? TryBuildReceiverSubstitution(TypeSymbol receiverType)
     {
-        if (receiverType is not StructSymbol start)
+        var start = receiverType switch
+        {
+            StructSymbol receiverStruct => receiverStruct,
+            TypeParameterSymbol { ClassConstraint: StructSymbol constraint } => constraint,
+            _ => null,
+        };
+        if (start == null)
         {
             return null;
         }

--- a/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodBodyEmitter.Calls.cs
@@ -161,12 +161,27 @@ internal sealed partial class MethodBodyEmitter
 
             var constraintInterface = (call.ConstrainedInterfaceType as InterfaceSymbol)
                 ?? (call.Method.ReceiverType as InterfaceSymbol);
+            var constraintClass = call.ConstrainedReceiverTypeParameter.ClassConstraint as StructSymbol;
             var openMethod = constraintInterface != null
                 ? ResolveOpenInterfaceMethod(constraintInterface, call.Method)
                 : call.Method;
+            var constraintGenericOwner = constraintClass != null
+                ? this.ResolveInheritedGenericBase(constraintClass, call.Method)
+                    ?? (ReflectionMetadataEmitter.IsUserGenericTypeReference(constraintClass)
+                        ? constraintClass
+                        : null)
+                : null;
             var constrainedMethodToken = constraintInterface != null
                 ? this.outer.userTokens.ResolveUserInterfaceInstanceMethodToken(constraintInterface, openMethod)
+                : constraintGenericOwner != null
+                    ? this.outer.userTokens.ResolveUserInstanceMethodToken(constraintGenericOwner, call.Method)
                 : this.outer.cache.MethodHandles[call.Method];
+            if (call.Method.IsGeneric && !call.Method.TypeParameters.IsDefaultOrEmpty)
+            {
+                constrainedMethodToken = this.outer.userTokens.BuildMethodSpecForGenericInstanceCall(
+                    constrainedMethodToken,
+                    call);
+            }
 
             this.il.OpCode(ILOpCode.Constrained);
             this.il.Token(this.outer.memberRefs.GetElementTypeToken(call.ConstrainedReceiverTypeParameter));

--- a/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2918InlineLambdaErasedReceiverTests.cs
@@ -394,6 +394,232 @@ public class Issue2918InlineLambdaErasedReceiverTests
             WithExecutionScope(declarations, statements, topLevel));
     }
 
+    [Fact]
+    public void Issue3874_ReceiverSubstitution_PreservesImportedDelegateIdentity_VerifyLoadAndRun()
+    {
+        const string source = """
+            package Issue3874ImportedDelegates
+            import System
+
+            class GenericPredicateFirst[T] {
+                func Add(cb Predicate[T]) string { return "generic-pred-first:pred" }
+                func Add(cb Func[T, bool]) string { return "generic-pred-first:func" }
+                func Call(cb Predicate[T]) string { return Add(cb) }
+                func Call(cb Func[T, bool]) string { return Add(cb) }
+            }
+
+            class GenericFuncFirst[T] {
+                func Add(cb Func[T, bool]) string { return "generic-func-first:func" }
+                func Add(cb Predicate[T]) string { return "generic-func-first:pred" }
+            }
+
+            class NonGeneric {
+                func Add(cb Predicate[int32]) string { return "non-generic:pred" }
+                func Add(cb Func[int32, bool]) string { return "non-generic:func" }
+            }
+
+            class GenericClosed[T] {
+                func Add(cb Predicate[int32]) string { return "generic-closed:pred" }
+                func Add(cb Func[int32, bool]) string { return "generic-closed:func" }
+            }
+
+            class ReceiverAndMethodGeneric[T] {
+                func Add[U](tag U, cb Predicate[T]) string { return "method:pred:" + tag.ToString() }
+                func Add[U](tag U, cb Func[T, bool]) string { return "method:func:" + tag.ToString() }
+            }
+
+            class ReceiverInferenceConflict[T] {
+                func Pick[U](cb Predicate[T], tag U) string { return "receiver" }
+                func Pick[U](cb Predicate[U], tag U) string { return "method" }
+            }
+
+            open class GenericBase[T] {
+                func Add(cb Predicate[T]) string { return "base:pred" }
+                func Add(cb Func[T, bool]) string { return "base:func" }
+                func Pick[U](tag U, cb Predicate[T]) string { return "base-method:pred:" + tag.ToString() }
+                func Pick[U](tag U, cb Func[T, bool]) string { return "base-method:func:" + tag.ToString() }
+            }
+
+            open class Derived : GenericBase[int32] {
+                func CallBase(cb Predicate[int32]) string { return base.Add(cb) }
+                func CallBase(cb Func[int32, bool]) string { return base.Add(cb) }
+            }
+
+            open class GenericDerived[T] : GenericBase[int32] {
+            }
+
+            func Always(value int32) bool { return true }
+            func AlwaysString(value string) bool { return true }
+            func ThroughConstraint[X GenericBase[int32]](
+                value X,
+                predicate Predicate[int32],
+                function Func[int32, bool]) string {
+                return value.Add(predicate) + "|" + value.Add(function)
+            }
+            func ThroughGenericConstraint[X GenericBase[int32]](
+                value X,
+                predicate Predicate[int32],
+                function Func[int32, bool]) string {
+                return value.Pick[string]("explicit", predicate)
+                    + "|" + value.Pick("inferred", function)
+            }
+            func ThroughDerivedConstraint[X Derived](
+                value X,
+                predicate Predicate[int32],
+                function Func[int32, bool]) string {
+                return value.Add(predicate) + "|" + value.Add(function)
+            }
+            func ThroughGenericDerivedConstraint[X GenericDerived[string]](
+                value X,
+                predicate Predicate[int32],
+                function Func[int32, bool]) string {
+                return value.Add(predicate) + "|" + value.Add(function)
+                    + "|" + value.Pick[string]("explicit", predicate)
+                    + "|" + value.Pick("inferred", function)
+            }
+
+            func Main() {
+                let keepAlive Action = () -> { }
+                let predicate Predicate[int32] = Always
+                let function Func[int32, bool] = Always
+
+                let genericPredicateFirst = GenericPredicateFirst[int32]()
+                Console.WriteLine(genericPredicateFirst.Add(predicate))
+                Console.WriteLine(genericPredicateFirst.Add(function))
+                Console.WriteLine(genericPredicateFirst.Call(predicate))
+                Console.WriteLine(genericPredicateFirst.Call(function))
+
+                let genericFuncFirst = GenericFuncFirst[int32]()
+                Console.WriteLine(genericFuncFirst.Add(predicate))
+                Console.WriteLine(genericFuncFirst.Add(function))
+
+                let nonGeneric = NonGeneric()
+                Console.WriteLine(nonGeneric.Add(predicate))
+                Console.WriteLine(nonGeneric.Add(function))
+
+                let genericClosed = GenericClosed[string]()
+                Console.WriteLine(genericClosed.Add(predicate))
+                Console.WriteLine(genericClosed.Add(function))
+
+                let methodGeneric = ReceiverAndMethodGeneric[int32]()
+                Console.WriteLine(methodGeneric.Add[string]("explicit", predicate))
+                Console.WriteLine(methodGeneric.Add("inferred", function))
+
+                let stringPredicate Predicate[string] = AlwaysString
+                Console.WriteLine(ReceiverInferenceConflict[int32]().Pick(stringPredicate, "method"))
+
+                let derived = Derived()
+                Console.WriteLine(derived.Add(predicate))
+                Console.WriteLine(derived.Add(function))
+                Console.WriteLine(derived.CallBase(predicate))
+                Console.WriteLine(derived.CallBase(function))
+                Console.WriteLine(ThroughConstraint[Derived](derived, predicate, function))
+                Console.WriteLine(ThroughGenericConstraint[Derived](derived, predicate, function))
+                Console.WriteLine(ThroughDerivedConstraint[Derived](derived, predicate, function))
+                let genericDerived = GenericDerived[string]()
+                Console.WriteLine(ThroughGenericDerivedConstraint[GenericDerived[string]](
+                    genericDerived,
+                    predicate,
+                    function))
+                keepAlive()
+            }
+            """;
+
+        Assert.Equal(
+            string.Join(
+                Environment.NewLine,
+                "generic-pred-first:pred",
+                "generic-pred-first:func",
+                "generic-pred-first:pred",
+                "generic-pred-first:func",
+                "generic-func-first:pred",
+                "generic-func-first:func",
+                "non-generic:pred",
+                "non-generic:func",
+                "generic-closed:pred",
+                "generic-closed:func",
+                "method:pred:explicit",
+                "method:func:inferred",
+                "method",
+                "base:pred",
+                "base:func",
+                "base:pred",
+                "base:func",
+                "base:pred|base:func",
+                "base-method:pred:explicit|base-method:func:inferred",
+                "base:pred|base:func",
+                "base:pred|base:func|base-method:pred:explicit|base-method:func:inferred",
+                string.Empty),
+            CompileVerifyLoadAndRun(source, expectedSourceTypeName: string.Empty));
+    }
+
+    [Fact]
+    public void Issue3874_ReceiverSubstitution_PreservesSourceNamedDelegateIdentity_VerifyLoadAndRun()
+    {
+        const string source = """
+            package Issue3874NamedDelegates
+            import System
+
+            delegate First[T](value T) bool;
+            delegate Second[T](value T) bool;
+
+            class NamedOverloads[T] {
+                func Add(cb First[T]) string { return "first" }
+                func Add(cb Second[T]) string { return "second" }
+            }
+
+            func Always(value int32) bool { return true }
+
+            func Main() {
+                let keepAlive Action = () -> { }
+                let first First[int32] = Always
+                let second Second[int32] = Always
+                let overloads = NamedOverloads[int32]()
+                Console.WriteLine(overloads.Add(first))
+                Console.WriteLine(overloads.Add(second))
+                keepAlive()
+            }
+            """;
+
+        Assert.Equal(
+            $"first{Environment.NewLine}second{Environment.NewLine}",
+            CompileVerifyLoadAndRun(source, expectedSourceTypeName: string.Empty));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void Issue3874_StructuralArguments_RemainAmbiguous(bool funcFirst, bool methodGroup)
+    {
+        var overloads = funcFirst
+            ? """
+                func Add(cb Func[T, bool]) string { return "func" }
+                func Add(cb Predicate[T]) string { return "pred" }
+                """
+            : """
+                func Add(cb Predicate[T]) string { return "pred" }
+                func Add(cb Func[T, bool]) string { return "func" }
+                """;
+        var argument = methodGroup ? "Always" : "(value int32) -> true";
+        var source = $$"""
+            package Issue3874StructuralAmbiguity
+            import System
+
+            class Overloads[T] {
+            {{overloads}}
+            }
+
+            func Always(value int32) bool { return true }
+
+            Console.WriteLine(Overloads[int32]().Add({{argument}}))
+            """;
+
+        var diagnostics = CompileExpectingFailure(source);
+        Assert.Contains("GS0266", diagnostics, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]


### PR DESCRIPTION
Fixes #3874

## Summary
- thread constructed receiver types into instance overload selection and compose receiver mappings with method type arguments before applicability/ranking
- preserve existing nominal named-delegate identity while retaining open parameter shapes for structural/task-lambda tie-breaks
- emit constructed TypeSpec/MethodSpec tokens for generic class-constrained calls uncovered by the regression matrix
- add executing, IL-verified coverage for generic/non-generic receivers, both overload orders, imported and source named delegate values, implicit/base/inherited/constrained receivers, explicit/inferred method generics, and structural lambda/method-group ambiguity controls

## Verification
- `dotnet test test/Compiler.Tests/Compiler.Tests.csproj --configuration Release --no-build --no-restore --filter 'FullyQualifiedName~Issue3874|FullyQualifiedName~Issue1056ClassConstraintEmitTests|FullyQualifiedName~Issue2172TaskRunAsyncLambdaEmitTests|FullyQualifiedName~Issue2918InlineLambdaErasedReceiverTests'` — 37 passed
- `dotnet test test/Core.Tests/Core.Tests.csproj --configuration Release --no-build --no-restore --filter 'FullyQualifiedName~Issue2172TaskRunAsyncLambdaOverloadTests'` — 3 passed
- `dotnet build GSharp.sln --configuration Release --no-restore -graph` — 0 warnings/errors
- `GSHARP_ILVERIFY_OUT=... ./build/run-ilverify.sh` — 135/135 verified, 2 documented suppressions
- `python3 build/nullable_hygiene.py --base origin/main` — OK
- `SELFMIG_PR_GUARD_ROOT=... ./build/run-cs2gs-selfmig-pr-guard.sh` — 8/8 guarded apps passed all stages

## ADR-0154 discrimination
Before the fix, the new `Issue3874` filter failed both executing identity tests with GS0266 at the generic-receiver call sites while all four structural ambiguity controls remained rejected. With the fix, all six xUnit cases pass and the runtime tags prove the correct overload executed. The non-generic/closed controls and reversed declaration order prevent an order-based or blanket structural-conversion workaround.

## Nullable hygiene justification
The optional receiver context is null for unchanged call paths and preserves their prior behavior. The receiver-substitution null branch is semantic composition control, not warning suppression; no nullable escape, suppression, or null-forgiving operator was added.