### PR TITLE
gsc: bind qualified generic constructor receivers (#4055)

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.Accessor.cs
@@ -1997,7 +1997,9 @@ internal sealed partial class ExpressionBinder
     /// parser shapes a single type argument as an <see cref="IndexExpressionSyntax"/>
     /// (target is the bare type name, e.g. <c>Comparer[int32]</c>) and multiple
     /// or type-shaped arguments as a <see cref="GenericNameExpressionSyntax"/>
-    /// (e.g. <c>Pair[int32, string]</c>, <c>Box[int32?]</c>).
+    /// (e.g. <c>Pair[int32, string]</c>, <c>Box[int32?]</c>). A generic
+    /// constructor followed by another access carries the same type arguments
+    /// on a <see cref="CallExpressionSyntax"/>.
     /// </summary>
     private static bool TryGetGenericSegmentNameAndArity(
         ExpressionSyntax segment,
@@ -2023,6 +2025,11 @@ internal sealed partial class ExpressionBinder
                 arity = generic.TypeArgumentList.Arguments.Count;
                 return true;
 
+            case CallExpressionSyntax { TypeArgumentList: not null } call:
+                identifier = call.Identifier;
+                arity = call.TypeArgumentList.Arguments.Count;
+                return true;
+
             default:
                 identifier = null;
                 arity = 0;
@@ -2045,6 +2052,14 @@ internal sealed partial class ExpressionBinder
 
             case GenericNameExpressionSyntax generic:
                 return TryBindGenericSegmentArguments(generic, out typeArgs) && typeArgs.Length == arity;
+
+            case CallExpressionSyntax { TypeArgumentList: not null } call:
+                return TryResolveClrConstructionTypeArgs(
+                    call.TypeArgumentList,
+                    out _,
+                    out typeArgs,
+                    out _)
+                    && typeArgs.Length == arity;
 
             default:
                 typeArgs = default;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -176,11 +176,11 @@ internal sealed partial class ExpressionBinder
     /// position, e.g. <c>System.Text.StringBuilder()</c> or
     /// <c>System.Collections.Generic.List[int]()</c>, including an object
     /// initializer suffix. Such an expression parses as an accessor chain whose
-    /// terminal segment is the constructor call (or its initializer wrapper), so
-    /// it never reaches <see cref="TryBindClrConstructorCall"/> (which only sees
-    /// simple-name calls). This walks the dotted name, resolves the closed CLR
-    /// type via the active references/imports, and reuses the shared
-    /// constructor-binding core (issue #293).
+    /// constructor call is either terminal or followed by an instance-member
+    /// suffix, so it never reaches <see cref="TryBindClrConstructorCall"/> (which
+    /// only sees simple-name calls). This walks the dotted name, resolves the
+    /// closed CLR type via the active references/imports, and reuses the shared
+    /// constructor-binding core (issues #293 and #4055).
     /// </summary>
     /// <param name="syntax">The accessor expression to bind.</param>
     /// <param name="result">The bound constructor call on success.</param>
@@ -204,18 +204,34 @@ internal sealed partial class ExpressionBinder
         ExpressionSyntax current = syntax;
         CallExpressionSyntax? terminalCall = null;
         ObjectCreationExpressionSyntax? terminalObjectCreation = null;
+        ExpressionSyntax? trailingAccess = null;
         while (true)
         {
             if (current is AccessorExpressionSyntax accessor)
             {
-                if (accessor.IsNullConditional || !(accessor.LeftPart is NameExpressionSyntax leftName))
+                if (accessor.IsNullConditional)
                 {
                     return false;
                 }
 
-                segments.Add(leftName.IdentifierToken.ValueText);
-                current = accessor.RightPart;
-                continue;
+                if (accessor.LeftPart is NameExpressionSyntax leftName)
+                {
+                    segments.Add(leftName.IdentifierToken.ValueText);
+                    current = accessor.RightPart;
+                    continue;
+                }
+
+                if (accessor.LeftPart is CallExpressionSyntax nestedCall)
+                {
+                    // `System.Nullable[int32]().HasValue` keeps the call on the
+                    // left of the final accessor; bind it here, then continue on
+                    // the constructed value rather than re-reading `System` as a type.
+                    terminalCall = nestedCall;
+                    trailingAccess = accessor.RightPart;
+                    break;
+                }
+
+                return false;
             }
 
             if (current is CallExpressionSyntax call)
@@ -318,6 +334,16 @@ internal sealed partial class ExpressionBinder
                 Invariant.Required(
                     result,
                     "a successful qualified constructor binding produces a bound target"));
+        }
+
+        if (handled && trailingAccess != null && result is not BoundErrorExpression)
+        {
+            result = BindAccessorStep(
+                Invariant.Required(
+                    result,
+                    "a successful qualified constructor binding produces a bound target"),
+                classSymbol: null,
+                trailingAccess);
         }
 
         return handled;

--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.cs
@@ -231,6 +231,14 @@ internal sealed partial class ExpressionBinder
                     break;
                 }
 
