### PR TITLE
ci: distinguish hot-core timeout from cancellation

### DIFF
--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -92,14 +92,18 @@ env:
   # Nerdbank.GitVersioning's GitBuildVersion* emission.
   NBGV_SetCloudBuildVersionVars: false
   SELFMIG_PR_GUARD_ROOT: /tmp/gsharp-cs2gs-pr-guard
+  # GitHub reports both job timeouts and concurrency cancellations as
+  # "cancelled". Expire migrate first so the script can identify a real timeout.
+  SELFMIG_PR_GUARD_MIGRATE_TIMEOUT: 75m
 
 jobs:
   guard:
     name: hot-core translation guard
     runs-on: ubuntu-latest
     # Current eight-project runs measure ~53-55 minutes. Ninety minutes restores
-    # runner-variance headroom while keeping a finite whole-job backstop; each
-    # compiler/test child retains its tighter ProcessRunner timeout.
+    # runner-variance headroom while keeping a finite whole-job backstop. The
+    # migrate step has a 75-minute reporting deadline, and each compiler/test
+    # child retains its tighter ProcessRunner timeout.
     timeout-minutes: 90
 
     steps:

--- a/build/run-cs2gs-selfmig-pr-guard.sh
+++ b/build/run-cs2gs-selfmig-pr-guard.sh
@@ -77,6 +77,9 @@
 #                          set can be widened (e.g. to tools/cs2gs/Cs2Gs.Tests
 #                          once #3836's ~9 known failures clear) without
 #                          editing this file.
+#   SELFMIG_PR_GUARD_MIGRATE_TIMEOUT
+#                          optional GNU timeout duration for migrate; CI sets
+#                          75m so it can report timeout before the 90m job cap.
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -250,18 +253,31 @@ dotnet build "$repo_root/src/Sdk/Gsharp.NET.Sdk/Gsharp.NET.Sdk.csproj" -c Releas
 
 started=$(date +%s)
 
+migrate_command=(
+  dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate
+  --corpus "$repo_root"
+  --out "$work_root/migrated"
+  --artifacts "$work_root/runs"
+  --config Release
+  "${excludes[@]}"
+)
+if [[ -n "${SELFMIG_PR_GUARD_MIGRATE_TIMEOUT:-}" ]]; then
+  migrate_command=(timeout --verbose "$SELFMIG_PR_GUARD_MIGRATE_TIMEOUT" "${migrate_command[@]}")
+fi
+
 set +e
-dotnet "$repo_root/out/bin/Release/Cs2Gs.Cli/cs2gs.dll" migrate \
-  --corpus "$repo_root" \
-  --out "$work_root/migrated" \
-  --artifacts "$work_root/runs" \
-  --config Release \
-  "${excludes[@]}" \
-  2>&1 | tee "$work_root/guard.log"
+"${migrate_command[@]}" 2>&1 | tee "$work_root/guard.log"
 migrate_exit=${PIPESTATUS[0]}
 set -e
 
 elapsed=$(( $(date +%s) - started ))
+
+if [[ -n "${SELFMIG_PR_GUARD_MIGRATE_TIMEOUT:-}" ]] && (( migrate_exit == 124 )); then
+  echo >&2
+  echo "::error title=Hot-core migration timeout::PR guard TIMED OUT: cs2gs migrate exceeded its $SELFMIG_PR_GUARD_MIGRATE_TIMEOUT deadline after ${elapsed}s." >&2
+  echo "This is the guard's internal timeout, not a push/concurrency cancellation." >&2
+  exit 124
+fi
 
 run_json=$(find "$work_root/runs" -maxdepth 2 -name run.json | sort | tail -1)
 if [[ -z "$run_json" ]]; then

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -16,6 +16,10 @@ if [[ "${1:-}" == build ]]; then
   exit 0
 fi
 
