### PR TITLE
cs2gs: propagate PR guard migration failures (#3993)

### DIFF
--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Restore .NET local tools
         run: dotnet tool restore
 
+      - name: Test PR guard failure propagation
+        run: ./build/test-cs2gs-selfmig-pr-guard.sh
+
       # The script builds the solution itself (which repacks the
       # Gsharp.NET.Sdk nupkg the compile stage consumes) and then migrates.
       # That ordering is load-bearing: a freshly built gsc.dll alone is

--- a/build/run-cs2gs-selfmig-pr-guard.sh
+++ b/build/run-cs2gs-selfmig-pr-guard.sh
@@ -257,7 +257,7 @@ dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
   --artifacts "$work_root/runs" \
   --config Release \
   "${excludes[@]}" \
-  | tee "$work_root/guard.log"
+  2>&1 | tee "$work_root/guard.log"
 migrate_exit=${PIPESTATUS[0]}
 set -e
 
@@ -272,6 +272,7 @@ fi
 green=$(jq '[.apps[] | select(.succeeded)] | length' "$run_json")
 total=$(jq '.apps | length' "$run_json")
 failed=$(jq -r '.apps[] | select(.succeeded | not) | .appId' "$run_json")
+run_succeeded=$(jq -r '.succeeded' "$run_json")
 
 echo
 echo "PR guard: $green/$total guarded app(s) migrated and compiled in ${elapsed}s (migrate exit $migrate_exit)."
@@ -301,6 +302,8 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo
     echo "\`$green/$total\` guarded app(s) migrated + compiled in ${elapsed}s."
     echo
+    echo "Migration run: **$([[ "$run_succeeded" == true ]] && echo PASSED || echo FAILED)** (exit \`$migrate_exit\`)."
+    echo
     if [[ -n "$failed" ]]; then
       echo "**Failed:**"
       echo "$failed" | sed 's/^/- `/; s/$/`/'
@@ -312,6 +315,14 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   } >> "$GITHUB_STEP_SUMMARY"
 fi
 
+guard_exit=$migrate_exit
+if (( guard_exit == 0 )) && [[ "$run_succeeded" != true ]]; then
+  guard_exit=1
+fi
+if (( guard_exit == 0 )) && [[ -n "$failed" ]]; then
+  guard_exit=1
+fi
+
 if [[ -n "$failed" ]]; then
   echo >&2
   echo "PR guard FAILED: the following guarded app(s) did not survive migration:" >&2
@@ -320,7 +331,17 @@ if [[ -n "$failed" ]]; then
   echo "This is the #3831/#3896/#3905 hazard: the C# compiles, the migrated G#" >&2
   echo "does not. See $work_root/guard.log and the uploaded run artifacts for the" >&2
   echo "diagnostics, and fix the source shape rather than the baseline." >&2
