### PR TITLE
cs2gs: clear migrated Cs2Gs checked-null crashes

### DIFF
--- a/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
+++ b/src/Core/CodeAnalysis/Binding/LambdaBinder.cs
@@ -2050,14 +2050,26 @@ internal sealed class LambdaBinder
                 return TypeSymbol.Void;
             }
 
-            if (targetReturn != null
-                && candidates.All(c => c == TypeSymbol.Error
-                    || Conversion.Classify(c, targetReturn).IsImplicit
-                    || ConversionClassifier.HasUserDefinedImplicitConversionForTypes(
-                        c,
-                        targetReturn)))
+            var allCandidatesConvert = targetReturn != null;
+            if (targetReturn != null)
             {
-                return targetReturn;
+                foreach (TypeSymbol candidate in candidates)
+                {
+                    if (candidate != TypeSymbol.Error
+                        && !Conversion.Classify(candidate, targetReturn).IsImplicit
+                        && !ConversionClassifier.HasUserDefinedImplicitConversionForTypes(
+                            candidate,
+                            targetReturn))
+                    {
+                        allCandidatesConvert = false;
+                        break;
+                    }
+                }
+            }
+
+            if (allCandidatesConvert)
+            {
+                return targetReturn!;
             }
         }
 
@@ -2066,7 +2078,7 @@ internal sealed class LambdaBinder
             return TypeSymbol.Void;
         }
 
-        var result = candidates[0];
+        TypeSymbol? result = candidates[0];
         for (var i = 1; i < candidates.Count; i++)
         {
             result = ComputeLambdaCommonType(result, candidates[i]);

--- a/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/DeclaredProjectItem.cs
@@ -26,11 +26,12 @@ public sealed class DeclaredProjectItem
     /// <param name="element">The namespace-free item XML.</param>
     /// <param name="sourceInclude">The absolute source ProjectReference target.</param>
     /// <param name="sourceAssemblyName">The evaluated referenced project's assembly name.</param>
+#nullable enable annotations
     public DeclaredProjectItem(
-        string itemGroupCondition,
+        string? itemGroupCondition,
         XElement element,
-        string sourceInclude = null,
-        string sourceAssemblyName = null)
+        string? sourceInclude = null,
+        string? sourceAssemblyName = null)
     {
         this.ItemGroupCondition = itemGroupCondition;
         this.Element = element ?? throw new ArgumentNullException(nameof(element));
@@ -39,16 +40,16 @@ public sealed class DeclaredProjectItem
     }
 
     /// <summary>Gets the containing ItemGroup condition, or <see langword="null"/>.</summary>
-    public string ItemGroupCondition { get; }
+    public string? ItemGroupCondition { get; }
 
     /// <summary>Gets the namespace-free item XML.</summary>
     public XElement Element { get; }
 
     /// <summary>Gets the absolute source ProjectReference target, when applicable.</summary>
-    public string SourceInclude { get; }
+    public string? SourceInclude { get; }
 
     /// <summary>Gets the evaluated referenced project's assembly name, when known.</summary>
-    public string SourceAssemblyName { get; }
+    public string? SourceAssemblyName { get; }
 }
 
 /// <summary>Reads and rewrites declared project dependency items.</summary>
@@ -98,13 +99,17 @@ internal static class DeclaredProjectItems
         IReadOnlyList<string> evaluatedProjectReferencePaths = null)
     {
         IReadOnlyList<DeclaredProjectItem> items = Read(projectPath, "ProjectReference");
-        return items
-            .Select(item => item.SourceInclude)
-            .Where(path => !string.IsNullOrEmpty(path))
-            .Concat(RequireEvaluatedProjectReferencePaths(
-                projectPath,
-                items,
-                evaluatedProjectReferencePaths))
+        var paths = new List<string>();
+        foreach (DeclaredProjectItem item in items)
+        {
+            if (item.SourceInclude is string sourceInclude)
+            {
+                paths.Add(sourceInclude);
+            }
+        }
+
+        return paths
+            .Concat(RequireEvaluatedProjectReferencePaths(projectPath, items, evaluatedProjectReferencePaths))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
     }

--- a/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/GscInvoker.cs
@@ -38,7 +38,8 @@ public sealed class GscInvoker
     /// dev tree gsc.dll and gsgen.dll are not siblings, so callers running
     /// against a dev build should resolve and pass this explicitly).
     /// </param>
