### PR TITLE
cs2gs: preserve nullable selector results for gsgen attributes

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue3644AnnotatedNullFlowBridgingTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3644AnnotatedNullFlowBridgingTests.cs
@@ -146,6 +146,66 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #4046: an inferred LINQ result that ultimately flows into a
+    /// promoted nullable sink must keep nullable elements alive long enough for
+    /// a later operator to inspect them. Asserting the selector result throws
+    /// before <c>FirstOrDefault(candidate =&gt; candidate != null)</c> can filter
+    /// the null.
+    /// </summary>
+    [Fact]
+    public void RuntimeLambdaResult_FlowingToPromotedNullableSink_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Demo
+{
+    public static class Paths
+    {
+        public static void Find(IEnumerable<string> values, out string result)
+        {
+            result = (values
+                .Select(value => Path.GetDirectoryName(value)))
+                .FirstOrDefault(candidate => candidate != null);
+        }
+    }
+}");
+
+        Assert.Contains("out result string?", printed);
+        Assert.DoesNotContain("GetDirectoryName(value)!!", printed);
+    }
+
+    /// <summary>
+    /// Precision guard: a fixed delegate return contract remains non-null even
+    /// when the invocation result later flows into a promoted nullable sink.
+    /// Only generic selector-result positions receive issue #4046's exemption.
+    /// </summary>
+    [Fact]
+    public void RuntimeLambdaResult_FixedDelegateContract_StillAssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.IO;
+
+namespace Demo
+{
+    public static class Paths
+    {
+        public static string Apply(Func<string, string> selector) => selector("""");
+
+        public static string Find()
+        {
+            return Apply(value => Path.GetDirectoryName(value));
+        }
+    }
+}");
+
+        Assert.Contains("GetDirectoryName(value)!!", printed);
+    }
+
+    /// <summary>
     /// Precision guard: a non-nullable value in the expanded params tail grows
     /// no assertion.
     /// </summary>

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3770SilentRuntimeDivergenceTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3770SilentRuntimeDivergenceTests.cs
@@ -219,6 +219,39 @@ public sealed class Issue3770SilentRuntimeDivergenceTests
     }
 
     /// <summary>
+    /// Issue #4046: a nullable imported value returned from a selector must not
+    /// be asserted before a later LINQ operator can observe and filter the nil.
+    /// </summary>
+    [Fact]
+    public void NullableLambdaResult_FlowingToNullableSink_DoesNotThrow()
+    {
+        string printed = Translate("""
+            using System.IO;
+            using System.Linq;
+
+            public static class Paths
+            {
+                public static string Find()
+                {
+                    return (new[] { "" }
+                        .Select(value =>
+                        {
+                            return Path.GetDirectoryName(value);
+                        }))
+                        .FirstOrDefault(candidate => candidate != null);
+                }
+            }
+            """, nullableEnabled: false);
+
+        Assert.DoesNotContain("GetDirectoryName(value)!!", printed, StringComparison.Ordinal);
+        string stdout = CompileAndRun(
+            printed,
+            "Console.WriteLine(Paths.Find() ?? \"nil\")");
+
+        Assert.Equal("nil", stdout.Trim());
+    }
+
+    /// <summary>
     /// Once gsc accepts a nilable event-subscription handler, cs2gs must not
     /// reintroduce the old run-time divergence by appending <c>!!</c>.
     /// </summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -3319,6 +3319,7 @@ public sealed partial class CSharpToGSharpTranslator
                 || !this.IsObliviousCompilation()
                 || this.IsWithinExpressionTreeLambda(use)
                 || this.FindResultLambda(use) is not { } lambda
+                || this.LambdaResultFlowsToNullableSink(lambda)
                 || this.GetLambdaTargetDelegateType(lambda) is not { DelegateInvokeMethod: { } invoke }
                 || invoke.ReturnType is not { IsReferenceType: true }
                 || invoke.ReturnType.NullableAnnotation == NullableAnnotation.Annotated)
@@ -3336,6 +3337,97 @@ public sealed partial class CSharpToGSharpTranslator
 
             return this.IsNullablePromotedValue(use)
                 || this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(use).Symbol);
+        }
+
+        private bool LambdaResultFlowsToNullableSink(AnonymousFunctionExpressionSyntax lambda)
+        {
+            // Issue #4046: a generic selector has no fixed return contract of
+            // its own. When its fluent call chain collapses back to the same
+            // scalar type and that final sink is emitted nullable, preserve nil
+            // for operators such as FirstOrDefault to inspect instead of
+            // throwing at the selector boundary.
+            SyntaxNode current = lambda;
+            if (current.Parent is not ArgumentSyntax argument
+                || argument.Expression != current
+                || argument.Parent?.Parent is not InvocationExpressionSyntax invocation
+                || this.context.SemanticModel.GetOperation(argument)
+                    is not IArgumentOperation { Parameter: { } selectorParameter }
+                || selectorParameter.ContainingSymbol is not IMethodSymbol containingMethod
+                || !ReturnsGenericSelectorResult(
+                    containingMethod.OriginalDefinition,
+                    selectorParameter.Ordinal))
+            {
+                return false;
+            }
+
+            current = invocation;
+            while (true)
+            {
+                if (current.Parent is ParenthesizedExpressionSyntax parenthesized)
+                {
+                    current = parenthesized;
+                    continue;
+                }
+
+                if (current.Parent is MemberAccessExpressionSyntax member
+                    && member.Expression == current
+                    && member.Parent is InvocationExpressionSyntax outerInvocation)
+                {
+                    current = outerInvocation;
+                    continue;
+                }
+
+                break;
+            }
+
+            if (current is not ExpressionSyntax expression)
+            {
+                return false;
+            }
+
+            ISymbol sink = this.ResolveValueSink(expression);
+            ITypeSymbol sinkType = sink switch
+            {
+                IMethodSymbol method => method.ReturnType,
+                IPropertySymbol property => property.Type,
+                IFieldSymbol field => field.Type,
+                ILocalSymbol local => local.Type,
+                IParameterSymbol parameter => parameter.Type,
+                _ => null,
+            };
+
+            ITypeSymbol resultType =
+                (this.context.GetSymbolInfo(lambda).Symbol as IMethodSymbol)?.ReturnType;
+            return sinkType is { IsReferenceType: true }
+                && SymbolEqualityComparer.Default.Equals(resultType, sinkType)
+                && !this.TargetWillRemainNonNullableReference(sinkType, sink);
+
+            static bool ReturnsGenericSelectorResult(
+                IMethodSymbol genericMethod,
+                int parameterOrdinal)
+            {
+                if (!genericMethod.IsGenericMethod
+                    || parameterOrdinal < 0
+                    || parameterOrdinal >= genericMethod.Parameters.Length
+                    || genericMethod.Parameters[parameterOrdinal].Type
+                        is not INamedTypeSymbol { TypeKind: TypeKind.Delegate } delegateType
+                    || delegateType.DelegateInvokeMethod?.ReturnType
+                        is not ITypeParameterSymbol resultParameter
+                    || resultParameter.TypeParameterKind != TypeParameterKind.Method
+                    || !SymbolEqualityComparer.Default.Equals(
+                        resultParameter.ContainingSymbol,
+                        genericMethod))
+                {
+                    return false;
+                }
+
+                return SymbolEqualityComparer.Default.Equals(
+                        genericMethod.ReturnType,
+                        resultParameter)
+                    || (genericMethod.ReturnType is INamedTypeSymbol named
+                        && named.TypeArguments.Any(argument =>
+                            SymbolEqualityComparer.Default.Equals(argument, resultParameter)));
+            }
         }
 
         private AnonymousFunctionExpressionSyntax FindResultLambda(ExpressionSyntax use)

--- a/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
+++ b/tools/gsgen/GSharp.GeneratorHost.Tests/GsgenCliTests.cs
@@ -300,10 +300,46 @@ public class GsgenCliTests : IDisposable
         Assert.Contains("ThisAssembly", content);
         Assert.Contains("AssemblyFileVersion", content);
         Assert.Contains("1.2.3.4", content);
+        AssertGeneratedSourceCompiles(content, "OrdinaryForeignFile");
 
         var manifestLines = File.ReadAllLines(manifest).Where(l => l.Length > 0).ToList();
         var manifestEntry = Assert.Single(manifestLines);
         Assert.Equal(Path.GetFullPath(single), Path.GetFullPath(manifestEntry));
+    }
+
+    [Theory]
+    [InlineData(
+        "AssemblyOnly.cs",
+        "using System.Reflection;\n[assembly: AssemblyTitleAttribute(\"Oahu\")]",
+        "System.Reflection.AssemblyTitleAttribute",
+        null)]
+    [InlineData(
+        "ModuleOnly.cs",
+        "using System;\n[module: CLSCompliantAttribute(true)]",
+        null,
+        "System.CLSCompliantAttribute")]
+    public void ForeignCsFile_WithSingleCompilationUnitAttribute_WritesCompilableOutput(
+        string fileName,
+        string source,
+        string expectedAssemblyAttribute,
+        string expectedModuleAttribute)
+    {
+        var outDir = Path.Combine(this.workDir, Path.GetFileNameWithoutExtension(fileName));
+        var gs = this.WriteGs(fileName + ".gs", "package Probe\n\nfunc Placeholder() {\n}\n");
+        var cs = this.WriteCs(fileName, source);
+        var args = new List<string> { $"/gs:{gs}", $"/csfile:{cs}", $"/out:{outDir}" };
+        args.AddRange(RuntimeReferencePaths().Select(p => $"/r:{p}"));
+
+        var stdout = new StringWriter();
+        int exit = GsgenProgram.Run(args.ToArray(), stdout);
+
+        Assert.True(exit == 0, stdout.ToString());
+        string content = File.ReadAllText(Assert.Single(Directory.EnumerateFiles(outDir, "*.g.gs")));
+        AssertGeneratedSourceCompiles(
+            content,
+            Path.GetFileNameWithoutExtension(fileName),
+            expectedAssemblyAttribute,
+            expectedModuleAttribute);
     }
 
     [Fact]
@@ -339,6 +375,10 @@ public class GsgenCliTests : IDisposable
         Assert.Contains("import System.Reflection", content);
         Assert.Contains("@assembly:System.Reflection.AssemblyTitleAttribute(\"Oahu\")", content);
         Assert.Contains("internal class Holder", content);
+        AssertGeneratedSourceCompiles(
+            content,
+            "AttributesAndType",
+            expectedAssemblyAttribute: "System.Reflection.AssemblyTitleAttribute");
     }
 
     [Fact]
@@ -369,29 +409,27 @@ public class GsgenCliTests : IDisposable
         Assert.Contains("@assembly:System.Reflection.AssemblyTitleAttribute(\"Oahu\")", content);
         Assert.Contains("@module:System.CLSCompliantAttribute(true)", content);
 
-        var tree = GsSyntaxTree.Parse(GsSourceText.From(content));
-        Assert.Empty(tree.Diagnostics);
-
-        using var pe = new MemoryStream();
-        var compilation = new GsCompilation(tree) { IsLibrary = true };
-        var emit = compilation.Emit(
-            pe,
-            pdbStream: null,
-            refStream: null,
-            assemblyName: "Issue2815FileAttributes");
-        Assert.True(
-            emit.Success,
-            "generated file should compile: " + string.Join("; ", emit.Diagnostics.Select(d => d.Message)));
-
-        pe.Position = 0;
-        using var peReader = new PEReader(pe, PEStreamOptions.LeaveOpen);
-        MetadataReader metadata = peReader.GetMetadataReader();
-        Assert.Contains(
+        AssertGeneratedSourceCompiles(
+            content,
+            "BothFileAttributes",
             "System.Reflection.AssemblyTitleAttribute",
-            GetAttributeTypeNames(metadata, metadata.GetAssemblyDefinition().GetCustomAttributes()));
-        Assert.Contains(
-            "System.CLSCompliantAttribute",
-            GetAttributeTypeNames(metadata, metadata.GetModuleDefinition().GetCustomAttributes()));
+            "System.CLSCompliantAttribute");
+    }
+
+    [Fact]
+    public void ForeignCsFile_WithNoMembers_WritesNoOutput()
+    {
+        var outDir = Path.Combine(this.workDir, "gen-empty");
+        var gs = this.WriteGs("Input.gs", "package Probe\n\nfunc Placeholder() {\n}\n");
+        var cs = this.WriteCs("Empty.cs", "using System;\n");
+        var args = new List<string> { $"/gs:{gs}", $"/csfile:{cs}", $"/out:{outDir}" };
+        args.AddRange(RuntimeReferencePaths().Select(p => $"/r:{p}"));
+
+        var stdout = new StringWriter();
+        int exit = GsgenProgram.Run(args.ToArray(), stdout);
+
+        Assert.True(exit == 0, stdout.ToString());
+        Assert.Empty(Directory.EnumerateFiles(outDir, "*.g.gs"));
     }
 
     [Fact]
@@ -425,6 +463,44 @@ public class GsgenCliTests : IDisposable
         var path = Path.Combine(this.workDir, name);
         File.WriteAllText(path, source);
         return path;
+    }
+
+    private static void AssertGeneratedSourceCompiles(
+        string content,
+        string assemblyName,
+        string expectedAssemblyAttribute = null,
+        string expectedModuleAttribute = null)
+    {
+        var tree = GsSyntaxTree.Parse(GsSourceText.From(content));
+        Assert.Empty(tree.Diagnostics);
+
+        using var pe = new MemoryStream();
+        var compilation = new GsCompilation(tree) { IsLibrary = true };
+        var emit = compilation.Emit(
+            pe,
+            pdbStream: null,
+            refStream: null,
+            assemblyName: assemblyName);
+        Assert.True(
+            emit.Success,
+            "generated file should compile: " + string.Join("; ", emit.Diagnostics.Select(d => d.Message)));
+
+        pe.Position = 0;
+        using var peReader = new PEReader(pe, PEStreamOptions.LeaveOpen);
+        MetadataReader metadata = peReader.GetMetadataReader();
+        if (expectedAssemblyAttribute != null)
+        {
+            Assert.Contains(
+                expectedAssemblyAttribute,
+                GetAttributeTypeNames(metadata, metadata.GetAssemblyDefinition().GetCustomAttributes()));
+        }
+
+        if (expectedModuleAttribute != null)
+        {
+            Assert.Contains(
+                expectedModuleAttribute,
+                GetAttributeTypeNames(metadata, metadata.GetModuleDefinition().GetCustomAttributes()));
+        }
     }
 
     private static IReadOnlyList<string> RuntimeReferencePaths()


### PR DESCRIPTION
Closes #4046.

## Root cause

The migrated exception stack is:

```
System.NullReferenceException
  at Cs2Gs.Translator.CSharpToGSharpTranslator.DeclarationVisitor.<closure_<lambda1>_251>.Invoke(...)
     CSharpToGSharpTranslator.Constructors.gs:935
  at ...ResolveAttributeType(...):931
  at ...MapAttributes(...):900
  at ...MapFileAttributes(...):640
  at ...TranslateDocument(...):250
  at GSharp.GeneratorHost.GeneratedDocTranslator.Translate(...):64
  at GSharp.Gsgen.Cli.GsgenProgram.TranslateForeignCSharp(...):161
```

`cs2gs` translated the nullable Roslyn alias lookup inside `ResolveAttributeType` as:

```gsharp
.Select(identifier -> SemanticModel.GetAliasInfo(identifier)!!)
```

The checked `!!` threw before `FirstOrDefault(candidate => candidate != null)` could filter the null. Compilation-unit assembly/module attributes are the path that executes this alias lookup in migrated gsgen.

## Fix

Keep a nullable selector result bare when its fluent call chain collapses back to the same scalar type and the final migration sink is nullable. Existing non-null selector contracts retain their `!!` bridge.

Regression coverage now executes:

- assembly-only foreign files
- module-only foreign files
- assembly + module attributes
- attributes plus namespace/type declarations
- files with no members
- ordinary foreign files

Generated attribute-bearing output is parsed, compiled, and inspected for assembly/module metadata.

## Validation

- Baseline migrated gate reproduced: translate PASS, compile PASS, ILVerify PASS, parity **29/31** (2 failures).
- Fixed migrated gate: translate PASS, compile PASS, ILVerify PASS, parity **34/34**.
- Focused cs2gs regressions: **7/7**.
- Focused gsgen foreign-file matrix: **6/6**.
- Source GeneratorHost.Tests: **34/34**.
- Release solution build: **0 warnings, 0 errors**.
- Nullable hygiene: PASS.
- Self-migration guard harness: PASS.
- Hot-core self-migration guard: **8/8 apps green** across translate/compile/ILVerify/parity.
