### PR TITLE
bench: preserve hosted report-only aggregates

### DIFF
--- a/.github/workflows/concurrency-bench.yml
+++ b/.github/workflows/concurrency-bench.yml
@@ -114,10 +114,12 @@ jobs:
 
       - name: Aggregate and report
         run: |
+          set -o pipefail
           python3 build/run-concurrency-bench.py \
             --from-json "$RUNNER_TEMP/concurrency-1.json" \
             --from-json "$RUNNER_TEMP/concurrency-2.json" \
             --from-json "$RUNNER_TEMP/concurrency-3.json" \
+            --allow-incomparable-aggregate \
             --json "$RUNNER_TEMP/concurrency.json" \
             | tee "$RUNNER_TEMP/summary.txt"
           {

--- a/bench/concurrency/README.md
+++ b/bench/concurrency/README.md
@@ -153,6 +153,11 @@ spike:
    may report, but cannot relabel untouched rows or gate with a different
    interval method.
 
+   The hosted nightly is deliberately report-only and may lack an observable
+   power identity. It uses `--allow-incomparable-aggregate` to retain a
+   clearly-marked aggregate for diagnosis; that flag never makes the result
+   baseline-comparable, and baseline update/check logic remains report-only.
+
 ## Known limits of the current numbers
 
 Carried here so they are not lost when the numbers are quoted:

--- a/build/run-concurrency-bench.py
+++ b/build/run-concurrency-bench.py
@@ -435,6 +435,13 @@ def aggregate_fingerprint(fingerprints: list[dict]) -> dict | None:
     comparison["intervalMethod"] = "range-of-run-medians"
     fingerprint.pop("runId", None)
     fingerprint["sourceRunIds"] = [item["runId"] for item in fingerprints]
+    reasons = sorted({
+        reason
+        for item in fingerprints
+        for reason in item.get("incomparabilityReasons", [])
+    })
+    fingerprint["comparable"] = all(item.get("comparable", True) for item in fingerprints)
+    fingerprint["incomparabilityReasons"] = reasons
     fingerprint["comparisonKey"] = stable_key(comparison)
     fingerprint["aggregationKey"] = stable_key({
         "comparison": comparison,

--- a/build/run-concurrency-bench.py
+++ b/build/run-concurrency-bench.py
@@ -654,7 +654,10 @@ def combine_loaded_runs(results: list[dict]) -> dict:
     return results[0] if len(results) == 1 else aggregate(results)
 
 
-def load_runs(paths: list[str]) -> tuple[list[dict], list[dict], list[dict], str | None, dict]:
+def load_runs(
+    paths: list[str],
+    allow_incomparable: bool = False,
+) -> tuple[list[dict], list[dict], list[dict], str | None, dict]:
     """Read run JSONs written by an earlier --json invocation."""
     gsharp, gsharp_aot, go = [], [], []
     recorded_class = None
@@ -700,7 +703,12 @@ def load_runs(paths: list[str]) -> tuple[list[dict], list[dict], list[dict], str
                 "refusing to aggregate incomparable benchmark runs: "
                 f"'{paths[0]}' has key {aggregation_key}, '{path}' has key {key}"
             )
-        if len(paths) > 1 and fingerprint and not fingerprint.get("comparable", True):
+        if (
+            len(paths) > 1
+            and fingerprint
+            and not fingerprint.get("comparable", True)
+            and not allow_incomparable
+        ):
             raise SystemExit(
                 f"refusing to aggregate '{path}': "
                 + "; ".join(fingerprint.get("incomparabilityReasons", ["run marked incomparable"]))
@@ -955,6 +963,12 @@ def main() -> int:
         help="aggregate previously written run JSONs instead of measuring; repeatable. "
              "Several whole runs is what a reported number should rest on — a single run's "
              "interval covers only its own launches.")
+    parser.add_argument(
+        "--allow-incomparable-aggregate",
+        action="store_true",
+        help="aggregate report-only runs whose environment fingerprint is incomplete; "
+             "the result remains incomparable and cannot update or gate a baseline",
+    )
     args = parser.parse_args()
     if args.launches < 1:
         parser.error("--launches must be at least 1")
@@ -976,7 +990,10 @@ def main() -> int:
     launch_order = None
     source_fingerprints = []
     if args.from_json:
-        gsharp_runs, aot_runs, go_runs, recorded_class, metadata = load_runs(args.from_json)
+        gsharp_runs, aot_runs, go_runs, recorded_class, metadata = load_runs(
+            args.from_json,
+            allow_incomparable=args.allow_incomparable_aggregate,
+        )
         measured = combine_loaded_runs(gsharp_runs)
         measured_aot = combine_loaded_runs(aot_runs)
         go_measured = combine_loaded_runs(go_runs)

--- a/build/test-concurrency-bench.py
+++ b/build/test-concurrency-bench.py
@@ -154,6 +154,12 @@ class ConcurrencyBenchTests(unittest.TestCase):
         self.assertNotEqual(fingerprint["comparisonKey"], aggregated["comparisonKey"])
         self.assertEqual([fingerprint["runId"], "second-run"], aggregated["sourceRunIds"])
 
+        second_fingerprint["comparable"] = False
+        second_fingerprint["incomparabilityReasons"] = ["power state changed"]
+        mixed = bench.aggregate_fingerprint([fingerprint, second_fingerprint])
+        self.assertFalse(mixed["comparable"])
+        self.assertEqual(["power state changed"], mixed["incomparabilityReasons"])
+
         preserved = {
             "select-ready": {
                 "median_ns": 72.0,

--- a/build/test-concurrency-bench.py
+++ b/build/test-concurrency-bench.py
@@ -207,15 +207,31 @@ class ConcurrencyBenchTests(unittest.TestCase):
             **common,
             "aggregationKey": "same",
             "fingerprint": {
+                "runId": "incomparable-1",
                 "comparable": False,
                 "incomparabilityReasons": ["power state changed"],
             },
         }
         first.write_text(json.dumps(incomparable))
-        second.write_text(json.dumps(incomparable))
+        second_incomparable = {
+            **second_run,
+            "aggregationKey": "same",
+            "fingerprint": {
+                "runId": "incomparable-2",
+                "comparable": False,
+                "incomparabilityReasons": ["power state changed"],
+            },
+        }
+        second.write_text(json.dumps(second_incomparable))
         bench.load_runs([str(first)])
         with self.assertRaisesRegex(SystemExit, "power state changed"):
             bench.load_runs([str(first), str(second)])
+        gsharp, _, _, _, metadata = bench.load_runs(
+            [str(first), str(second)],
+            allow_incomparable=True,
+        )
+        self.assertEqual(2, len(gsharp))
+        self.assertEqual(2, len(metadata["sourceFingerprints"]))
 
         aggregate_payload = {
             **common,

--- a/build/verify-concurrency-bench.py
+++ b/build/verify-concurrency-bench.py
@@ -82,6 +82,12 @@ def smoke() -> int:
     else:
         subprocess.run([sys.executable, str(tests)], check=True, cwd=REPO)
 
+    workflow = (REPO / ".github" / "workflows" / "concurrency-bench.yml").read_text()
+    if "set -o pipefail" not in workflow:
+        failures.append("concurrency workflow can mask aggregation failures through tee")
+    if "--allow-incomparable-aggregate" not in workflow:
+        failures.append("concurrency workflow cannot aggregate hosted-runner report-only evidence")
+
     for failure in failures:
         print(f"error: {failure}", file=sys.stderr)
 

--- a/docs/adr/0174-goroutines-and-channels-wave-2.md
+++ b/docs/adr/0174-goroutines-and-channels-wave-2.md
@@ -3350,9 +3350,11 @@ implementation had to refine it.
     range-of-run-medians interval. A scoped paired run
     selects and warms the matching Go row rather than running Go's whole suite;
     a row with no honest Go counterpart omits Go. A host that exposes no
-    power-state identity is explicitly report-only. The existing `gsharp`,
-    `gsharp_aot`, `go` and `hardwareClass` JSON fields remain unchanged for
-    dashboard consumers.
+    power-state identity is explicitly report-only. The hosted nightly may
+    aggregate those runs only with an explicit report-only flag, preserving
+    diagnostics without making the result baseline-comparable. The existing
+    `gsharp`, `gsharp_aot`, `go` and `hardwareClass` JSON fields remain
+    unchanged for dashboard consumers.
 
 ## Addendum A — The ten patterns, three ways
 


### PR DESCRIPTION
## Summary

Post-merge artifact inspection of #4078 found two coupled CI defects:

- hosted runners correctly marked all three passes incomparable because no power identity was observable, so strict aggregation rejected them
- the aggregate command was piped to `tee` without `pipefail`, masking that rejection and leaving no aggregate artifact while the job appeared green

This keeps strict aggregation as the default, adds an explicit `--allow-incomparable-aggregate` path for the hosted report-only workflow, and enables `pipefail` so any other aggregation failure fails CI. The resulting aggregate remains `comparable: false`, cannot update a baseline, and cannot gate.

## Reproduction evidence

Using the three artifacts from the final #4078 benchmark run:

- strict aggregation exits 1; `pipefail` propagates that exit
- explicit report-only aggregation succeeds
- output remains incomparable with reason `the host exposes no observable power-state identity`
- 3 source run IDs, 18 retained `select-ready` launch samples, and run medians `[201.0, 195.95, 197.45]` survive

## Validation

- `python3 build/verify-concurrency-bench.py --smoke` (10 tests)
- `python3 build/nullable_hygiene.py --base origin/main`
- `python3 -m py_compile build/run-concurrency-bench.py build/test-concurrency-bench.py build/verify-concurrency-bench.py`
- real strict/report-only aggregation against the three #4078 CI JSON artifacts

Closes #3901
