### PR TITLE
gsc: close test/Interpreter.Tests' two selfmig test-parity failures (#4130)

### DIFF
--- a/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
+++ b/test/Interpreter.Tests/Issue3015ImportedBaseIdentityTests.cs
@@ -447,6 +447,37 @@ public class Issue3015OverloadedBase
     public string Label { get; }
 }
 
+/// <summary>
+/// Issue #4130: a real (never-instantiated) C# subclass of
+/// <see cref="Issue3015OverloadedBase"/>. <see cref="OverloadedBaseConstructors_ShareOneDerivedRuntimeType"/>'s
+/// actual subclass (<c>OverloadedSentinel</c>) exists only inside the G#
+/// source string that <c>EmittedOracle.Evaluate</c> compiles at test time
+/// — invisible to Roslyn, and therefore invisible to cs2gs's
+/// <c>subclassedBases</c> heuristic (<c>CSharpToGSharpTranslator.
+/// Declarations.cs</c>) for deciding whether a translated class needs G#'s
+/// <c>open</c> modifier. <see cref="Issue3015ProtectedParameterizedBase"/>
+/// escapes this gap by accident — its constructor is <see langword="protected"/>,
+/// a second, independent signal the same heuristic honors — but
+/// <see cref="Issue3015OverloadedBase"/> has only <see langword="public"/> members,
+/// so without a real subclass the migrated build compiles it as a plain
+/// (ADR-0017 default CLR-<see langword="sealed"/>) class. The G# fixture's
+/// <c>class OverloadedSentinel : Issue3015OverloadedBase</c> then fails to
+/// resolve its base: <c>DeclarationBinder.Structs.cs</c>'s imported-base-type
+/// branch only accepts <c>clrType.IsClass &amp;&amp; !clrType.IsSealed</c>, and a
+/// sealed imported class falls through every explicit case to the generic
+/// <c>GS0157</c> diagnostic — "Cannot find type Issue3015OverloadedBase. Are
+/// you missing an import?" — exactly the failure #4130 reported, cascading
+/// into "requires an explicit base class" and "Cannot find member Label".
+/// This type's only job is to give cs2gs the same signal
+/// <see cref="Issue3015ProtectedParameterizedBase"/> gets for free, so the
+/// migrated <c>Issue3015OverloadedBase</c> is translated <c>open class</c>
+/// and stays subclassable at runtime, matching the fixture it actually has
+/// to support.
+/// </summary>
+internal sealed class Issue3015OverloadedBaseOpenSignal : Issue3015OverloadedBase
+{
+}
+
 /// <summary>Imported protected-constructor probe for issue #3015.</summary>
 public class Issue3015ProtectedParameterizedBase
 {

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -170,6 +170,51 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
         }
     }
 