-    public GscInvoker(string gscPath, string gsgenPath = null)
+#nullable enable annotations
+    public GscInvoker(string gscPath, string? gsgenPath = null)
     {
         this.GscPath = gscPath ?? throw new ArgumentNullException(nameof(gscPath));
         this.GsgenPath = gsgenPath;
@@ -48,7 +49,7 @@ public sealed class GscInvoker
     public string GscPath { get; }
 
     /// <summary>Gets the resolved <c>gsgen.dll</c> path, or <see langword="null"/> to use gsc's own default.</summary>
-    public string GsgenPath { get; }
+    public string? GsgenPath { get; }
 
     /// <summary>
     /// Resolves the <c>gsc.dll</c> to use: the explicit override when supplied,
@@ -59,7 +60,8 @@ public sealed class GscInvoker
     /// <param name="config">The build configuration to probe (e.g. <c>Release</c>).</param>
     /// <param name="startDirectory">The directory to begin the upward walk from.</param>
     /// <returns>The resolved path, or <see langword="null"/> if none was found.</returns>
-    public static string Resolve(string explicitPath, string config, string startDirectory) =>
+#nullable enable annotations
+    public static string? Resolve(string? explicitPath, string config, string startDirectory) =>
         ResolveSiblingTool(explicitPath, config, startDirectory, "Compiler", "gsc.dll");
 
     /// <summary>
@@ -75,7 +77,7 @@ public sealed class GscInvoker
     /// <param name="config">The build configuration to probe (e.g. <c>Release</c>).</param>
     /// <param name="startDirectory">The directory to begin the upward walk from.</param>
     /// <returns>The resolved path, or <see langword="null"/> if none was found.</returns>
-    public static string ResolveGsgenTool(string explicitPath, string config, string startDirectory) =>
+    public static string? ResolveGsgenTool(string? explicitPath, string config, string startDirectory) =>
         ResolveSiblingTool(explicitPath, config, startDirectory, "Gsgen.Cli", "gsgen.dll");
 
     /// <summary>
@@ -228,8 +230,9 @@ public sealed class GscInvoker
         return diagnostics;
     }
 
-    private static string ResolveSiblingTool(
-        string explicitPath, string config, string startDirectory, string projectDirName, string dllName)
+#nullable enable annotations
+    private static string? ResolveSiblingTool(
+        string? explicitPath, string config, string startDirectory, string projectDirName, string dllName)
     {
         if (!string.IsNullOrEmpty(explicitPath))
         {

--- a/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/NullAssertionPolishPass.cs
@@ -156,8 +156,8 @@ public static class NullAssertionPolishPass
             .Where(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal)
                 && d.Line == d.EndLine
                 && d.EndColumn - d.Column == 2)
-            .GroupBy(d => ResolveStrippableFile(d.File, ownedByFullPath, strippableRoot))
-            .Where(g => g.Key != null);
+            .GroupBy(d => ResolveStrippableFile(d.File, ownedByFullPath, strippableRoot) ?? string.Empty)
+            .Where(g => g.Key.Length != 0);
 
         foreach (IGrouping<string, GscDiagnostic> group in byFile)
         {
@@ -215,11 +215,24 @@ public static class NullAssertionPolishPass
         }
 
         Dictionary<string, string> ownedByFullPath = BuildOwnedIndex(emittedGsFiles);
+        var files = new List<string>();
+        foreach (GscDiagnostic diagnostic in diagnostics)
+        {
+            if (!string.Equals(diagnostic.Id, DiagnosticId, StringComparison.Ordinal))
+            {
+                continue;
+            }
 
-        return diagnostics
-            .Where(d => string.Equals(d.Id, DiagnosticId, StringComparison.Ordinal))
-            .Select(d => ResolveStrippableFile(d.File, ownedByFullPath, strippableRoot))
-            .Where(f => f != null)
+            if (ResolveStrippableFile(
+                diagnostic.File,
+                ownedByFullPath,
+                strippableRoot) is string file)
+            {
+                files.Add(file);
+            }
+        }
+
+        return files
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
@@ -361,10 +374,11 @@ public static class NullAssertionPolishPass
         return index;
     }
 
