### PR TITLE
gsc: emit virtual for a struct method's explicit interface-slot binding (#4157)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
+++ b/src/Core/CodeAnalysis/Emit/MethodInfoHelpers.cs
@@ -64,6 +64,37 @@ internal static class MethodInfoHelpers
             }
         }
 
+        // Issue #4157: the property loop above checks a PROPERTY accessor's
+        // explicit-interface clause, but an ordinary METHOD's own explicit
+        // binding to an interface slot was never checked here — the code fell
+        // straight through to the implicit-match fallback below, whose own
+        // contract (see its doc comment) only recognizes an IMPLICIT
+        // same-name/same-signature match. Two distinct explicit-binding shapes
+        // both need the same "must be virtual" answer as the property case:
+        //   - `function.HasExplicitInterfaceClause` — a G#-authored explicit
+        //     qualifier clause (`func (IFoo) M(...)`, ADR-0149), whether the
+        //     clause target is a G# interface (ExplicitInterfaceMember) or an
+        //     imported CLR interface (ExplicitInterfaceSlot) — mirrors the
+        //     property check immediately above.
+        //   - `function.ExplicitInterfaceSlot != null` — set WITHOUT any
+        //     explicit-interface clause syntax at all (G# has none for plain
+        //     methods) when DeclarationBinder.Structs.cs's covariant-return
+        //     interface bridge (issue #985) binds a same-name/same-parameter
+        //     method to a DIFFERENT interface slot than its sibling overload
+        //     — the exact shape of the non-generic `IEnumerable.GetEnumerator`
+        //     bridge alongside a public generic `GetEnumerator()` that this
+        //     issue's failing corpus fixtures hit. Both shapes emit a
+        //     `MethodImpl` row (see InterfaceImplEmitter) that binds the
+        //     method to an interface slot; per ECMA-335 the CLR type loader
+        //     requires that method to be `virtual` or the type fails to load
+        //     (`TypeLoadException: "...must be virtual to implement a method
+        //     on an interface or super type."`) — a defect ilverify does not
+        //     catch (see the dotnet/runtime issue this fix cites).
+        if (function.HasExplicitInterfaceClause || function.ExplicitInterfaceSlot != null)
+        {
+            return true;
+        }
+
         return MethodImplicitlyImplementsInterface(receiverStruct, function);
     }
 

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue4157StructExplicitInterfaceBridgeVirtualEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue4157StructExplicitInterfaceBridgeVirtualEmitTests.cs
@@ -139,4 +139,114 @@ public class Issue4157StructExplicitInterfaceBridgeVirtualEmitTests
         Assert.Null(result.UnhandledException);
         Assert.Equal(6, result.Value);
     }
