### PR TITLE
gsc: bind narrow literals to imported indexers

### DIFF
--- a/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/ExpressionBinder.Access.MemberLookup.cs
@@ -1388,6 +1388,7 @@ internal sealed partial class ExpressionBinder
         // matches the single argument by assignability).
         // Issue #209: when the target carries inner-position nullable flags,
         // use them to type the element correctly (e.g., `list[0]` on `List<string?>` → `string?`).
+        var clrIndexerOutcome = ClrIndexerResolutionOutcome.NoneFound;
         if (target.Type is TypeParameterSymbol tpIndexTarget)
         {
             var clrIndexConstraint = tpIndexTarget.ClrInterfaceConstraint;
@@ -1395,12 +1396,13 @@ internal sealed partial class ExpressionBinder
             if (clrIndexConstraint != null && clrConstraintType != null)
             {
                 var idxArgs = ImmutableArray.Create(BoundIndexArg());
-                if (this.memberLookup.TryResolveClrIndexer(
+                var outcome = this.memberLookup.TryResolveClrIndexer(
                     clrIndexConstraint,
                     clrConstraintType,
                     idxArgs,
                     out var idxProp,
-                    out var resolvedIdxArgs))
+                    out var resolvedIdxArgs);
+                if (outcome == ClrIndexerResolutionOutcome.Resolved)
                 {
                     if (ClrMemberVisibility.GetVisibleGetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
                     {
@@ -1427,6 +1429,8 @@ internal sealed partial class ExpressionBinder
                             tpIndexTarget,
                             declaringInterface));
                 }
+
+                clrIndexerOutcome = outcome;
             }
         }
 
@@ -1435,7 +1439,13 @@ internal sealed partial class ExpressionBinder
         if (annotIdx != null && clrAnnotIdx != null)
         {
             var idxArgsAnnot = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(target.Type, clrAnnotIdx, idxArgsAnnot, out var idxPropAnnot, out var resolvedIdxArgsAnnot))
+            var outcome = this.memberLookup.TryResolveClrIndexer(
+                target.Type,
+                clrAnnotIdx,
+                idxArgsAnnot,
+                out var idxPropAnnot,
+                out var resolvedIdxArgsAnnot);
+            if (outcome == ClrIndexerResolutionOutcome.Resolved)
             {
                 // A successful CLR indexer resolution establishes a non-null property.
                 if (ClrMemberVisibility.GetVisibleGetter(idxPropAnnot!, CanAccessInternalsOf(idxPropAnnot!.DeclaringType)) == null)
@@ -1452,6 +1462,8 @@ internal sealed partial class ExpressionBinder
                     indexSyntax.Location);
                 return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxPropAnnot, convertedIdxArgsAnnot, elemTypeAnnot));
             }
+
+            clrIndexerOutcome = outcome;
         }
 
         var clrTarget = target.Type.ClrType;
@@ -1459,7 +1471,13 @@ internal sealed partial class ExpressionBinder
             && clrTarget != null)
         {
             var idxArgs = ImmutableArray.Create(BoundIndexArg());
-            if (this.memberLookup.TryResolveClrIndexer(target.Type, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
+            var outcome = this.memberLookup.TryResolveClrIndexer(
+                target.Type,
+                clrTarget,
+                idxArgs,
+                out var idxProp,
+                out var resolvedIdxArgs);
+            if (outcome == ClrIndexerResolutionOutcome.Resolved)
             {
                 // A successful CLR indexer resolution establishes a non-null property.
                 if (ClrMemberVisibility.GetVisibleGetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
@@ -1478,6 +1496,8 @@ internal sealed partial class ExpressionBinder
                     indexSyntax.Location);
                 return ConversionClassifier.AutoDereferenceRefReturn(new BoundClrIndexExpression(null, target, idxProp, convertedIdxArgs, elementType));
             }
+
+            clrIndexerOutcome = outcome;
         }
 
         // ADR-0118 / issue #944: index access on a user-defined type that
@@ -1542,7 +1562,8 @@ internal sealed partial class ExpressionBinder
                 elementType);
         }
 
-        if (target.Type != TypeSymbol.Error)
+        if (!ReportClrIndexerResolutionFailure(clrIndexerOutcome, indexSyntax.Location)
+            && target.Type != TypeSymbol.Error)
         {
             Diagnostics.ReportTypeNotIndexable(targetLocation, target.Type);
         }