+if [[ -n "${FAKE_MIGRATE_SLEEP:-}" ]]; then
+  sleep "$FAKE_MIGRATE_SLEEP"
+fi
+
 artifacts=
 while (( $# )); do
   if [[ "$1" == --artifacts ]]; then
@@ -48,13 +52,16 @@ chmod +x "$fake_bin/dotnet"
 
 run_case() {
   local name=$1 run_succeeded=$2 migrate_exit=$3 expected_exit=$4
+  local migrate_timeout=${5:-} migrate_sleep=${6:-}
   local case_root="$test_root/$name"
   local log="$case_root.log"
   set +e
   PATH="$fake_bin:$PATH" \
     FAKE_RUN_SUCCEEDED="$run_succeeded" \
     FAKE_MIGRATE_EXIT="$migrate_exit" \
+    FAKE_MIGRATE_SLEEP="$migrate_sleep" \
     SELFMIG_PR_GUARD_ROOT="$case_root" \
+    SELFMIG_PR_GUARD_MIGRATE_TIMEOUT="$migrate_timeout" \
     "$repo_root/build/run-cs2gs-selfmig-pr-guard.sh" >"$log" 2>&1
   local actual_exit=$?
   set -e
@@ -65,22 +72,31 @@ run_case() {
     exit 1
   fi
 
-  grep -q "PR guard: 8/8 guarded app(s)" "$log"
 }
 
 run_case success true 0 0
+grep -q "PR guard: 8/8 guarded app(s)" "$test_root/success.log"
 grep -q "PR guard PASSED." "$test_root/success.log"
 
 run_case migrate-exit-nonzero true 7 7
+grep -q "PR guard: 8/8 guarded app(s)" "$test_root/migrate-exit-nonzero.log"
 grep -q "migrate exit 7" "$test_root/migrate-exit-nonzero.log"
 grep -q "PR guard FAILED: cs2gs reported a global migration failure" "$test_root/migrate-exit-nonzero.log"
 ! grep -q "PR guard PASSED." "$test_root/migrate-exit-nonzero.log"
 
 run_case run-failed false 0 1
+grep -q "PR guard: 8/8 guarded app(s)" "$test_root/run-failed.log"
 grep -q "run FAILED" "$test_root/run-failed.log"
 grep -q "run succeeded=false" "$test_root/run-failed.log"
 ! grep -q "PR guard PASSED." "$test_root/run-failed.log"
 
+run_case migrate-timeout true 0 124 1s 2
+grep -q "PR guard TIMED OUT: cs2gs migrate exceeded its 1s deadline" "$test_root/migrate-timeout.log"
+grep -q "not a push/concurrency cancellation" "$test_root/migrate-timeout.log"
+! grep -q "no run.json produced" "$test_root/migrate-timeout.log"
+
 grep -qx '    timeout-minutes: 90' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -qx '  SELFMIG_PR_GUARD_MIGRATE_TIMEOUT: 75m' \
+  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 
 echo "selfmig PR guard regressions PASSED."


### PR DESCRIPTION
## Summary

- impose a 75-minute migrate deadline inside the existing 90-minute job limit
- report that deadline as an explicit `Hot-core migration timeout` annotation and exit 124
- add a lightweight behavioral timeout regression using the existing fake-`dotnet` harness

Fixes #4077
Follow-up to #4104, which merged immediately before this review request.

## Progress regression gap

The merged #4104 head already replaced source-text greps with `MigrationPipelineTests.StageProgress_ReportsStartBeforePassOrFail_WithElapsedTime`. That test runs the real pipeline coordinator with existing pass/fail fake stages, captures stdout, and verifies:

- app and stage names are present
- `started` precedes `passed` / `failed`
- elapsed time has invariant one-decimal-second formatting

No additional test abstraction is needed.

## Cancellation-cause investigation

GitHub's available workflow state does not expose a cancellation-reason field. Both the timed-out run attempt and a push-cancelled run report workflow/job/step conclusion `cancelled`; `github`/`job` contexts expose status, not whether cancellation came from `timeout-minutes` or `concurrency.cancel-in-progress`.

An after-the-fact `if: always()` / `cancelled()` classifier is not reliable: GitHub re-evaluates conditions while cancelling and then signals or kills the runner process tree. In this repository, the existing `if: always()` artifact step ran after both observed causes and still had no distinguishing context.

References:
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation
- https://docs.github.com/en/actions/reference/workflows-and-actions/contexts

## Remedy

Rather than guessing after cancellation, CI now sets `SELFMIG_PR_GUARD_MIGRATE_TIMEOUT=75m`. The guard runs `cs2gs migrate` under GNU `timeout`:

- healthy work keeps 20+ minutes of migrate headroom over measured 50-55 minute slow runs
- a real migrate overrun ends before the 90-minute GitHub job cap, emits an explicit error annotation naming the 75-minute deadline, and exits 124 as a failure
- a superseding push still uses GitHub concurrency cancellation and remains `cancelled`, with no false timeout annotation
- the 90-minute job timeout remains a final backstop for setup or abnormal termination

This sidesteps the platform's missing cancellation-cause field without an external service, API race, or post-cancellation step.

## Validation

- `bash -n build/run-cs2gs-selfmig-pr-guard.sh build/test-cs2gs-selfmig-pr-guard.sh`
- `./build/test-cs2gs-selfmig-pr-guard.sh`
  - fake migrate exceeding a 1-second deadline exits 124
  - log identifies internal timeout and explicitly excludes push/concurrency cancellation
  - generic `no run.json produced` diagnosis is suppressed
- `git diff --check`
- no local `dotnet` restore/build/test, per constraint; GitHub CI is the full validation path