+
+    /// <summary>
+    /// Review finding on PR #4174: every existing explicit-clause (ADR-0149)
+    /// emit test uses a CLASS receiver, and
+    /// <see cref="GSharp.Core.CodeAnalysis.Emit.FunctionEmitter"/>
+    /// (<c>!receiverIsValueType || ...</c>) stamps <c>Virtual</c> on a class
+    /// method UNCONDITIONALLY, before <c>RequiresVirtualOnValueType</c> is
+    /// ever consulted — so no existing test exercises this function on a
+    /// STRUCT receiver with an explicit-interface-clause method at all. This
+    /// closes that gap.
+    /// <para>
+    /// It does NOT isolate the <c>HasExplicitInterfaceClause</c> operand from
+    /// <c>MethodImplicitlyImplementsInterface</c>, and — checked directly,
+    /// not assumed — no G# program currently can: an explicit-clause method's
+    /// FunctionSymbol keeps the plain interface-member name (only the
+    /// metadata name is mangled, in <c>ExplicitInterfaceMetadataNaming</c>),
+    /// so <c>MethodSignaturesMatch</c> finds it by name+signature alone,
+    /// against ANY of the struct's declared interfaces — it does not check
+    /// which specific interface slot the clause targets. Verified by
+    /// temporarily deleting the <c>HasExplicitInterfaceClause</c> operand
+    /// from the production fix and rebuilding: this fixture, AND the
+    /// disambiguating two-interface/same-signature shape
+    /// (<c>struct W : IFoo, IBaz { private func (IFoo) Bar()...;
+    /// private func (IBaz) Bar()...; }</c>) that ADR-0149 exists for, both
+    /// still emitted <c>Virtual</c> — because both interfaces' <c>Bar</c>
+    /// methods share one signature, so the implicit-match loop finds a hit
+    /// against EITHER declared interface regardless of which one a given
+    /// method's clause actually names. The operand is real defensive code —
+    /// removing it is not proven safe by this repo's current binder rules,
+    /// which could change — but no scenario constructible today makes it
+    /// load-bearing, so no test here can honestly claim to isolate it. What
+    /// these tests DO prove: a struct with an explicit-clause method emits
+    /// correctly and loads through the interface, which had zero coverage
+    /// before this PR.
+    /// </para>
+    /// </summary>
+    private const string StructExplicitClauseSource = """
+        package Issue4174Repro
+        import System
+
+        interface IPoker {
+            func Poke() int32;
+        }
+
+        struct Widget : IPoker {
+            private var _n int32 = 0
+            func Bump() int32 {
+                _n = _n + 1
+                return _n
+            }
+            private func (IPoker) Poke() int32 { return Bump() }
+        }
+        """;
+
+    [Fact]
+    public void StructExplicitClauseMethod_EmitsVirtualNewSlotFinal()
+    {
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(StructExplicitClauseSource));
+        var compilation = new Compilation(tree);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+
+        var typeDef = md.TypeDefinitions
+            .Select(md.GetTypeDefinition)
+            .Single(t => md.GetString(t.Name) == "Widget");
+
+        // ADR-0149: an explicit-interface-clause method's CLR metadata name is
+        // mangled ("Issue4174Repro.IPoker.Poke" -- package-qualified, via
+        // ExplicitInterfaceMetadataNaming) to stay collision-free; the plain
+        // source name "Poke" is never emitted. Confirmed by dumping this
+        // fixture's actual emitted method names rather than assumed.
+        var poke = typeDef.GetMethods()
+            .Select(md.GetMethodDefinition)
+            .Single(m => md.GetString(m.Name) == "Issue4174Repro.IPoker.Poke");
+
+        Assert.True(
+            (poke.Attributes & MethodAttributes.Virtual) != 0,
+            "an explicit-interface-clause method on a struct must be emitted Virtual, "
+                + $"but found {poke.Attributes}");
+        Assert.True(
+            (poke.Attributes & MethodAttributes.NewSlot) != 0,
+            $"expected NewSlot, found {poke.Attributes}");
+        Assert.True(
+            (poke.Attributes & MethodAttributes.Final) != 0,
+            $"expected Final, found {poke.Attributes}");
+    }
+
+    [Fact]
+    public void StructExplicitClauseMethod_LoadsAndRunsThroughTheInterface()
+    {
+        var result = EmittedOracle.Evaluate(StructExplicitClauseSource + """
+
+            var w = Widget{}
+            var p IPoker = w
+            var a = p.Poke()
+            var b = p.Poke()
+            a + b
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(3, result.Value);
+    }
 }

--- a/test/Core.Tests/CodeAnalysis/Emit/Issue4157StructExplicitInterfaceBridgeVirtualEmitTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Emit/Issue4157StructExplicitInterfaceBridgeVirtualEmitTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="Issue4157StructExplicitInterfaceBridgeVirtualEmitTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using GSharp.Core.CodeAnalysis.Compilation;
+using GSharp.Core.CodeAnalysis.Syntax;
+using GSharp.Core.CodeAnalysis.Text;
+using GSharp.Tests;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Emit;
+
+/// <summary>
+/// Issue #4157: <see cref="GSharp.Core.CodeAnalysis.Emit.MethodInfoHelpers.RequiresVirtualOnValueType"/>
+/// checked a PROPERTY accessor's explicit-interface clause but never a plain
+/// METHOD's own explicit binding to an interface slot, so a value-type
+/// (<c>struct</c>) covariant-return interface bridge (issue #985 — a
+/// non-generic <c>IEnumerable.GetEnumerator()</c> bridge alongside a public
+/// generic <c>GetEnumerator() IEnumerator[T]</c>) fell through to
+/// <c>MethodImplicitlyImplementsInterface</c>, which by its own doc comment
+/// only detects an IMPLICIT same-name/same-signature match — never an
+/// explicit one. The bridge method still got a correct <c>MethodImpl</c> row
+/// (the <c>.override</c>), but was emitted WITHOUT the CLR <c>virtual</c> bit,
+/// which ECMA-335 requires of any method bound to an interface slot. The
+/// resulting type failed to load the moment it was used:
+/// <c>TypeLoadException: "...must be virtual to implement a method on an
+/// interface or super type."</c> — a defect this project's <c>ilverify</c>
+/// gate does not catch (see the corroborating dotnet/runtime issue filed
+/// against ILVerify's interface-implementation check). 117 of 165 (70%) of
+/// <c>test/Core.Tests</c>' first test-parity failures were this one root
+/// cause, hitting synthesized wrapper types (<c>ImmutableArrayOfDiagnostic</c>
+/// and friends) that implement <c>IReadOnlyCollection[T]</c> and so carry the
+/// same non-generic/generic <c>GetEnumerator</c> bridge pair as a value type
+/// (this <c>struct</c> repro reduces the same shape independent of that
+/// corpus fixture). Reference-type (<c>class</c>) receivers were never
+/// affected — <see cref="GSharp.Core.CodeAnalysis.Emit.FunctionEmitter"/>
+/// always stamps <c>virtual</c> for a non-value-type receiver regardless of
+/// <c>RequiresVirtualOnValueType</c>'s answer, which is why the existing
+/// class-shaped #985 emit test never caught this: the defect is
+/// value-type-only.
+/// </summary>
+public class Issue4157StructExplicitInterfaceBridgeVirtualEmitTests
+{
+    private const string StructBridgeSource = """
+        package Issue4157Repro
+        import System
+        import System.Collections
+        import System.Collections.Generic
+
+        struct Bag : IEnumerable[int32] {
+            private let _items List[int32] = List[int32]()
+            func Add(value int32) { _items.Add(value) }
+            func GetEnumerator() IEnumerator[int32] { return _items.GetEnumerator() }
+            private func GetEnumerator() IEnumerator { return GetEnumerator() }
+        }
+        """;
+
+    [Fact]
+    public void StructCovariantBridgeMethod_EmitsVirtualNewSlotFinal()
+    {
+        // The metadata contract that was silently violated pre-fix: BOTH
+        // GetEnumerator overloads on a value-type (struct) receiver — the
+        // public generic one AND the private non-generic bridge bound via
+        // MethodImpl to System.Collections.IEnumerable.GetEnumerator — must
+        // carry Virtual (with NewSlot | Final, matching the C#-conventional
+        // explicit-interface-implementation shape: neither overrides
+        // anything, and both are effectively sealed). Pre-fix, the bridge
+        // method's attributes were bare `Private, HideBySig` — no Virtual,
+        // no NewSlot, no Final — even though its MethodImpl row correctly
+        // bound it to the interface slot.
+        using var peStream = new MemoryStream();
+        var tree = SyntaxTree.Parse(SourceText.From(StructBridgeSource));
+        var compilation = new Compilation(tree);
+        var emitResult = compilation.Emit(peStream);
+        Assert.True(
+            emitResult.Success,
+            "compilation should succeed: " + string.Join("; ", emitResult.Diagnostics.Select(d => d.Message)));
+
+        peStream.Position = 0;
+        using var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+        var md = peReader.GetMetadataReader();
+
+        var typeDef = md.TypeDefinitions
+            .Select(md.GetTypeDefinition)
+            .Single(t => md.GetString(t.Name) == "Bag");
+
+        var getEnumeratorMethods = typeDef.GetMethods()
+            .Select(md.GetMethodDefinition)
+            .Where(m => md.GetString(m.Name) == "GetEnumerator")
+            .ToList();
+
+        Assert.Equal(2, getEnumeratorMethods.Count);
+
+        foreach (var method in getEnumeratorMethods)
+        {
+            Assert.True(
+                (method.Attributes & MethodAttributes.Virtual) != 0,
+                "every GetEnumerator overload bound to an interface slot must be emitted Virtual, "
+                    + $"but found {method.Attributes}");
+            Assert.True(
+                (method.Attributes & MethodAttributes.NewSlot) != 0,
+                $"expected NewSlot (neither overload overrides an inherited slot), found {method.Attributes}");
+            Assert.True(
+                (method.Attributes & MethodAttributes.Final) != 0,
+                $"expected Final (neither overload is declared open/override), found {method.Attributes}");
+        }
+    }
+
+    [Fact]
+    public void StructCovariantBridge_LoadsAndEnumeratesThroughNonGenericInterface()
+    {
+        // The sharp witness: pre-fix, the CLR refused to LOAD the struct the
+        // moment it was boxed/used through IEnumerable — the emitted
+        // GetEnumerator() with the missing Virtual bit is exactly the shape
+        // that trips System.TypeLoadException at class-load time. Enumerating
+        // through the non-generic IEnumerable bridge is the path that must
+        // not throw.
+        var result = EmittedOracle.Evaluate(StructBridgeSource + """
+
+            var b = Bag{}
+            b.Add(1)
+            b.Add(2)
+            b.Add(3)
+            var seq IEnumerable = b
+            var e IEnumerator = seq.GetEnumerator()
+            var sum = 0
+            while e.MoveNext() {
+                sum = sum + (e.Current as int32?)!!
+            }
+            sum
+            """);
+
+        Assert.Empty(result.Diagnostics);
+        Assert.Null(result.UnhandledException);
+        Assert.Equal(6, result.Value);
+    }
+}


### PR DESCRIPTION
## Summary

- `MethodInfoHelpers.RequiresVirtualOnValueType` checked a PROPERTY accessor's explicit-interface clause but never checked a plain METHOD's own explicit binding to an interface slot, so it fell through to `MethodImplicitlyImplementsInterface`, which by its own doc comment only detects an *implicit* same-name/same-signature match, not an explicit one.
- On a value type (`struct`), this meant a covariant-return interface bridge method (issue #985 — e.g. the non-generic `IEnumerable.GetEnumerator()` bridge alongside a public generic `GetEnumerator() IEnumerator[T]`) got a correct `MethodImpl` row binding it to the interface slot, but was emitted **without** the CLR `virtual` bit. Per ECMA-335 the CLR type loader requires a method bound to an interface slot to be virtual — the type fails to load the first time it's used: `TypeLoadException: "...must be virtual to implement a method on an interface or super type."` `ilverify` does not catch this (filed https://github.com/dotnet/runtime/issues/133500 against ILVerify's interface-implementation check, with a minimal standalone repro).
- Fixes #4157: 117 of `test/Core.Tests`' first 165 test-parity failures (70%) were this one root cause, hitting synthesized wrapper structs (`ImmutableArrayOfDiagnostic` and friends — a `private readonly struct : IReadOnlyCollection<Diagnostic>` with an explicit `IEnumerable.GetEnumerator()`, declared in ~17 `test/Core.Tests` files) with this exact shape.
- Fix: add `function.HasExplicitInterfaceClause || function.ExplicitInterfaceSlot != null` before the implicit-match fallback — mirrors the existing property-accessor check for the ADR-0149 explicit-clause case, and additionally covers the #985 bridge case, which carries no explicit-interface clause syntax at all (G# has none for plain methods) but still sets `ExplicitInterfaceSlot` directly.

## Root cause and evidence

- Traced `ExplicitInterfaceSlot`'s two setters: `DeclarationBinder.InterfaceVerification.cs` (an ADR-0149 explicit-interface clause resolved against an imported CLR interface) and `DeclarationBinder.Structs.cs` (`TryResolveCovariantInterfaceBridge`, issue #985's bridge case — no clause syntax involved). Both leave a method bound to an interface slot via `MethodImpl` without `RequiresVirtualOnValueType` ever noticing.
- Reduced a minimal standalone repro (`struct Bag : IEnumerable[int32]` with a public generic `GetEnumerator() IEnumerator[int32]` and a private non-generic bridge `GetEnumerator() IEnumerator`) and inspected the emitted metadata directly with `System.Reflection.Metadata`:
  - **Before**: public `GetEnumerator` → `Public, Final, Virtual, HideBySig`; the bridge → `Private, HideBySig` (no Virtual/NewSlot/Final at all).
  - **After**: both → `..., Final, Virtual, HideBySig, ...` (NewSlot included).
  - Running a compiled `.gs` exe that constructs `Bag`, upcasts to `IEnumerable`, and enumerates through the non-generic bridge: **before** → `System.TypeLoadException` at class-load time (confirmed); **after** → runs cleanly, prints `1 2 3`.

## Test plan

- [x] New regression test `test/Core.Tests/CodeAnalysis/Emit/Issue4157StructExplicitInterfaceBridgeVirtualEmitTests.cs`:
  - `StructCovariantBridgeMethod_EmitsVirtualNewSlotFinal` — metadata-level: both `GetEnumerator` overloads on the struct must carry `Virtual | NewSlot | Final`.
  - `StructCovariantBridge_LoadsAndEnumeratesThroughNonGenericInterface` — end-to-end: constructs the struct, enumerates through the non-generic `IEnumerable` bridge via `EmittedOracle`, asserts no exception and the correct sum.
  - Confirmed both tests **fail** (one with the exact `TypeLoadException`, one with a metadata assertion) when the production fix is reverted, and **pass** once restored — not vacuous.
- [x] `dotnet test test/Compiler.Tests/Compiler.Tests.csproj` filtered to existing explicit-interface / #985 emit tests (27 tests across `Issue2010`, `Issue2181`, `Issue2362`, `Issue2543`, `Issue3814`, `Issue985DualGetEnumeratorEmitTests`) — all pass, no regression on the class-typed / clause-based explicit-interface paths.
- [x] Full `dotnet test test/Core.Tests/Core.Tests.csproj -c Debug`: **9072 passed**, 2 failed (both the pre-existing, documented `NETStandard.Library.Ref` targeting-pack environment gap — unrelated).
- [x] Full `dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Debug`: **5809 passed**, 3 failed (same pre-existing `NETStandard.Library.Ref` gap — unrelated).
- Note: these `dotnet test` runs exercise the **native C#-built** compiler/tests, which were never affected by this gsc-emission-only defect — they confirm no regression, not that the bug is fixed. The real validation is the before/after IL inspection and the load-and-run repro above, both gsc-emitted. Reproducing the full sharded self-migration gate (cs2gs-translated `test/Core.Tests` compiled and run through gsc) was judged out of scope for local validation per the issue's guidance — the mechanism-level fix plus the targeted repro is the deliverable. Based on the pattern match, this should clear all 117 `TypeLoadException` failures in the next gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ptr4sovcAwpgaUEM4rEin