### PR TITLE
Repair end-to-end Visual Studio extension integration

### DIFF
--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -1279,10 +1279,11 @@ public sealed class LspServer
         }
     }
 
-    // Re-evaluates diagnostics for open documents once background workspace discovery has
-    // finished. A file opened before discovery completed was initially bound without its
-    // project's references. Pull clients are asked to re-pull; push-only clients get a new
-    // full bind against the now-discovered project.
+    // Refreshes open-document snapshots once background workspace discovery has finished.
+    // A file opened before discovery completed was initially recorded without its owning
+    // project, so every project-aware feature (definition, hover, references, diagnostics,
+    // etc.) must see a replacement snapshot. Pull clients are then asked to re-pull
+    // diagnostics; push-only clients get a new full bind immediately.
     private void RefreshOpenDocumentDiagnosticsAfterDiscovery()
     {
         this.TestOnDiagnosticRefreshAfterDiscovery?.Invoke();
@@ -1294,12 +1295,6 @@ public sealed class LspServer
     // retain its existing per-document cancellation ordering.
     private void RefreshOpenDocumentDiagnostics()
     {
-        if (this.clientSupportsPullDiagnostics)
-        {
-            this.RequestDiagnosticRefresh();
-            return;
-        }
-
         foreach (var document in this.documentContentService.AllDocuments.ToList())
         {
             var uri = DocumentUri.From(document.Key);
@@ -1318,9 +1313,17 @@ public sealed class LspServer
                 project,
                 this.workspaceState);
             this.documentContentService.AddOrUpdate(document.Key, content);
-            this.SchedulePushDiagnosticsBind(
-                uri,
-                new DiagnosticComputationResult(content, Array.Empty<Diagnostic>()));
+            if (!this.clientSupportsPullDiagnostics)
+            {
+                this.SchedulePushDiagnosticsBind(
+                    uri,
+                    new DiagnosticComputationResult(content, Array.Empty<Diagnostic>()));
+            }
+        }
+
+        if (this.clientSupportsPullDiagnostics)
+        {
+            this.RequestDiagnosticRefresh();
         }
     }
 

--- a/src/Sdk/Gsharp.NET.Sdk/Sdk/Sdk.props
+++ b/src/Sdk/Gsharp.NET.Sdk/Sdk/Sdk.props
@@ -9,6 +9,7 @@
     <DefaultLanguageSourceExtension>.gs</DefaultLanguageSourceExtension>
     <EnableDefaultCompileItems Condition=" '$(EnableDefaultCompileItems)' == '' ">true</EnableDefaultCompileItems>
     <EnableDefaultItems Condition=" '$(EnableDefaultItems)' == '' ">true</EnableDefaultItems>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
 
     <!-- gsc emits a metadata-only sibling assembly via /refout:. Enable the
          SDK's reference-assembly pipeline so consumers get refint/ and ref/