+                if (accessor.LeftPart is ObjectCreationExpressionSyntax { Target: CallExpressionSyntax nestedObjectCall } nestedObjectCreation)
+                {
+                    terminalCall = nestedObjectCall;
+                    terminalObjectCreation = nestedObjectCreation;
+                    trailingAccess = accessor.RightPart;
+                    break;
+                }
+
                 return false;
             }
 

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue4055QualifiedGenericConstructorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue4055QualifiedGenericConstructorTests.cs
@@ -49,7 +49,7 @@ public sealed class Issue4055QualifiedGenericConstructorTests
     }
 
     [Fact]
-    public void NestedGenericTypeArguments_Execute()
+    public void NestedGenericTypeArguments_Executes()
     {
         var result = EmittedOracle.Evaluate(
             """
@@ -80,6 +80,21 @@ public sealed class Issue4055QualifiedGenericConstructorTests
 
         Assert.Empty(result.Diagnostics);
         Assert.Equal($"ok{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void QualifiedGenericObjectInitializerReceiver_Executes()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            Console.WriteLine(System.Collections.Generic.KeyValuePair[int32, string](){}.Key)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"0{System.Environment.NewLine}", result.Output);
     }
 
     [Fact]

--- a/test/Core.Tests/CodeAnalysis/Binding/Issue4055QualifiedGenericConstructorTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Binding/Issue4055QualifiedGenericConstructorTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="Issue4055QualifiedGenericConstructorTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Linq;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Binding;
+
+/// <summary>
+/// Issue #4055: a fully-qualified generic CLR type followed by a constructor
+/// argument list must use the same qualified type walk and constructor binding
+/// as its static-member and unqualified-constructor spellings.
+/// </summary>
+public sealed class Issue4055QualifiedGenericConstructorTests
+{
+    [Fact]
+    public void FullyQualifiedNullableDefaultConstruction_Executes()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            Console.WriteLine(System.Nullable[int32]().HasValue)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"False{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void MultiSegmentGenericReferenceTypeConstruction_Executes()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            let values = System.Collections.Generic.List[int32]()
+            values.Add(7)
+            Console.WriteLine(values[0])
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"7{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void NestedGenericTypeArguments_Execute()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            let values = System.Collections.Generic.Dictionary[string, System.Collections.Generic.List[int32]]()
+            values["x"] = System.Collections.Generic.List[int32]()
+            values["x"].Add(9)
+            Console.WriteLine(values["x"][0])
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"9{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void NonGenericQualifiedConstructor_StillExecutes()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            let value = System.Text.StringBuilder("ok")
+            Console.WriteLine(value.ToString())
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"ok{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void MissingGenericType_ReportsTerminalTypeNotNamespace()
+    {
+        var diagnostic = Assert.Single(Errors(
+            """
+            package P
+
+            let value = System.Collections.Generic.Missing[int32]().Count
+            """));
+
+        Assert.Equal("GS0157", diagnostic.Id);
+        Assert.Equal(
+            "Cannot find type 'Missing' in namespace 'System.Collections.Generic'. Are you missing an import?",
+            diagnostic.Message);
+        Assert.Equal("Missing", diagnostic.Location.Text!.ToString(diagnostic.Location.Span));
+    }
+
+    [Fact]
+    public void InapplicableGenericConstructor_ReportsOverloadNotNamespace()
+    {
+        var diagnostics = Errors(
+            """
+            package P
+
+            let value = System.Collections.Generic.List[int32]("not-capacity").Count
+            """);
+
+        Assert.Equal(new[] { "GS0267" }, diagnostics.Select(diagnostic => diagnostic.Id));
+    }
+
+    [Fact]
+    public void MissingMemberOnQualifiedGenericType_StillReportsMember()
+    {
+        var diagnostic = Assert.Single(Errors(
+            """
+            package P
+
+            System.Collections.Generic.List[int32].Missing()
+            """));
+
+        Assert.Equal("GS0159", diagnostic.Id);
+        Assert.Equal("Cannot find function Missing.", diagnostic.Message);
+    }
+
+    [Fact]
+    public void NamespaceAndSourceTypeCollision_StillBindsClrConstruction()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            class System {
+            }
+
+            Console.WriteLine(System.Nullable[int32]().HasValue)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"False{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void QualifiedGenericStaticMember_StillExecutes()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            Console.WriteLine(System.Collections.Generic.Comparer[int32].Default.Compare(1, 2))
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"-1{System.Environment.NewLine}", result.Output);
+    }
+
+    [Fact]
+    public void QualifiedGenericTypeClause_StillBinds()
+    {
+        Assert.Empty(Errors(
+            """
+            package P
+
+            var value System.Nullable[int32]
+            """));
+    }
+
+    [Fact]
+    public void QualifiedSourceConstructor_StillExecutes()
+    {
+        var result = EmittedOracle.Evaluate(
+            """
+            package P
+            import System
+
+            class Box {
+                prop Value int32 -> 13
+            }
+
+            let box = P.Box()
+            Console.WriteLine(box.Value)
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Equal($"13{System.Environment.NewLine}", result.Output);
+    }
+
+    private static Diagnostic[] Errors(string source)
+        => EmittedOracle.Evaluate(source).Diagnostics
+            .Where(diagnostic => diagnostic.IsError)
+            .ToArray();
+}


