### PR TITLE
ci: restore hot-core guard timeout headroom

### DIFF
--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -24,7 +24,7 @@ name: cs2gs-pr-guard
 #
 # WHAT IT IS NOT
 #
-# It is not the gate. It checks six projects, not fifty-three; it says
+# It is not the gate. It checks eight projects, not fifty-three; it says
 # nothing about the readability ceilings or corpus-wide test parity. The job's
 # own output repeats that on every run, pass or fail, because a partial check
 # mistaken for a full one is worse than no check at all.
@@ -49,11 +49,10 @@ name: cs2gs-pr-guard
 #
 # WHAT THAT COSTS
 #
-# The job takes ~30-45 minutes (five consecutive runs measured 29, 41, 44, 44
-# and 45 minutes), and it is now paid on PRs that cannot possibly affect
-# translation. build.yml's entire matrix finishes in ~21-25 minutes, so on a
-# docs-only PR this guard becomes the critical path and roughly doubles the
-# time to green. That is the price of the check being reportable on every PR.
+# Recent successful runs of the current eight-project set take ~53-55 minutes,
+# almost all inside the migrate step. Runner variance has pushed that work past
+# the old 60-minute job limit. The cost is paid even on PRs that cannot affect
+# translation because the check must report on every PR to remain required.
 #
 # WHAT THE OLD FILTER SAID, AND WHERE THAT KNOWLEDGE LIVES NOW
 #
@@ -98,9 +97,10 @@ jobs:
   guard:
     name: hot-core translation guard
     runs-on: ubuntu-latest
-    # The measured run is well under this; the headroom is for a gsc hang,
-    # which is a failure mode this job specifically exists to catch (#3905).
-    timeout-minutes: 60
+    # Current eight-project runs measure ~53-55 minutes. Ninety minutes restores
+    # runner-variance headroom while keeping a finite whole-job backstop; each
+    # compiler/test child retains its tighter ProcessRunner timeout.
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5

--- a/build/run-cs2gs-selfmig-pr-guard.sh
+++ b/build/run-cs2gs-selfmig-pr-guard.sh
@@ -136,8 +136,8 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # translate/compile/ilverify/test-parity green in gate run 33943018295, so it
 # is not a red-from-day-one addition. Cs2Gs.ProjectLoading comes with it only
 # to keep the set closed under ProjectReference (verify_closure below would
-# otherwise fail the run). The two add roughly one more app's worth of
-# translate + compile to a ~30-minute job.
+# otherwise fail the run). This expanded the guard from six apps to eight;
+# recent eight-app migrations measure ~50-52 minutes on GitHub-hosted runners.
 #
 # STILL DELIBERATELY ABSENT: tools/cs2gs/Cs2Gs.Tests, which #3836 names as the
 # natural next step. It has ~9 known migration failures and would be red by
@@ -210,7 +210,7 @@ done < <(cd "$repo_root" && git ls-files '*.csproj' | sort)
 
 # A short list would mean the enumeration silently failed, and a migrate with
 # too few --excludes would quietly migrate the whole repository instead of the
