### PR TITLE
gsc: advance migrated Cs2Gs.Tests through ILVerify (#3880)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
+++ b/src/Core/CodeAnalysis/Binding/DeclarationBinder.Constructors.cs
@@ -24,13 +24,11 @@ namespace GSharp.Core.CodeAnalysis.Binding;
 internal sealed partial class DeclarationBinder
 {
     /// <summary>
-    /// Issue #306: binds the explicit base-constructor argument list
-    /// (<c>: Base(args)</c>) of a class declaration and resolves it against the
-    /// base class's constructors. The arguments are bound in a scope that
-    /// exposes the primary-constructor parameters so they can be forwarded to
-    /// the base. On success the resolved <see cref="BaseConstructorInitializer"/>
-    /// is recorded on <paramref name="structSymbol"/> for the emitter; failures
-    /// surface a diagnostic.
+    /// Binds a class declaration's explicit <c>: Base(args)</c> initializer, or
+    /// its implicit zero-argument base call when no <c>init</c> body owns that
+    /// call. Resolution materializes omitted optional arguments, so the emitter
+    /// calls the constructor that actually exists instead of inventing a
+    /// parameterless MemberRef.
     /// </summary>
     private void BindBaseConstructorInitializer(
         StructDeclarationSyntax syntax,
@@ -39,7 +37,13 @@ internal sealed partial class DeclarationBinder
         TypeSymbol? importedBaseType,
         ImmutableArray<ParameterSymbol> primaryCtorParameters)
     {
-        if (!syntax.HasBaseConstructorArguments)
+        var hasImplicitBaseConstructorToResolve =
+            importedBaseType != null
+            || baseClassSymbol?.EffectiveExplicitConstructors.IsDefaultOrEmpty == false;
+        if (!syntax.HasBaseConstructorArguments
+            && ((!hasImplicitBaseConstructorToResolve)
+                || (!syntax.Constructors.IsDefaultOrEmpty
+                    && !structSymbol.HasPrimaryConstructor)))
         {
             return;
         }
@@ -56,13 +60,17 @@ internal sealed partial class DeclarationBinder
             // ambient lookup preference (see field-initializer closure above
             // for the full rationale) for the duration of this deferred bind.
             var savedPackage = scope.SetCurrentDeclaringPackage(structSymbol.PackageName);
-            var savedTree = scope.SetCurrentReferencingSyntaxTree(
-                Invariant.Required(
-                    syntax.BaseConstructorOpenParenthesisToken,
-                    "a base-constructor argument list has an opening parenthesis").SyntaxTree);
+            var savedTree = scope.SetCurrentReferencingSyntaxTree(syntax.SyntaxTree);
             try
             {
-                BindBaseConstructorInitializerCore(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);
+                if (syntax.HasBaseConstructorArguments)
+                {
+                    BindBaseConstructorInitializerCore(syntax, structSymbol, baseClassSymbol, importedBaseType, primaryCtorParameters);
+                }
+                else
+                {
+                    BindImplicitBaseConstructorInitializer(syntax, structSymbol, baseClassSymbol, importedBaseType);
+                }
             }
             finally
             {
@@ -71,6 +79,44 @@ internal sealed partial class DeclarationBinder
                 scope = outerScope;
             }
         });
+    }
+
+    private void BindImplicitBaseConstructorInitializer(
+        StructDeclarationSyntax syntax,
+        StructSymbol structSymbol,
+        StructSymbol? baseClassSymbol,
+        TypeSymbol? importedBaseType)
+    {
+        var location = syntax.Identifier?.Location ?? syntax.Location;
+        var arguments = ImmutableArray.CreateBuilder<BoundExpression>();
+        BaseConstructorInitializer? initializer;
+        if (importedBaseType?.ClrType is System.Type clrBase)
+        {
+            initializer = ResolveClrBaseConstructor(
+                _ => location,
+                clrBase,
+                importedBaseType,
+                arguments,
+                location);
+        }
+        else if (baseClassSymbol?.EffectiveExplicitConstructors.IsDefaultOrEmpty == false)
+        {
+            initializer = ResolveGSharpBaseConstructor(
+                _ => location,
+                structSymbol.Name,
+                baseClassSymbol,
+                arguments,
+                location);
+        }
+        else
+        {
+            return;
+        }
+
+        if (initializer is { Arguments.IsEmpty: false })
+        {
+            structSymbol.SetBaseConstructorInitializer(initializer);
+        }
     }
 
     private void BindBaseConstructorInitializerCore(
@@ -812,17 +858,29 @@ internal sealed partial class DeclarationBinder
         }
 
         var baseParams = baseClassSymbol.PrimaryConstructorParameters;
