### PR TITLE
selfmig: expose original fixtures to stage 4

### DIFF
--- a/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GsharpTestProjectRunner.cs
@@ -40,6 +40,12 @@ public enum GsharpTestRunStatus
 /// </summary>
 public class GsharpTestProjectRunner
 {
+    /// <summary>
+    /// The stage-4 child-process contract for the original, read-only C# source
+    /// tree. The variable is set only for <c>dotnet test --no-build</c>.
+    /// </summary>
+    public const string SourceRootEnvironmentVariable = "CS2GS_TEST_SOURCE_ROOT";
+
     private const string SdkPackageId = "Gsharp.NET.Sdk";
     private const string SdkPackagePrefix = SdkPackageId + ".";
 
@@ -353,6 +359,12 @@ public class GsharpTestProjectRunner
 
     internal static string FindRepoRoot()
     {
+        string configuredRoot = Environment.GetEnvironmentVariable(SourceRootEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(configuredRoot))
+        {
+            return ResolveConfiguredSourceRoot(configuredRoot, Environment.CurrentDirectory);
+        }
+
         string dir = Path.GetDirectoryName(typeof(GsharpTestProjectRunner).Assembly.Location);
         while (!string.IsNullOrEmpty(dir))
         {
@@ -365,7 +377,23 @@ public class GsharpTestProjectRunner
             dir = Path.GetDirectoryName(dir);
         }
 
-        return Environment.CurrentDirectory;
+        throw new DirectoryNotFoundException(
+            $"Could not locate the repository source root above " +
+            $"{typeof(GsharpTestProjectRunner).Assembly.Location}. Set " +
+            $"{SourceRootEnvironmentVariable} to the original source tree.");
+    }
+
+    internal static string ResolveConfiguredSourceRoot(string configuredRoot, string baseDirectory)
+    {
+        string fullPath = Path.GetFullPath(configuredRoot, baseDirectory);
+        string canonical = CanonicalRootPath.Resolve(fullPath);
+        if (!Directory.Exists(canonical))
+        {
+            throw new DirectoryNotFoundException(
+                $"Stage-4 source root from {SourceRootEnvironmentVariable} does not exist: '{canonical}'.");
+        }
+
+        return canonical;
     }
 
     private static (int[] Numbers, string Suffix) SplitVersion(string version)

--- a/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/ProcessRunner.cs
@@ -86,6 +86,11 @@ public static class ProcessRunner
             psi.ArgumentList.Add(arg);
         }
 
+        // Stage 4 grants the original C# source tree only to the mirrored test
+        // host. Nested compiler/test/program launches must opt in explicitly;
+        // otherwise they could consume original fixtures as build inputs.
+        psi.Environment.Remove(GsharpTestProjectRunner.SourceRootEnvironmentVariable);
+
         if (environment is not null)
         {
             foreach ((string name, string value) in environment)

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -526,6 +526,37 @@ public sealed class SdkCompileRunner
         return SdkCompileResult.Completed(result.ExitCode, result.Output, diagnostics, assemblyPath);
     }
 
+    internal static IReadOnlyDictionary<string, string> IsolatedNugetEnvironment(string root) =>
+        new Dictionary<string, string>
+        {
+            ["NUGET_PACKAGES"] = Path.Combine(root, ".nuget-packages"),
+            [GsharpTestProjectRunner.SourceRootEnvironmentVariable] = string.Empty,
+        };
+
+    internal static IReadOnlyDictionary<string, string> MirroredTestEnvironment(
+        string artifactRoot, string sourceRoot)
+    {
+        if (string.IsNullOrWhiteSpace(sourceRoot))
+        {
+            throw new DirectoryNotFoundException(
+                $"Stage 4 requires the original C# source root; " +
+                $"{GsharpTestProjectRunner.SourceRootEnvironmentVariable} was not configured.");
+        }
+
+        string canonicalSourceRoot = CanonicalRootPath.Resolve(sourceRoot);
+        if (!Directory.Exists(canonicalSourceRoot))
+        {
+            throw new DirectoryNotFoundException(
+                $"Stage-4 source root does not exist: '{canonicalSourceRoot}'.");
+        }
+
+        var environment = new Dictionary<string, string>(IsolatedNugetEnvironment(artifactRoot))
+        {
+            [GsharpTestProjectRunner.SourceRootEnvironmentVariable] = canonicalSourceRoot,
+        };
+        return environment;
+    }
+
     /// <summary>
     /// Partitions a flat reference-path list into reconstructed
     /// <c>PackageReference</c> ids/versions (for dlls that live under a NuGet