@@ -2132,6 +2153,7 @@ internal sealed partial class ExpressionBinder
         // Phase 4 exit: CLR indexer write on an imported reference type
         // (e.g. `d["k"] = 1` on Dictionary[string, int]).
         // Issue #209: honour inner-position nullable flags when present.
+        var clrIndexerOutcome = ClrIndexerResolutionOutcome.NoneFound;
         if (targetType is TypeParameterSymbol tpIndexTarget)
         {
             var clrIndexConstraint = tpIndexTarget.ClrInterfaceConstraint;
@@ -2139,12 +2161,13 @@ internal sealed partial class ExpressionBinder
             if (clrIndexConstraint != null && clrConstraintType != null)
             {
                 var idxArgs = ImmutableArray.Create(BindIndexValue());
-                if (this.memberLookup.TryResolveClrIndexer(
+                var outcome = this.memberLookup.TryResolveClrIndexer(
                     clrIndexConstraint,
                     clrConstraintType,
                     idxArgs,
                     out var idxProp,
-                    out var resolvedIdxArgs))
+                    out var resolvedIdxArgs);
+                if (outcome == ClrIndexerResolutionOutcome.Resolved)
                 {
                     if (ClrMemberVisibility.GetVisibleSetter(idxProp!, CanAccessInternalsOf(idxProp!.DeclaringType)) == null)
                     {
@@ -2170,12 +2193,20 @@ internal sealed partial class ExpressionBinder
                         tpIndexTarget,
                         declaringInterface);
                 }
+
+                clrIndexerOutcome = outcome;
             }
         }
         else if (targetType is NullabilityAnnotatedTypeSymbol annotWr && targetType.ClrType is System.Type clrAnnotWr)
         {
             var idxArgsAnnotWr = ImmutableArray.Create(BindIndexValue());
-            if (this.memberLookup.TryResolveClrIndexer(targetType, clrAnnotWr, idxArgsAnnotWr, out var idxPropAnnotWr, out var resolvedIdxArgsAnnotWr))
+            var outcome = this.memberLookup.TryResolveClrIndexer(
+                targetType,
+                clrAnnotWr,
+                idxArgsAnnotWr,
+                out var idxPropAnnotWr,
+                out var resolvedIdxArgsAnnotWr);
+            if (outcome == ClrIndexerResolutionOutcome.Resolved)
             {
                 // A successful CLR indexer resolution establishes a non-null property.
                 if (ClrMemberVisibility.GetVisibleSetter(idxPropAnnotWr!, CanAccessInternalsOf(idxPropAnnotWr!.DeclaringType)) == null)
@@ -2199,11 +2230,19 @@ internal sealed partial class ExpressionBinder
                     constrainedReceiverTypeParameter: null,
                     constrainedInterfaceType: null);
             }
+
+            clrIndexerOutcome = outcome;
         }
         else if ((targetType is ImportedTypeSymbol || targetType is StructSymbol) && targetType.ClrType is System.Type clrTarget)
         {
             var idxArgs = ImmutableArray.Create(BindIndexValue());
-            if (this.memberLookup.TryResolveClrIndexer(targetType, clrTarget, idxArgs, out var idxProp, out var resolvedIdxArgs))
+            var outcome = this.memberLookup.TryResolveClrIndexer(
+                targetType,
+                clrTarget,
+                idxArgs,
+                out var idxProp,
+                out var resolvedIdxArgs);
+            if (outcome == ClrIndexerResolutionOutcome.Resolved)
             {
                 // A successful CLR indexer resolution establishes a non-null property.
                 var convertedIdxArgs = BindClrIndexerArguments(
@@ -2272,6 +2311,8 @@ internal sealed partial class ExpressionBinder
                     constrainedReceiverTypeParameter: null,
                     constrainedInterfaceType: null);
             }
+
+            clrIndexerOutcome = outcome;
         }
 
         // ADR-0118 / issue #944: index assignment on a user-defined type that
@@ -2335,12 +2376,30 @@ internal sealed partial class ExpressionBinder
                 elementType);
         }
 
-        if (targetType != TypeSymbol.Error)
+        if (!ReportClrIndexerResolutionFailure(clrIndexerOutcome, indexSyntax.Location)
+            && targetType != TypeSymbol.Error)
         {
             Diagnostics.ReportTypeNotIndexable(diagnosticLocation, targetType);
         }
 
         return new BoundErrorExpression(null);
