### PR TITLE
gsc: parse brace expressions in for conditions

### DIFF
--- a/src/Core/CodeAnalysis/Binding/Binder.cs
+++ b/src/Core/CodeAnalysis/Binding/Binder.cs
@@ -7068,24 +7068,9 @@ public sealed class Binder
         // walk is bounded anyway so a malformed symbol cannot hang the binder.
         if (typeArgument is TypeParameterSymbol argumentParameter)
         {
-            // The pattern is deliberately NOT in the loop condition. G#'s `for`
-            // header carries no parentheses, so an empty property pattern
-            // (`is { } next`) there prints as `for …is { } next; steps++ {`,
-            // where the pattern's brace is indistinguishable from the loop
-            // body's — cs2gs emits it verbatim and the migrated G# does not
-            // parse. That is the #3831/#3896/#3905 hazard the hot-core
-            // translation guard exists to catch, and it took the guard from
-            // 8/8 to 2/8 apps green. Hoisting the read out of the condition is
-            // equivalent, and translates.
             var current = argumentParameter;
-            for (var steps = 0; steps < 64; steps++)
+            for (var steps = 0; steps < 64 && current.TypeParameterBound is { } next; steps++)
             {
-                var next = current.TypeParameterBound;
-                if (next == null)
-                {
-                    break;
-                }
-
                 if (ReferenceEquals(next, boundArgument))
                 {
                     return true;

--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -1252,7 +1252,9 @@ public partial class Parser
         ExpressionSyntax? condition = null;
         if (Current.Kind != SyntaxKind.SemicolonToken)
         {
-            condition = ParseExpressionInBodyHeader();
+            // Unlike a condition-only loop, this expression ends at `;`, so
+            // brace-carrying expressions cannot consume the loop body.
+            condition = ParseExpression();
         }
 
         var secondSemicolon = MatchToken(SyntaxKind.SemicolonToken);

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue4080ForClauseBraceExpressionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue4080ForClauseBraceExpressionParserTests.cs
@@ -62,13 +62,8 @@ public sealed class Issue4080ForClauseBraceExpressionParserTests
         Assert.IsType<BlockStatementSyntax>(statement.Body);
     }
 
-    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode? node)
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
     {
-        if (node == null)
-        {
-            yield break;
-        }
-
         foreach (var child in node.GetChildren())
         {
             yield return child;

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue4080ForClauseBraceExpressionParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue4080ForClauseBraceExpressionParserTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="Issue4080ForClauseBraceExpressionParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #4080: a C-style <c>for</c> condition is terminated by its second
+/// semicolon, so braces inside that expression must not be mistaken for the
+/// loop body.
+/// </summary>
+public sealed class Issue4080ForClauseBraceExpressionParserTests
+{
+    [Fact]
+    public void EmptyPropertyPatternInConditionParsesBeforeSemicolon()
+    {
+        const string source = """
+            package p
+            class Node { var Next Node? }
+            class C {
+                func F(current Node) {
+                    for var steps = 0; steps < 64 && current.Next is { } next; steps++ {
+                        current = next
+                    }
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var statement = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        var pattern = Descendants(statement.Condition).OfType<PropertyPatternSyntax>().Single();
+        Assert.Empty(pattern.Fields);
+        Assert.Equal("next", pattern.Designation?.Text);
+        Assert.IsType<BlockStatementSyntax>(statement.Body);
+    }
+
+    [Fact]
+    public void ObjectInitializerInConditionParsesBeforeSemicolon()
+    {
+        const string source = """
+            package p
+            class Box { var Value int32 }
+            class C {
+                func F() {
+                    for var i = 0; Box() { Value = i }.Value < 4; i++ { }
+                }
+            }
+            """;
+
+        var tree = SyntaxTree.Parse(source);
+
+        Assert.Empty(tree.Diagnostics);
+        var statement = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.Contains(Descendants(statement.Condition), node => node is ObjectCreationExpressionSyntax);
+        Assert.IsType<BlockStatementSyntax>(statement.Body);
+    }
+
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode? node)
+    {
+        if (node == null)
+        {
+            yield break;
+        }
+
+        foreach (var child in node.GetChildren())
+        {
+            yield return child;
+            foreach (var descendant in Descendants(child))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- parse semicolon-delimited C-style for conditions in normal expression mode
- restore the natural empty-property-pattern loop in Binder.cs
- cover the original pattern failure and object initializers in parser tests

Fixes #4080

## Validation
- git diff --check
- GitHub CI (local .NET build/test intentionally skipped per repository workflow preference)