@@ -925,6 +956,7 @@ public sealed class SdkCompileRunner
         string artifactDirectory,
         string config,
         IReadOnlyDictionary<string, string> generatedProjectPaths,
+        string sourceRoot,
         TimeSpan timeout)
     {
         string projectDirectory = Path.GetDirectoryName(Path.GetFullPath(generatedProjectPath));
@@ -955,7 +987,7 @@ public sealed class SdkCompileRunner
                 },
                 projectDirectory,
                 timeout,
-                IsolatedNugetEnvironment(artifactDirectory));
+                MirroredTestEnvironment(artifactDirectory, sourceRoot));
         }
         finally
         {
@@ -1523,12 +1555,6 @@ public sealed class SdkCompileRunner
         string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         return string.IsNullOrEmpty(home) ? null : Path.Combine(home, ".nuget", "packages");
     }
-
-    private static IReadOnlyDictionary<string, string> IsolatedNugetEnvironment(string root) =>
-        new Dictionary<string, string>
-        {
-            ["NUGET_PACKAGES"] = Path.Combine(root, ".nuget-packages"),
-        };
 
     private static (string NupkgPath, string Version)? ResolveFallbackSdkPackageFromLocalFeed(string repoRoot)
     {

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -536,6 +536,7 @@ public sealed partial class TestParityStage : IMigrationStage
             context.ArtifactDir,
             context.Options.Config,
             context.Options.GeneratedProjectPaths,
+            context.Options.SourceRoot,
             budget);
         return this.EvaluateMirroredTestRun(context, result, budget);
     }

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169AnalyzerTranslationTests.cs
@@ -1092,21 +1092,7 @@ public static class NotAnAnalyzer
     }
 
     private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "nuget.config")) &&
-                File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
-            {
-                return dir.FullName;
-            }
-
-            dir = dir.Parent;
-        }
-
-        return null;
-    }
+        => TestFixtureSource.Root;
 
     private static LoadedCSharpProject LoadAnalyzerProject(string source)
         => LoadAnalyzerProject(new[] { ("Analyzer.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Tests/Adr0169TranslatedAnalyzerHarness.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Adr0169TranslatedAnalyzerHarness.cs
@@ -166,19 +166,5 @@ public static class DiagnosticDescriptors
     /// </summary>
     /// <returns>The repo root path.</returns>
     public static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "nuget.config")) &&
-                File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
-            {
-                return dir.FullName;
-            }
-
-            dir = dir.Parent;
-        }
-
-        return null;
-    }
+        => TestFixtureSource.Root;
 }

--- a/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/BodyTranslationTests.cs
@@ -526,22 +526,8 @@ public class BodyTranslationTests
     }
 
     private static string ResolveCorpusProject(string projectFolder, string projectFile)
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus", projectFolder, projectFile);
-            if (File.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new FileNotFoundException(
-            $"Could not locate corpus project '{projectFolder}/{projectFile}' above {AppContext.BaseDirectory}.");
-    }
+        => TestFixtureSource.Resolve(
+            "tools", "cs2gs", "corpus", projectFolder, projectFile);
 
     /// <summary>
     /// Translates a small C# statement snippet (wrapped in a method with an

--- a/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Coverage/TranslatorExhaustivenessTests.cs
@@ -141,18 +141,5 @@ public class TranslatorExhaustivenessTests
         Path.Combine(RepoRoot(), ConstructInventory.RepoRelativePath.Replace('/', Path.DirectorySeparatorChar));
 
     private static string RepoRoot()
-    {
-        var dir = new DirectoryInfo(Path.GetDirectoryName(typeof(TranslatorExhaustivenessTests).Assembly.Location));
-        while (dir != null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "GSharp.sln")))
-            {
-                return dir.FullName;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new InvalidOperationException("GSharp.sln not found above the test assembly.");
-    }
+        => TestFixtureSource.Root;
 }

--- a/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/IlVerifyStageTests.cs
@@ -631,19 +631,5 @@ public class IlVerifyStageTests
     }
 
     private static string ResolveCorpusDir()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException("Could not locate tools/cs2gs/corpus above " + AppContext.BaseDirectory);
