### PR TITLE
ci: finish hot-core guard timeout diagnosis

### DIFF
--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -115,19 +115,35 @@ jobs:
           # migrated tree is restored as NuGet packages that carry it.
           fetch-depth: 0
 
+      - name: Test PR guard control and failure propagation
+        run: ./build/test-cs2gs-selfmig-pr-guard.sh
+
       - name: Detect changes that can affect the guard
         id: scope
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]] ||
-             ./build/cs2gs-pr-guard-control.sh relevant-paths \
-               < <(git diff --no-renames --name-only -z "$BASE_SHA...$HEAD_SHA"); then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
+          run_guard=true
+          if [[ "$GITHUB_EVENT_NAME" != workflow_dispatch ]]; then
+            changed_paths="$RUNNER_TEMP/cs2gs-pr-guard-paths"
+            if git diff --no-renames --name-only -z "$BASE_SHA...$HEAD_SHA" > "$changed_paths"; then
+              if ./build/cs2gs-pr-guard-control.sh relevant-paths < "$changed_paths"; then
+                :
+              else
+                helper_status=$?
+                if (( helper_status == 1 )); then
+                  run_guard=false
+                else
+                  echo "::warning title=Path classification failed::Classifier exited $helper_status; running guard."
+                fi
+              fi
+            else
+              diff_status=$?
+              echo "::warning title=PR diff failed::git diff exited $diff_status; running guard."
+            fi
           fi
+          echo "run=$run_guard" >> "$GITHUB_OUTPUT"
 
       - name: Report unaffected change
         if: steps.scope.outputs.run != 'true'
@@ -153,10 +169,6 @@ jobs:
       - name: Restore .NET local tools
         if: steps.scope.outputs.run == 'true'
         run: dotnet tool restore
-
-      - name: Test PR guard failure propagation
-        if: steps.scope.outputs.run == 'true'
-        run: ./build/test-cs2gs-selfmig-pr-guard.sh
 
       # The script builds the solution itself (which repacks the
       # Gsharp.NET.Sdk nupkg the compile stage consumes) and then migrates.

--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]] ||
              ./build/cs2gs-pr-guard-control.sh relevant-paths \
-               < <(git diff --name-only -z "$BASE_SHA...$HEAD_SHA"); then
+               < <(git diff --no-renames --name-only -z "$BASE_SHA...$HEAD_SHA"); then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -174,6 +174,7 @@ jobs:
         with:
           name: cs2gs-pr-guard
           retention-days: 7
+          if-no-files-found: ignore
           path: |
             /tmp/gsharp-cs2gs-pr-guard/guard.log
             /tmp/gsharp-cs2gs-pr-guard/runs/**/*.json
@@ -221,23 +222,25 @@ jobs:
           done
           messages=$(jq -r '.[].message // empty' <<< "$annotations")
 
+          case "$cause" in
+            superseded)
+              summary="**Superseded by a newer push.** This was not a timeout."
+              echo "::notice title=Hot-core guard superseded::Cancelled because a newer push replaced this run; this was not a timeout."
+              ;;
+            timeout)
+              summary="**Timed out.** GitHub stopped the guard after its 90-minute job limit."
+              echo "::error title=Hot-core guard timed out::GitHub stopped the guard after its 90-minute job limit."
+              ;;
+            *)
+              summary="**Unknown cancellation.** GitHub did not return a recognized timeout or concurrency annotation."
+              echo "::error title=Hot-core cancellation unknown::GitHub did not return a recognized timeout or concurrency annotation."
+              ;;
+          esac
+
           {
             echo "### Hot-core guard cancellation"
             echo
-            case "$cause" in
-              superseded)
-                echo "**Superseded by a newer push.** This was not a timeout."
-                echo "::notice title=Hot-core guard superseded::Cancelled because a newer push replaced this run; this was not a timeout."
-                ;;
-              timeout)
-                echo "**Timed out.** GitHub stopped the guard after its 90-minute job limit."
-                echo "::error title=Hot-core guard timed out::GitHub stopped the guard after its 90-minute job limit."
-                ;;
-              *)
-                echo "**Unknown cancellation.** GitHub did not return a recognized timeout or concurrency annotation."
-                echo "::error title=Hot-core cancellation unknown::GitHub did not return a recognized timeout or concurrency annotation."
-                ;;
-            esac
+            echo "$summary"
             echo
             echo '```text'
             printf '%s\n' "$messages"