+    /// <summary>
+    /// Review finding on #4178: the sibling test above exercises only bare
+    /// `gsc`'s STDOUT diagnostic path. `gsi` (<see cref="GSharp.Repl.Program"/>)
+    /// renders every diagnostic to STANDARD ERROR regardless of severity — a
+    /// different stream than bare `gsc` uses — so a `StripDiagnosticNoise`
+    /// regression specific to stderr, or to `gsi`'s own diagnostic
+    /// rendering, would not be caught by the stdout-only test above. This is
+    /// the same deterministic GS0536 shape, routed through
+    /// <see cref="RunScriptDriver"/> and checked with the same
+    /// <see cref="CheckDriver"/> the real `Issue3149` test uses for its own
+    /// `gsi` leg, so this test and that one can never disagree about what
+    /// `CheckDriver` accepts on the `gsi` path.
+    /// </summary>
+    [Fact]
+    public void ScriptDriverWarning_RedundantNullAssertion_DoesNotFailDriverCheck()
+    {
+        var directory = CreateEmptyTestDirectory("RedundantBangBangScript");
+        try
+        {
+            var sourcePath = WriteSource(
+                directory,
+                "warn.gs",
+                """
+                import System
+                let value = 41
+                Console.WriteLine(value!! + 1)
+                """);
+
+            var script = RunScriptDriver(sourcePath);
+
+            // The warning must actually have fired, and on STDERR specifically
+            // -- otherwise this test would pass whether or not the gsi leg of
+            // #4130's fix is present, and would not be discriminating.
+            Assert.Contains("GS0536", script.StandardError, StringComparison.Ordinal);
+
+            var failures = new List<string>();
+            CheckDriver("gsi", script, "42" + Environment.NewLine, failures);
+            Assert.True(failures.Count == 0, string.Join("\n\n", failures));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -453,13 +498,50 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
     // Matching (and removing) the run as one unit, rather than per-line,
     // keeps that shared trailing blank line from being left behind as
     // stray whitespace once the diagnostics themselves are stripped.
+    //
+    // Review finding on #4178: deliberately WARNING/INFO only, never
+    // `error`. #4130's fix is meant to tolerate a driver that succeeds
+    // despite printing a non-fatal diagnostic -- it is not meant to make
+    // this check blind to a driver that emits an actual error and still
+    // (incorrectly) exits 0. Stripping `error` text here would leave
+    // CheckDriver trusting ExitCode alone for that case, silently
+    // re-opening the exact class of false-negative this fix exists to
+    // close, just for a worse condition than the one it was written for.
     private static readonly Regex CompilerDiagnosticsBlock = new(
-        @"(?:\r?\n(?:.*\(\d+,\d+,\d+,\d+\):\ (?:error|warning|info)\ [A-Za-z0-9]+:\ .*\r?\n.*\r?\n" +
-        @"|(?:error|warning|info)\ [A-Za-z0-9]+:\ .*\r?\n))+\r?\n",
+        @"(?:\r?\n(?:.*\(\d+,\d+,\d+,\d+\):\ (?:warning|info)\ [A-Za-z0-9]+:\ .*\r?\n.*\r?\n" +
+        @"|(?:warning|info)\ [A-Za-z0-9]+:\ .*\r?\n))+\r?\n",
         RegexOptions.Compiled);
 
     private static string StripDiagnosticNoise(string text) =>
         string.IsNullOrEmpty(text) ? text : CompilerDiagnosticsBlock.Replace(text, string.Empty);
+
+    /// <summary>
+    /// Review finding on #4178: confirms the boundary the fix deliberately
+    /// keeps -- <see cref="CompilerDiagnosticsBlock"/> strips WARNING/INFO
+    /// text so a legitimate non-fatal diagnostic cannot fail
+    /// <see cref="CheckDriver"/>, but must never strip an ERROR. A driver
+    /// that (hypothetically, via its own bug) reports a real error yet still
+    /// exits 0 must still be caught here through the exact-output-equality
+    /// check, not silently waved through because #4130's fix trusted
+    /// <c>ExitCode</c> alone. Constructs the hazard directly (a synthetic
+    /// <see cref="DriverResult"/> with an error diagnostic AND exit code 0)
+    /// rather than trying to make a real driver misbehave.
+    /// </summary>
+    [Fact]
+    public void ErrorDiagnosticAlongsideFakeSuccessExitCode_StillFailsCheckDriver()
+    {
+        var fakeResult = new DriverResult(
+            0,
+            "\nfake.gs(1,1,1,2): error GS9999: something is actually broken\nlet x = 1\n\n" + "42" + Environment.NewLine,
+            string.Empty);
+        var failures = new List<string>();
+        CheckDriver("probe", fakeResult, "42" + Environment.NewLine, failures);
+        Assert.True(
+            failures.Count > 0,
+            "CheckDriver must still fail when an error diagnostic is present, even though "
+                + "warnings/info are excluded from the stdout-equality strip -- if this assertion "
+                + "fails, the strip regex is (again) silently eating errors too.");
+    }
 
     private static DriverResult RunCompiler(params string[] arguments) =>
         Capture(() => GSharp.Compiler.Program.Main(arguments));

--- a/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
+++ b/test/Interpreter.Tests/Issue3149NamedDelegateReificationDriverTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -114,6 +115,53 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
             CheckBareDriver(bare, expectedOutput, failures);
             CheckDriver("gsc /out:", emitted, expectedOutput, failures);
             CheckDriver("gsi", script, expectedOutput, failures);
+            Assert.True(failures.Count == 0, string.Join("\n\n", failures));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// Issue #4130 regression: a driver that exits 0 with the right program
+    /// output must still pass even when it also prints a legitimate
+    /// WARNING-severity diagnostic. This is deliberately independent of the
+    /// self-hosting nondeterminism that originally surfaced the bug —
+    /// GS0536 ("Redundant '!!'", reported by ExpressionBinder's
+    /// <c>ReportNullAssertionIfRedundant</c>) fires unconditionally whenever
+    /// <c>!!</c> is applied to a statically non-nullable value, so a plain
+    /// <c>int</c> reproduces the same "warning alongside a successful run"
+    /// shape deterministically under the *native* compiler, with no need to
+    /// reproduce the self-hosted build that #4130 actually hit. Before
+    /// #4130's fix to <see cref="CheckDriver"/>, this test fails because the
+    /// warning's text pollutes the bare driver's stdout / breaks the
+    /// exact-output-equality check.
+    /// </summary>
+    [Fact]
+    public void BareDriverWarning_RedundantNullAssertion_DoesNotFailDriverCheck()
+    {
+        var directory = CreateEmptyTestDirectory("RedundantBangBang");
+        try
+        {
+            var sourcePath = WriteSource(
+                directory,
+                "warn.gs",
+                """
+                import System
+                let value = 41
+                Console.WriteLine(value!! + 1)
+                """);
+
+            var bare = RunCompiler(sourcePath);
+
+            // The warning must actually have fired — otherwise this test
+            // would pass whether or not #4130's CheckDriver fix is present,
+            // and would not be discriminating between the two.
+            Assert.Contains("GS0536", bare.StandardOutput, StringComparison.Ordinal);
+
+            var failures = new List<string>();
+            CheckBareDriver(bare, "42" + Environment.NewLine, failures);
             Assert.True(failures.Count == 0, string.Join("\n\n", failures));
         }
         finally
@@ -353,15 +401,40 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
         List<string> failures) =>
         CheckDriver("gsc", result, expectedOutput + "Success.\n", failures);
 
+    // Issue #4130: bare `gsc` and `gsi` both document that a *successful*
+    // run may still print diagnostics — bare `gsc`'s ExecuteInMemory
+    // (src/Compiler/Program.cs) prints warnings to stdout ahead of its
+    // "Success." trailer, and gsi's RunScript (src/Repl/Program.cs) always
+    // "renders [diagnostics] to standard error, the program's output
+    // streams straight through" regardless of severity. Neither driver's
+    // success contract is "diagnostic-free" — it is "exit code 0", which
+    // both already gate on the absence of an ERROR-severity diagnostic
+    // (ExecuteInMemory returns non-zero when `effective.Any(d => d.IsError)`;
+    // RunScript returns 1 when `!result.Success`). Requiring the raw
+    // stdout/stderr text to be byte-for-byte diagnostic-free — as this check
+    // did before #4130 — turns a legitimate warning into a false "driver
+    // failed", which is exactly what happened here: the reified open-generic
+    // delegate case (`selectOpen: true`) triggers GS0536 ("Redundant '!!':
+    // the value is already non-null here") on `callback!!("abc")` under a
+    // self-hosted gsc whose nullability inference for the mixed open/closed
+    // overload is tighter than the native compiler's, even though the actual
+    // program output — the whole point of this test — is unaffected. Strip
+    // the compiler's own diagnostic blocks (recognisable by
+    // TextWriterExtensions.WriteDiagnostics's fixed shape) before comparing,
+    // so a driver that exits 0 with the right program output only fails here
+    // when its OWN output is actually wrong.
     private static void CheckDriver(
         string name,
         DriverResult result,
         string expectedOutput,
         List<string> failures)
     {
+        var actualOutput = StripDiagnosticNoise(result.StandardOutput);
+        var actualError = StripDiagnosticNoise(result.StandardError);
+
         if (result.ExitCode != 0
-            || !string.Equals(Normalize(result.StandardOutput), expectedOutput, StringComparison.Ordinal)
-            || result.StandardError.Length != 0)
+            || !string.Equals(Normalize(actualOutput), expectedOutput, StringComparison.Ordinal)
+            || actualError.Length != 0)
         {
             failures.Add(
                 $"{name} failed:"
@@ -370,6 +443,23 @@ public sealed class Issue3149NamedDelegateReificationDriverTests
                 + $"\n  stderr:\n{result.StandardError}");
         }
     }
+
+    // Matches one full TextWriterExtensions.WriteDiagnostics dump: one or
+    // more diagnostic entries, each a blank separator line followed by
+    // either a located header ("<file>(sl,sc,el,ec): <severity> <id>:
+    // <message>") plus its one-line source snippet, or a location-less
+    // header ("<severity> <id>: <message>") alone — then the single extra
+    // blank line WriteDiagnostics always appends after the last entry.
+    // Matching (and removing) the run as one unit, rather than per-line,
+    // keeps that shared trailing blank line from being left behind as
+    // stray whitespace once the diagnostics themselves are stripped.
+    private static readonly Regex CompilerDiagnosticsBlock = new(
+        @"(?:\r?\n(?:.*\(\d+,\d+,\d+,\d+\):\ (?:error|warning|info)\ [A-Za-z0-9]+:\ .*\r?\n.*\r?\n" +
+        @"|(?:error|warning|info)\ [A-Za-z0-9]+:\ .*\r?\n))+\r?\n",
+        RegexOptions.Compiled);
+
+    private static string StripDiagnosticNoise(string text) =>
+        string.IsNullOrEmpty(text) ? text : CompilerDiagnosticsBlock.Replace(text, string.Empty);
 
     private static DriverResult RunCompiler(params string[] arguments) =>
         Capture(() => GSharp.Compiler.Program.Main(arguments));


### PR DESCRIPTION
## Summary

Two independent, root-caused fixes for `test/Interpreter.Tests`' last two migrated-build failures ([#4130](https://github.com/DavidObando/gsharp/issues/4130)), leaving the app fully green — one of the last four red apps in the 56-app self-migration effort ([#3501](https://github.com/DavidObando/gsharp/issues/3501)).

**`OverloadedBaseConstructors_ShareOneDerivedRuntimeType`** — the issue's own "ReferenceResolver.Default() can't see its own assembly" hypothesis is **refuted**: `ReferenceResolver.Default()` scans `AppDomain.CurrentDomain.GetAssemblies()`, which necessarily includes the executing test assembly, and — decisively — `ProtectedParameterizedBaseConstructor_PreservesStateAndIdentity` imports a base type from the *same* assembly the *same* way and is **not** among the two reported failures. The real cause: cs2gs's `open`-inference heuristic (`subclassedBases` / `HasProtectedMember` in `CSharpToGSharpTranslator.Declarations.cs`) only sees C#-visible extensibility signals. `Issue3015OverloadedBase`'s only subclass lives inside a G# source string that `EmittedOracle.Evaluate` compiles at test time — invisible to Roslyn — so cs2gs translated it as a plain class, which is CLR-`sealed` by ADR-0017's default. `DeclarationBinder.Structs.cs`'s imported-base-type branch only accepts `clrType.IsClass && !clrType.IsSealed`; a sealed imported base falls through every explicit case to the generic `GS0157` diagnostic — "Cannot find type ... Are you missing an import?" — exactly the failure reported, cascading into the two "requires an explicit base class" and two "Cannot find member Label" lines.
  - Confirmed against the actual migrated build via `cs2gs migrate --translate-only`: before this fix, the migrated `Issue3015OverloadedBase` lacked `open`; after, it carries it.
  - Fixed by adding a real (never-instantiated) C# subclass, `Issue3015OverloadedBaseOpenSignal`, giving cs2gs the same signal `Issue3015ProtectedParameterizedBase` already gets for free from its `protected` constructor. No production code changed — `tools/cs2gs/` untouched, per the concurrent #4167 work in that area.

**`MixedOpenAndClosedCandidates_ReifySelectedDelegateAcrossDrivers(selectOpen: true)`** — the "gsc failed: exit: 0" contradiction is **confirmed**: gsc succeeds and prints the right output, but the test harness's `CheckDriver` required byte-for-byte diagnostic-free stdout/stderr, so a legitimate WARNING-severity diagnostic (`GS0536` "Redundant '!!'", which fires whenever `!!` asserts an already non-nullable value) turned a passing run into a false driver failure. Both bare `gsc` (`ExecuteInMemory`) and `gsi` (`RunScript`) document that a successful run may still print diagnostics; only exit code gates a real (error-severity) failure.
  - Fixed by stripping the compiler's own diagnostic blocks from stdout/stderr before comparing, in the test harness only.
  - Added a deterministic regression test (a plain `int!!`) independent of the self-hosting nondeterminism that originally surfaced the bug.

Both fixes are test-only, confined to `test/Interpreter.Tests`, and independent per the issue's own framing — kept as one PR since they close the same issue for the same app.

## Test plan

- [x] `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Debug`: **1517/1517 passed** (1516 baseline + 2 new regression tests), up from a 1516/1516 native baseline that never exercised either bug.
- [x] Anti-vacuity, GS0536 harness fix: reverted `CheckDriver`'s stripping, rebuilt, confirmed `BareDriverWarning_RedundantNullAssertion_DoesNotFailDriverCheck` goes red with the exact "gsc failed: exit: 0" shape from the issue; restored, confirmed green.
- [x] Anti-vacuity, `open`-signal fix: ran `cs2gs migrate --translate-only` over the whole repo before and after adding `Issue3015OverloadedBaseOpenSignal` — migrated `Issue3015OverloadedBase` lacked `open` before, carries it after. A full self-hosted compile+test repro was impractical (no supported single-app scope for the Repository-layout pipeline; a full corpus self-hosting bootstrap is well beyond this PR's budget), so this is the closest verifiable proxy for the actual migrated-build defect and fix.
- [x] `dotnet test test/Interpreter.Tests/Interpreter.Tests.csproj -c Debug --filter Issue3015ImportedBaseIdentityTests`: 12/12 passed (no regression from the added subclass).
- [x] `dotnet build test/Interpreter.Tests/Interpreter.Tests.csproj -c Debug` / `-c Release`: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ptr4sovcAwpgaUEM4rEin