-  exit 1
+  exit "$guard_exit"
+fi
+
+if (( guard_exit != 0 )); then
+  echo >&2
+  echo "PR guard FAILED: cs2gs reported a global migration failure even though" >&2
+  echo "all guarded app stage rows are green (run succeeded=$run_succeeded," >&2
+  echo "migrate exit $migrate_exit)." >&2
+  echo "See $work_root/guard.log and run.json; global repository validation and" >&2
+  echo "report failures must never be masked by the per-app summary." >&2
+  exit "$guard_exit"
 fi
 
 echo "PR guard PASSED."

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+test_root="$repo_root/out/test/cs2gs-selfmig-pr-guard"
+fake_bin="$test_root/bin"
+rm -rf "$test_root"
+mkdir -p "$fake_bin"
+trap 'rm -rf "$test_root"' EXIT
+
+cat > "$fake_bin/dotnet" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == build ]]; then
+  exit 0
+fi
+
+artifacts=
+while (( $# )); do
+  if [[ "$1" == --artifacts ]]; then
+    artifacts=$2
+    break
+  fi
+  shift
+done
+
+mkdir -p "$artifacts/fake-run"
+cat > "$artifacts/fake-run/run.json" <<EOF_JSON
+{
+  "succeeded": ${FAKE_RUN_SUCCEEDED},
+  "apps": [
+    {"appId":"src/Analyzers/InternalAnalyzers/InternalAnalyzers.csproj","succeeded":true},
+    {"appId":"src/Core/Core.csproj","succeeded":true},
+    {"appId":"src/Formatting/GSharp.Formatting/GSharp.Formatting.csproj","succeeded":true},
+    {"appId":"src/Sdk/Gsharp.Runtime.Channels/Gsharp.Runtime.Channels.csproj","succeeded":true},
+    {"appId":"tools/cs2gs/Cs2Gs.CodeModel/Cs2Gs.CodeModel.csproj","succeeded":true},
+    {"appId":"tools/cs2gs/Cs2Gs.Pipeline/Cs2Gs.Pipeline.csproj","succeeded":true},
+    {"appId":"tools/cs2gs/Cs2Gs.ProjectLoading/Cs2Gs.ProjectLoading.csproj","succeeded":true},
+    {"appId":"tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj","succeeded":true}
+  ]
+}
+EOF_JSON
+echo "8/8 apps green; run $([[ "$FAKE_RUN_SUCCEEDED" == true ]] && echo PASSED || echo FAILED)."
+exit "$FAKE_MIGRATE_EXIT"
+EOF
+chmod +x "$fake_bin/dotnet"
+
+run_case() {
+  local name=$1 run_succeeded=$2 migrate_exit=$3 expected_exit=$4
+  local case_root="$test_root/$name"
+  local log="$case_root.log"
+  set +e
+  PATH="$fake_bin:$PATH" \
+    FAKE_RUN_SUCCEEDED="$run_succeeded" \
+    FAKE_MIGRATE_EXIT="$migrate_exit" \
+    SELFMIG_PR_GUARD_ROOT="$case_root" \
+    "$repo_root/build/run-cs2gs-selfmig-pr-guard.sh" >"$log" 2>&1
+  local actual_exit=$?
+  set -e
+
+  if (( actual_exit != expected_exit )); then
+    cat "$log" >&2
+    echo "$name: expected exit $expected_exit, got $actual_exit" >&2
+    exit 1
+  fi
+
+  grep -q "PR guard: 8/8 guarded app(s)" "$log"
+}
+
+run_case success true 0 0
+grep -q "PR guard PASSED." "$test_root/success.log"
+
+run_case migrate-exit-nonzero true 7 7
+grep -q "migrate exit 7" "$test_root/migrate-exit-nonzero.log"
+grep -q "PR guard FAILED: cs2gs reported a global migration failure" "$test_root/migrate-exit-nonzero.log"
+! grep -q "PR guard PASSED." "$test_root/migrate-exit-nonzero.log"
+
+run_case run-failed false 0 1
+grep -q "run FAILED" "$test_root/run-failed.log"
+grep -q "run succeeded=false" "$test_root/run-failed.log"
+! grep -q "PR guard PASSED." "$test_root/run-failed.log"
+
+echo "selfmig PR guard regressions PASSED."

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -340,7 +340,8 @@ public sealed class MigrationPipeline
                         destinationRoot,
                         repositoryFiles,
                         this.options.RepositoryAdditionalFiles,
-                        excludedScope);
+                        excludedScope,
+                        this.options.RepositoryTranslations.Keys);
                 }
                 catch (InvalidOperationException ex)
                 {

--- a/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RepositoryMirror.cs
@@ -140,7 +140,8 @@ internal static class RepositoryMirror
         string destinationRoot,
         IReadOnlyList<string> sourceFiles,
         IEnumerable<string> additionalFiles = null,
-        RepositoryExcludedScope excludedScope = null)
+        RepositoryExcludedScope excludedScope = null,
+        IEnumerable<string> translatedSourceFiles = null)
     {
         // Issue #3580: sources a targeted run's --exclude removed from scope
         // have no TRANSLATED mirrors by design — the completeness contract
@@ -163,6 +164,19 @@ internal static class RepositoryMirror
         if (additionalFiles is not null)
         {
             expected.UnionWith(additionalFiles);
+        }
+
+        // Issue #3993: an excluded project may link a shared source that an
+        // included project also evaluates. The exclusion scope alone cannot
+        // decide ownership; the repository-wide translation manifest can.
+        if (translatedSourceFiles is not null)
+        {
+            string source = Path.GetFullPath(sourceRoot);
+            expected.UnionWith(
+                translatedSourceFiles
+                    .Select(path => Path.GetRelativePath(source, Path.GetFullPath(path)))
+                    .Where(path => !RepositoryFileInventory.HasExcludedDirectory(path))
+                    .SelectMany(DestinationRelativePaths));
         }
 
         if (!sourceFiles.Any(path =>

--- a/tools/cs2gs/Cs2Gs.Tests/RepositoryMirrorTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/RepositoryMirrorTests.cs
@@ -206,6 +206,72 @@ public sealed class RepositoryMirrorTests
     }
 
     [Fact]
+    public void ValidateCompleted_RejectsUnexpectedOutput()
+    {
+        using var scratch = new ScratchDirectory();
+        string source = Path.Combine(scratch.Path, "source");
+        string destination = Path.Combine(scratch.Path, "destination");
+        Directory.CreateDirectory(source);
+        Directory.CreateDirectory(destination);
+        File.WriteAllText(Path.Combine(source, "Product.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(destination, "Product.slnx"), "<Solution />");
+        File.WriteAllText(Path.Combine(destination, "Unexpected.gs"), "func unexpected() {}");
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => RepositoryMirror.ValidateCompleted(
+                source,
+                destination,
+                new[] { "Product.slnx" }));
+
+        Assert.Contains("unexpected file 'Unexpected.gs'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateCompleted_AcceptsTranslatedLinkedOutputExcludedByAnotherProject()
+    {
+        using var scratch = new ScratchDirectory();
+        string source = Path.Combine(scratch.Path, "source");
+        string destination = Path.Combine(scratch.Path, "destination");
+        string sharedSource = Path.Combine(source, "test", "Shared", "GoldenFile.cs");
+        string excludedProject = Path.Combine(source, "test", "Core.Tests", "Core.Tests.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(sharedSource));
+        Directory.CreateDirectory(Path.GetDirectoryName(excludedProject));
+        Directory.CreateDirectory(Path.Combine(destination, "test", "Shared"));
+        File.WriteAllText(Path.Combine(source, "Product.slnx"), "<Solution />");
+        File.WriteAllText(sharedSource, "internal static class GoldenFile {}");
+        File.WriteAllText(
+            excludedProject,
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <ItemGroup>
+                <Compile Include="..\Shared\GoldenFile.cs" Link="GoldenFile.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(destination, "Product.slnx"), "<Solution />");
+        File.WriteAllText(
+            Path.Combine(destination, "test", "Shared", "GoldenFile.gs"),
+            "internal class GoldenFile {}");
+        RepositoryExcludedScope scope = RepositoryExcludedScope.Compute(source, new[] { excludedProject });
+
+        RepositoryMirror.ValidateCompleted(
+            source,
+            destination,
+            new[]
+            {
+                "Product.slnx",
+                "test/Core.Tests/Core.Tests.csproj",
+                "test/Shared/GoldenFile.cs",
+            },
+            excludedScope: scope,
+            translatedSourceFiles: new[]
+            {
+                sharedSource,
+                Path.Combine(source, "out", "obj", "Core", "Generated.cs"),
+            });
+    }
+
+    [Fact]
     public void RepositoryDiscovery_IncludesTestsAndUsesRelativeProjectPaths()
     {
         using var scratch = new ScratchDirectory();


### PR DESCRIPTION
Closes #3993.

## Contract

The hot-core PR guard now succeeds only when all three views agree:

1. `cs2gs migrate` exits 0;
2. `run.json.succeeded` is `true`; and
3. every selected app stage row is green.

A nonzero migrate exit is preserved. A contradictory `run FAILED` with exit 0, or failed app rows with exit 0, becomes exit 1. Diagnostics, `guard.log`, `run.json`, and the scope summary remain available; stderr is now included in `guard.log` so repository/report failures are not lost.

## Manifest handling

`test/Shared/GoldenFile.cs` is evaluated by the included `Cs2Gs.Pipeline` project even though excluded test projects also link it. Repository mirror validation now unions the actual repository translation manifest into the expected set, while still filtering `bin`/`obj`/`TestResults` generated inputs. This accepts `test/Shared/GoldenFile.gs` because it was truly translated, without weakening unexpected-output detection.

## Regressions

- successful migration → guard passes
- nonzero migrate exit with all apps green → original exit preserved, guard fails
- `run.json.succeeded=false` with all apps green → guard fails
- unexpected mirror output remains rejected
- expected linked output is accepted through the evaluated translation manifest

## Validation

- exact hot-core guard reproducer: **8/8, run PASSED, exit 0**
- guard shell regressions: passed
- repository mirror + report tests: **32 passed**
- readability counter regression: passed
- Release solution build: **0 warnings, 0 errors**
- nullable hygiene: passed
- classic self-migration check executed: 50/56 green locally; it included an untracked `out/scratch/ildump` project and hit existing non-hot-core app/baseline failures. The issue-specific hot-core reproducer is green and CI runs from a clean checkout.

The production behavior changes are limited to `MigrationPipeline` passing its evaluated translation keys into `RepositoryMirror.ValidateCompleted`, and the PR guard enforcing the global migrate verdict.