-    private static string ResolveStrippableFile(
+#nullable enable annotations
+    private static string? ResolveStrippableFile(
         string diagnosticFile,
         IReadOnlyDictionary<string, string> ownedByFullPath,
-        string strippableRoot)
+        string? strippableRoot)
     {
         if (string.IsNullOrEmpty(diagnosticFile))
         {

--- a/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/PipelineOptions.cs
@@ -30,7 +30,8 @@ public sealed class PipelineOptions
     /// the pipeline discovers <c>out/bin/&lt;Config&gt;/Compiler/gsc.dll</c> by
     /// walking up from the working directory.
     /// </summary>
-    public string GscPath { get; set; }
+#nullable enable annotations
+    public string? GscPath { get; set; }
 
     /// <summary>
     /// Gets or sets the explicit <c>gsgen.dll</c> path (issue #2215), forwarded
@@ -39,19 +40,19 @@ public sealed class PipelineOptions
     /// <c>out/bin/&lt;Config&gt;/Gsgen.Cli/gsgen.dll</c> the same way it
     /// discovers <see cref="GscPath"/>.
     /// </summary>
-    public string GsgenPath { get; set; }
+    public string? GsgenPath { get; set; }
 
     /// <summary>
     /// Gets or sets the destination repository in repository layout, or the
     /// runs-root directory in diagnostic layout.
     /// </summary>
-    public string OutputRoot { get; set; }
+    public string? OutputRoot { get; set; }
 
     /// <summary>
     /// Gets or sets the runs-root used for logs, triage records, reports, and
     /// build intermediates in repository layout. Ignored in diagnostic layout.
     /// </summary>
-    public string ArtifactRoot { get; set; }
+    public string? ArtifactRoot { get; set; }
 
     /// <summary>
     /// Gets or sets the output layout. Programmatic pipeline callers retain
@@ -60,7 +61,7 @@ public sealed class PipelineOptions
     public MigrationOutputLayout OutputLayout { get; set; } = MigrationOutputLayout.DiagnosticRun;
 
     /// <summary>Gets or sets the source directory being migrated.</summary>
-    public string SourceRoot { get; set; }
+    public string? SourceRoot { get; set; }
 
     /// <summary>
     /// Gets repository-relative app-id prefixes excluded from repository
@@ -114,28 +115,28 @@ public sealed class PipelineOptions
     /// reports green. <see langword="null"/> is treated as
     /// <see cref="TestParityAllowList.Empty"/> — every failure fails the app.
     /// </summary>
-    public TestParityAllowList TestParityAllowList { get; set; }
+    public TestParityAllowList? TestParityAllowList { get; set; }
 
     /// <summary>
     /// Gets or sets the canonical source-project to generated-project mapping
     /// established before migration starts.
     /// </summary>
-    internal IReadOnlyDictionary<string, string> GeneratedProjectPaths { get; set; }
+    internal IReadOnlyDictionary<string, string>? GeneratedProjectPaths { get; set; }
 
     /// <summary>Gets or sets the inventoried checked-in C# source paths.</summary>
-    internal IReadOnlyCollection<string> RepositorySourceFiles { get; set; }
+    internal IReadOnlyCollection<string>? RepositorySourceFiles { get; set; }
 
     /// <summary>Gets or sets repository source paths and their emitted G# text.</summary>
-    internal IDictionary<string, string> RepositoryTranslations { get; set; }
+    internal IDictionary<string, string>? RepositoryTranslations { get; set; }
 
     /// <summary>Gets or sets source projects loaded once for repository-wide analysis.</summary>
-    internal IReadOnlyDictionary<string, LoadedCSharpProject> RepositoryLoadedProjects { get; set; }
+    internal IReadOnlyDictionary<string, LoadedCSharpProject>? RepositoryLoadedProjects { get; set; }
 
     /// <summary>Gets or sets the pinned SDK moniker used by repository project transforms.</summary>
-    internal string RepositorySdkMoniker { get; set; }
+    internal string? RepositorySdkMoniker { get; set; }
 
     /// <summary>Gets or sets extra G# files required when one C# file declares multiple namespaces.</summary>
-    internal ISet<string> RepositoryAdditionalFiles { get; set; }
+    internal ISet<string>? RepositoryAdditionalFiles { get; set; }
 
     /// <summary>
     /// Gets or sets the absolute project paths that another app in this run
@@ -146,5 +147,5 @@ public sealed class PipelineOptions
     /// flattening would erase it from the migrated assembly (GS0157 at every
     /// cross-project use site).
     /// </summary>
-    internal IReadOnlyCollection<string> ProjectsReferencedByOtherApps { get; set; }
+    internal IReadOnlyCollection<string>? ProjectsReferencedByOtherApps { get; set; }
 }

--- a/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/RunResult.cs
@@ -91,7 +91,8 @@ public sealed class AppResult
     /// <summary>Gets or sets the category of the first failing stage, or null when green.</summary>
     [JsonPropertyName("failureCategory")]
     [JsonPropertyOrder(3)]
-    public string FailureCategory { get; set; }
+#nullable enable annotations
+    public string? FailureCategory { get; set; }
 
     /// <summary>Gets or sets the per-stage results, in execution order.</summary>
     [JsonPropertyName("stages")]

--- a/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/SdkCompileRunner.cs
@@ -1242,7 +1242,8 @@ public sealed class SdkCompileRunner
     private static void AppendDeclaredItems(StringBuilder sb, IReadOnlyList<DeclaredProjectItem> items)
     {
         foreach (IGrouping<string, DeclaredProjectItem> group in
-            (items ?? Array.Empty<DeclaredProjectItem>()).GroupBy(item => item.ItemGroupCondition))
+            (items ?? Array.Empty<DeclaredProjectItem>())
+                .GroupBy(item => item.ItemGroupCondition ?? string.Empty))
         {
             sb.Append('\n');
             sb.Append("  <ItemGroup");

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.CompletedTestRun.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.CompletedTestRun.cs
@@ -1,0 +1,27 @@
+// <copyright file="TestParityStage.CompletedTestRun.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+#nullable enable annotations
+
+using System.Text.RegularExpressions;
+
+namespace Cs2Gs.Pipeline;
+
+public sealed partial class TestParityStage
+{
+    /// <summary>
+    /// Issue #2867: detects the VSTest run summary that only ever appears once
+    /// the test project has built and its tests have actually executed.
+    /// </summary>
+    /// <param name="output">The captured <c>dotnet test</c> output.</param>
+    /// <returns><see langword="true"/> when a test run completed.</returns>
+    internal static bool CompletedTestRun(string? output)
+    {
+        return !string.IsNullOrEmpty(output)
+            && Regex.IsMatch(
+                output,
+                @"^\s*(Passed|Failed)!\s+-\s+Failed:",
+                RegexOptions.Multiline | RegexOptions.CultureInvariant);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
+++ b/tools/cs2gs/Cs2Gs.Pipeline/TestParityStage.cs
@@ -46,7 +46,7 @@ namespace Cs2Gs.Pipeline;
 /// Runs only after a green stage-3 (it short-circuits with the rest), so L2/L3
 /// — which stop at stage 1 today — never reach it until they translate.
 /// </summary>
-public sealed class TestParityStage : IMigrationStage
+public sealed partial class TestParityStage : IMigrationStage
 {
     private readonly GsharpTestProjectRunner libraryRunner;
 
@@ -95,21 +95,6 @@ public sealed class TestParityStage : IMigrationStage
         // or a library with no `.Tests` baseline): nothing to verify.
         this.Note(context, "no parity oracle (no stdout golden and no .Tests baseline); nothing to verify.");
         return StageOutcome.Passed();
-    }
-
-    /// <summary>
-    /// Issue #2867: detects the VSTest run summary that only ever appears once
-    /// the test project has built and its tests have actually executed.
-    /// </summary>
-    /// <param name="output">The captured <c>dotnet test</c> output.</param>
-    /// <returns><see langword="true"/> when a test run completed.</returns>
-    internal static bool CompletedTestRun(string output)
-    {
-        return !string.IsNullOrEmpty(output)
-            && Regex.IsMatch(
-                output,
-                @"^\s*(Passed|Failed)!\s+-\s+Failed:",
-                RegexOptions.Multiline | RegexOptions.CultureInvariant);
     }
 
     /// <summary>

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/NuGetAuditAdvisoryPolicy.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/NuGetAuditAdvisoryPolicy.cs
@@ -86,7 +86,8 @@ public static class NuGetAuditAdvisoryPolicy
     /// any genuine workspace failure, and for a mixed/multiline message that
     /// carries even one non-advisory line.
     /// </returns>
-    public static bool IsBenignAdvisory(string message)
+#nullable enable annotations
+    public static bool IsBenignAdvisory(string? message)
     {
         if (string.IsNullOrWhiteSpace(message))
         {

--- a/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
+++ b/tools/cs2gs/Cs2Gs.Report/ReportModel.cs
@@ -385,7 +385,8 @@ public sealed class AppReport
     /// <summary>Gets or sets the first failing stage's category, or null when green.</summary>
     [JsonPropertyName("failureCategory")]
     [JsonPropertyOrder(3)]
-    public string FailureCategory { get; set; }
+#nullable enable annotations
+    public string? FailureCategory { get; set; }
 
     /// <summary>Gets or sets the per-stage statuses, in execution order.</summary>
     [JsonPropertyName("stages")]

--- a/tools/cs2gs/Cs2Gs.Tests/Issue3802ConditionalNotNullPostconditionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue3802ConditionalNotNullPostconditionTests.cs
@@ -30,6 +30,29 @@ namespace Cs2Gs.Tests;
 public class Issue3802ConditionalNotNullPostconditionTests
 {
     /// <summary>
+    /// Issue #4071: a symbol resolver is allowed to miss. The null must reach
+    /// the helper so its pattern check can reject the candidate; asserting at
+    /// the callback boundary crashes before that check.
+    /// </summary>
+    [Fact]
+    public void MissingInvocationSymbol_DoesNotCrashPostconditionAnalysis()
+    {
+        string printed = Translate(@"
+namespace Demo
+{
+    public class Probe
+    {
+        public static string Run(string @select)
+        {
+            return nameof(@select);
+        }
+    }
+}");
+
+        Assert.Contains("\"select\"", printed);
+    }
+
+    /// <summary>
     /// The migrated shape, reduced: the iterator element must stay
     /// <c>string</c>, the local must stay <c>string</c>, and the dictionary
     /// index that consumes them must bind.

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1075,11 +1075,20 @@ public sealed partial class CSharpToGSharpTranslator
 
                 if (targetExpr is DeclarationExpressionSyntax declaration)
                 {
-                    values.Add(this.LowerDeconstructionDeclaration(
+                    GExpression declaredValue = this.LowerDeconstructionDeclaration(
                         declaration.Designation,
                         tempRead,
                         forceRealTemps,
-                        statements));
+                        statements);
+                    if (declaredValue is not null)
+                    {
+                        values.Add(declaredValue);
+                    }
+                    else
+                    {
+                        values.Add(null);
+                    }
+
                     continue;
                 }
 
@@ -1108,7 +1117,8 @@ public sealed partial class CSharpToGSharpTranslator
             return values;
         }
 
-        private GExpression LowerDeconstructionDeclaration(
+#nullable enable annotations
+        private GExpression? LowerDeconstructionDeclaration(
             VariableDesignationSyntax designation,
             GExpression value,
             bool preserveValue,
@@ -1153,11 +1163,19 @@ public sealed partial class CSharpToGSharpTranslator
                     continue;
                 }
 
-                values.Add(this.LowerDeconstructionDeclaration(
+                GExpression declaredValue = this.LowerDeconstructionDeclaration(
                     parenthesized.Variables[i],
                     new IdentifierExpression(temps[i]),
                     preserveValue,
-                    statements));
+                    statements);
+                if (declaredValue is not null)
+                {
+                    values.Add(declaredValue);
+                }
+                else
+                {
+                    values.Add(null);
+                }
             }
 
             return preserveValue ? new TupleLiteralExpression(values) : null;

--- a/tools/cs2gs/Cs2Gs.Translator/ConditionalNotNullPostcondition.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/ConditionalNotNullPostcondition.cs
@@ -61,10 +61,11 @@ internal static class ConditionalNotNullPostcondition
     /// </param>
     /// <param name="forwarded">Receives the named argument.</param>
     /// <returns>Whether a forwarded argument was found.</returns>
+#nullable enable annotations
     public static bool TryGetForwardedArgument(
         ExpressionSyntax expression,
-        Func<ExpressionSyntax, ISymbol> getSymbol,
-        out ExpressionSyntax forwarded)
+        Func<ExpressionSyntax, ISymbol?> getSymbol,
+        out ExpressionSyntax? forwarded)
     {
         forwarded = null;
         if (expression is not InvocationExpressionSyntax invocation || getSymbol == null)
@@ -102,7 +103,7 @@ internal static class ConditionalNotNullPostcondition
     private static IReadOnlyList<string> NamedParameters(IMethodSymbol method)
     {
         IMethodSymbol definition = (method.ReducedFrom ?? method).OriginalDefinition;
-        List<string> names = null;
+        List<string>? names = null;
         foreach (AttributeData attribute in definition.GetReturnTypeAttributes())
         {
             if (attribute.AttributeClass?.Name != AttributeName
@@ -117,14 +118,19 @@ internal static class ConditionalNotNullPostcondition
             }
         }
 
-        return (IReadOnlyList<string>)names ?? Array.Empty<string>();
+        if (names is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return names;
     }
 
     // The argument expression bound to the parameter called <paramref
     // name="name"/>, honouring named arguments. Returns null when the
     // parameter is not supplied (an omitted optional argument defaults to
     // null far more often than not, so absence must never narrow).
-    private static ExpressionSyntax ArgumentFor(
+    private static ExpressionSyntax? ArgumentFor(
         InvocationExpressionSyntax invocation,
         IMethodSymbol method,
         string name)


### PR DESCRIPTION
Closes #4071.

## Baseline and final

Fresh `origin/main` baseline (`15b799386`) reached translate/compile/ILVerify, then timed out at 10 minutes after 126 observed failures:

- 49 distinct `NullReferenceException` tests
- 26 explicit `FileNotFoundException` tests observed before the timeout

The complete final source-exact run on the rebased fix finished all tests:

- translate: PASS (56/56)
- compile: PASS
- ILVerify: PASS
- parity: 2,782 passed / 97 failed / 2,879 total in 7m36s
- genuine #4071 checked-null crashes: **33 → 0**
- remaining NREs: 15, all fixture/compiler lookup assertions owned by #4072

The residual parity set is split without allow-list or floor changes: #4072 owns the fixture overlay; #4073 owns 7 enum TypeSpec failures; #4074 owns the semantic/runtime remainder. Updated measurements are posted on #4072 and #4074.

## Roots fixed

- optional `GscPath`/`GsgenPath` and repository pipeline option contracts (12 crashes)
- green-app `FailureCategory` report contract (10)
- nullable Roslyn symbol callback result (2)
- nullable MSBuild `ItemGroup` conditions (2)
- nullable null-polish selector results (2)
- null-tolerant test-run and NuGet advisory inputs (2)
- nullable project-reference selector result (1)
- deconstruction's intentional nil placeholder (1)
- lambda common-type inference's nullable intermediate (1)

The fixes keep assertions at genuine non-null sinks. Nullable selector values are normalized or guarded before entering non-null collections; optional/callback/report contracts are declared explicitly rather than widened globally.

## Regression and hygiene

- focused executing Cs2Gs regressions: 166/166
- added anti-vacuity coverage for a valid `nameof(...)` invocation whose Roslyn symbol lookup is null
- Release solution build: 0 warnings, 0 errors
- nullable hygiene: PASS; no disable/restore escapes or CS8xxx suppressions
- the single added `targetReturn!` is guarded by `allCandidatesConvert`, which is initialized from and evaluated under `targetReturn != null`; it retains the intentional non-null return bridge after removing the unsafe captured-lambda bridge
- fresh translate metrics before polish: labels 0, lifts 30, reducible long lines 434, assertions 22,269
- exact-app post-polish observation: labels 0, lifts 30, reducible long lines 434, assertions 12,485 (not the whole-corpus ceiling measurement)
- hot-core guard: PASS, 8/8 apps green through translate/compile/ILVerify/parity

## Behavior-capable hunks

- `LambdaBinder`: replaces nullable capture inside `All` with guarded direct iteration and preserves nullable common-type failure until the existing `?? Error` fallback.
- `DeclaredProjectItem` / `NullAssertionPolishPass`: carry nullable selectors through explicit pattern guards before adding non-null values.
- `SdkCompileRunner`: normalizes null/empty item-group conditions to the same unconditional group key.
- `CSharpToGSharpTranslator.Deconstruction`: preserves intentional nil placeholders instead of asserting before the existing branch.
- `ConditionalNotNullPostcondition`: makes nullable callback/forwarded-argument contracts explicit.
- `TestParityStage`: isolates the nullable input contract in a small partial.