--- a/src/vs-gsharp/scripts/Install-ExperimentalVsix.ps1
+++ b/src/vs-gsharp/scripts/Install-ExperimentalVsix.ps1
@@ -15,6 +15,7 @@ if (-not (Test-Path -LiteralPath $vswhere)) {
 $installationPath = (& $vswhere -latest -products * -property installationPath).Trim()
 $instanceId = (& $vswhere -latest -products * -property instanceId).Trim()
 $resolvedVsix = (Resolve-Path -LiteralPath $VsixPath).Path
+$extensionId = 'GSharp-VisualStudio'
 if (-not $installationPath -or -not $instanceId) {
     throw 'No Visual Studio instance was found.'
 }
@@ -92,7 +93,7 @@ $installed = Get-Item -Path $profilePattern -ErrorAction SilentlyContinue |
     Get-ChildItem -Filter extension.vsixmanifest -Recurse -File -ErrorAction SilentlyContinue |
     Where-Object {
         try {
-            ([xml](Get-Content -LiteralPath $_.FullName)).PackageManifest.Metadata.Identity.Id -eq 'GSharp.VisualStudio'
+            ([xml](Get-Content -LiteralPath $_.FullName)).PackageManifest.Metadata.Identity.Id -eq $extensionId
         }
         catch {
             $false
@@ -101,7 +102,7 @@ $installed = Get-Item -Path $profilePattern -ErrorAction SilentlyContinue |
     Select-Object -First 1
 
 if ($installed) {
-    & $installer /quiet /shutdownprocesses "/instanceIds:$instanceId" "/rootSuffix:$RootSuffix" /uninstall:GSharp.VisualStudio
+    & $installer /quiet /shutdownprocesses "/instanceIds:$instanceId" "/rootSuffix:$RootSuffix" "/uninstall:$extensionId"
     if ($LASTEXITCODE -ne 0) {
         throw "VSIX uninstall failed with exit code $LASTEXITCODE."
     }
@@ -127,7 +128,8 @@ Start-Sleep -Seconds 30
 $null = $discovery.CloseMainWindow()
 if (-not $discovery.WaitForExit(60000)) {
     Stop-Process -Id $discovery.Id
-    throw 'Visual Studio extension discovery did not close within one minute.'
+    Wait-Process -Id $discovery.Id -Timeout 30 -ErrorAction SilentlyContinue
+    Write-Warning 'Visual Studio extension discovery required a forced shutdown.'
 }
 
 Write-Host "Installed '$resolvedVsix' into root suffix '$RootSuffix'."

--- a/src/vs-gsharp/test/ProjectDebugFixtures/Directory.Build.props
+++ b/src/vs-gsharp/test/ProjectDebugFixtures/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
+</Project>

--- a/src/vs-gsharp/test/ProjectDebugFixtures/Validate-Debugger.ps1
+++ b/src/vs-gsharp/test/ProjectDebugFixtures/Validate-Debugger.ps1
@@ -3,11 +3,29 @@ param(
     [Parameter(Mandatory)]
     [int]$VisualStudioProcessId,
 
-    [int]$TimeoutSeconds = 60
+    [int]$TimeoutSeconds = 60,
+
+    [string]$ProtocolTracePath = (Join-Path $PSScriptRoot '..\artifacts\vs2026-lsp-protocol.log')
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+if ($PSVersionTable.PSEdition -eq 'Core') {
+    & "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe" `
+        -NoLogo `
+        -NoProfile `
+        -ExecutionPolicy Bypass `
+        -File $PSCommandPath `
+        -VisualStudioProcessId $VisualStudioProcessId `
+        -TimeoutSeconds $TimeoutSeconds `
+        -ProtocolTracePath $ProtocolTracePath
+    if ($LASTEXITCODE -ne 0) {
+        throw "Debugger validation failed with exit code $LASTEXITCODE."
+    }
+
+    return
+}
 
 $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
 $installationPath = (& $vswhere -latest -products * -property installationPath).Trim()
@@ -74,6 +92,67 @@ public static class RunningVisualStudio
         return (EnvDTE.DTE)value;
     }
 
+    public static bool IsSolutionLoaded(object dte, int expectedProjectCount)
+    {
+        EnvDTE.Solution solution = Dte(dte).Solution;
+        return solution != null && solution.Projects.Count >= expectedProjectCount;
+    }
+
+    public static int GetProjectCount(object dte)
+    {
+        EnvDTE.Solution solution = Dte(dte).Solution;
+        return solution == null ? 0 : solution.Projects.Count;
+    }
+
+    public static int BuildSolution(object dte)
+    {
+        EnvDTE.Solution solution = Dte(dte).Solution;
+        EnvDTE.SolutionBuild build = solution.SolutionBuild;
+        build.Clean(true);
+        System.Threading.Thread.Sleep(2000);
+        int failedBuilds = 0;
+        foreach (EnvDTE.SolutionContext context in build.ActiveConfiguration.SolutionContexts)
+        {
+            if (context.ShouldBuild)
+            {
+                build.BuildProject(
+                    context.ConfigurationName,
+                    context.ProjectName,
+                    true);
+                failedBuilds += build.LastBuildInfo;
+            }
+        }
+
+        return failedBuilds;
+    }
+
+    public static string GetBuildContexts(object dte)
+    {
+        EnvDTE.SolutionConfiguration configuration =
+            Dte(dte).Solution.SolutionBuild.ActiveConfiguration;
+        var contexts = new System.Text.StringBuilder();
+        foreach (EnvDTE.SolutionContext context in configuration.SolutionContexts)
+        {
+            contexts.AppendLine(
+                context.ProjectName + "|" +
+                context.ConfigurationName + "|" +
+                context.PlatformName + "|build=" +
+                context.ShouldBuild);
+        }
+
+        return contexts.ToString();
+    }
+
+    public static string GetOutputPaneText(object dte, string paneName)
+    {
+        EnvDTE.OutputWindow output = (EnvDTE.OutputWindow)Dte(dte)
+            .Windows.Item(EnvDTE.Constants.vsWindowKindOutput).Object;
+        EnvDTE.OutputWindowPane pane = output.OutputWindowPanes.Item(paneName);
+        EnvDTE.TextDocument document = (EnvDTE.TextDocument)pane.TextDocument;
+        EnvDTE.EditPoint start = document.StartPoint.CreateEditPoint();
+        return start.GetText(document.EndPoint);
+    }
+
     public static void DeleteAllBreakpoints(object dte)
     {
         EnvDTE.Breakpoints breakpoints = Dte(dte).Debugger.Breakpoints;
@@ -138,9 +217,40 @@ public static class RunningVisualStudio
         return selection.ActivePoint.Line;
     }
 
+    public static void OpenFileAt(object dteObject, string path, int line, int column)
+    {
+        EnvDTE.DTE dte = Dte(dteObject);
+        EnvDTE.Window window = dte.ItemOperations.OpenFile(path);
+        window.Activate();
+        EnvDTE.TextSelection selection = (EnvDTE.TextSelection)dte.ActiveDocument.Selection;
+        selection.MoveToLineAndOffset(line, column, false);
+    }
+
+    public static string GetActiveDocumentPath(object dteObject)
+    {
+        return Dte(dteObject).ActiveDocument.FullName;
+    }
+
+    public static void ExecuteCommand(object dteObject, string command)
+    {
+        EnvDTE.DTE dte = Dte(dteObject);
+        EnvDTE.Command commandInfo = dte.Commands.Item(command);
+        if (!commandInfo.IsAvailable)
+        {
+            throw new InvalidOperationException(command + " is not available.");
+        }
+
+        dte.ExecuteCommand(command);
+    }
+
     public static void TerminateAll(object dte)
     {
         Dte(dte).Debugger.TerminateAll();
+    }
+
+    public static void Continue(object dte)
+    {
+        Dte(dte).Debugger.Go(false);
     }
 
     public static void AttachToProcess(object dteObject, int processId)
@@ -161,6 +271,50 @@ public static class RunningVisualStudio
     public static void DetachAll(object dte)
     {
         Dte(dte).Debugger.DetachAll();
+    }
+}
+
+[ComImport]
+[Guid("00000016-0000-0000-C000-000000000046")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IOleMessageFilter
+{
+    [PreserveSig]
+    int HandleInComingCall(int callType, IntPtr taskCaller, int tickCount, IntPtr interfaceInfo);
+
+    [PreserveSig]
+    int RetryRejectedCall(IntPtr taskCallee, int tickCount, int rejectType);
+
+    [PreserveSig]
+    int MessagePending(IntPtr taskCallee, int tickCount, int pendingType);
+}
+
+public sealed class OleMessageFilter : IOleMessageFilter
+{
+    [DllImport("ole32.dll")]
+    private static extern int CoRegisterMessageFilter(
+        IOleMessageFilter newFilter,
+        out IOleMessageFilter oldFilter);
+
+    public static void Register()
+    {
+        IOleMessageFilter oldFilter;
+        CoRegisterMessageFilter(new OleMessageFilter(), out oldFilter);
+    }
+
+    public int HandleInComingCall(int callType, IntPtr taskCaller, int tickCount, IntPtr interfaceInfo)
+    {
+        return 0;
+    }
+
+    public int RetryRejectedCall(IntPtr taskCallee, int tickCount, int rejectType)
+    {
+        return rejectType == 2 && tickCount < 60000 ? 100 : -1;
+    }
+
+    public int MessagePending(IntPtr taskCallee, int tickCount, int pendingType)
+    {
+        return 2;
     }
 }
 '@
@@ -203,16 +357,78 @@ function Invoke-ComRetry([scriptblock]$Operation, [string]$Description) {
     throw "Timed out waiting to $Description."
 }
 
+function Read-SharedText([string]$Path) {
+    $stream = [IO.FileStream]::new(
+        $Path,
+        [IO.FileMode]::Open,
+        [IO.FileAccess]::Read,
+        [IO.FileShare]::ReadWrite)
+    try {
+        $reader = [IO.StreamReader]::new($stream)
+        try {
+            return $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+[OleMessageFilter]::Register()
 $dte = [RunningVisualStudio]::GetDte($VisualStudioProcessId)
 $webProcess = $null
 try {
-Wait-Until { $dte.Solution.IsOpen -and $dte.Solution.Projects.Count -eq 4 } 'the fixture solution'
+Write-Host "DTE project count: $([RunningVisualStudio]::GetProjectCount($dte))"
+Wait-Until {
+    [RunningVisualStudio]::IsSolutionLoaded($dte, 4)
+} 'the fixture solution'
+$consoleProjectUniqueName = [RunningVisualStudio]::SetStartupProject($dte, 'Console')
+Write-Host "Build contexts:`n$([RunningVisualStudio]::GetBuildContexts($dte))"
+$failedBuilds = [RunningVisualStudio]::BuildSolution($dte)
+Write-Host "Build output:`n$([RunningVisualStudio]::GetOutputPaneText($dte, 'Build'))"
+if ($failedBuilds -ne 0) {
+    throw "Visual Studio solution build reported $failedBuilds failed project(s)."
+}
+
+$source = Join-Path $PSScriptRoot 'Console\Program.gs'
+$definitionSource = Join-Path $PSScriptRoot 'Library\Greeter.gs'
+$traceOffset = if (Test-Path -LiteralPath $ProtocolTracePath) {
+    (Read-SharedText $ProtocolTracePath).Length
+} else {
+    0
+}
+$greeterUse = Select-String -LiteralPath $source -SimpleMatch 'Greeter("debugger")'
+$greeterColumn = $greeterUse.Line.IndexOf('Greeter', [StringComparison]::Ordinal) + 1
+[RunningVisualStudio]::OpenFileAt($dte, $source, $greeterUse.LineNumber, $greeterColumn)
+Wait-Until {
+    if (-not (Test-Path -LiteralPath $ProtocolTracePath)) {
+        return $false
+    }
+
+    $trace = Read-SharedText $ProtocolTracePath
+    $trace.Length -gt $traceOffset -and
+    $trace.Substring([Math]::Min($traceOffset, $trace.Length)).Contains('textDocument/semanticTokens')
+} 'live semantic highlighting'
+[RunningVisualStudio]::ExecuteCommand($dte, 'Edit.GoToDefinition')
+Wait-Until {
+    [string]::Equals(
+        [RunningVisualStudio]::GetActiveDocumentPath($dte),
+        $definitionSource,
+        [StringComparison]::OrdinalIgnoreCase)
+} 'Go To Definition to open Greeter.gs'
+Wait-Until {
+    (Read-SharedText $ProtocolTracePath).Contains('textDocument/definition')
+} 'the live definition request'
+[RunningVisualStudio]::OpenFileAt($dte, $source, 1, 1)
+
 if ([RunningVisualStudio]::GetDebuggerMode($dte) -ne 1) {
     [RunningVisualStudio]::TerminateAll($dte)
     Wait-Until { [RunningVisualStudio]::GetDebuggerMode($dte) -eq 1 } 'the previous debugger session to stop'
 }
 
-$consoleProjectUniqueName = [RunningVisualStudio]::SetStartupProject($dte, 'Console')
 $existingConsoleIds = @(Get-Process -Name Console -ErrorAction SilentlyContinue |
     Select-Object -ExpandProperty Id)
 $dte.ExecuteCommand('Debug.StartWithoutDebugging')
@@ -221,7 +437,6 @@ Wait-Until {
         Where-Object Id -notin $existingConsoleIds).Count -gt 0
 } 'Start Without Debugging to launch Console'
 
-$source = Join-Path $PSScriptRoot 'Console\Program.gs'
 $line = (Select-String -LiteralPath $source -SimpleMatch 'BREAKPOINT:console-locals').LineNumber
 [RunningVisualStudio]::DeleteAllBreakpoints($dte)
 [RunningVisualStudio]::AddBreakpoint($dte, $source, $line)
@@ -243,7 +458,7 @@ Wait-Until { [RunningVisualStudio]::GetDebuggerMode($dte) -eq 2 } 'Step Over to 
 $afterStepOverLine = Invoke-ComRetry {
     [RunningVisualStudio]::GetActiveLine($dte)
 } 'read the Step Over source line'
-[RunningVisualStudio]::TerminateAll($dte)
+[RunningVisualStudio]::Continue($dte)
 Wait-Until { [RunningVisualStudio]::GetDebuggerMode($dte) -eq 1 } 'the first debugger session to stop'
 [RunningVisualStudio]::DeleteAllBreakpoints($dte)
 
@@ -263,7 +478,7 @@ if ($stepIntoFunction -notmatch 'StepTarget') {
     throw "Step Into stopped in '$stepIntoFunction' at line $afterStepIntoLine after Step Over reached line $afterStepOverLine."
 }
 
-[RunningVisualStudio]::TerminateAll($dte)
+[RunningVisualStudio]::Continue($dte)
 Wait-Until { [RunningVisualStudio]::GetDebuggerMode($dte) -eq 1 } 'the debugger to stop'
 [RunningVisualStudio]::DeleteAllBreakpoints($dte)
 
@@ -288,7 +503,7 @@ if ($actualCatchLine -ne $exceptionCatchLine) {
     throw "The handled exception stopped at line $actualCatchLine instead of catch line $exceptionCatchLine."
 }
 
-[RunningVisualStudio]::TerminateAll($dte)
+[RunningVisualStudio]::Continue($dte)
 Wait-Until { [RunningVisualStudio]::GetDebuggerMode($dte) -eq 1 } 'the exception debugger session to stop'
 [RunningVisualStudio]::DeleteAllBreakpoints($dte)
 
@@ -329,6 +544,9 @@ $validationResult = [pscustomobject]@{
     Breakpoint = "$source`:$line"
     Input = $input
     Result = $result
+    Build = 'passed'
+    SemanticHighlighting = 'passed'
+    GoToDefinition = 'passed'
     StartWithoutDebugging = 'passed'
     F5 = 'passed'
     StepOver = "passed (line $afterStepOverLine)"

--- a/src/vs-gsharp/test/VsGsharp.UnitTests/ProjectDebugAcceptanceTests.cs
+++ b/src/vs-gsharp/test/VsGsharp.UnitTests/ProjectDebugAcceptanceTests.cs
@@ -33,6 +33,15 @@ public sealed class ProjectDebugAcceptanceTests
         Assert.True(File.Exists(Path.Combine(
             fixtureRoot,
             RequiredString(manifest.RootElement, "driver"))));
+        XDocument fixtureProps = XDocument.Load(Path.Combine(
+            fixtureRoot,
+            "Directory.Build.props"));
+        Assert.Equal("true", Property(fixtureProps, "DisableFastUpToDateCheck"));
+        string driver = File.ReadAllText(Path.Combine(
+            fixtureRoot,
+            RequiredString(manifest.RootElement, "driver")));
+        Assert.Contains("$PSVersionTable.PSEdition -eq 'Core'", driver);
+        Assert.DoesNotContain("$dte.Solution.IsOpen", driver);
 
         JsonElement[] projects = manifest.RootElement.GetProperty("projects")
             .EnumerateArray().ToArray();
@@ -171,6 +180,8 @@ public sealed class ProjectDebugAcceptanceTests
         string root = FindRepositoryRoot();
         string sdkRoot = Path.Combine(root, "src", "Sdk", "Gsharp.NET.Sdk");
         XDocument sdkTargets = XDocument.Load(Path.Combine(sdkRoot, "Sdk", "Sdk.targets"));
+        XDocument sdkProps = XDocument.Load(Path.Combine(sdkRoot, "Sdk", "Sdk.props"));
+        Assert.Equal("true", Property(sdkProps, "DisableFastUpToDateCheck"));
         string[] capabilities = sdkTargets.Descendants()
             .Where(element => element.Name.LocalName == "ProjectCapability")
             .Select(element => (string?)element.Attribute("Include") ?? string.Empty)

--- a/src/vs-gsharp/test/VsGsharp.UnitTests/TemplateAssetTests.cs
+++ b/src/vs-gsharp/test/VsGsharp.UnitTests/TemplateAssetTests.cs
@@ -11,8 +11,9 @@ public sealed class TemplateAssetTests
     [Fact]
     public void Vsix_DeclaresProjectAndItemTemplateAssets()
     {
+        string extensionRoot = FindExtensionRoot();
         XDocument manifest = XDocument.Load(Path.Combine(
-            FindExtensionRoot(),
+            extensionRoot,
             "src",
             "VsGsharp",
             "source.extension.vsixmanifest"));
@@ -26,6 +27,15 @@ public sealed class TemplateAssetTests
 
         Assert.Contains("Microsoft.VisualStudio.ProjectTemplate", assetTypes);
         Assert.Contains("Microsoft.VisualStudio.ItemTemplate", assetTypes);
+
+        string extensionId = manifest.Descendants()
+            .Single(element => element.Name.LocalName == "Identity")
+            .Attribute("Id")!.Value;
+        string installer = File.ReadAllText(Path.Combine(
+            extensionRoot,
+            "scripts",
+            "Install-ExperimentalVsix.ps1"));
+        Assert.Contains("$extensionId = '" + extensionId + "'", installer);
     }
 
     [Fact]

--- a/test/LanguageServer.Tests/CrossProjectDefinitionTests.cs
+++ b/test/LanguageServer.Tests/CrossProjectDefinitionTests.cs
@@ -265,6 +265,9 @@ public class CrossProjectDefinitionTests
 
             var libDllPath = System.IO.Path.Combine(libDir, "XProjTestLib.dll");
             var libPdbPath = System.IO.Path.Combine(libDir, "XProjTestLib.pdb");
+            var libRefDir = System.IO.Path.Combine(libDir, "ref");
+            System.IO.Directory.CreateDirectory(libRefDir);
+            var libRefPath = System.IO.Path.Combine(libRefDir, "XProjTestLib.dll");
 
             var libCompilation = new GSharp.Core.CodeAnalysis.Compilation.Compilation(
                 GSharp.Core.CodeAnalysis.Symbols.ReferenceResolver.Default(),
@@ -276,8 +279,9 @@ public class CrossProjectDefinitionTests
             };
             using (var peStream = new System.IO.FileStream(libDllPath, System.IO.FileMode.Create))
             using (var pdbStream = new System.IO.FileStream(libPdbPath, System.IO.FileMode.Create))
+            using (var refStream = new System.IO.FileStream(libRefPath, System.IO.FileMode.Create))
             {
-                var libResult = libCompilation.Emit(peStream, pdbStream, refStream: null, assemblyName: "XProjTestLib");
+                var libResult = libCompilation.Emit(peStream, pdbStream, refStream, assemblyName: "XProjTestLib");
                 Assert.True(libResult.Success, "Lib should compile: " + string.Join(", ", libResult.Diagnostics.Select(d => d.Message)));
             }
 
@@ -302,7 +306,7 @@ public class CrossProjectDefinitionTests
 
             var appProject = workspace.AddProject(System.IO.Path.Combine(appDir, "XProjTestApp.gsproj"));
             appProject.AssemblyName = "XProjTestApp";
-            appProject.References = new[] { libDllPath };
+            appProject.References = new[] { libRefPath };
             appProject.AddFileFromDisk(appSourcePath);
             workspace.RegisterFile(appSourcePath, appProject);
 

--- a/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
+++ b/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
@@ -24,9 +24,10 @@ namespace GSharp.LanguageServer.Tests;
 /// persisted because nothing re-pulled the file once discovery finished — the user had to edit
 /// the file to trigger a refresh.
 ///
-/// This test locks in the fix: once background discovery completes, the server asks the client
-/// to refresh diagnostics, and the resulting re-pull binds each open file against its
-/// now-discovered project, clearing the spurious diagnostics.
+/// This test locks in the fix: once background discovery completes, the server replaces each
+/// open document snapshot with one attached to its now-discovered project and asks the client
+/// to refresh diagnostics. Project-aware requests such as Go-to-Definition then work immediately,
+/// and the resulting re-pull clears the spurious diagnostics.
 /// </summary>
 public class WorkspaceDiscoveryDiagnosticRefreshTests
 {
@@ -68,6 +69,15 @@ public class WorkspaceDiscoveryDiagnosticRefreshTests
             server.Initialized(doc.RootElement.Clone());
 
             await WaitForAsync(() => refreshRequested && workspace.GetProjectForFile(fooPath) != null);
+
+            var definitions = await server.DefinitionAsync(
+                new DefinitionParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = uri },
+                    Position = LanguageServerTestHelpers.PositionOf(FooSource, "Bar"),
+                });
+            var definition = Assert.Single(definitions);
+            Assert.EndsWith("Bar.gs", definition.Uri.GetFileSystemPath());
 
             // The refresh-driven re-pull now binds Foo.gs against its project (both source files),
             // so the sibling symbols resolve and the spurious diagnostics are gone.


### PR DESCRIPTION
## Summary
- repair experimental-profile VSIX replacement and validate the manifest identity contract
- make Visual Studio builds reliable by disabling the unsafe fast up-to-date shortcut
- harden the live DTE/debugger acceptance driver and cover semantic highlighting, navigation, build, run, debugging, exceptions, and attach/detach
- refresh open language-server document snapshots after asynchronous project discovery so cross-project Go-to-Definition works for pull-diagnostics clients

## Validation
- `VsGsharp.UnitTests`: 43 passed
- cross-project/workspace language-server regressions: 14 passed
- Release VSIX build and experimental-profile installation passed
- live Visual Studio 2026 acceptance passed: semantic highlighting, clean/build, Start Without Debugging, F5, breakpoint binding, locals, Step Over, Step Into, handled exceptions, managed attach/detach, and cross-project Go-to-Definition