+    }
+
+    private bool ReportClrIndexerResolutionFailure(
+        ClrIndexerResolutionOutcome outcome,
+        TextLocation location)
+    {
+        switch (outcome)
+        {
+            case ClrIndexerResolutionOutcome.NoneApplicable:
+                Diagnostics.ReportNoApplicableOverload(location, "this[]");
+                return true;
+            case ClrIndexerResolutionOutcome.Ambiguous:
+                Diagnostics.ReportAmbiguousOverloadResolution(location, "this[]");
+                return true;
+            default:
+                return false;
+        }
     }
 
     private ImmutableArray<BoundExpression> BindClrIndexerArguments(

--- a/src/Core/CodeAnalysis/Binding/MemberLookup.cs
+++ b/src/Core/CodeAnalysis/Binding/MemberLookup.cs
@@ -16,6 +16,22 @@ using GSharp.Core.CodeAnalysis.Symbols;
 
 namespace GSharp.Core.CodeAnalysis.Binding;
 
+/// <summary>Result of resolving an imported CLR indexer overload set.</summary>
+internal enum ClrIndexerResolutionOutcome
+{
+    /// <summary>The receiver exposes no visible CLR indexers.</summary>
+    NoneFound,
+
+    /// <summary>Visible indexers exist, but none accepts the arguments.</summary>
+    NoneApplicable,
+
+    /// <summary>Multiple applicable indexers are equally good.</summary>
+    Ambiguous,
+
+    /// <summary>A unique best indexer was selected.</summary>
+    Resolved,
+}
+
 /// <summary>
 /// PR-B-2: the binder-facing facade for "given a type T and a member name N,
 /// return the candidates". Delegates low-level CLR member walks (including
@@ -4220,8 +4236,8 @@ internal sealed class MemberLookup
     /// <param name="boundArguments">The pre-bound index argument expressions.</param>
     /// <param name="indexer">The matching <see cref="PropertyInfo"/>, on success.</param>
     /// <param name="resolvedArguments">The arguments in parameter order, including omitted optional defaults.</param>
-    /// <returns><see langword="true"/> when a matching indexer is found.</returns>
-    public bool TryResolveClrIndexer(
+    /// <returns>The result of indexer overload resolution.</returns>
+    public ClrIndexerResolutionOutcome TryResolveClrIndexer(
         TypeSymbol targetType,
         Type clrTarget,
         ImmutableArray<BoundExpression> boundArguments,
@@ -4232,6 +4248,11 @@ internal sealed class MemberLookup
         resolvedArguments = default;
 
         var properties = CollectVisibleClrIndexers(targetType, clrTarget);
+        if (properties.Length == 0)
+        {
+            return ClrIndexerResolutionOutcome.NoneFound;
+        }
+
         var hasSymbolicArgument = false;
         foreach (var argument in boundArguments)
         {
@@ -4272,7 +4293,7 @@ internal sealed class MemberLookup
                 {
                     var parameterType = GetIndexerParameterTypeSymbol(targetType, property, i);
                     parameterTypes.Add(parameterType);
-                    var conversion = ClassifySymbolicIndexerConversion(boundArguments[i].Type, parameterType);
+                    var conversion = ClassifySymbolicIndexerConversion(boundArguments[i], parameterType);
                     if (!conversion.IsImplicit)
                     {
                         candidateApplicable = false;
@@ -4319,18 +4340,18 @@ internal sealed class MemberLookup
                     resolvedArguments = ConversionClassifier.AppendOmittedOptionalArguments(
                         boundArguments,
                         indexer.GetIndexParameters());
-                    return true;
+                    return ClrIndexerResolutionOutcome.Resolved;
                 }
 
                 // Do not retry a genuine symbolic ambiguity against the
                 // object-erased CLR shape: doing so can incorrectly prefer an
                 // object overload over a more specific symbolic interface.
-                return false;
+                return ClrIndexerResolutionOutcome.Ambiguous;
             }
 
             if (hasSetOnlyIndexer)
             {
-                return false;
+                return ClrIndexerResolutionOutcome.NoneApplicable;
             }
         }
 
@@ -4360,16 +4381,21 @@ internal sealed class MemberLookup
             }
         }
 
-        var resolution = ClrOverloadResolution.Resolve<MethodInfo>(getterMethods, argTypes);
+        var resolution = ClrOverloadResolution.Resolve<MethodInfo>(
+            getterMethods,
+            argTypes,
+            constantNarrowingArgumentCheck: ExpressionBinder.MakeConstantNarrowingArgumentCheck(boundArguments));
         if (resolution.Outcome != ClrOverloadResolution.ResolutionOutcome.Resolved)
         {
-            return false;
+            return resolution.Outcome == ClrOverloadResolution.ResolutionOutcome.Ambiguous
+                ? ClrIndexerResolutionOutcome.Ambiguous
+                : ClrIndexerResolutionOutcome.NoneApplicable;
         }
 
         var best = resolution.Best;
         if (best == null)
         {
-            return false;
+            return ClrIndexerResolutionOutcome.NoneApplicable;
         }
 
         foreach (var property in properties)
@@ -4383,14 +4409,14 @@ internal sealed class MemberLookup
 
         if (indexer is null)
         {
-            return false;
+            return ClrIndexerResolutionOutcome.NoneApplicable;
         }
 
         resolvedArguments = OverloadResolver.BuildOrderedCallArguments(
             boundArguments,
             resolution.ParameterMapping,
             best.GetParameters());
-        return true;
+        return ClrIndexerResolutionOutcome.Resolved;
     }
 
     /// <summary>