--- a/.github/workflows/cs2gs-pr-guard.yml
+++ b/.github/workflows/cs2gs-pr-guard.yml
@@ -47,12 +47,20 @@ name: cs2gs-pr-guard
 # each reached `main` with CI fully green, which is precisely the situation an
 # advisory check does not survive.
 #
-# WHAT THAT COSTS
+# WHAT THAT COSTS, AND WHEN IT IS PAID
 #
 # Recent successful runs of the current eight-project set take ~53-55 minutes,
 # almost all inside the migrate step. Runner variance has pushed that work past
-# the old 60-minute job limit. The cost is paid even on PRs that cannot affect
-# translation because the check must report on every PR to remain required.
+# the old 60-minute job limit. Run 34153792929's stage timings put 1,747 of
+# 2,217 migrate seconds in compile, with Pipeline + ProjectLoading accounting
+# for 625 seconds. Those builds intentionally isolate outputs and package
+# caches per app; sharing or parallelizing them would change the gate rather
+# than safely optimize it.
+#
+# The workflow still starts on every PR so the required check always reports,
+# but the first step compares the PR diff with the inputs that can affect this
+# guard. An unrelated PR reports a successful no-op instead of paying ~55
+# minutes. Relevant changes retain the complete eight-app gate unchanged.
 #
 # WHAT THE OLD FILTER SAID, AND WHERE THAT KNOWLEDGE LIVES NOW
 #
@@ -64,13 +72,9 @@ name: cs2gs-pr-guard
 # which decide whether the translated result compiles (#3905 was a gsc crash,
 # not a translation defect), and this job's own definition.
 #
-# That set is still the honest answer to "which changes can turn this job
-# red". It is simply no longer the answer to "when does this job run". If the
-# cost above stops being acceptable, the shape to reach for is a changed-paths
-# step INSIDE the job that short-circuits the expensive steps with `if:`, so
-# the check still reports on every PR. Do not reintroduce a top-level `paths:`
-# filter while this check is required — that is the failure this trigger
-# exists to avoid.
+# That set is the input to build/cs2gs-pr-guard-control.sh. Keep the workflow
+# always-triggering: the in-job check is what preserves both required-check
+# eligibility and the old filter's cost profile.
 #
 # `push:` on `main` is deliberately absent, and `tags:` more so. This is a
 # PR-time instrument (see the concurrency group, keyed on the PR number); the
@@ -83,10 +87,6 @@ on:
       - main
   workflow_dispatch:
 
-concurrency:
-  group: cs2gs-pr-guard-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 env:
   # See build.yml: parallel MSBuild nodes corrupt $GITHUB_ENV via
   # Nerdbank.GitVersioning's GitBuildVersion* emission.
@@ -97,6 +97,12 @@ jobs:
   guard:
     name: hot-core translation guard
     runs-on: ubuntu-latest
+    # Job-level concurrency cancels only obsolete expensive work. The separate
+    # classifier job survives and turns GitHub's cancellation annotation into
+    # an explicit superseded-push or timeout result.
+    concurrency:
+      group: cs2gs-pr-guard-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     # Current eight-project runs measure ~53-55 minutes. Ninety minutes restores
     # runner-variance headroom while keeping a finite whole-job backstop; each
     # compiler/test child retains its tighter ProcessRunner timeout.
@@ -109,18 +115,47 @@ jobs:
           # migrated tree is restored as NuGet packages that carry it.
           fetch-depth: 0
 