-# hot core — a 30-minute job pretending to be a 20-minute one.
+# hot core.
 if (( ${#excludes[@]} < 80 )); then
   echo "PR guard: enumerated only $(( ${#excludes[@]} / 2 )) project(s) to exclude; the" >&2
   echo "repository has ~60. Is this a git checkout?" >&2

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -81,4 +81,12 @@ grep -q "run FAILED" "$test_root/run-failed.log"
 grep -q "run succeeded=false" "$test_root/run-failed.log"
 ! grep -q "PR guard PASSED." "$test_root/run-failed.log"
 
+grep -qx '    timeout-minutes: 90' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -Fq 'Console.WriteLine($"cs2gs: {app.Id}: {stageName} started.");' \
+  "$repo_root/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs"
+grep -Fq '$"cs2gs: {app.Id}: {stageName} {outcome.Status.ToString().ToLowerInvariant()} in "' \
+  "$repo_root/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs"
+grep -Fq '$"{stageTimer.Elapsed.TotalSeconds:F1}s.");' \
+  "$repo_root/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs"
+
 echo "selfmig PR guard regressions PASSED."

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -82,11 +82,5 @@ grep -q "run succeeded=false" "$test_root/run-failed.log"
 ! grep -q "PR guard PASSED." "$test_root/run-failed.log"
 
 grep -qx '    timeout-minutes: 90' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
-grep -Fq 'Console.WriteLine($"cs2gs: {app.Id}: {stageName} started.");' \
-  "$repo_root/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs"
-grep -Fq '$"cs2gs: {app.Id}: {stageName} {outcome.Status.ToString().ToLowerInvariant()} in "' \
-  "$repo_root/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs"
-grep -Fq '$"{stageTimer.Elapsed.TotalSeconds:F1}s.");' \
-  "$repo_root/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs"
 
 echo "selfmig PR guard regressions PASSED."

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -786,6 +787,11 @@ public sealed class MigrationPipeline
                 continue;
             }
 
+            // ProcessRunner captures child output for diagnostics. Emit the
+            // outer boundary so CI still identifies the active app and stage.
+            var stageTimer = Stopwatch.StartNew();
+            Console.WriteLine($"cs2gs: {app.Id}: {stageName} started.");
+
             StageOutcome outcome;
             try
             {
@@ -805,6 +811,10 @@ public sealed class MigrationPipeline
                 Console.Error.WriteLine(ex);
                 outcome = StageOutcome.Failed(new[] { StageCrashArtifact(context.Triage, stage.Kind, ex) });
             }
+
+            Console.WriteLine(
+                $"cs2gs: {app.Id}: {stageName} {outcome.Status.ToString().ToLowerInvariant()} in " +
+                $"{stageTimer.Elapsed.TotalSeconds:F1}s.");
 
             if (outcome.Status == StageStatus.Passed)
             {

--- a/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/MigrationPipeline.cs
@@ -814,7 +814,7 @@ public sealed class MigrationPipeline
 
             Console.WriteLine(
                 $"cs2gs: {app.Id}: {stageName} {outcome.Status.ToString().ToLowerInvariant()} in " +
-                $"{stageTimer.Elapsed.TotalSeconds:F1}s.");
+                $"{stageTimer.Elapsed.TotalSeconds.ToString("F1", CultureInfo.InvariantCulture)}s.");
 
             if (outcome.Status == StageStatus.Passed)
             {

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -554,6 +554,61 @@ public class MigrationPipelineTests
         Assert.False(result.Unverified);
     }
 
+    /// <summary>
+    /// Stage progress names the active app/stage before work starts, then reports
+    /// its pass/fail result and elapsed time after the stage completes.
+    /// </summary>
+    [Fact]
+    public async Task StageProgress_ReportsStartBeforePassOrFail_WithElapsedTime()
+    {
+        string outRoot = NewOutputRoot("stage-progress");
+        string projectPath = Path.Combine(outRoot, "Progress.csproj");
+        File.WriteAllText(projectPath, "<Project />");
+        var options = new PipelineOptions
+        {
+            GscPath = typeof(MigrationPipeline).Assembly.Location,
+            OutputRoot = outRoot,
+        };
+        var pipeline = new MigrationPipeline(
+            options,
+            new IMigrationStage[]
+            {
+                new PassStage(MigrationStageKind.Translate),
+                new FailStage(MigrationStageKind.Compile),
+            });
+        var app = new CorpusApp("tests/Progress", projectPath, TargetKind.Library);
+
+        TextWriter originalOut = Console.Out;
+        using var captured = new StringWriter();
+        try
+        {
+            Console.SetOut(captured);
+            await pipeline.RunAsync(new[] { app });
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        string[] lines = captured.ToString()
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        int translateStart = Array.IndexOf(lines, "cs2gs: tests/Progress: translate started.");
+        int translatePass = Array.FindIndex(
+            lines,
+            line => line.StartsWith("cs2gs: tests/Progress: translate passed in ", StringComparison.Ordinal));
+        int compileStart = Array.IndexOf(lines, "cs2gs: tests/Progress: compile started.");
+        int compileFail = Array.FindIndex(
+            lines,
+            line => line.StartsWith("cs2gs: tests/Progress: compile failed in ", StringComparison.Ordinal));
+
+        Assert.True(translateStart >= 0);
+        Assert.True(translateStart < translatePass);
+        Assert.True(translatePass < compileStart);
+        Assert.True(compileStart < compileFail);
+        Assert.Matches(@"^cs2gs: tests/Progress: translate passed in [0-9]+\.[0-9]s\.$", lines[translatePass]);
+        Assert.Matches(@"^cs2gs: tests/Progress: compile failed in [0-9]+\.[0-9]s\.$", lines[compileFail]);
+    }
+
     /// <summary>A fixed-outcome stage double, used to drive pipeline rollup tests deterministically.</summary>
     private sealed class PassStage : IMigrationStage
     {


### PR DESCRIPTION
## Summary

- raise the hot-core guard timeout from 60 to 90 minutes
- print start and completion lines, including status and elapsed time, for every app/stage
- update stale runtime/scope comments and add focused timeout/progress regression coverage

Fixes #4077

## Root cause

The job timeout stopped being a hang detector once normal work occupied nearly the whole budget. Pre-fix Actions measurements for the current eight-app guard show 2,979s and 3,090s in `cs2gs migrate`, while the four setup builds remain about three minutes total. A slower runner therefore crossed the 60-minute whole-job limit during healthy work.

The silent interval is expected sequential pipeline work, not a gsc hang. `MigrationPipeline` runs each app's stages in order; `CompileStage` calls `SdkCompileRunner.CompileMirroredProject`, which synchronously waits for a `dotnet build` child through `ProcessRunner`. `ProcessRunner` captures child stdout/stderr for diagnostics, so the outer job previously exposed no active app or stage.

## Remedies

- `timeout-minutes: 90` restores roughly 35 minutes of runner-variance headroom while retaining a finite whole-job backstop. Existing per-child `ProcessRunner` timeouts remain tighter.
- Pipeline output now reports lines such as:

  ```text
  cs2gs: src/Core/Core.csproj: compile started.
  cs2gs: src/Core/Core.csproj: compile passed in 472.4s.
  ```

  A slow or terminated run therefore leaves the active project/stage as its last progress line; completed stages also expose measured duration for future drift analysis.

## Runtime-drift investigation

Repository history and Actions data show the guard scope grew from four apps to five, six, then eight as Channels, Formatting, Pipeline, and ProjectLoading closed real coverage holes. Measured migrate times were 1,365s for four apps, 1,605s for five, 1,224–2,437s for six, and 2,217–3,090s for eight. The wide ranges demonstrate substantial hosted-runner variance; this PR's 2,217s run is not a claimed optimization because the execution path is unchanged apart from logging.

No safe runtime optimization is included or claimed. Current code isolates each app's NuGet cache, build outputs, and intermediates under its artifact directory and temporarily rewrites mirrored build props around synchronous builds. Sharing those outputs or parallelizing stages would change correctness/isolation behavior and cannot be justified without targeted CI measurement. Scope growth plus runner variance is established; a low-risk performance fix is not established from repository evidence.

## Regression coverage

- `build/test-cs2gs-selfmig-pr-guard.sh` statically requires the 90-minute workflow timeout while retaining its fake-`dotnet` failure-propagation cases.
- `MigrationPipelineTests.StageProgress_ReportsStartBeforePassOrFail_WithElapsedTime` exercises start ordering, pass/fail status, and invariant elapsed-time formatting through the real pipeline coordinator.

## Validation

- `bash -n build/run-cs2gs-selfmig-pr-guard.sh build/test-cs2gs-selfmig-pr-guard.sh`
- `./build/test-cs2gs-selfmig-pr-guard.sh`
- `git diff --check`
- no local `dotnet` restore/build/test, per issue constraint
- GitHub `build` workflow: all executed jobs passed
- GitHub `hot-core translation guard`: passed in 40m59s; migrate completed 8/8 apps in 2,217s and emitted 32 start plus 32 completion markers