-        if (boundArguments.Count != baseParams.Length)
+        var requiredCount = baseParams.Length;
+        while (requiredCount > 0 && baseParams[requiredCount - 1].HasExplicitDefaultValue)
+        {
+            requiredCount--;
+        }
+
+        if (boundArguments.Count < requiredCount || boundArguments.Count > baseParams.Length)
         {
             Diagnostics.ReportNoMatchingBaseConstructor(location, baseClassSymbol.Name, boundArguments.Count);
             return null;
         }
 
-        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Count);
-        for (var i = 0; i < boundArguments.Count; i++)
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(baseParams.Length);
+        for (var i = 0; i < baseParams.Length; i++)
         {
-            var argument = boundArguments[i];
             var parameter = baseParams[i];
+            if (i >= boundArguments.Count)
+            {
+                convertedArgs.Add(CreateProjectedOptionalUserDefaultArgument(parameter, parameter.Type));
+                continue;
+            }
+
+            var argument = boundArguments[i];
             if (ExpressionBinder.IsDeferredBranchyArgumentPlaceholder(argument, out _))
             {
                 argument = conversions.BindConversion(argLocation(i), argument, parameter.Type);
@@ -884,6 +942,7 @@ internal sealed partial class DeclarationBinder
         ConstructorSymbol? best = null;
         ImmutableArray<TypeSymbol> bestParamTypes = default;
         var bestExactMatches = -1;
+        var bestOmittedCount = int.MaxValue;
         var ambiguous = false;
         var anyArgIsError = false;
 
@@ -903,14 +962,21 @@ internal sealed partial class DeclarationBinder
         foreach (var candidate in baseClassSymbol.EffectiveExplicitConstructors)
         {
             var paramTypes = baseClassSymbol.GetConstructorParameterTypesForConstruction(candidate);
-            if (paramTypes.Length != boundArguments.Count)
+            var requiredCount = candidate.Parameters.Length;
+            while (requiredCount > 0
+                && candidate.Parameters[requiredCount - 1].HasExplicitDefaultValue)
+            {
+                requiredCount--;
+            }
+
+            if (boundArguments.Count < requiredCount || boundArguments.Count > paramTypes.Length)
             {
                 continue;
             }
 
             var applicable = true;
             var exactMatches = 0;
-            for (var i = 0; i < paramTypes.Length; i++)
+            for (var i = 0; i < boundArguments.Count; i++)
             {
                 var argType = boundArguments[i].Type;
                 var paramType = paramTypes[i];
@@ -976,14 +1042,17 @@ internal sealed partial class DeclarationBinder
                 continue;
             }
 
-            if (exactMatches > bestExactMatches)
+            var omittedCount = paramTypes.Length - boundArguments.Count;
+            if (exactMatches > bestExactMatches
+                || (exactMatches == bestExactMatches && omittedCount < bestOmittedCount))
             {
                 best = candidate;
                 bestParamTypes = paramTypes;
                 bestExactMatches = exactMatches;
+                bestOmittedCount = omittedCount;
                 ambiguous = false;
             }
-            else if (exactMatches == bestExactMatches)
+            else if (exactMatches == bestExactMatches && omittedCount == bestOmittedCount)
             {
                 ambiguous = true;
             }
@@ -1001,15 +1070,36 @@ internal sealed partial class DeclarationBinder
             return null;
         }
 
-        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(boundArguments.Count);
-        for (var i = 0; i < boundArguments.Count; i++)
+        var convertedArgs = ImmutableArray.CreateBuilder<BoundExpression>(best.Parameters.Length);
+        for (var i = 0; i < best.Parameters.Length; i++)
         {
+            if (i >= boundArguments.Count)
+            {
+                convertedArgs.Add(
+                    CreateProjectedOptionalUserDefaultArgument(
+                        best.Parameters[i],
+                        bestParamTypes[i]));
+                continue;
+            }
+
             convertedArgs.Add(best.Parameters[i].RefKind != RefKind.None
                 ? boundArguments[i]
                 : conversions.BindConversion(argLocation(i), boundArguments[i], bestParamTypes[i]));
         }
 
         return new BaseConstructorInitializer(convertedArgs.ToImmutable(), baseClassSymbol, best);
+    }
+
+    private static BoundExpression CreateProjectedOptionalUserDefaultArgument(
+        ParameterSymbol parameter,
+        TypeSymbol targetType)
+    {
+        if (parameter.ExplicitDefaultValue == null)
+        {
+            return new BoundDefaultExpression(null, targetType);
+        }
+
+        return new BoundLiteralExpression(null, parameter.ExplicitDefaultValue, targetType);
     }
 
     private static bool TryGetAddressedArgumentType(
@@ -1292,15 +1382,20 @@ internal sealed partial class DeclarationBinder
             constructorSymbol.MarkConvenience();
         }
 
-        // Resolve the optional `: base(args)` initializer, with the constructor
-        // parameters in scope so they can be forwarded to the base.
+        // Resolve the explicit `: base(args)` initializer, or the implicit
+        // zero-argument base call of a designated constructor, with the
+        // constructor parameters in scope so explicit arguments can be
+        // forwarded to the base.
         //
         // Issue #1085: the argument expressions may construct other user types
         // whose explicit constructors are not yet populated when this type body
         // is bound (the constructed type may live in a source file processed
         // later). Defer the argument binding and base-constructor resolution to
         // a post-pass that runs after every declared type's constructors exist.
-        if (ctorSyntax.HasBaseInitializer)
+        if (ctorSyntax.HasBaseInitializer
+            || (!ctorSyntax.IsConvenience
+                && (importedBaseType != null
+                    || baseClassSymbol?.EffectiveExplicitConstructors.IsDefaultOrEmpty == false)))
         {
             var capturedScope = scope;
             pendingBaseInitializerBindings.Add(() =>
@@ -1338,9 +1433,12 @@ internal sealed partial class DeclarationBinder
         StructSymbol? baseClassSymbol,
         TypeSymbol? importedBaseType)
     {
-        var location = Invariant.Required(
-            ctorSyntax.BaseKeyword,
-            "a constructor base initializer has a base keyword").Location;
+        var hasExplicitBaseInitializer = ctorSyntax.HasBaseInitializer;
+        var location = hasExplicitBaseInitializer
+            ? Invariant.Required(
+                ctorSyntax.BaseKeyword,
+                "a constructor base initializer has a base keyword").Location
+            : ctorSyntax.InitKeyword.Location;
 
         // Issue #1194: expose the enclosing type's static members (consts, static
         // fields/properties, static methods) and — because this runs after all
@@ -1376,8 +1474,9 @@ internal sealed partial class DeclarationBinder
                     scope.TryDeclareVariable(p);
                 }
 
-                boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(ctorSyntax.BaseArguments.Count);
-                for (var i = 0; i < ctorSyntax.BaseArguments.Count; i++)
+                var baseArgumentCount = hasExplicitBaseInitializer ? ctorSyntax.BaseArguments.Count : 0;
+                boundArguments = ImmutableArray.CreateBuilder<BoundExpression>(baseArgumentCount);
+                for (var i = 0; i < baseArgumentCount; i++)
                 {
                     boundArguments.Add(BindConstructorInitializerArgument(ctorSyntax.BaseArguments[i]));
                 }
@@ -1401,13 +1500,17 @@ internal sealed partial class DeclarationBinder
                 }
                 else if (importedBaseType?.ClrType is System.Type clrBase)
                 {
-                    System.Func<int, TextLocation> argumentLocation = i => ctorSyntax.BaseArguments[i].Location;
-                    System.Func<int, ExpressionSyntax> argumentSyntax = i => ctorSyntax.BaseArguments[i];
+                    System.Func<int, TextLocation> argumentLocation =
+                        i => hasExplicitBaseInitializer ? ctorSyntax.BaseArguments[i].Location : location;
+                    System.Func<int, ExpressionSyntax>? argumentSyntax = hasExplicitBaseInitializer
+                        ? i => ctorSyntax.BaseArguments[i]
+                        : null;
                     init = ResolveClrBaseConstructor(argumentLocation, clrBase, importedBaseType, boundArguments, location, argumentSyntax);
                 }
                 else
                 {
-                    System.Func<int, TextLocation> argumentLocation = i => ctorSyntax.BaseArguments[i].Location;
+                    System.Func<int, TextLocation> argumentLocation =
+                        i => hasExplicitBaseInitializer ? ctorSyntax.BaseArguments[i].Location : location;
                     init = ResolveGSharpBaseConstructor(
                         argumentLocation,
                         structSymbol.Name,

--- a/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
+++ b/src/Core/CodeAnalysis/Binding/OverloadResolution/OverloadResolver.Arguments.cs
@@ -865,6 +865,15 @@ internal sealed partial class OverloadResolver
         {
             var slot = parameterOffset + sourceToParameterMapping[sourceIndex];
             BoundExpression argument = parameterOrderedArguments[slot];
+            if (StatementBinder.IsNilLiteral(argument))
+            {
+                // A nil literal has no evaluation to preserve. Capturing it
+                // would create a local whose type is `nil`, which has no CLR
+                // signature representation; leave it in its parameter slot.
+                replacements[slot] = argument;
+                continue;
+            }
+
             var temp = new LocalVariableSymbol(
                 $"<>namedArg{sourceIndex}",
                 isReadOnly: true,
@@ -876,7 +885,7 @@ internal sealed partial class OverloadResolver
         var carrier = parameterOffset;
         replacements[carrier] = new BoundBlockExpression(
             parameterOrderedArguments[carrier].Syntax,
-            evaluations.MoveToImmutable(),
+            evaluations.ToImmutable(),
             replacements[carrier]);
         return ImmutableArray.Create(replacements);
     }

--- a/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
+++ b/src/Core/CodeAnalysis/Symbols/StructSymbol.cs
@@ -2114,12 +2114,18 @@ public sealed class StructSymbol : TypeSymbol
             var builder = ImmutableArray.CreateBuilder<ParameterSymbol>(source.Length);
             foreach (var parameter in source)
             {
-                builder.Add(new ParameterSymbol(
+                var substituted = new ParameterSymbol(
                     parameter.Name,
                     SubstituteTypeForConstruction(parameter.Type, GetSubstitutionMap(), mapClrType),
                     isVariadic: parameter.IsVariadic,
                     isScoped: parameter.IsScoped,
-                    refKind: parameter.RefKind));
+                    refKind: parameter.RefKind);
+                if (parameter.HasExplicitDefaultValue)
+                {
+                    substituted.SetExplicitDefaultValue(parameter.ExplicitDefaultValue);
+                }
+
+                builder.Add(substituted);
             }
 
             value = builder.MoveToImmutable();

--- a/test/Compiler.Tests/Emit/NamedArgumentEmitTests.cs
+++ b/test/Compiler.Tests/Emit/NamedArgumentEmitTests.cs
@@ -120,6 +120,72 @@ public class NamedArgumentEmitTests
     }
 
     [Fact]
+    public void ClrStatic_ReorderedNamedArguments_DoNotCaptureNilIntoALocal()
+    {
+        // Issue #3880: reordered calls captured every source argument into a
+        // temp, including side-effect-free nil, whose unencodable local type
+        // crashed emission with GS9998.
+        var source = """
+            package P
+
+            public var trace = ""
+            public var result = 0
+
+            func mark(value string) string {
+                trace = trace + "B"
+                return value
+            }
+
+            result = string.Compare(
+                strB: mark("x"),
+                strA: nil)
+            """;
+
+        var assembly = CompileToAssembly(source, target: "exe");
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var traceField = program.GetField("trace", BindingFlags.Public | BindingFlags.Static);
+        var resultField = program.GetField("result", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+
+        Assert.Equal("B", (string)traceField!.GetValue(null)!);
+        Assert.Equal(-1, (int)resultField!.GetValue(null)!);
+    }
+
+    [Fact]
+    public void UserFunction_ReorderedNamedArguments_CaptureSideEffectingNilExpression()
+    {
+        var source = """
+            package P
+
+            public var trace = ""
+
+            func mark(label string) bool {
+                trace = trace + label
+                return true
+            }
+
+            func consume(a string?, b string?) {
+                trace = trace + if a == nil && b == nil { "N" } else { "V" }
+            }
+
+            consume(
+                b: if mark("B") { nil } else { nil },
+                a: if mark("A") { nil } else { nil })
+            """;
+
+        var assembly = CompileToAssembly(source, target: "exe");
+        var program = assembly.GetTypes().Single(t => t.Name == "<Program>");
+        var entry = program.GetMethod("<Main>$", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        var traceField = program.GetField("trace", BindingFlags.Public | BindingFlags.Static);
+
+        entry!.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { System.Array.Empty<string>() });
+
+        Assert.Equal("BAN", (string)traceField!.GetValue(null)!);
+    }
+
+    [Fact]
     public void UserClassPrimaryCtor_NamedArguments_ReorderFields()
     {
         var source = """

--- a/test/Compiler.Tests/Issue3984BaseInitializerOpenArgumentTests.cs
+++ b/test/Compiler.Tests/Issue3984BaseInitializerOpenArgumentTests.cs
@@ -168,6 +168,16 @@ public class Issue3984BaseInitializerOpenArgumentTests
             public string Tag { get; }
         }
 
+        public class OptionalOnlyBase
+        {
+            public OptionalOnlyBase(string? tag = null)
+            {
+                this.Tag = tag ?? "default";
+            }
+
+            public string Tag { get; }
+        }
+
         public class FallbackHolder<T>
         {
             public FallbackHolder(IEnumerable<T> items, T fallback = default!)
@@ -742,6 +752,75 @@ public class Issue3984BaseInitializerOpenArgumentTests
                 .Where(line => line.Length > 0)
                 .ToArray();
             Assert.Equal(expectedLines, lines);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ImplicitBaseCall_MaterializesOmittedOptionalArgument()
+    {
+        // Issue #3880: derived default/designated ctors referenced a nonexistent
+        // base .ctor() instead of calling the real optional-only .ctor(string)
+        // with its materialized nil default.
+        var tempDir = Directory.CreateTempSubdirectory("gs_3880_base_").FullName;
+        try
+        {
+            var libPath = CompileCSharpLibrary(tempDir);
+            const string source = """
+                package P
+                import System
+                import Interop
+
+                class Derived : OptionalOnlyBase {
+                }
+
+                class DerivedWithConstructor : OptionalOnlyBase {
+                    init(value int32) {
+                    }
+                }
+
+                class PrimaryAndExplicit(value int32) : OptionalOnlyBase {
+                    init() {
+                    }
+                }
+
+                open class GPrimaryBase(tag string? = nil) {
+                }
+
+                class GPrimaryDerived : GPrimaryBase {
+                }
+
+                open class GExplicitBase {
+                    prop Tag string
+
+                    init(tag string? = nil) {
+                        this.Tag = tag ?? "default"
+                    }
+                }
+
+                class GExplicitDerived : GExplicitBase {
+                }
+
+                Console.WriteLine(Derived().Tag)
+                Console.WriteLine(DerivedWithConstructor(1).Tag)
+                Console.WriteLine(PrimaryAndExplicit(1).Tag)
+                Console.WriteLine(GPrimaryDerived().tag ?? "default")
+                Console.WriteLine(GExplicitDerived().Tag)
+                """;
+
+            var appPath = Path.Combine(tempDir, "implicit-optional-base.dll");
+            var appLog = Compile(tempDir, "App.gs", source, appPath, "/target:exe", "/reference:" + libPath);
+            Assert.True(File.Exists(appPath), $"The derived class must compile. Log:\n{appLog}");
+
+            IlVerifier.Verify(appPath, new[] { libPath });
+            var (exit, output) = RunDotnet(appPath);
+            Assert.Equal(0, exit);
+            Assert.Equal(
+                string.Concat(Enumerable.Repeat($"default{Environment.NewLine}", 5)),
+                output);
         }
         finally
         {


### PR DESCRIPTION
Part of #3880. The compile wall from #3964/#3966/#3967 is cleared; this PR fixes the two newly reachable compiler failures and advances migrated `tools/cs2gs/Cs2Gs.Tests` through ILVerify. The newly reachable parity wall is independently tracked in #4071, #4072, #4073, and #4074, so this does **not** close #3880.

## Newly reached root causes

1. **Compile — GS9998 `Cannot encode signature for type 'nil'`.** Named-argument evaluation-order preservation captured every reordered argument into a local. A literal `nil` has no evaluation to preserve, but became a `nil`-typed local, which has no CLR signature representation. Literal `nil` now stays in its parameter slot; non-literal nil-valued expressions are still captured so lexical side effects remain intact.
2. **ILVerify — MissingMethod on base `.ctor()`.** Migrated test doubles derive from `IlVerifyRunner`/`GsharpTestProjectRunner`, whose only constructor has an optional `string` parameter. Derived default/designated constructors emitted calls to nonexistent parameterless MemberRefs instead of resolving the real constructor and materializing its omitted `nil` default. Implicit imported-base calls now use the existing resolver/emitter path. G# explicit-constructor bases also accept/materialize omitted optional defaults, including substituted generic parameters; primary-only G# bases keep their existing synthesized default-ctor path.

Review follow-ups also cover a primary constructor coexisting with explicit `init` overloads, source-defined optional base constructors, and side-effecting nil-valued named arguments.

## Exact app gate

Fresh `origin/main` `12c05da99`, locally built gsc `0.4.540+56307a910b`:

```text
whole-repository translate: 56/56 PASS
Cs2Gs.Tests compile:         PASS
Cs2Gs.Tests ILVerify:        PASS
Cs2Gs.Tests test-parity:     FAIL (182 failed, 2683 passed, 2865 total)
```

The 182 parity failures are split without allow-lists or lowered floors:

- #4071 — 101 checked-null assertion crashes
- #4072 — 36 unavailable original C# source/project fixtures
- #4073 — 7 enum generic-attribute TypeSpec failures
- #4074 — 38 remaining semantic/assertion mismatches

## Validation

- focused compiler regressions: **33/33 pass**
- affected Core baseline/interface tests: **2/2 pass**
- affected Interpreter regression: **1/1 pass**
- Release `GSharp.sln`: **0 warnings, 0 errors**
- nullable hygiene: **OK**
- local hot-core self-migration: **8/8 apps pass translate, compile, ILVerify, parity**; guard exits 0
- exact latest-main whole migrate + targeted validate gate: results above

No baseline, allow-list, floor, or ceiling changed.
