### PR TITLE
cs2gs: exclude validation artifacts from readability counters

### DIFF
--- a/build/cs2gs-counters.sh
+++ b/build/cs2gs-counters.sh
@@ -78,7 +78,11 @@ cs2gs_find_translated_sources() {
   local tree=$1
   shift
   find "$tree" \
-    \( -type d \( -name bin -o -name obj \) -prune \) -o \
+    \( -type d \( \
+      -name '[Bb][Ii][Nn]' -o \
+      -name '[Oo][Bb][Jj]' -o \
+      -name '[Tt][Ee][Ss][Tt][Rr][Ee][Ss][Uu][Ll][Tt][Ss]' \
+    \) -prune \) -o \
     \( -type f -name '*.gs' "$@" \)
 }
 

--- a/build/cs2gs-counters.sh
+++ b/build/cs2gs-counters.sh
@@ -70,6 +70,18 @@ cs2gs_synthetic_families=(
 # How many distinct unknown identifiers to name in the table before truncating.
 cs2gs_unknown_sample_limit=${CS2GS_UNKNOWN_SAMPLE_LIMIT:-25}
 
+# Visits translated source files while pruning conventional build-output trees.
+# Validation can create transient .gs test fixtures under these directories;
+# they are artifacts, not translator output, and must not move readability
+# counters. Callers supply the find action so every metric shares this scope.
+cs2gs_find_translated_sources() {
+  local tree=$1
+  shift
+  find "$tree" \
+    \( -type d \( -name out -o -name bin -o -name obj \) -prune \) -o \
+    \( -type f -name '*.gs' "$@" \)
+}
+
 # Emits the CODE lines of a migrated tree: every line of every .gs file minus
 # the ones that are not code for metric purposes.
 #
@@ -84,14 +96,14 @@ cs2gs_unknown_sample_limit=${CS2GS_UNKNOWN_SAMPLE_LIMIT:-25}
 # alongside, clearly labelled, so the gap is visible instead of merely absent.
 cs2gs_code_lines() {
   local tree=$1
-  find "$tree" -name '*.gs' -type f -exec cat {} + 2>/dev/null \
+  cs2gs_find_translated_sources "$tree" -exec cat {} + 2>/dev/null \
     | grep -v '"' | grep -vE '^[[:space:]]*//' || true
 }
 
 # Every line of every .gs file, unfiltered.
 cs2gs_raw_lines() {
   local tree=$1
-  find "$tree" -name '*.gs' -type f -exec cat {} + 2>/dev/null || true
+  cs2gs_find_translated_sources "$tree" -exec cat {} + 2>/dev/null || true
 }
 
 # Prints "<reducible> <single-atom-bounded> <total>" for lines wider than 300
@@ -100,17 +112,19 @@ cs2gs_raw_lines() {
 # can shorten that line without changing the token stream (ADR-0179).
 cs2gs_long_line_counts() {
   local tree=$1
-  python3 - "$tree" <<'PY'
+  python3 - 3< <(cs2gs_find_translated_sources "$tree" -print0) <<'PY'
+import os
 import pathlib
 import re
-import sys
 
-root = pathlib.Path(sys.argv[1])
 string_atom = re.compile(r'"(?:\\.|[^"\\])*"')
 identifier_atom = re.compile(r'\b[A-Za-z_$][A-Za-z0-9_$]*\b')
 reducible = atomic = 0
 
-for path in root.rglob("*.gs"):
+for raw_path in os.fdopen(3, "rb").read().split(b"\0"):
+    if not raw_path:
+        continue
+    path = pathlib.Path(os.fsdecode(raw_path))
     in_raw = False
     for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         if len(raw_line) <= 300:
@@ -213,7 +227,7 @@ cs2gs_counter_report() {
   awk -F'\t' '{ c[$1]++ } END { for (f in c) print f, c[f] }' "$raw_ids" > "$raw_tally"
 
   local gs_files bangs bangs_raw long_lines atomic_long_lines total_long_lines syn_total syn_total_raw
-  gs_files=$(find "$tree" -name '*.gs' -type f | wc -l | tr -d ' ')
+  gs_files=$(cs2gs_find_translated_sources "$tree" -print | wc -l | tr -d ' ')
   bangs=$(cs2gs_count_stream '!!' < "$code_lines")
   bangs_raw=$(cs2gs_count_stream '!!' < "$raw_lines")
   read -r long_lines atomic_long_lines total_long_lines < <(cs2gs_long_line_counts "$tree")

--- a/build/cs2gs-counters.sh
+++ b/build/cs2gs-counters.sh
@@ -70,7 +70,7 @@ cs2gs_synthetic_families=(
 # How many distinct unknown identifiers to name in the table before truncating.
 cs2gs_unknown_sample_limit=${CS2GS_UNKNOWN_SAMPLE_LIMIT:-25}
 
-# Visits translated source files while pruning conventional build-output trees.
+# Visits translated source files while pruning generated project-output trees.
 # Validation can create transient .gs test fixtures under these directories;
 # they are artifacts, not translator output, and must not move readability
 # counters. Callers supply the find action so every metric shares this scope.
@@ -78,7 +78,7 @@ cs2gs_find_translated_sources() {
   local tree=$1
   shift
   find "$tree" \
-    \( -type d \( -name out -o -name bin -o -name obj \) -prune \) -o \
+    \( -type d \( -name bin -o -name obj \) -prune \) -o \
     \( -type f -name '*.gs' "$@" \)
 }
 

--- a/build/cs2gs-counters.sh
+++ b/build/cs2gs-counters.sh
@@ -79,9 +79,9 @@ cs2gs_find_translated_sources() {
   shift
   find "$tree" \
     \( -type d \( \
-      -name '[Bb][Ii][Nn]' -o \
-      -name '[Oo][Bb][Jj]' -o \
-      -name '[Tt][Ee][Ss][Tt][Rr][Ee][Ss][Uu][Ll][Tt][Ss]' \
+      -iname bin -o \
+      -iname obj -o \
+      -iname TestResults \
     \) -prune \) -o \
     \( -type f -name '*.gs' "$@" \)
 }

--- a/build/test-cs2gs-counters.sh
+++ b/build/test-cs2gs-counters.sh
@@ -61,7 +61,7 @@ grep -Fq 'GATE: reducible raw >300-char line count 1 exceeded ceiling 0.' <<< "$
 
 measurement_tree="$scratch/measurement-tree"
 artifact="$measurement_tree/out/bin/Release/Cs2Gs.Tests/issue-2231-e2e/guid/Snippet.gs"
-source_file="$measurement_tree/src/Translated.gs"
+source_file="$measurement_tree/out/scratch/ildump/Program.gs"
 mkdir -p "$(dirname "$artifact")" "$(dirname "$source_file")"
 python3 - "$artifact" <<'PY'
 import pathlib

--- a/build/test-cs2gs-counters.sh
+++ b/build/test-cs2gs-counters.sh
@@ -59,4 +59,38 @@ fi
 grep -Fq 'lines>300(raw)=1 reducible' <<< "$output"
 grep -Fq 'GATE: reducible raw >300-char line count 1 exceeded ceiling 0.' <<< "$output"
 
+measurement_tree="$scratch/measurement-tree"
+artifact="$measurement_tree/out/bin/Release/Cs2Gs.Tests/issue-2231-e2e/guid/Snippet.gs"
+source_file="$measurement_tree/src/Translated.gs"
+mkdir -p "$(dirname "$artifact")" "$(dirname "$source_file")"
+python3 - "$artifact" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_text(
+    "goto __patternGuardEnd0\n"
+    "__patternGuardEnd0:\n"
+    "let __local_0 = value!!\n"
+    + "let reducible = " + " + ".join(["x"] * 90) + "\n",
+    encoding="utf-8",
+)
+PY
+mkdir -p "$measurement_tree/src/App/bin/Release" "$measurement_tree/src/App/obj/Release"
+cp "$artifact" "$measurement_tree/src/App/bin/Release/Snippet.gs"
+cp "$artifact" "$measurement_tree/src/App/obj/Release/Snippet.gs"
+
+selfmig_measure "$measurement_tree"
+[[ "$labels $lifts $long_lines $long_lines_atomic $bangs" == "0 0 0 0 0" ]]
+
+cp "$artifact" "$source_file"
+selfmig_measure "$measurement_tree"
+[[ "$labels $lifts $long_lines $long_lines_atomic $bangs" == "2 1 1 0 1" ]]
+
+report=$(TMPDIR="$scratch" cs2gs_counter_report "$measurement_tree" "artifact exclusion")
+grep -Fq '| `.gs` files | 1 | 1 |' <<< "$report"
+grep -Fq '| `__patternGuardEnd` | 2 | 2 |' <<< "$report"
+grep -Fq '| `__local_` | 1 | 1 |' <<< "$report"
+grep -Fq '| `!!` null assertions | 1 | 1 |' <<< "$report"
+grep -Fq '| lines >300 chars (reducible) | n/a | 1 |' <<< "$report"
+
 echo "cs2gs counter contract tests passed"

--- a/build/test-cs2gs-counters.sh
+++ b/build/test-cs2gs-counters.sh
@@ -75,12 +75,25 @@ pathlib.Path(sys.argv[1]).write_text(
     encoding="utf-8",
 )
 PY
-mkdir -p "$measurement_tree/src/App/bin/Release" "$measurement_tree/src/App/obj/Release"
-cp "$artifact" "$measurement_tree/src/App/bin/Release/Snippet.gs"
-cp "$artifact" "$measurement_tree/src/App/obj/Release/Snippet.gs"
+for generated in \
+  "$measurement_tree/out/BiN/Release/App/Snippet.gs" \
+  "$measurement_tree/out/OBJ/Release/App/Snippet.gs" \
+  "$measurement_tree/out/TeStReSuLtS/App/Snippet.gs"
+do
+  mkdir -p "$(dirname "$generated")"
+  cp "$artifact" "$generated"
+done
 
 selfmig_measure "$measurement_tree"
 [[ "$labels $lifts $long_lines $long_lines_atomic $bangs" == "0 0 0 0 0" ]]
+
+report=$(TMPDIR="$scratch" cs2gs_counter_report "$measurement_tree" "artifact exclusion")
+grep -Fq '| `.gs` files | 0 | 0 |' <<< "$report"
+grep -Fq '| `!!` null assertions | 0 | 0 |' <<< "$report"
+grep -Fq '| lines >300 chars (reducible) | n/a | 0 |' <<< "$report"
+grep -Fq '| lines >300 chars (single-atom-bounded) | n/a | 0 |' <<< "$report"
+grep -Fq '| lines >300 chars (total) | n/a | 0 |' <<< "$report"
+grep -Fq '| synthetic `__` identifiers | 0 | 0 |' <<< "$report"
 
 cp "$artifact" "$source_file"
 selfmig_measure "$measurement_tree"
@@ -92,5 +105,8 @@ grep -Fq '| `__patternGuardEnd` | 2 | 2 |' <<< "$report"
 grep -Fq '| `__local_` | 1 | 1 |' <<< "$report"
 grep -Fq '| `!!` null assertions | 1 | 1 |' <<< "$report"
 grep -Fq '| lines >300 chars (reducible) | n/a | 1 |' <<< "$report"
+grep -Fq '| lines >300 chars (single-atom-bounded) | n/a | 0 |' <<< "$report"
+grep -Fq '| lines >300 chars (total) | n/a | 1 |' <<< "$report"
+grep -Fq '| synthetic `__` identifiers | 3 | 3 |' <<< "$report"
 
 echo "cs2gs counter contract tests passed"

--- a/build/test-cs2gs-counters.sh
+++ b/build/test-cs2gs-counters.sh
@@ -61,7 +61,7 @@ grep -Fq 'GATE: reducible raw >300-char line count 1 exceeded ceiling 0.' <<< "$
 
 measurement_tree="$scratch/measurement-tree"
 artifact="$measurement_tree/out/bin/Release/Cs2Gs.Tests/issue-2231-e2e/guid/Snippet.gs"
-source_file="$measurement_tree/out/scratch/ildump/Program.gs"
+source_file="$measurement_tree/out/scratch/Translated.gs"
 mkdir -p "$(dirname "$artifact")" "$(dirname "$source_file")"
 python3 - "$artifact" <<'PY'
 import pathlib


### PR DESCRIPTION
## Summary

- route every readability metric through one translated-source finder
- match `RepositoryFileInventory` by pruning `bin/`, `obj/`, and `TestResults/` segments case-insensitively
- keep legitimate translated source under `out/` measurable
- add shell regressions for test-generated `Snippet.gs` contamination and mixed-case artifact layouts

## Root cause

Classic self-migration measures the migrated tree after validation and test parity. `Cs2Gs.Tests` creates transient `.gs` snippets beneath paths such as `migrated/out/bin/Release/Cs2Gs.Tests/issue-2231-e2e/<guid>/Snippet.gs`; the prior unrestricted `find ... -name '*.gs'` treated those test artifacts as translated corpus source and breached the zero synthetic-label ratchet.

## Fix

`cs2gs_find_translated_sources` is now the shared file-selection point for filtered lines, raw lines, long-line classification, and report file counts. Its `find -iname` segment pruning matches the established `RepositoryFileInventory` generated-path predicate for `bin`, `obj`, and `TestResults`. It deliberately does not prune `out`: self-migration includes legitimate source there, including the green app `out/scratch/ildump/ildump.csproj`. The reported contamination under `out/bin/...` remains excluded by the nested `bin` prune.

## Regression

`build/test-cs2gs-counters.sh` creates identical synthetic-bearing content under `out/bin` and mixed-case `BiN`, `OBJ`, and `TeStReSuLtS` paths, then confirms every readability metric remains zero. It copies the same file to `out/scratch/Translated.gs` and confirms labels, lifted locals, long lines, null assertions, synthetic totals, raw counters, and `.gs` file totals count that legitimate translated source.

## Validation

- `bash -n build/cs2gs-counters.sh build/selfmig-common.sh build/test-cs2gs-counters.sh`
- `build/test-cs2gs-counters.sh`
- `git diff --check`
- all readability metric file traversal re-audited through `cs2gs_find_translated_sources`
- no local dotnet build, restore, or test commands run

Fixes #4085