+      - name: Detect changes that can affect the guard
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]] ||
+             ./build/cs2gs-pr-guard-control.sh relevant-paths \
+               < <(git diff --name-only -z "$BASE_SHA...$HEAD_SHA"); then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report unaffected change
+        if: steps.scope.outputs.run != 'true'
+        run: |
+          {
+            echo "### cs2gs PR translation guard"
+            echo
+            echo "Skipped: this PR changes no input that can affect the hot-core translation guard."
+            echo
+            echo "The required check still reports; no translation, compile, ILVerify, or parity gate was needed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Setup .NET SDK
+        if: steps.scope.outputs.run == 'true'
         uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
       - name: Restore
+        if: steps.scope.outputs.run == 'true'
         run: dotnet restore GSharp.sln --locked-mode
 
       - name: Restore .NET local tools
+        if: steps.scope.outputs.run == 'true'
         run: dotnet tool restore
 
       - name: Test PR guard failure propagation
+        if: steps.scope.outputs.run == 'true'
         run: ./build/test-cs2gs-selfmig-pr-guard.sh
 
       # The script builds the solution itself (which repacks the
@@ -130,10 +165,11 @@ jobs:
       # another `dotnet build` between the pack and the migrate is how MSB4236
       # appears here. Do not add build steps above this one.
       - name: Migrate and compile the hot core
+        if: steps.scope.outputs.run == 'true'
         run: ./build/run-cs2gs-selfmig-pr-guard.sh
 
       - name: Upload guard artifacts
-        if: always()
+        if: always() && steps.scope.outputs.run == 'true'
         uses: actions/upload-artifact@v5
         with:
           name: cs2gs-pr-guard
@@ -146,3 +182,66 @@ jobs:
             # The migrated .gs of the guarded projects, so a failure can be
             # read at the source rather than reproduced locally.
             /tmp/gsharp-cs2gs-pr-guard/migrated/**/*.gs
+
+  classify-cancellation:
+    name: hot-core cancellation cause
+    needs: guard
+    if: always() && needs.guard.result == 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Report cancellation cause
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          job_id=$(
+            gh api \
+              "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$GITHUB_RUN_ATTEMPT/jobs?per_page=100" \
+              --jq '.jobs[] | select(.name == "hot-core translation guard") | .id' |
+              head -1
+          )
+          if [[ -z "$job_id" ]]; then
+            echo "::error title=Hot-core cancellation unknown::Could not find the cancelled guard job."
+            exit 1
+          fi
+
+          cause=unknown
+          for attempt in {1..5}; do
+            annotations=$(gh api \
+              "repos/$GITHUB_REPOSITORY/check-runs/$job_id/annotations?per_page=100")
+            cause=$(./build/cs2gs-pr-guard-control.sh cancellation <<< "$annotations")
+            [[ "$cause" != unknown ]] && break
+            sleep 2
+          done
+          messages=$(jq -r '.[].message // empty' <<< "$annotations")
+
+          {
+            echo "### Hot-core guard cancellation"
+            echo
+            case "$cause" in
+              superseded)
+                echo "**Superseded by a newer push.** This was not a timeout."
+                echo "::notice title=Hot-core guard superseded::Cancelled because a newer push replaced this run; this was not a timeout."
+                ;;
+              timeout)
+                echo "**Timed out.** GitHub stopped the guard after its 90-minute job limit."
+                echo "::error title=Hot-core guard timed out::GitHub stopped the guard after its 90-minute job limit."
+                ;;
+              *)
+                echo "**Unknown cancellation.** GitHub did not return a recognized timeout or concurrency annotation."
+                echo "::error title=Hot-core cancellation unknown::GitHub did not return a recognized timeout or concurrency annotation."
+                ;;
+            esac
+            echo
+            echo '```text'
+            printf '%s\n' "$messages"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          [[ "$cause" == superseded ]]