-    }
+        => TestFixtureSource.Resolve("tools", "cs2gs", "corpus");
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1911ExplicitInterfaceImplementationTests.cs
@@ -226,19 +226,5 @@ namespace Corpus.Issue1911
     }
 
     private static string ResolveCorpusDir()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException("Could not locate tools/cs2gs/corpus above " + AppContext.BaseDirectory);
-    }
+        => TestFixtureSource.Resolve("tools", "cs2gs", "corpus");
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue1933UnsafeIlVerifyPolicyTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue1933UnsafeIlVerifyPolicyTests.cs
@@ -302,19 +302,5 @@ public class Issue1933UnsafeIlVerifyPolicyTests
     }
 
     private static string ResolveCorpusDir()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException("Could not locate tools/cs2gs/corpus above " + AppContext.BaseDirectory);
-    }
+        => TestFixtureSource.Resolve("tools", "cs2gs", "corpus");
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue2546ImplicitUsingsTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue2546ImplicitUsingsTests.cs
@@ -18,8 +18,10 @@ public class Issue2546ImplicitUsingsTests
     [Fact]
     public async Task EffectiveGlobalUsings_ImportOnlyNamespacesUsedByBareFrameworkTypes()
     {
-        string projectPath = Path.Combine(
-            AppContext.BaseDirectory,
+        string projectPath = TestFixtureSource.Resolve(
+            "tools",
+            "cs2gs",
+            "Cs2Gs.Tests",
             "Fixtures",
             "Issue2546ImplicitUsings",
             "Issue2546ImplicitUsings.csproj");

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3086GeneratedRegexPipelineTests.cs
@@ -190,7 +190,8 @@ public sealed class Issue3086GeneratedRegexPipelineTests
 
     private static void CopyFixture(string destination)
     {
-        string source = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Issue3086GeneratedRegex");
+        string source = TestFixtureSource.Resolve(
+            "tools", "cs2gs", "Cs2Gs.Tests", "Fixtures", "Issue3086GeneratedRegex");
         Directory.CreateDirectory(destination);
         foreach (string file in Directory.GetFiles(source))
         {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3090AwaitInvocationArgumentTests.cs
@@ -496,20 +496,5 @@ public sealed class Issue3090AwaitInvocationArgumentTests
     }
 
     private static string ResolveCorpusDir()
-    {
-        var directory = new DirectoryInfo(AppContext.BaseDirectory);
-        while (directory is not null)
-        {
-            string candidate = Path.Combine(directory.FullName, "tools", "cs2gs", "corpus");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            directory = directory.Parent;
-        }
-
-        throw new DirectoryNotFoundException(
-            "Could not locate tools/cs2gs/corpus above " + AppContext.BaseDirectory);
-    }
+        => TestFixtureSource.Resolve("tools", "cs2gs", "corpus");
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4072Stage4FixtureContractTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4072Stage4FixtureContractTests.cs
@@ -1,0 +1,190 @@
+// <copyright file="Issue4072Stage4FixtureContractTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Cs2Gs.Pipeline;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Integration coverage for the stage-4 original-source fixture contract.
+/// </summary>
+public class Issue4072Stage4FixtureContractTests
+{
+    [Fact]
+    public void SourceRoot_ProvidesAnalyzerCorpusUnsupportedAndProjectLoadingFixtures()
+    {
+        string analyzer = TestFixtureSource.Resolve(
+            "src", "Analyzers", "InternalAnalyzers", "StructFieldDefsReadAnalyzer.cs");
+        Assert.Contains("StructFieldDefsReadAnalyzer", File.ReadAllText(analyzer), StringComparison.Ordinal);
+
+        Assert.True(File.Exists(TestFixtureSource.Resolve(
+            "tools", "cs2gs", "corpus", "L1-Console", "L1-Console.csproj")));
+        Assert.True(File.Exists(TestFixtureSource.Resolve(
+            "tools", "cs2gs", "corpus", "L4-Console", "L4-Console.csproj")));
+
+        string unsupported = TestFixtureSource.Resolve(
+            "tools", "cs2gs", "Cs2Gs.Tests", "Fixtures", "Grid", "Unsupported", "MakeRefExpression.cs");
+        Assert.Contains("__makeref", File.ReadAllText(unsupported), StringComparison.Ordinal);
+
+        string coreProjectPath = TestFixtureSource.Resolve("src", "Core", "Core.csproj");
+        Assert.Contains(
+            "<Project",
+            File.ReadAllText(coreProjectPath),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FixtureResolution_NormalizesRelativeSegmentsAndPreservesSpaces()
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory,
+            "issue4072 fixture root with spaces",
+            Guid.NewGuid().ToString("N"));
+        string fixtureDirectory = Path.Combine(root, "fixtures");
+        Directory.CreateDirectory(fixtureDirectory);
+        string fixture = Path.Combine(fixtureDirectory, "input.cs");
+        File.WriteAllText(fixture, "class C { }");
+
+        try
+        {
+            string relativeRoot = Path.GetRelativePath(AppContext.BaseDirectory, root);
+            Assert.Equal(
+                CanonicalRootPath.Resolve(root),
+                GsharpTestProjectRunner.ResolveConfiguredSourceRoot(
+                    relativeRoot, AppContext.BaseDirectory));
+            Assert.Equal(
+                CanonicalRootPath.Resolve(fixture),
+                TestFixtureSource.ResolveFromRoot(
+                    root, "fixtures", "nested", "..", "input.cs"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MissingSourceRootAndFixture_FailWithActionableErrors()
+    {
+        string missingRoot = Path.Combine(
+            AppContext.BaseDirectory, "missing-source-root-" + Guid.NewGuid().ToString("N"));
+        DirectoryNotFoundException rootError = Assert.Throws<DirectoryNotFoundException>(() =>
+            GsharpTestProjectRunner.ResolveConfiguredSourceRoot(
+                Path.GetFileName(missingRoot), AppContext.BaseDirectory));
+        Assert.Contains(
+            GsharpTestProjectRunner.SourceRootEnvironmentVariable,
+            rootError.Message,
+            StringComparison.Ordinal);
+
+        string existingRoot = Path.Combine(
+            AppContext.BaseDirectory, "fixture-root-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(existingRoot);
+        try
+        {
+            FileNotFoundException fixtureError = Assert.Throws<FileNotFoundException>(() =>
+                TestFixtureSource.ResolveFromRoot(existingRoot, "missing.cs"));
+            Assert.Contains("missing.cs", fixtureError.Message, StringComparison.Ordinal);
+            Assert.Contains(
+                GsharpTestProjectRunner.SourceRootEnvironmentVariable,
+                fixtureError.Message,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(existingRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FixtureResolution_RejectsPathsOutsideSourceRoot()
+    {
+        string root = Path.Combine(
+            AppContext.BaseDirectory, "fixture-root-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        string outside = Path.Combine(Path.GetDirectoryName(root), "outside-" + Guid.NewGuid().ToString("N") + ".cs");
+        File.WriteAllText(outside, "class Outside { }");
+
+        try
+        {
+            InvalidOperationException error = Assert.Throws<InvalidOperationException>(() =>
+                TestFixtureSource.ResolveFromRoot(root, "..", Path.GetFileName(outside)));
+            Assert.Contains("escapes", error.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(outside);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void OriginalSourceRoot_IsExposedOnlyToTheTestProcess()
+    {
+        string artifactRoot = Path.Combine(
+            AppContext.BaseDirectory, "issue4072-artifacts", Guid.NewGuid().ToString("N"));
+        string sourceRoot = Path.Combine(
+            AppContext.BaseDirectory, "issue4072 source root with spaces", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(artifactRoot);
+        Directory.CreateDirectory(sourceRoot);
+        string originalSourceRoot = Environment.GetEnvironmentVariable(
+            GsharpTestProjectRunner.SourceRootEnvironmentVariable);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                GsharpTestProjectRunner.SourceRootEnvironmentVariable,
+                sourceRoot);
+            IReadOnlyDictionary<string, string> compileEnvironment =
+                SdkCompileRunner.IsolatedNugetEnvironment(artifactRoot);
+            IReadOnlyDictionary<string, string> testEnvironment =
+                SdkCompileRunner.MirroredTestEnvironment(artifactRoot, sourceRoot);
+
+            Assert.Equal(
+                string.Empty,
+                compileEnvironment[GsharpTestProjectRunner.SourceRootEnvironmentVariable]);
+            Assert.Equal(
+                CanonicalRootPath.Resolve(sourceRoot),
+                testEnvironment[GsharpTestProjectRunner.SourceRootEnvironmentVariable]);
+
+            ProcessRunResult inheritedProbe = ProcessRunner.Run(
+                "printenv",
+                new[] { GsharpTestProjectRunner.SourceRootEnvironmentVariable },
+                AppContext.BaseDirectory,
+                TimeSpan.FromSeconds(10));
+            Assert.NotEqual(0, inheritedProbe.ExitCode);
+
+            ProcessRunResult compileProbe = ProcessRunner.Run(
+                "printenv",
+                new[] { GsharpTestProjectRunner.SourceRootEnvironmentVariable },
+                AppContext.BaseDirectory,
+                TimeSpan.FromSeconds(10),
+                compileEnvironment);
+            Assert.Equal(0, compileProbe.ExitCode);
+            Assert.Equal(string.Empty, compileProbe.Stdout.Trim());
+
+            ProcessRunResult testProbe = ProcessRunner.Run(
+                "printenv",
+                new[] { GsharpTestProjectRunner.SourceRootEnvironmentVariable },
+                AppContext.BaseDirectory,
+                TimeSpan.FromSeconds(10),
+                testEnvironment);
+            Assert.Equal(0, testProbe.ExitCode);
+            Assert.Equal(
+                CanonicalRootPath.Resolve(sourceRoot),
+                testProbe.Stdout.Trim());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                GsharpTestProjectRunner.SourceRootEnvironmentVariable,
+                originalSourceRoot);
+            Directory.Delete(sourceRoot, recursive: true);
+            Directory.Delete(artifactRoot, recursive: true);
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/L1MigrationEndToEndTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/L1MigrationEndToEndTests.cs
@@ -171,20 +171,6 @@ public class L1MigrationEndToEndTests
     }
 
     private static string ResolveCorpusFile(string projectFolder, string fileName)
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus", projectFolder, fileName);
-            if (File.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new FileNotFoundException(
-            $"Could not locate corpus file '{projectFolder}/{fileName}' above {AppContext.BaseDirectory}.");
-    }
+        => TestFixtureSource.Resolve(
+            "tools", "cs2gs", "corpus", projectFolder, fileName);
 }

--- a/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/MigrationPipelineTests.cs
@@ -722,19 +722,5 @@ public class MigrationPipelineTests
     }
 
     private static string ResolveCorpusDir()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException("Could not locate tools/cs2gs/corpus above " + AppContext.BaseDirectory);
-    }
+        => TestFixtureSource.Resolve("tools", "cs2gs", "corpus");
 }

--- a/tools/cs2gs/Cs2Gs.Tests/TestFixtureSource.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestFixtureSource.cs
@@ -1,0 +1,64 @@
+// <copyright file="TestFixtureSource.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using Cs2Gs.Pipeline;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Resolves read-only C# and project fixtures from the original source tree.
+/// Native tests discover that tree above their assembly; migrated stage-4
+/// tests receive it through <see cref="GsharpTestProjectRunner.SourceRootEnvironmentVariable"/>.
+/// </summary>
+internal static class TestFixtureSource
+{
+    public static string Root => GsharpTestProjectRunner.FindRepoRoot();
+
+    public static string Resolve(params string[] relativeSegments) =>
+        ResolveFromRoot(Root, relativeSegments);
+
+    internal static string ResolveFromRoot(string root, params string[] relativeSegments)
+    {
+        string canonicalRoot = CanonicalRootPath.Resolve(root);
+        if (!Directory.Exists(canonicalRoot))
+        {
+            throw new DirectoryNotFoundException(
+                $"Configured source fixture root does not exist: '{canonicalRoot}'. Set " +
+                $"{GsharpTestProjectRunner.SourceRootEnvironmentVariable} to the original source tree.");
+        }
+
+        string candidate = canonicalRoot;
+        foreach (string segment in relativeSegments)
+        {
+            candidate = Path.Combine(candidate, segment);
+        }
+
+        candidate = CanonicalRootPath.Resolve(candidate);
+        string rootPrefix = canonicalRoot.TrimEnd(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!string.Equals(candidate, canonicalRoot, comparison) &&
+            !candidate.StartsWith(rootPrefix, comparison))
+        {
+            throw new InvalidOperationException(
+                $"Source fixture path escapes the configured root '{canonicalRoot}': '{candidate}'.");
+        }
+
+        if (!File.Exists(candidate) && !Directory.Exists(candidate))
+        {
+            throw new FileNotFoundException(
+                $"Source fixture was not found under '{canonicalRoot}': " +
+                $"'{string.Join(Path.DirectorySeparatorChar.ToString(), relativeSegments)}'. " +
+                $"Set {GsharpTestProjectRunner.SourceRootEnvironmentVariable} to the original source tree.",
+                candidate);
+        }
+
+        return candidate;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/TestParityStageTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TestParityStageTests.cs
@@ -139,19 +139,5 @@ public class TestParityStageTests
     }
 
     private static string ResolveCorpusDir()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(dir.FullName, "tools", "cs2gs", "corpus");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new DirectoryNotFoundException("Could not locate tools/cs2gs/corpus above " + AppContext.BaseDirectory);
-    }
+        => TestFixtureSource.Resolve("tools", "cs2gs", "corpus");
 }

--- a/tools/cs2gs/Cs2Gs.Tests/TranslatorIngestionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/TranslatorIngestionTests.cs
@@ -141,23 +141,6 @@ namespace Sample.Geometry
     }
 
     private static string ResolveCorpusProject(string projectFolder, string projectFile)
-    {
-        // Walk up from the test assembly location until the cs2gs corpus is found,
-        // so the test is independent of the working directory / build layout.
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            string candidate = Path.Combine(
-                dir.FullName, "tools", "cs2gs", "corpus", projectFolder, projectFile);
-            if (File.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        throw new FileNotFoundException(
-            $"Could not locate corpus project '{projectFolder}/{projectFile}' above {AppContext.BaseDirectory}.");
-    }
+        => TestFixtureSource.Resolve(
+            "tools", "cs2gs", "corpus", projectFolder, projectFile);
 }


### PR DESCRIPTION
Closes #4072.

## Summary

- pass the canonical original source root to mirrored `dotnet test --no-build` through `CS2GS_TEST_SOURCE_ROOT`
- resolve analyzer, corpus, unsupported-grid, and project-loading C#/.csproj fixtures through one path-safe test helper
- scrub the source-root variable from every nested subprocess by default, then explicitly opt in only for the stage-4 test host, so original C# cannot become migrated compilation input
- fail clearly for absent roots, missing fixtures, and path escapes; cover spaces and normalized relative paths
- compose with main's suite-sized parity budget so the newly reachable fixture tests complete rather than being killed at the old fixed timeout

The validate runner derives the root from its own `--corpus` checkout. No stage-1 absolute path is persisted in artifacts, so sharded CI remains self-contained and runner-path independent.

## Measurement

Fresh `origin/main` (`15b799386`) baseline:

- translate: 56/56 projects
- Cs2Gs.Tests compile: PASS
- ILVerify: PASS
- parity: 2,747 passed / 136 failed / 2,883 total
- missing-fixture failures: **36**

Final rebased run (`85cb974f0` on `4a0518553`, including merged #4071 and the suite-sized budget):

- translate: 56/56 projects
- Cs2Gs.Tests compile: PASS
- ILVerify: PASS
- parity completed in 18m34s: 2,854 passed / 43 failed / 2,897 total
- missing-fixture failures: **0**
- new #4072 contract failures: **0**

The remaining parity failures are independent migration/runtime issues; no allow-list or stage floor changed.

## Verification

- native `Cs2Gs.Tests`: 2,883/2,883 PASS before the concurrent #4071/#4125 merge; their added tests are green in required CI
- affected fixture/analyzer/corpus/project-loading slice: 112/112 PASS
- final #4072 + ProcessRunner + scaled-budget contract slice: 28/28 PASS
- final whole-repository translate + exact Cs2Gs.Tests compile/ILVerify/complete parity: reached all stages; 36 -> 0 missing fixtures
- `dotnet build GSharp.sln -c Release --no-restore -graph`: 0 warnings, 0 errors
- `python3 build/nullable_hygiene.py --base origin/main`: OK
- `./build/test-cs2gs-selfmig-pr-guard.sh`: PASS
- exact local hot-core guard: 8/8 PASS across translate/compile/ILVerify/parity
- Copilot review finding fixed and thread resolved: nested subprocesses now scrub the source-root variable centrally
- `git diff --check`: clean