@@ -5760,9 +5786,8 @@ internal sealed class MemberLookup
         var hasBetterConversion = false;
         for (var i = 0; i < arguments.Length; i++)
         {
-            var source = arguments[i].Type;
-            var candidateConversion = ClassifySymbolicIndexerConversion(source, candidate[i]);
-            var otherConversion = ClassifySymbolicIndexerConversion(source, other[i]);
+            var candidateConversion = ClassifySymbolicIndexerConversion(arguments[i], candidate[i]);
+            var otherConversion = ClassifySymbolicIndexerConversion(arguments[i], other[i]);
             if (candidateConversion.IsIdentity != otherConversion.IsIdentity)
             {
                 if (!candidateConversion.IsIdentity)
@@ -5790,6 +5815,17 @@ internal sealed class MemberLookup
         }
 
         return hasBetterConversion;
+    }
+
+    private static (bool IsImplicit, bool IsIdentity) ClassifySymbolicIndexerConversion(
+        BoundExpression source,
+        TypeSymbol target)
+    {
+        var conversion = ClassifySymbolicIndexerConversion(source.Type, target);
+        return !conversion.IsImplicit
+            && ExpressionBinder.IsImplicitConstantNarrowingArgument(source, target)
+                ? (true, false)
+                : conversion;
     }
 
     private static (bool IsImplicit, bool IsIdentity) ClassifySymbolicIndexerConversion(

--- a/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
+++ b/test/Compiler.Tests/Emit/Issue2525ImportedIndexerHidingEmitTests.cs
@@ -717,9 +717,7 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
     [Theory]
     [InlineData("func Bad(value IGetDerived) { value[0] = 1 }")]
     [InlineData("func Bad(value ISetDerived) int32 -> value[0]")]
-    [InlineData("func Bad(value IAmbiguous) string -> value[\"key\"]")]
-    [InlineData("func Bad(value IDiamondAmbiguous) string -> value[\"key\"]")]
-    public void HiddenAccessorAvailabilityAndUnrelatedAmbiguity_ReportGS0116(string declaration)
+    public void HiddenAccessorAvailability_ReportsGS0116(string declaration)
     {
         var source = $$"""
             package Issue2525.Errors
@@ -731,6 +729,23 @@ public sealed class Issue2525ImportedIndexerHidingEmitTests
         using var result = Compile(source, "library", expectSuccess: false);
         Assert.Contains("GS0116", result.Diagnostics, StringComparison.Ordinal);
         Assert.Contains("not indexable", result.Diagnostics, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("func Bad(value IAmbiguous) string -> value[\"key\"]")]
+    [InlineData("func Bad(value IDiamondAmbiguous) string -> value[\"key\"]")]
+    public void UnrelatedIndexerAmbiguity_ReportsGS0266(string declaration)
+    {
+        var source = $$"""
+            package Issue2525.Errors
+            import Issue2525.Contracts
+
+            {{declaration}}
+            """;
+
+        using var result = Compile(source, "library", expectSuccess: false);
+        Assert.Contains("GS0266", result.Diagnostics, StringComparison.Ordinal);
+        Assert.DoesNotContain("GS0116", result.Diagnostics, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/Compiler.Tests/Issue4057ImportedGenericIndexerLiteralTests.cs
+++ b/test/Compiler.Tests/Issue4057ImportedGenericIndexerLiteralTests.cs
@@ -1,0 +1,548 @@
+// <copyright file="Issue4057ImportedGenericIndexerLiteralTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using GSharp.Compiler;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace GSharp.Compiler.Tests;
+
+/// <summary>
+/// Issue #4057: integer literals at imported generic indexers use the
+/// substituted key type for conversion and report overload failures rather
+/// than falsely claiming the receiver has no indexer.
+/// </summary>
+public class Issue4057ImportedGenericIndexerLiteralTests
+{
+    private const int RunTimeout = 60_000;
+
+    private const string LibrarySource = """
+        using System.Collections.Generic;
+
+        namespace HelperLib4057;
+
+        public sealed class GenericGetter<T>
+            where T : notnull
+        {
+            public string this[T key] => "generic:" + key;
+
+            public string this[string key] => "string:" + key;
+        }
+
+        public sealed class GenericSetter<T>
+            where T : notnull
+        {
+            public string Last { get; private set; } = "";
+
+            public string this[T key]
+            {
+                set => Last = "generic:" + key + ":" + value;
+            }
+
+            public string this[string key]
+            {
+                set => Last = "string:" + key + ":" + value;
+            }
+        }
+
+        public sealed class ByteIndexer
+        {
+            private readonly Dictionary<byte, string> values = new();
+            public string this[byte key]
+            {
+                get => values[key];
+                set => values[key] = value;
+            }
+        }
+
+        public sealed class SByteIndexer
+        {
+            private readonly Dictionary<sbyte, string> values = new();
+            public string this[sbyte key]
+            {
+                get => values[key];
+                set => values[key] = value;
+            }
+        }
+
+        public sealed class Int16Indexer
+        {
+            private readonly Dictionary<short, string> values = new();
+            public string this[short key]
+            {
+                get => values[key];
+                set => values[key] = value;
+            }
+        }
+
+        public sealed class UInt16Indexer
+        {
+            private readonly Dictionary<ushort, string> values = new();
+            public string this[ushort key]
+            {
+                get => values[key];
+                set => values[key] = value;
+            }
+        }
+
+        public sealed class AmbiguousIndexer
+        {
+            public string this[System.IComparable key]
+            {
+                get => "comparable";
+                set { }
+            }
+
+            public string this[System.IFormattable key]
+            {
+                get => "formattable";
+                set { }
+            }
+        }
+        """;
+
+    public static IEnumerable<object[]> OutOfRangeLiterals()
+    {
+        foreach (var access in new[] { "read", "write" })
+        {
+            yield return new object[] { "uint8-negative-" + access, "uint8", "-1", access };
+            yield return new object[] { "uint8-positive-" + access, "uint8", "256", access };
+            yield return new object[] { "int8-negative-" + access, "int8", "-129", access };
+            yield return new object[] { "int8-positive-" + access, "int8", "128", access };
+            yield return new object[] { "int16-negative-" + access, "int16", "-32769", access };
+            yield return new object[] { "int16-positive-" + access, "int16", "32768", access };
+            yield return new object[] { "uint16-negative-" + access, "uint16", "-1", access };
+            yield return new object[] { "uint16-positive-" + access, "uint16", "65536", access };
+        }
+    }
+
+    [Fact]
+    public void DictionaryReadWriteAndInitializer_LiteralsAtEveryNarrowBoundary_CompileVerifyAndRun()
+    {
+        const string Source = """
+            package P
+            import System
+            import System.Collections.Generic
+
+            let bytes = Dictionary[uint8, string]()
+            bytes[0] = "b0"
+            bytes[255] = "b255"
+            Console.WriteLine(bytes[0])
+            Console.WriteLine(bytes[255])
+
+            let sbytes = Dictionary[int8, string]()
+            sbytes[-128] = "sbmin"
+            sbytes[127] = "sbmax"
+            Console.WriteLine(sbytes[-128])
+            Console.WriteLine(sbytes[127])
+
+            let shorts = Dictionary[int16, string]()
+            shorts[-32768] = "smin"
+            shorts[32767] = "smax"
+            Console.WriteLine(shorts[-32768])
+            Console.WriteLine(shorts[32767])
+
+            let ushorts = Dictionary[uint16, string]()
+            ushorts[0] = "us0"
+            ushorts[65535] = "usmax"
+            Console.WriteLine(ushorts[0])
+            Console.WriteLine(ushorts[65535])
+
+            let initializedBytes = Dictionary[uint8, string]{[0x00] = "init-byte"}
+            let initializedSBytes = Dictionary[int8, string]{[-128] = "init-sbyte"}
+            let initializedShorts = Dictionary[int16, string]{[-32768] = "init-short"}
+            let initializedUShorts = Dictionary[uint16, string]{[65535] = "init-ushort"}
+            Console.WriteLine(initializedBytes[0])
+            Console.WriteLine(initializedSBytes[-128])
+            Console.WriteLine(initializedShorts[-32768])
+            Console.WriteLine(initializedUShorts[65535])
+            """;
+
+        AssertCompilesVerifiesAndRuns(
+            Source,
+            null,
+            "b0", "b255", "sbmin", "sbmax", "smin", "smax", "us0", "usmax",
+            "init-byte", "init-sbyte", "init-short", "init-ushort");
+    }
+
+    [Fact]
+    public void TypedVariables_SourceGenericAndImportedNonGenericIndexers_RemainControls()
+    {
+        const string Source = """
+            package P
+            import System
+            import System.Collections.Generic
+            import HelperLib4057
+
+            class SourceBox[T] {
+                var Stored string
+                prop this[key T] string {
+                    get { return Stored }
+                    set { Stored = value }
+                }
+            }
+
+            let byteKey uint8 = 255
+            let sbyteKey int8 = -128
+            let shortKey int16 = -32768
+            let ushortKey uint16 = 65535
+
+            let bytesByVariable = Dictionary[uint8, string]()
+            bytesByVariable[byteKey] = "typed-byte"
+            Console.WriteLine(bytesByVariable[byteKey])
+            let sbytesByVariable = Dictionary[int8, string]()
+            sbytesByVariable[sbyteKey] = "typed-sbyte"
+            Console.WriteLine(sbytesByVariable[sbyteKey])
+            let shortsByVariable = Dictionary[int16, string]()
+            shortsByVariable[shortKey] = "typed-short"
+            Console.WriteLine(shortsByVariable[shortKey])
+            let ushortsByVariable = Dictionary[uint16, string]()
+            ushortsByVariable[ushortKey] = "typed-ushort"
+            Console.WriteLine(ushortsByVariable[ushortKey])
+
+            let sourceByte = SourceBox[uint8]()
+            sourceByte[255] = "source-byte"
+            Console.WriteLine(sourceByte[255])
+            let sourceSByte = SourceBox[int8]()
+            sourceSByte[-128] = "source-sbyte"
+            Console.WriteLine(sourceSByte[-128])
+            let sourceShort = SourceBox[int16]()
+            sourceShort[-32768] = "source-short"
+            Console.WriteLine(sourceShort[-32768])
+            let sourceUShort = SourceBox[uint16]()
+            sourceUShort[65535] = "source-ushort"
+            Console.WriteLine(sourceUShort[65535])
+
+            let bytes = ByteIndexer()
+            bytes[255] = "non-generic-byte"
+            Console.WriteLine(bytes[255])
+            let sbytes = SByteIndexer()
+            sbytes[-128] = "non-generic-sbyte"
+            Console.WriteLine(sbytes[-128])
+            let shorts = Int16Indexer()
+            shorts[-32768] = "non-generic-short"
+            Console.WriteLine(shorts[-32768])
+            let ushorts = UInt16Indexer()
+            ushorts[65535] = "non-generic-ushort"
+            Console.WriteLine(ushorts[65535])
+            """;
+
+        AssertCompilesVerifiesAndRuns(
+            Source,
+            LibrarySource,
+            "typed-byte",
+            "typed-sbyte",
+            "typed-short",
+            "typed-ushort",
+            "source-byte",
+            "source-sbyte",
+            "source-short",
+            "source-ushort",
+            "non-generic-byte",
+            "non-generic-sbyte",
+            "non-generic-short",
+            "non-generic-ushort");
+    }
+
+    [Fact]
+    public void ImportedGenericGetterAndSetterOverloads_UseTheSubstitutedNarrowType()
+    {
+        const string Source = """
+            package P
+            import System
+            import HelperLib4057
+
+            Console.WriteLine(GenericGetter[uint8]()[255])
+            Console.WriteLine(GenericGetter[int8]()[-128])
+            Console.WriteLine(GenericGetter[int16]()[-32768])
+            Console.WriteLine(GenericGetter[uint16]()[65535])
+            Console.WriteLine(GenericGetter[uint8]()["key"])
+
+            let byteSetter = GenericSetter[uint8]()
+            byteSetter[255] = "b"
+            Console.WriteLine(byteSetter.Last)
+            let sbyteSetter = GenericSetter[int8]()
+            sbyteSetter[-128] = "sb"
+            Console.WriteLine(sbyteSetter.Last)
+            let shortSetter = GenericSetter[int16]()
+            shortSetter[-32768] = "s"
+            Console.WriteLine(shortSetter.Last)
+            let ushortSetter = GenericSetter[uint16]()
+            ushortSetter[65535] = "us"
+            Console.WriteLine(ushortSetter.Last)
+            byteSetter["key"] = "text"
+            Console.WriteLine(byteSetter.Last)
+            """;
+
+        AssertCompilesVerifiesAndRuns(
+            Source,
+            LibrarySource,
+            "generic:255",
+            "generic:-128",
+            "generic:-32768",
+            "generic:65535",
+            "string:key",
+            "generic:255:b",
+            "generic:-128:sb",
+            "generic:-32768:s",
+            "generic:65535:us",
+            "string:key:text");
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfRangeLiterals))]
+    public void OutOfRangeLiteral_ReportsNoApplicableOverload_NotNotIndexable(
+        string name,
+        string keyType,
+        string literal,
+        string access)
+    {
+        var operation = access == "read"
+            ? $"return values[{literal}]"
+            : $"values[{literal}] = \"value\"";
+        var returnType = access == "read" ? " string" : string.Empty;
+        var source = $$"""
+            package P
+            import System.Collections.Generic
+
+            func Probe(){{returnType}} {
+                let values = Dictionary[{{keyType}}, string]()
+                {{operation}}
+            }
+            """;
+
+        var log = CompileExpectingFailure(name, source);
+        Assert.Equal(new[] { "GS0267" }, ErrorIds(log));
+        Assert.DoesNotContain("GS0116", log, StringComparison.Ordinal);
+        Assert.Contains("No overload", log, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OutOfRangeInitializerLiteral_ReportsNoApplicableOverload_NotNotIndexable()
+    {
+        const string Source = """
+            package P
+            import System.Collections.Generic
+
+            func Probe() {
+                let values = Dictionary[uint8, string]{[256] = "value"}
+            }
+            """;
+
+        var log = CompileExpectingFailure("initializer", Source);
+        Assert.Equal(new[] { "GS0267" }, ErrorIds(log));
+        Assert.DoesNotContain("GS0116", log, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("read")]
+    [InlineData("write")]
+    public void EquallyApplicableImportedIndexerOverloads_ReportAmbiguous_NotNotIndexable(string access)
+    {
+        var operation = access == "read"
+            ? "return values[key]"
+            : "values[key] = \"value\"";
+        var returnType = access == "read" ? " string" : string.Empty;
+        var source = $$"""
+            package P
+            import HelperLib4057
+
+            func Probe(values AmbiguousIndexer, key int32){{returnType}} {
+                {{operation}}
+            }
+            """;
+
+        var log = CompileExpectingFailure("ambiguous-" + access, source, LibrarySource);
+        Assert.Equal(new[] { "GS0266" }, ErrorIds(log));
+        Assert.DoesNotContain("GS0116", log, StringComparison.Ordinal);
+        Assert.Contains("ambiguous", log, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ATypeWithoutAnIndexer_StillReportsNotIndexable()
+    {
+        const string Source = """
+            package P
+
+            func Probe() {
+                var value = 1
+                value[0] = 2
+            }
+            """;
+
+        var log = CompileExpectingFailure("not-indexable-control", Source);
+        Assert.Equal(new[] { "GS0116" }, ErrorIds(log));
+    }
+
+    private static void AssertCompilesVerifiesAndRuns(
+        string source,
+        string csharpSource,
+        params string[] expectedLines)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_4057_").FullName;
+        try
+        {
+            var references = csharpSource == null
+                ? Array.Empty<string>()
+                : new[] { CompileCSharpLibrary(workDir, csharpSource) };
+            var appPath = Path.Combine(workDir, "App.dll");
+            var log = Compile(workDir, source, appPath, "exe", references);
+
+            Assert.True(File.Exists(appPath), $"gsc failed:\n{log}");
+            IlVerifier.Verify(appPath, references);
+
+            var (exitCode, output) = RunDotnet(appPath);
+            Assert.True(exitCode == 0, $"dotnet exec failed ({exitCode}):\n{output}");
+            Assert.Equal(
+                expectedLines,
+                output.Split('\n')
+                    .Select(line => line.TrimEnd('\r'))
+                    .Where(line => line.Length != 0)
+                    .ToArray());
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    private static string CompileExpectingFailure(
+        string name,
+        string source,
+        string csharpSource = null)
+    {
+        var workDir = Directory.CreateTempSubdirectory("gs_4057_error_").FullName;
+        try
+        {
+            var references = csharpSource == null
+                ? Array.Empty<string>()
+                : new[] { CompileCSharpLibrary(workDir, csharpSource) };
+            var appPath = Path.Combine(workDir, name + ".dll");
+            var log = Compile(workDir, source, appPath, "library", references);
+            Assert.False(File.Exists(appPath), $"'{name}' unexpectedly compiled:\n{log}");
+            return log;
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    private static string Compile(
+        string workDir,
+        string source,
+        string outputPath,
+        string target,
+        IReadOnlyList<string> references)
+    {
+        var sourcePath = Path.Combine(workDir, "App.gs");
+        File.WriteAllText(sourcePath, source);
+
+        var args = new List<string>
+        {
+            "/out:" + outputPath,
+            "/target:" + target,
+            "/targetframework:net10.0",
+            "/nowarn:GS9100",
+        };
+        args.AddRange(references.Select(reference => "/reference:" + reference));
+        args.Add(sourcePath);
+
+        using var stdout = new StringWriter();
+        using var stderr = new StringWriter();
+        var previousOut = Console.Out;
+        var previousError = Console.Error;
+        Console.SetOut(stdout);
+        Console.SetError(stderr);
+        try
+        {
+            _ = Program.Main(args.ToArray());
+            return stdout.ToString() + stderr;
+        }
+        finally
+        {
+            Console.SetOut(previousOut);
+            Console.SetError(previousError);
+        }
+    }
+
+    private static string CompileCSharpLibrary(string workDir, string source)
+    {
+        var outputPath = Path.Combine(workDir, "HelperLib4057.dll");
+        var references = TrustedPlatformAssemblies()
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "HelperLib4057",
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = File.Create(outputPath);
+        var result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return outputPath;
+    }
+
+    private static IEnumerable<string> TrustedPlatformAssemblies()
+    {
+        var value = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        Assert.False(string.IsNullOrWhiteSpace(value));
+        return value!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static (int ExitCode, string Output) RunDotnet(string assemblyPath)
+    {
+        var runtimeConfig = Path.ChangeExtension(assemblyPath, ".runtimeconfig.json");
+        if (!File.Exists(runtimeConfig))
+        {
+            File.WriteAllText(runtimeConfig, """
+                {
+                  "runtimeOptions": {
+                    "tfm": "net10.0",
+                    "framework": { "name": "Microsoft.NETCore.App", "version": "10.0.0" }
+                  }
+                }
+                """);
+        }
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(assemblyPath)!,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfig);
+        startInfo.ArgumentList.Add(assemblyPath);
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start dotnet exec.");
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(RunTimeout))
+        {
+            process.Kill(entireProcessTree: true);
+            process.WaitForExit();
+            Assert.Fail("dotnet exec timed out.");
+        }
+
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    private static string[] ErrorIds(string log)
+        => Regex.Matches(log, @"error (GS[0-9]{4})")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+}


### PR DESCRIPTION
Fixes #4057

## Summary

- pass imported CLR indexer candidates through the ordinary checked constant-literal narrowing path, including substituted symbolic parameter types
- preserve indexer resolution outcomes so argument mismatch reports GS0267/GS0266 instead of false GS0116
- add executing, ILVerify-backed coverage for read/write/initializer paths, byte/sbyte/short/ushort boundaries, typed variables, source-generic and imported non-generic controls, getter/setter overloads, and ambiguous overloads

## Verification

- `dotnet build GSharp.sln --configuration Release --no-restore -graph`: succeeded, 0 warnings / 0 errors
- focused Core binder tests: 82 passed
- focused compiler/indexer tests: 53 passed, including 23 new #4057 cases
- `python3 build/nullable_hygiene.py`: clean; no nullable suppressions, guards, or null-forgiving operators introduced
- `build/test-cs2gs-selfmig-pr-guard.sh`: passed
- exact `test/Compiler.Tests` self-migration: translate PASS, compile PASS (restored), ILVerify PASS; test-parity reached its existing failure stage (261 failures / 5,231 passes), with no #4057 test failure
- `build/run-cs2gs-selfmig-pr-guard.sh`: 8/8 apps green across translate, compile, ILVerify, and parity

## Witness

The initial regression suite on `origin/main` failed 11/12 cases with GS0116; after the binder fix, the expanded final suite passes 23/23. Out-of-range cases now report exactly one GS0267, ambiguous read/write cases report exactly one GS0266, and neither degrades to GS0116.

## Checklist

- [x] Behavioral tests carry a witness of discrimination (ADR-0154)
- [x] Self-review verdict: MERGEABLE; no known residual specific to #4057