### PR DESCRIPTION
## Summary

- recognize a qualified CLR constructor call when the parser places it on the left of a following member access
- continue the accessor chain from the constructed value instead of rebinding the namespace root
- extend the existing qualified CLR type walker to recognize call-shaped generic segments, preserving longest-resolvable-prefix diagnostics
- add executing and exact-diagnostic coverage for nullable/default construction, deep and nested generics, non-generic/source constructors, static members, missing types/members, overload failures, and namespace/type collisions

Closes #4055.

## Root cause

`System.Nullable[int32]().HasValue` parses the constructor call as the left side of the final accessor. `TryBindQualifiedClrConstructorCall` only accepted bare-name segments before a terminal call, so it rejected the shape before CLR constructor resolution. The later accessor path re-read `System` as a type and emitted GS0157.

The fix retains the trailing accessor, uses the existing qualified-constructor/type resolution, and then binds the suffix on the constructed value. Failed generic resolution is handed to the existing qualified CLR walker; teaching that walker the call-shaped generic segment preserves #3842's deepest-prefix diagnostic rather than adding a second path.

## Validation

- pre-fix discrimination: the nullable execution and missing-generic diagnostic tests both fail with `GS0157 Cannot find type System`
- focused Core qualified-binding regressions: 76 passed
- #4051 compiler regressions: 24 passed
- `dotnet build GSharp.sln --configuration Release --no-restore -graph`: succeeded, 0 warnings/errors
- `python3 build/nullable_hygiene.py --base origin/main`: passed
- `build/test-cs2gs-selfmig-pr-guard.sh`: passed
- hot-core self-migration guard: 8/8 apps green

Nullable-hygiene guard note: the new `trailingAccess`/error-result guard is intentional control flow. It continues member binding only after a successful constructor result and prevents consequential member diagnostics after a constructor error.