--- a/build/cs2gs-pr-guard-control.sh
+++ b/build/cs2gs-pr-guard-control.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  relevant-paths)
+    while IFS= read -r -d '' path; do
+      case "$path" in
+        .config/*|build/*|src/Analyzers/*|src/Compiler/*|src/Core/*|\
+        src/Formatting/*|src/Sdk/*|tools/*|Directory.Build.*|\
+        Directory.Packages.props|global.json|GSharp.sln|nuget.config|version.json|\
+        .github/workflows/cs2gs-pr-guard.yml)
+          printf '%s\n' "$path"
+          exit 0
+          ;;
+      esac
+    done
+    exit 1
+    ;;
+
+  cancellation)
+    messages=$(jq -r 'if type == "array" then .[]?.message // empty else error("expected array") end')
+    if grep -Eqi 'exceeded the maximum execution time|timed out after' <<< "$messages"; then
+      echo timeout
+    elif grep -Eqi 'Canceling since a higher priority waiting request' <<< "$messages"; then
+      echo superseded
+    else
+      echo unknown
+    fi
+    ;;
+
+  *)
+    echo "usage: $0 {relevant-paths|cancellation}" >&2
+    exit 2
+    ;;
+esac

--- a/build/cs2gs-pr-guard-control.sh
+++ b/build/cs2gs-pr-guard-control.sh
@@ -5,7 +5,8 @@ case "${1:-}" in
   relevant-paths)
     while IFS= read -r -d '' path; do
       case "$path" in
-        .config/*|build/*|src/Analyzers/*|src/Compiler/*|src/Core/*|\
+        .config/*|.editorconfig|.gitattributes|build/*|\
+        src/Analyzers/*|src/Compiler/*|src/Core/*|\
         src/Formatting/*|src/Sdk/*|tools/*|Directory.Build.*|\
         Directory.Packages.props|global.json|GSharp.sln|nuget.config|version.json|\
         test/Shared/*|.github/workflows/cs2gs-pr-guard.yml)

--- a/build/cs2gs-pr-guard-control.sh
+++ b/build/cs2gs-pr-guard-control.sh
@@ -8,7 +8,7 @@ case "${1:-}" in
         .config/*|build/*|src/Analyzers/*|src/Compiler/*|src/Core/*|\
         src/Formatting/*|src/Sdk/*|tools/*|Directory.Build.*|\
         Directory.Packages.props|global.json|GSharp.sln|nuget.config|version.json|\
-        .github/workflows/cs2gs-pr-guard.yml)
+        test/Shared/*|.github/workflows/cs2gs-pr-guard.yml)
           printf '%s\n' "$path"
           exit 0
           ;;

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -97,6 +97,52 @@ linked_path=$(printf 'test/Shared/GoldenFile.cs\0' | "$control" relevant-paths)
 config_path=$(printf '.editorconfig\0' | "$control" relevant-paths)
 [[ "$config_path" == .editorconfig ]]
 
+workflow="$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+scope_root="$test_root/scope"
+scope_script="$scope_root/scope.sh"
+mkdir -p "$scope_root/build" "$scope_root/tmp"
+awk '
+  $0 == "      - name: Detect changes that can affect the guard" { found = 1; next }
+  found && $0 == "        run: |" { in_run = 1; next }
+  in_run && $0 ~ /^      - name:/ { exit }
+  in_run { sub(/^          /, ""); print }
+' "$workflow" > "$scope_script"
+grep -q 'git diff --no-renames --name-only -z' "$scope_script"
+
+cat > "$fake_bin/git" <<'EOF'
+#!/usr/bin/env bash
+printf 'docs/only.md\0'
+exit "${FAKE_DIFF_EXIT:?}"
+EOF
+chmod +x "$fake_bin/git"
+
+cat > "$scope_root/build/cs2gs-pr-guard-control.sh" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+exit "${FAKE_HELPER_EXIT:?}"
+EOF
+chmod +x "$scope_root/build/cs2gs-pr-guard-control.sh"
+
+run_scope_case() {
+  local name=$1 diff_exit=$2 helper_exit=$3 expected=$4
+  local output="$scope_root/$name.output"
+  (
+    cd "$scope_root"
+    PATH="$fake_bin:$PATH" \
+      GITHUB_EVENT_NAME=pull_request \
+      BASE_SHA=base HEAD_SHA=head RUNNER_TEMP="$scope_root/tmp" \
+      GITHUB_OUTPUT="$output" \
+      FAKE_DIFF_EXIT="$diff_exit" FAKE_HELPER_EXIT="$helper_exit" \
+      bash "$scope_script"
+  )
+  grep -qx "run=$expected" "$output"
+}
+
+run_scope_case irrelevant 0 1 false
+run_scope_case relevant 0 0 true
+run_scope_case diff-failure 128 1 true
+run_scope_case helper-failure 0 2 true
+
 timeout_cause=$(printf '%s' \
   '[{"message":"The job has exceeded the maximum execution time of 1h30m0s"},'\
 '{"message":"The operation was canceled."}]' |
@@ -113,14 +159,12 @@ unknown_cause=$(printf '%s' '[{"message":"The operation was canceled."}]' |
   "$control" cancellation)
 [[ "$unknown_cause" == unknown ]]
 
-grep -qx '    timeout-minutes: 90' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
-grep -qx '    concurrency:' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
-grep -qx '    name: hot-core cancellation cause' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -qx '    timeout-minutes: 90' "$workflow"
+grep -qx '    concurrency:' "$workflow"
+grep -qx '    name: hot-core cancellation cause' "$workflow"
 grep -q '::notice title=Hot-core guard superseded::' \
-  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+  "$workflow"
 grep -qx '          if-no-files-found: ignore' \
-  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
-grep -q 'git diff --no-renames --name-only -z' \
-  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+  "$workflow"
 
 echo "selfmig PR guard regressions PASSED."

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -81,6 +81,36 @@ grep -q "run FAILED" "$test_root/run-failed.log"
 grep -q "run succeeded=false" "$test_root/run-failed.log"
 ! grep -q "PR guard PASSED." "$test_root/run-failed.log"
 
+control="$repo_root/build/cs2gs-pr-guard-control.sh"
+if printf 'docs/self-migration-policy.md\0website/docs/intro.md\0' |
+  "$control" relevant-paths; then
+  echo "irrelevant paths unexpectedly selected the expensive guard" >&2
+  exit 1
+fi
+relevant_path=$(
+  printf 'docs/self-migration-policy.md\0src/Core/CodeAnalysis/Binder.cs\0' |
+    "$control" relevant-paths
+)
+[[ "$relevant_path" == src/Core/CodeAnalysis/Binder.cs ]]
+
+timeout_cause=$(printf '%s' \
+  '[{"message":"The job has exceeded the maximum execution time of 1h30m0s"},'\
+'{"message":"The operation was canceled."}]' |
+  "$control" cancellation)
+[[ "$timeout_cause" == timeout ]]
+
+superseded_cause=$(printf '%s' \
+  '[{"message":"Canceling since a higher priority waiting request for cs2gs-pr-guard-4077 exists"},'\
+'{"message":"The operation was canceled."}]' |
+  "$control" cancellation)
+[[ "$superseded_cause" == superseded ]]
+
+unknown_cause=$(printf '%s' '[{"message":"The operation was canceled."}]' |
+  "$control" cancellation)
+[[ "$unknown_cause" == unknown ]]
+
 grep -qx '    timeout-minutes: 90' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -qx '    concurrency:' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -qx '    name: hot-core cancellation cause' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 
 echo "selfmig PR guard regressions PASSED."

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -94,6 +94,8 @@ relevant_path=$(
 [[ "$relevant_path" == src/Core/CodeAnalysis/Binder.cs ]]
 linked_path=$(printf 'test/Shared/GoldenFile.cs\0' | "$control" relevant-paths)
 [[ "$linked_path" == test/Shared/GoldenFile.cs ]]
+config_path=$(printf '.editorconfig\0' | "$control" relevant-paths)
+[[ "$config_path" == .editorconfig ]]
 
 timeout_cause=$(printf '%s' \
   '[{"message":"The job has exceeded the maximum execution time of 1h30m0s"},'\

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -92,6 +92,8 @@ relevant_path=$(
     "$control" relevant-paths
 )
 [[ "$relevant_path" == src/Core/CodeAnalysis/Binder.cs ]]
+linked_path=$(printf 'test/Shared/GoldenFile.cs\0' | "$control" relevant-paths)
+[[ "$linked_path" == test/Shared/GoldenFile.cs ]]
 
 timeout_cause=$(printf '%s' \
   '[{"message":"The job has exceeded the maximum execution time of 1h30m0s"},'\
@@ -115,6 +117,8 @@ grep -qx '    name: hot-core cancellation cause' "$repo_root/.github/workflows/c
 grep -q '::notice title=Hot-core guard superseded::' \
   "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 grep -qx '          if-no-files-found: ignore' \
+  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -q 'git diff --no-renames --name-only -z' \
   "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 
 echo "selfmig PR guard regressions PASSED."

--- a/build/test-cs2gs-selfmig-pr-guard.sh
+++ b/build/test-cs2gs-selfmig-pr-guard.sh
@@ -112,5 +112,9 @@ unknown_cause=$(printf '%s' '[{"message":"The operation was canceled."}]' |
 grep -qx '    timeout-minutes: 90' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 grep -qx '    concurrency:' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 grep -qx '    name: hot-core cancellation cause' "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -q '::notice title=Hot-core guard superseded::' \
+  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
+grep -qx '          if-no-files-found: ignore' \
+  "$repo_root/.github/workflows/cs2gs-pr-guard.yml"
 
 echo "selfmig PR guard regressions PASSED."

--- a/tools/cs2gs/README.md
+++ b/tools/cs2gs/README.md
@@ -159,13 +159,16 @@ core** — the projects whose migration failures cascade widest:
 
 ```
 src/Analyzers/InternalAnalyzers  src/Core
+src/Formatting/GSharp.Formatting src/Sdk/Gsharp.Runtime.Channels
 tools/cs2gs/Cs2Gs.CodeModel      tools/cs2gs/Cs2Gs.Translator
+tools/cs2gs/Cs2Gs.ProjectLoading tools/cs2gs/Cs2Gs.Pipeline
 ```
 
-That is `Cs2Gs.Translator`'s reference closure, so it covers #3831 and #3896
-but **not** #3905: `src/Sdk/Gsharp.Runtime.Channels` is outside the closure and
-is red on `main` today (#3907), and a guard that is red from day one gets
-disabled. Adding it back is one line, and worth doing the moment #3907 closes.
+That includes `Cs2Gs.Translator`'s reference closure plus Channels,
+Formatting, Pipeline, and ProjectLoading, covering #3831, #3896, #3905, and
+#3978. The workflow reports on every PR so it can remain required. An in-job
+changed-path check skips the expensive migration when a PR cannot affect these
+projects or the compiler/SDK/translation machinery.
 
 Everything else is `--exclude`d. That is safe here — and only here — because
 the set is **closed under `ProjectReference`**, so no kept app references an
@@ -174,7 +177,7 @@ refuses to run otherwise. Widening the set means adding whole reference
 closures, never a single project. `SELFMIG_PR_GUARD_APPS` overrides the list
 (e.g. to add `tools/cs2gs/Cs2Gs.Tests` once #3836's known failures clear).
 
-**It is not the gate.** Four apps, no readability ceilings, no corpus-wide
+**It is not the gate.** Eight apps, no readability ceilings, no corpus-wide
 test parity. The script prints that disclaimer on every run, pass or fail,
 because a partial check mistaken for a full one is how #3831/#3896/#3905
 reached `main` in the first place.


### PR DESCRIPTION
## Summary

- preserve #4104's 90-minute ceiling and per-app/stage timing
- skip the expensive guard inside the always-reporting job when the PR diff cannot affect translation
- move concurrency cancellation onto the expensive job and add a separate classifier job that survives it
- classify GitHub's own check-run annotations as a superseding push, a real timeout, or an unknown cancellation

Fixes #4077
Supersedes #4105.

## Why #4077 was reopened

#4104 restored timeout headroom and made the silent work observable, but it merged at 2026-09-07 19:42:08 UTC, immediately before the follow-up review request. The merged result already replaces source-text progress checks with `MigrationPipelineTests.StageProgress_ReportsStartBeforePassOrFail_WithElapsedTime`: it runs the real coordinator with existing fake stages, captures stdout, and verifies app/stage identity, start-before-result ordering, pass/fail output, and elapsed-time formatting.

Two cancellation/runtime gaps remained:

1. every PR still paid the full 40-55 minute guard cost, including changes that cannot affect translation;
2. the visible step tail still ended in `The operation was canceled.` for both a superseding push and a job timeout.

This follow-up keeps all #4104 behavior and closes those gaps.

## Measured runtime evidence

Run 34153792929 is the first complete run with #4104's stage timers:

- migrate: 2,217s
- compile stages: 1,746.9s (78.8% of migrate)
- Core compile: 472.4s
- CodeModel compile: 244.6s
- Translator compile: 282.5s
- ProjectLoading compile: 289.5s
- Pipeline compile: 308.9s
- Pipeline + ProjectLoading total: 624.9s (28.2% of migrate)

The observed growth is therefore explained by the guard expanding from four to six to eight projects, dominated by isolated SDK compiles, plus hosted-runner variance. Sharing outputs/caches or parallelizing these builds would change the gate's isolation and correctness model, so this PR does not claim a speculative compiler optimization.

The safe performance fix is native and already anticipated by the workflow's history: keep the workflow trigger unconditional so the required check always exists, but short-circuit expensive setup/migration inside the job when the PR diff cannot affect the guard. Relevant changes still execute all eight apps through translate, compile, ILVerify, and parity.

## Cancellation evidence and fix

GitHub's workflow/job/step conclusions use `cancelled` for both causes, but check-run annotations do distinguish them:

- timeout attempt 34081308934 / job 101617001759: `The job has exceeded the maximum execution time of 1h0m0s`
- superseded run 34079861399 / job 101612972852: `Canceling since a higher priority waiting request for cs2gs-pr-guard-4064 exists`

A post-step inside the cancelled job is not a reliable classifier. Instead, concurrency now applies only to the expensive `guard` job. A separate `classify-cancellation` job runs with `if: always()` after a cancelled guard, reads the completed guard check's annotations through the Actions/checks APIs, and emits an explicit workflow summary and notice/error. Superseded pushes pass the classifier; real or unknown timeouts fail it visibly.

## Regression protection

`build/test-cs2gs-selfmig-pr-guard.sh` now verifies:

- docs/website-only paths skip the expensive work
- any relevant path selects it
- diff-generation failures and unexpected path-helper exits run the full guard instead of skipping it
- classifier regressions run before scope detection, so a broken classifier cannot skip its own tests
- recorded real timeout and concurrency annotation shapes classify differently
- concurrency remains job-scoped and the classifier job remains present

## Validation

- `bash -n build/cs2gs-pr-guard-control.sh build/run-cs2gs-selfmig-pr-guard.sh build/test-cs2gs-selfmig-pr-guard.sh`
- `./build/test-cs2gs-selfmig-pr-guard.sh`
- classifier verified against live annotations from jobs 101617001759 and 101612972852
- three deliberately superseded CI runs completed `hot-core cancellation cause` successfully and emitted `Cancelled because a newer push replaced this run; this was not a timeout.`
- final head `16e0061a` passed the full GitHub build workflow and hot-core translation guard; classifier correctly skipped on success
- workflow parsed with Python/PyYAML
- `git diff --check`
- no local dotnet build/test/restore, per issue constraint