### PR TITLE
Validate the VS Code extension in a live instance

### DIFF
--- a/src/LanguageServer/ProjectDiscovery.cs
+++ b/src/LanguageServer/ProjectDiscovery.cs
@@ -96,6 +96,11 @@ public static class ProjectDiscovery
     internal static IReadOnlyList<string> ParseGsAnalyzersFromResponseFile(string rspPath)
         => ParseSwitchValuesFromResponseFile(rspPath, "gsanalyzer");
 
+    internal static (IReadOnlyList<string> References, string? ReferenceSourcePath) DiscoverReferences(
+        string projectFilePath,
+        string projectDir)
+        => DiscoverReferencesCore(projectFilePath, projectDir);
+
     /// <summary>
     /// Resolves the project's effective <c>AssemblyName</c>, which the SDK uses
     /// as the base of the response-file name. Defaults to the project file's
@@ -359,7 +364,7 @@ public static class ProjectDiscovery
     /// <param name="projectFilePath">Absolute path to the <c>.gsproj</c> file.</param>
     /// <param name="projectDir">The project directory.</param>
     /// <returns>The discovered references plus the source <c>.rsp</c> path. Both are empty/null when no response file has been produced (e.g. the project has not been built or restored yet).</returns>
-    private static (IReadOnlyList<string> References, string? ReferenceSourcePath) DiscoverReferences(string projectFilePath, string projectDir)
+    private static (IReadOnlyList<string> References, string? ReferenceSourcePath) DiscoverReferencesCore(string projectFilePath, string projectDir)
     {
         if (!Directory.Exists(projectDir))
         {

--- a/src/LanguageServer/ProjectState.cs
+++ b/src/LanguageServer/ProjectState.cs
@@ -37,6 +37,7 @@ public class ProjectState
     private IReadOnlyList<string> references = Array.Empty<string>();
     private string? referenceSourcePath;
     private DateTime referenceSourceMtimeUtc = DateTime.MinValue;
+    private DateTime nextReferenceDiscoveryUtc = DateTime.MinValue;
     private ReferenceResolver? cachedResolver;
     private IReadOnlyList<string>? resolverReferences;
     private DateTime gsAnalyzerSourceMtimeUtc = DateTime.MinValue;
@@ -506,7 +507,25 @@ public class ProjectState
     {
         if (string.IsNullOrEmpty(referenceSourcePath))
         {
-            return;
+            var now = DateTime.UtcNow;
+            if (now < nextReferenceDiscoveryUtc)
+            {
+                return;
+            }
+
+            nextReferenceDiscoveryUtc = now.AddSeconds(1);
+            var discovered = ProjectDiscovery.DiscoverReferences(ProjectFilePath, ProjectDirectory);
+            if (string.IsNullOrEmpty(discovered.ReferenceSourcePath))
+            {
+                return;
+            }
+
+            referenceSourcePath = discovered.ReferenceSourcePath;
+            references = discovered.References;
+            referenceSourceMtimeUtc = DateTime.MinValue;
+            cachedResolver = null;
+            resolverReferences = null;
+            Invalidate();
         }
 
         DateTime currentMtime;

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -1279,10 +1279,11 @@ public sealed class LspServer
         }
     }
 
-    // Re-evaluates diagnostics for open documents once background workspace discovery has
-    // finished. A file opened before discovery completed was initially bound without its
-    // project's references. Pull clients are asked to re-pull; push-only clients get a new
-    // full bind against the now-discovered project.
+    // Refreshes open-document snapshots once background workspace discovery has finished.
+    // A file opened before discovery completed was initially recorded without its owning
+    // project, so every project-aware feature (definition, hover, references, diagnostics,
+    // etc.) must see a replacement snapshot. Pull clients are then asked to re-pull
+    // diagnostics; push-only clients get a new full bind immediately.
     private void RefreshOpenDocumentDiagnosticsAfterDiscovery()
     {
         this.TestOnDiagnosticRefreshAfterDiscovery?.Invoke();
@@ -1294,12 +1295,6 @@ public sealed class LspServer
     // retain its existing per-document cancellation ordering.
     private void RefreshOpenDocumentDiagnostics()
     {
-        if (this.clientSupportsPullDiagnostics)
-        {
-            this.RequestDiagnosticRefresh();
-            return;
-        }
-
         foreach (var document in this.documentContentService.AllDocuments.ToList())
         {
             var uri = DocumentUri.From(document.Key);
@@ -1318,9 +1313,17 @@ public sealed class LspServer
                 project,
                 this.workspaceState);
             this.documentContentService.AddOrUpdate(document.Key, content);
-            this.SchedulePushDiagnosticsBind(
-                uri,
-                new DiagnosticComputationResult(content, Array.Empty<Diagnostic>()));
+            if (!this.clientSupportsPullDiagnostics)
+            {
+                this.SchedulePushDiagnosticsBind(
+                    uri,
+                    new DiagnosticComputationResult(content, Array.Empty<Diagnostic>()));
+            }
+        }
+
+        if (this.clientSupportsPullDiagnostics)
+        {
+            this.RequestDiagnosticRefresh();
         }
     }
 

--- a/src/vscode-gsharp/esbuild.js
+++ b/src/vscode-gsharp/esbuild.js
@@ -12,7 +12,7 @@ const serverTargetDir = path.join(__dirname, '.server');
 /** Build the .NET Language Server and copy it to .server/ */
 function buildLanguageServer() {
   console.log('Building GSharp Language Server...');
-  execSync('dotnet build src/LanguageServer -nologo -clp:NoSummary', {
+  execSync('dotnet build src/LanguageServer -nologo -clp:NoSummary -p:NuGetAudit=false', {
     cwd: repoRoot,
     stdio: 'inherit',
   });

--- a/src/vscode-gsharp/package.json
+++ b/src/vscode-gsharp/package.json
@@ -344,7 +344,7 @@
     "lint": "eslint src --ext ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "test:unit": "jest --passWithNoTests",
-    "test:integration": "node ./out/test/runTest.js",
+    "test:integration": "npm run compile && node ./test/live/runTest.js",
     "package": "vsce package"
   },
   "dependencies": {

--- a/src/vscode-gsharp/src/extension.ts
+++ b/src/vscode-gsharp/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (serverManager) {
         logger.info('Restarting language server...');
         await serverManager.restart();
-        testing.refresh();
+        await testing.refresh();
       }
     }),
     vscode.commands.registerCommand('gsharp.openOutput', () => {
@@ -46,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // The server is running once start() resolves; kick off an initial test discovery
   // so the Test Explorer is populated immediately (even before any .gs file is opened).
-  testing.refresh();
+  await testing.refresh();
 
   // Register debugger
   registerDebugger(context);
@@ -65,4 +65,3 @@ export function deactivate(): Thenable<void> | undefined {
   }
   return undefined;
 }
-

--- a/src/vscode-gsharp/src/features/testing.ts
+++ b/src/vscode-gsharp/src/features/testing.ts
@@ -31,7 +31,7 @@ export function registerTestingFeatures(
   context: vscode.ExtensionContext,
   getClient: () => LanguageClient | undefined,
   logger: Logger,
-): { refresh: () => void } {
+): { refresh: () => Promise<void> } {
   const testController = vscode.tests.createTestController('gsharp-tests', 'GSharp Tests');
   context.subscriptions.push(testController);
 
@@ -114,7 +114,7 @@ export function registerTestingFeatures(
     }),
   );
 
-  return { refresh: scheduleDiscovery };
+  return { refresh: () => discoverTests(testController, getClient, logger) };
 }
 
 async function runTestAtCursor(
@@ -496,7 +496,11 @@ async function runTestProcess(
  * process groups here; `killProcessTree` instead uses `taskkill /T` to walk the actual
  * process tree by pid.
  */
-function spawnDotnet(args: string[], cwd: string, env?: NodeJS.ProcessEnv): cp.ChildProcessWithoutNullStreams {
+function spawnDotnet(
+  args: string[],
+  cwd: string,
+  env?: NodeJS.ProcessEnv,
+): cp.ChildProcessWithoutNullStreams {
   return cp.spawn('dotnet', args, {
     cwd,
     env,

--- a/src/vscode-gsharp/test/live/runTest.js
+++ b/src/vscode-gsharp/test/live/runTest.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { runTests } = require('@vscode/test-electron');
+
+async function main() {
+  const extensionDevelopmentPath = path.resolve(__dirname, '../..');
+  const extensionTestsPath = path.resolve(__dirname, 'suite');
+  const repoRoot = path.resolve(extensionDevelopmentPath, '../..');
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsharp-vscode-live-'));
+  const sourceRoot = path.join(repoRoot, 'src', 'vs-gsharp', 'test', 'ProjectDebugFixtures');
+
+  fs.cpSync(path.join(sourceRoot, 'Console'), path.join(fixtureRoot, 'Console'), {
+    recursive: true,
+    filter: (source) => !/[\\/](?:bin|obj|\.vscode)(?:[\\/]|$)/i.test(source),
+  });
+  fs.cpSync(path.join(sourceRoot, 'Library'), path.join(fixtureRoot, 'Library'), {
+    recursive: true,
+    filter: (source) => !/[\\/](?:bin|obj|\.vscode)(?:[\\/]|$)/i.test(source),
+  });
+
+  const executable =
+    process.env.VSCODE_EXECUTABLE_PATH ||
+    (process.platform === 'win32' && process.env.LOCALAPPDATA
+      ? path.join(process.env.LOCALAPPDATA, 'Programs', 'Microsoft VS Code', 'Code.exe')
+      : undefined);
+
+  try {
+    await runTests({
+      vscodeExecutablePath: executable,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        path.join(fixtureRoot, 'Console'),
+        `--extensions-dir=${path.join(os.homedir(), '.vscode', 'extensions')}`,
+        `--user-data-dir=${path.join(fixtureRoot, 'user-data')}`,
+      ],
+      extensionTestsEnv: {
+        GSHARP_VSCODE_FIXTURE_ROOT: fixtureRoot,
+      },
+    });
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/vscode-gsharp/test/live/runTest.js
+++ b/src/vscode-gsharp/test/live/runTest.js
@@ -24,6 +24,14 @@ async function main() {
     (process.platform === 'win32' && process.env.LOCALAPPDATA
       ? path.join(process.env.LOCALAPPDATA, 'Programs', 'Microsoft VS Code', 'Code.exe')
       : undefined);
+  if (!executable) {
+    throw new Error(
+      'Set VSCODE_EXECUTABLE_PATH to the installed VS Code executable on this platform.',
+    );
+  }
+  if (!fs.existsSync(executable)) {
+    throw new Error(`Installed VS Code executable was not found: ${executable}`);
+  }
 
   try {
     await runTests({

--- a/src/vscode-gsharp/test/live/suite/index.js
+++ b/src/vscode-gsharp/test/live/suite/index.js
@@ -190,25 +190,41 @@ async function runTestExplorer(folder) {
     (value) => Array.isArray(value) && value.some((symbol) => symbol.name === 'LiveTests'),
     60000,
   );
-  await delay(1000);
   editor.selection = new vscode.Selection(
     positionOf(document, 'RunsInVsCode'),
     positionOf(document, 'RunsInVsCode'),
   );
-  const marker = await waitFor(
-    'Test Explorer execution',
-    async () => {
-      await vscode.commands.executeCommand('gsharp.test.runInContext');
-      try {
-        return await vscode.workspace.fs.readFile(markerUri);
-      } catch {
-        return undefined;
-      }
-    },
-    (value) => value != null,
-    120000,
-  );
+  await vscode.commands.executeCommand('gsharp.test.runInContext');
+  let marker;
+  try {
+    marker = await vscode.workspace.fs.readFile(markerUri);
+  } catch {
+    assert.fail('Test Explorer run did not execute the selected G# test.');
+  }
   assert.strictEqual(Buffer.from(marker).toString(), 'passed');
+}
+
+async function verifyFormatting(document) {
+  const original = document.getText();
+  const malformed = original.replace('var input = 20', 'var input=20');
+  assert.notStrictEqual(malformed, original, 'Could not create malformed formatting input.');
+
+  const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(original.length));
+  const makeMalformed = new vscode.WorkspaceEdit();
+  makeMalformed.replace(document.uri, fullRange, malformed);
+  assert.strictEqual(await vscode.workspace.applyEdit(makeMalformed), true);
+
+  const edits = await vscode.commands.executeCommand(
+    'vscode.executeFormatDocumentProvider',
+    document.uri,
+  );
+  assert.ok(Array.isArray(edits) && edits.length > 0, 'Formatter returned no edits.');
+
+  const applyFormatting = new vscode.WorkspaceEdit();
+  applyFormatting.set(document.uri, edits);
+  assert.strictEqual(await vscode.workspace.applyEdit(applyFormatting), true);
+  assert.ok(document.getText().includes('var input = 20'));
+  assert.ok(!document.getText().includes('var input=20'));
 }
 
 async function run() {
@@ -263,8 +279,7 @@ async function run() {
   );
   assert.ok(completions.items.some((item) => String(item.label) === 'WriteLine'));
 
-  const edits = await vscode.commands.executeCommand('vscode.executeFormatDocumentProvider', uri);
-  assert.ok(Array.isArray(edits), 'Formatting provider was not registered.');
+  await verifyFormatting(document);
 
   const semanticTokens = await waitFor(
     'semantic tokens',

--- a/src/vscode-gsharp/test/live/suite/index.js
+++ b/src/vscode-gsharp/test/live/suite/index.js
@@ -1,0 +1,286 @@
+const assert = require('assert');
+const path = require('path');
+const vscode = require('vscode');
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function waitFor(description, action, predicate, timeoutMilliseconds = 30000) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  let last;
+  while (Date.now() < deadline) {
+    last = await action();
+    if (predicate(last)) {
+      return last;
+    }
+    await delay(200);
+  }
+  throw new Error(`Timed out waiting for ${description}. Last value: ${String(last)}`);
+}
+
+function positionOf(document, text, occurrence = 0) {
+  const source = document.getText();
+  let offset = -1;
+  for (let i = 0; i <= occurrence; i++) {
+    offset = source.indexOf(text, offset + 1);
+  }
+  assert.notStrictEqual(offset, -1, `Could not find '${text}' occurrence ${occurrence}.`);
+  return document.positionAt(offset);
+}
+
+async function executeProvider(command, uri, position) {
+  return waitFor(
+    command,
+    () => vscode.commands.executeCommand(command, uri, position),
+    (value) => (Array.isArray(value) ? value.length > 0 : value != null),
+  );
+}
+
+async function executeTaskCommand(command, taskName) {
+  const ended = new Promise((resolve) => {
+    const subscription = vscode.tasks.onDidEndTaskProcess((event) => {
+      if (event.execution.task.source === 'gsharp' && event.execution.task.name === taskName) {
+        subscription.dispose();
+        resolve(event.exitCode);
+      }
+    });
+  });
+  await vscode.commands.executeCommand(command);
+  const exitCode = await Promise.race([
+    ended,
+    delay(120000).then(() => {
+      throw new Error(`${taskName} task did not finish.`);
+    }),
+  ]);
+  assert.strictEqual(exitCode, 0, `${taskName} task failed with exit code ${exitCode}.`);
+}
+
+async function debugProgram(folder, document) {
+  const marker = 'Console.WriteLine(JsonConvert.SerializeObject(result))';
+  const breakpointLine = positionOf(document, marker).line;
+  const breakpoint = new vscode.SourceBreakpoint(
+    new vscode.Location(document.uri, new vscode.Position(breakpointLine, 0)),
+  );
+  vscode.debug.addBreakpoints([breakpoint]);
+
+  let stoppedResolve;
+  let stoppedReject;
+  const stopped = new Promise((resolve, reject) => {
+    stoppedResolve = resolve;
+    stoppedReject = reject;
+  });
+
+  const tracker = vscode.debug.registerDebugAdapterTrackerFactory('*', {
+    createDebugAdapterTracker(session) {
+      return {
+        onDidSendMessage(message) {
+          if (message.type === 'event' && message.event === 'stopped') {
+            Promise.resolve()
+              .then(async () => {
+                assert.strictEqual(message.body.reason, 'breakpoint');
+                const stack = await session.customRequest('stackTrace', {
+                  threadId: message.body.threadId,
+                });
+                assert.ok(stack.stackFrames.length > 0, 'Debugger returned no stack frames.');
+                const frame = stack.stackFrames[0];
+                assert.strictEqual(
+                  frame.line,
+                  breakpointLine + 1,
+                  `Debugger stopped at ${frame.source?.path}:${frame.line}.`,
+                );
+                const input = await session.customRequest('evaluate', {
+                  expression: 'input',
+                  frameId: frame.id,
+                  context: 'watch',
+                });
+                const result = await session.customRequest('evaluate', {
+                  expression: 'result',
+                  frameId: stack.stackFrames[0].id,
+                  context: 'watch',
+                });
+                assert.strictEqual(input.result, '20');
+                assert.strictEqual(result.result, '42');
+                stoppedResolve();
+                await session.customRequest('continue', { threadId: message.body.threadId });
+              })
+              .catch(stoppedReject);
+          }
+        },
+      };
+    },
+  });
+
+  const terminated = new Promise((resolve) => {
+    const subscription = vscode.debug.onDidTerminateDebugSession(() => {
+      subscription.dispose();
+      resolve();
+    });
+  });
+
+  try {
+    const started = await vscode.debug.startDebugging(folder, {
+      name: 'GSharp live acceptance',
+      type: 'gsharp',
+      request: 'launch',
+      program: path.join(folder.uri.fsPath, 'bin', 'Debug', 'net10.0', 'Console.dll'),
+      cwd: folder.uri.fsPath,
+      console: 'internalConsole',
+    });
+    assert.strictEqual(started, true, 'VS Code did not start the GSharp debug session.');
+    await Promise.race([
+      stopped,
+      delay(60000).then(() => {
+        throw new Error('Debugger did not stop at the GSharp breakpoint.');
+      }),
+    ]);
+    await Promise.race([
+      terminated,
+      delay(30000).then(() => {
+        throw new Error('Debug session did not terminate.');
+      }),
+    ]);
+  } finally {
+    tracker.dispose();
+    vscode.debug.removeBreakpoints([breakpoint]);
+  }
+}
+
+async function runTestExplorer(folder) {
+  const testDirectory = vscode.Uri.joinPath(folder.uri, 'Live.Tests');
+  const projectUri = vscode.Uri.joinPath(testDirectory, 'Live.Tests.gsproj');
+  const sourceUri = vscode.Uri.joinPath(testDirectory, 'LiveTests.gs');
+  const markerUri = vscode.Uri.joinPath(testDirectory, 'test-explorer.passed');
+  const markerPath = markerUri.fsPath.replace(/\\/g, '/');
+
+  await vscode.workspace.fs.createDirectory(testDirectory);
+  await vscode.workspace.fs.writeFile(
+    projectUri,
+    Buffer.from(
+      '<Project Sdk="Gsharp.NET.Sdk/0.3.159">\n' +
+        '  <PropertyGroup>\n' +
+        '    <TargetFramework>net10.0</TargetFramework>\n' +
+        '    <IsPackable>false</IsPackable>\n' +
+        '    <IsTestProject>true</IsTestProject>\n' +
+        '  </PropertyGroup>\n' +
+        '  <ItemGroup>\n' +
+        '    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />\n' +
+        '    <PackageReference Include="xunit" Version="2.9.2" />\n' +
+        '    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />\n' +
+        '  </ItemGroup>\n' +
+        '</Project>\n',
+    ),
+  );
+  const source =
+    'package Live.Tests\n\n' +
+    'import System.IO\n' +
+    'import Xunit\n\n' +
+    'class LiveTests {\n' +
+    '    @Fact\n' +
+    '    func RunsInVsCode() {\n' +
+    `        File.WriteAllText("${markerPath}", "passed")\n` +
+    '    }\n' +
+    '}\n';
+  await vscode.workspace.fs.writeFile(sourceUri, Buffer.from(source));
+
+  const document = await vscode.workspace.openTextDocument(sourceUri);
+  const editor = await vscode.window.showTextDocument(document);
+  await vscode.commands.executeCommand('gsharp.restartServer');
+  await waitFor(
+    'new test project discovery',
+    () => vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', sourceUri),
+    (value) => Array.isArray(value) && value.some((symbol) => symbol.name === 'LiveTests'),
+    60000,
+  );
+  await delay(1000);
+  editor.selection = new vscode.Selection(
+    positionOf(document, 'RunsInVsCode'),
+    positionOf(document, 'RunsInVsCode'),
+  );
+  const marker = await waitFor(
+    'Test Explorer execution',
+    async () => {
+      await vscode.commands.executeCommand('gsharp.test.runInContext');
+      try {
+        return await vscode.workspace.fs.readFile(markerUri);
+      } catch {
+        return undefined;
+      }
+    },
+    (value) => value != null,
+    120000,
+  );
+  assert.strictEqual(Buffer.from(marker).toString(), 'passed');
+}
+
+async function run() {
+  const extension = vscode.extensions.getExtension('gsharplang.vscode-gsharp');
+  assert.ok(extension, 'GSharp extension was not loaded.');
+  await extension.activate();
+  assert.strictEqual(extension.isActive, true);
+
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(folder, 'The live fixture workspace was not opened.');
+  const uri = vscode.Uri.joinPath(folder.uri, 'Program.gs');
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document);
+  assert.strictEqual(document.languageId, 'gsharp');
+
+  const symbols = await waitFor(
+    'language server startup',
+    () => vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', uri),
+    (value) => Array.isArray(value) && value.length > 0,
+    60000,
+  );
+  assert.ok(symbols.length > 0);
+
+  await vscode.commands.executeCommand('gsharp.generateAssets');
+  const tasks = vscode.Uri.joinPath(folder.uri, '.vscode', 'tasks.json');
+  const launch = vscode.Uri.joinPath(folder.uri, '.vscode', 'launch.json');
+  assert.ok((await vscode.workspace.fs.stat(tasks)).type & vscode.FileType.File);
+  assert.ok((await vscode.workspace.fs.stat(launch)).type & vscode.FileType.File);
+
+  await executeTaskCommand('gsharp.buildProject', 'build');
+
+  const greeterPosition = positionOf(document, 'Greeter("debugger")');
+  const definitions = await executeProvider(
+    'vscode.executeDefinitionProvider',
+    uri,
+    greeterPosition,
+  );
+  const definitionUri = definitions[0].targetUri || definitions[0].uri;
+  assert.ok(definitionUri.fsPath.endsWith(path.join('Library', 'Greeter.gs')));
+
+  const hover = await executeProvider('vscode.executeHoverProvider', uri, greeterPosition);
+  assert.ok(hover.length > 0);
+
+  const completionPosition = positionOf(document, 'Console.WriteLine').translate(
+    0,
+    'Console.'.length,
+  );
+  const completions = await executeProvider(
+    'vscode.executeCompletionItemProvider',
+    uri,
+    completionPosition,
+  );
+  assert.ok(completions.items.some((item) => String(item.label) === 'WriteLine'));
+
+  const edits = await vscode.commands.executeCommand('vscode.executeFormatDocumentProvider', uri);
+  assert.ok(Array.isArray(edits), 'Formatting provider was not registered.');
+
+  const semanticTokens = await waitFor(
+    'semantic tokens',
+    () => vscode.commands.executeCommand('vscode.provideDocumentSemanticTokens', uri),
+    (value) => value && value.data && value.data.length > 0,
+  );
+  assert.ok(semanticTokens.data.length > 0);
+
+  await executeTaskCommand('gsharp.runProject', 'run');
+  await debugProgram(folder, document);
+  await runTestExplorer(folder);
+
+  const errors = vscode.languages
+    .getDiagnostics(uri)
+    .filter((diagnostic) => diagnostic.severity === vscode.DiagnosticSeverity.Error);
+  assert.deepStrictEqual(errors, []);
+}
+
+module.exports = { run };

--- a/test/LanguageServer.Tests/ProjectStateTests.cs
+++ b/test/LanguageServer.Tests/ProjectStateTests.cs
@@ -201,6 +201,43 @@ public class ProjectStateTests
     }
 
     [Fact]
+    public void GetCompilation_DiscoversResponseFileCreatedAfterProjectLoad()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var projectPath = Path.Combine(tempDir, "Sample.gsproj");
+            var sourcePath = Path.Combine(tempDir, "Program.gs");
+            File.WriteAllText(projectPath, "<Project Sdk=\"Gsharp.NET.Sdk\" />");
+            File.WriteAllText(sourcePath, "import System\nvar value = Uri(\"https://example.com\")\n");
+
+            var project = new ProjectState(projectPath);
+            project.AssemblyName = "Sample";
+            project.AddFileFromDisk(sourcePath);
+            var first = project.GetCompilation();
+
+            var rspDir = Path.Combine(tempDir, "obj", "Debug", "net10.0");
+            Directory.CreateDirectory(rspDir);
+            File.WriteAllLines(
+                Path.Combine(rspDir, "Sample.rsp"),
+                new[] { "/r:" + typeof(Uri).Assembly.Location });
+
+            Thread.Sleep(1100);
+            var second = project.GetCompilation();
+
+            Assert.NotSame(first, second);
+            Assert.NotNull(second.References);
+            Assert.Single(second.References.Assemblies);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); }
+            catch (IOException) { }
+        }
+    }
+
+    [Fact]
     public void UpdateFile_WithIdenticalText_PreservesCompilationCache()
     {
         // Hot-path optimization: the LSP re-invokes ComputeDiagnostics (which calls

--- a/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
+++ b/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
@@ -24,9 +24,10 @@ namespace GSharp.LanguageServer.Tests;
 /// persisted because nothing re-pulled the file once discovery finished — the user had to edit
 /// the file to trigger a refresh.
 ///
-/// This test locks in the fix: once background discovery completes, the server asks the client
-/// to refresh diagnostics, and the resulting re-pull binds each open file against its
-/// now-discovered project, clearing the spurious diagnostics.
+/// This test locks in the fix: once background discovery completes, the server replaces each
+/// open document snapshot with one attached to its now-discovered project and asks the client
+/// to refresh diagnostics. Project-aware requests such as Go-to-Definition then work immediately,
+/// and the resulting re-pull clears the spurious diagnostics.
 /// </summary>
 public class WorkspaceDiscoveryDiagnosticRefreshTests
 {
@@ -68,6 +69,15 @@ public class WorkspaceDiscoveryDiagnosticRefreshTests
             server.Initialized(doc.RootElement.Clone());
 
             await WaitForAsync(() => refreshRequested && workspace.GetProjectForFile(fooPath) != null);
+
+            var definitions = await server.DefinitionAsync(
+                new DefinitionParams
+                {
+                    TextDocument = new TextDocumentIdentifier { Uri = uri },
+                    Position = LanguageServerTestHelpers.PositionOf(FooSource, "Bar"),
+                });
+            var definition = Assert.Single(definitions);
+            Assert.EndsWith("Bar.gs", definition.Uri.GetFileSystemPath());
 
             // The refresh-driven re-pull now binds Foo.gs against its project (both source files),
             // so the sibling symbols resolve and the spurious diagnostics are gone.


### PR DESCRIPTION
## Summary
- add a repeatable live VS Code Extension Host acceptance test using the installed VS Code build
- validate activation, semantic highlighting, diagnostics, completion, hover, formatting, symbols, cross-project Go-to-Definition, generated assets, build, run, CoreCLR breakpoints/evaluation, and Test Explorer execution
- discover compiler response files produced after initial workspace load so first-build references become available without reopening VS Code
- make the extension compile/package path deterministic when NuGet audit data is unavailable

## Validation
- `npm --prefix src\vscode-gsharp run lint`
- `npm --prefix src\vscode-gsharp run test:unit` — 80 passed
- related `LanguageServer.Tests` — 35 passed
- `npm --prefix src\vscode-gsharp run test:integration` — passed in VS Code 1.136.1
- packaged `vscode-gsharp-0.1.0.vsix` successfully

The branch is based directly on `main`.