### PR TITLE
cs2gs: stop asserting a Select result forwarded whole to a nullable-tolerant sink (#4180)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
@@ -149,6 +149,108 @@ public sealed class Issue4180NullableSelectResultRegressionTests
         }
     }
 
+    // The COVARIANT sibling shape flagged on this PR's own review (Copilot,
+    // on the original `SymbolEqualityComparer.Default.Equals(resultType,
+    // sinkElement...)` fix): the sink's nullable-annotated element type need
+    // not be IDENTICAL to the selector's result type, only ASSIGNABLE to it
+    // through an implicit reference conversion. `Consume(IEnumerable<object?>
+    // values)` accepts `types.Select(t => t.FullName)`'s `IEnumerable<string?>`
+    // through `IEnumerable<T>`'s covariance — `string` is not symbol-equal to
+    // `object`, but every `string` IS an `object`. Exact-identity missed this:
+    // the selector result stayed `!!`-asserted and threw on a null
+    // `FullName` even though the sink tolerates it exactly like #4180's
+    // `string.Join` case.
+    private const string CovariantSource = """
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public static class Probe
+        {
+            public static string Consume(IEnumerable<object?> values)
+            {
+                return string.Join(", ", values);
+            }
+
+            public static string Describe(IEnumerable<Type> types)
+            {
+                return Consume(types.Select(t => t.FullName));
+            }
+
+            public static void Main()
+            {
+                Type[] typeParameters = typeof(List<>).GetGenericArguments();
+                string described = Describe(typeParameters);
+                Console.WriteLine("OK:" + described);
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Translates the covariant reproduction snippet and asserts the emitted
+    /// G# no longer asserts the selector's nullable result — the cheap,
+    /// syntactic guard that discriminates the review fix (reverting the
+    /// element-conversion check back to exact identity turns this test red;
+    /// see
+    /// <see cref="SelfHostedNullableSelectResult_DoesNotThrowWhenForwardedThroughCovariantSink"/>
+    /// for the full functional proof).
+    /// </summary>
+    [Fact]
+    public void TranslatedSnippet_NoLongerAssertsTheSelectResultForwardedThroughCovariantSink()
+    {
+        string printed = Translate(CovariantSource);
+
+        Assert.DoesNotContain("t.FullName!!", printed, StringComparison.Ordinal);
+        Assert.Contains("types.Select((t Type) -> t.FullName)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The functional proof that the covariant shape actually survives
+    /// self-hosting: translates the covariant reproduction snippet, compiles
+    /// the result with the REAL <c>gsc.dll</c>, and runs it. With the
+    /// pre-review exact-identity check this throws
+    /// <see cref="NullReferenceException"/> from inside the <c>Select</c>
+    /// lambda (the same shape of crash as #4180's report, but through a
+    /// covariant sink rather than an identical one); after the fix it prints
+    /// <c>OK:</c> with an empty joined segment for the null <c>FullName</c>.
+    /// </summary>
+    [Fact]
+    public void SelfHostedNullableSelectResult_DoesNotThrowWhenForwardedThroughCovariantSink()
+    {
+        string printed = Translate(CovariantSource);
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue4180NullableSelectResultRegressionTests),
+            Guid.NewGuid().ToString("N") + "-covariant");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            string gsPath = Path.Combine(workDir, "Probe.gs");
+            string dllPath = Path.Combine(workDir, "Probe.dll");
+            File.WriteAllText(gsPath, printed);
+
+            (int compileExit, string compileOutput) = RunDotnet(
+                $"\"{compiler}\" /target:exe /targetframework:net10.0 /out:\"{dllPath}\" \"{gsPath}\"");
+            Assert.True(
+                compileExit == 0,
+                "gsc must compile the translated probe. Output:\n" + compileOutput
+                    + "\n\nTranslated G#:\n" + printed);
+
+            (int runExit, string output) = RunDotnet($"\"{dllPath}\"");
+            Assert.True(
+                runExit == 0,
+                "the compiled probe must run without throwing. Output:\n" + output);
+            Assert.Equal("OK:", output.Trim());
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
     private static string Translate(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
@@ -1,0 +1,216 @@
+// <copyright file="Issue4180NullableSelectResultRegressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4180 (split from #4129's clustering work, umbrella #3501): six of
+/// #4129's test-parity failures (all sharing the shared
+/// <c>AssertImplementsGenericOf</c>/<c>AssertImplementsEnumerableOf</c> helper
+/// pattern in <c>test/Compiler.Tests/Emit/Issue1489GenericAsyncIteratorEmitTests.cs</c>,
+/// <c>Issue1481MapFunctionIteratorEmitTests.cs</c> and
+/// <c>Issue813TupleSequenceReturnEmitTests.cs</c>) crashed under self-hosting
+/// with a bare <c>System.NullReferenceException</c> raised INSIDE a
+/// <c>.Select(i =&gt; i.FullName)</c> lambda (via
+/// <c>System.Linq.Enumerable.ArraySelectIterator.MoveNext()</c>, invoked from
+/// <c>String.Join</c>) — even though the same C# compiled and run natively
+/// never throws, because <see cref="Type.FullName"/> legitimately returns
+/// <see langword="null"/> (not merely falsy) for a reified generic
+/// interface row closed over an unresolved class type parameter — exactly
+/// the shape these tests construct and reflect over.
+/// <para>
+/// Root cause: this is NOT a gsc emitter defect (the emitted state machines'
+/// interface metadata is correct under both native and self-hosted gsc — see
+/// the issue's investigation). It is a cs2gs TRANSLATOR defect:
+/// <c>CSharpToGSharpTranslator.Expressions.LambdaResultFlowsToNullableSink</c>
+/// (added by issue #4046 to keep a generic selector's result unasserted when
+/// its fluent call chain "collapses back to the same scalar type" as a
+/// nullable-tolerant terminal operator, e.g. <c>.Select(...).FirstOrDefault()</c>)
+/// only recognised that shape — a Select result CHAINED into a further
+/// scalar-returning call. It did not recognise the sibling shape where the
+/// Select result flows WHOLE, as a collection, into an ordinary ARGUMENT
+/// position whose parameter itself accepts a nullable-element sequence (e.g.
+/// <c>string.Join(string?, IEnumerable&lt;string?&gt;)</c>). Its final
+/// <c>sinkType == resultType</c> equality check compares the SCALAR lambda
+/// result type against the whole COLLECTION parameter type, which can never
+/// match, so the function reports "does not flow to a nullable sink" and
+/// falls through to the general oblivious-forwarding bridge, which inserts a
+/// G# <c>!!</c> — a RUNTIME assertion, unlike C#'s erased <c>!</c> — on
+/// <c>i.FullName</c>. The fix teaches the function to also unwrap a single
+/// generic type argument from the sink and compare ELEMENT-to-element,
+/// matching when that element is already nullable-ANNOTATED (e.g. the
+/// BCL-declared <c>IEnumerable&lt;string?&gt;</c> <c>string.Join</c> accepts).
+/// </para>
+/// </summary>
+public sealed class Issue4180NullableSelectResultRegressionTests
+{
+    // The minimal reproduction of the mistranslated shape: an oblivious file
+    // (no `<Nullable>` setting — exactly test/Compiler.Tests.csproj's own
+    // condition) whose `Describe` forwards a `.Select(t => t.FullName)`
+    // result WHOLE into `string.Join`'s `IEnumerable<string?> values`
+    // parameter, never chaining into a further scalar-returning call. `Main`
+    // feeds it a genuinely null-FullName `Type` (an unbound generic type
+    // parameter, `List<>`'s own `T` — issue #4180 does not require building a
+    // full reified state machine to exhibit the same defect).
+    private const string Source = """
+        using System;
+        using System.Collections.Generic;
+        using System.Linq;
+
+        public static class Probe
+        {
+            public static string Describe(IEnumerable<Type> types)
+            {
+                return string.Join(", ", types.Select(t => t.FullName));
+            }
+
+            public static void Main()
+            {
+                Type[] typeParameters = typeof(List<>).GetGenericArguments();
+                string described = Describe(typeParameters);
+                Console.WriteLine("OK:" + described);
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Translates the reproduction snippet and asserts the emitted G# no
+    /// longer asserts the selector's nullable result — the cheap, syntactic
+    /// guard that discriminates this PR's fix (reverting the production hunk
+    /// turns this test red; see
+    /// <see cref="SelfHostedNullableSelectResult_DoesNotThrowWhenForwardedToStringJoin"/>
+    /// for the full functional proof that the fixed shape survives
+    /// self-hosted compilation and execution).
+    /// </summary>
+    [Fact]
+    public void TranslatedSnippet_NoLongerAssertsTheSelectResultForwardedToStringJoin()
+    {
+        string printed = Translate(Source);
+
+        Assert.DoesNotContain("t.FullName!!", printed, StringComparison.Ordinal);
+        Assert.Contains("types.Select((t Type) -> t.FullName)", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The functional proof that the fixed shape actually survives
+    /// self-hosting: translates the SAME reproduction snippet, compiles the
+    /// result with the REAL <c>gsc.dll</c>, and runs it. Before the fix this
+    /// throws <see cref="NullReferenceException"/> from inside the
+    /// <c>Select</c> lambda (exactly the crash reported in #4180's gate
+    /// runs); after the fix it prints <c>OK:</c> with an empty joined
+    /// segment for the null <c>FullName</c>, the same as running the
+    /// original C# natively.
+    /// </summary>
+    [Fact]
+    public void SelfHostedNullableSelectResult_DoesNotThrowWhenForwardedToStringJoin()
+    {
+        string printed = Translate(Source);
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        string workDir = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue4180NullableSelectResultRegressionTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            string gsPath = Path.Combine(workDir, "Probe.gs");
+            string dllPath = Path.Combine(workDir, "Probe.dll");
+            File.WriteAllText(gsPath, printed);
+
+            (int compileExit, string compileOutput) = RunDotnet(
+                $"\"{compiler}\" /target:exe /targetframework:net10.0 /out:\"{dllPath}\" \"{gsPath}\"");
+            Assert.True(
+                compileExit == 0,
+                "gsc must compile the translated probe. Output:\n" + compileOutput
+                    + "\n\nTranslated G#:\n" + printed);
+
+            (int runExit, string output) = RunDotnet($"\"{dllPath}\"");
+            Assert.True(
+                runExit == 0,
+                "the compiled probe must run without throwing. Output:\n" + output);
+            Assert.Equal("OK:", output.Trim());
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static string Translate(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Issue4180.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("failed to start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(directory.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -3501,11 +3501,26 @@ public sealed partial class CSharpToGSharpTranslator
             // reified open-generic interface row, #4180's reported crash), even
             // though the ORIGINAL C# `string.Join`/`.Select` pipeline tolerates
             // null elements silently.
-            return sinkType is INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } sinkCollection
-                && sinkCollection.TypeArguments[0] is { NullableAnnotation: NullableAnnotation.Annotated } sinkElement
-                && SymbolEqualityComparer.Default.Equals(
-                    resultType,
-                    sinkElement.WithNullableAnnotation(NullableAnnotation.None));
+            if (sinkType is not INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } sinkCollection
+                || sinkCollection.TypeArguments[0] is not { NullableAnnotation: NullableAnnotation.Annotated } sinkElement
+                || resultType == null)
+            {
+                return false;
+            }
+
+            // Element compatibility is an ASSIGNABILITY check, not identity: the
+            // sink accepts the selector's result through an implicit reference
+            // conversion (including IEnumerable<T> covariance), e.g.
+            // `Consume(IEnumerable<object?> values)` called with
+            // `types.Select(t => t.FullName)` -- `string` is not symbol-equal
+            // to `object`, but every `string` IS an `object`. Exact identity
+            // missed this: the selector result stayed `!!`-asserted and threw
+            // on a null `FullName` even though the sink tolerates it.
+            ITypeSymbol sinkElementType = sinkElement.WithNullableAnnotation(NullableAnnotation.None);
+            Microsoft.CodeAnalysis.CSharp.Conversion elementConversion =
+                this.context.Compilation.ClassifyConversion(resultType, sinkElementType);
+            return elementConversion.IsImplicit
+                && (elementConversion.IsReference || elementConversion.IsIdentity);
 
             static bool ReturnsGenericSelectorResult(
                 IMethodSymbol genericMethod,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -3475,9 +3475,37 @@ public sealed partial class CSharpToGSharpTranslator
 
             ITypeSymbol resultType =
                 (this.context.GetSymbolInfo(lambda).Symbol as IMethodSymbol)?.ReturnType;
-            return sinkType is { IsReferenceType: true }
-                && SymbolEqualityComparer.Default.Equals(resultType, sinkType)
-                && !this.TargetWillRemainNonNullableReference(sinkType, sink);
+            if (sinkType is not { IsReferenceType: true })
+            {
+                return false;
+            }
+
+            if (SymbolEqualityComparer.Default.Equals(resultType, sinkType))
+            {
+                // The #4046 shape: the chain collapses back to the SAME scalar
+                // type as the selector's own result (`.Select(...).FirstOrDefault()`).
+                return !this.TargetWillRemainNonNullableReference(sinkType, sink);
+            }
+
+            // Issue #4180: `current` never left the Select-shaped invocation itself
+            // (e.g. `string.Join(sep, xs.Select(i => i.FullName))` — the selector's
+            // result is passed WHOLE as a collection argument rather than chained
+            // into a further scalar-returning call), so `sinkType` is the SINK
+            // PARAMETER'S OWN type (`IEnumerable<TResult?>`), not `resultType`
+            // itself; the equality check above can never match a collection type
+            // against a scalar one. Unwrap one generic type argument and compare
+            // ELEMENT-to-element instead — an already-nullable-ANNOTATED element
+            // (e.g. `string.Join`'s BCL-declared `IEnumerable<string?>`) accepts a
+            // nullable selector result with no bridge; asserting `!!` here throws
+            // whenever the selector legitimately returns null (`Type.FullName` on a
+            // reified open-generic interface row, #4180's reported crash), even
+            // though the ORIGINAL C# `string.Join`/`.Select` pipeline tolerates
+            // null elements silently.
+            return sinkType is INamedTypeSymbol { IsGenericType: true, TypeArguments.Length: 1 } sinkCollection
+                && sinkCollection.TypeArguments[0] is { NullableAnnotation: NullableAnnotation.Annotated } sinkElement
+                && SymbolEqualityComparer.Default.Equals(
+                    resultType,
+                    sinkElement.WithNullableAnnotation(NullableAnnotation.None));
 
             static bool ReturnsGenericSelectorResult(
                 IMethodSymbol genericMethod,


### PR DESCRIPTION
## Summary

- Fixes #4180: 6 of #4129's test-parity failures — `StateMachine_BareElement_IsGeneric_ImplementsAsyncEnumerableOfVar0`, `StateMachine_MapElement_ImplementsAsyncEnumerableOfReifiedDictionary`, `StateMachine_FunctionElement_ImplementsAsyncEnumerableOfReifiedFunc` (`Issue1489GenericAsyncIteratorEmitTests.cs`), `StateMachineClass_MapElement_ImplementsIEnumerableOfReifiedDictionary`, `StateMachineClass_FunctionElement_ImplementsIEnumerableOfReifiedFunc` (`Issue1481MapFunctionIteratorEmitTests.cs`), and `StateMachineClass_TupleElement_ImplementsIEnumerableOfValueTuple` (`Issue813TupleSequenceReturnEmitTests.cs`) — crashed under self-hosting with a bare `NullReferenceException` raised inside a `.Select(i => i.FullName)` lambda (via `System.Linq.Enumerable.ArraySelectIterator.MoveNext()`, invoked from `String.Join`), even though the same C# never throws natively. `Type.FullName` is documented to return `null` (not merely falsy) for a reified generic interface row closed over an unresolved type parameter — exactly the shape these tests construct and reflect over.

## Root cause

**Not a gsc emitter defect.** I built a self-hosted `gsc.dll` (translated `src/Core` + `src/Compiler` + deps with cs2gs, compiled the result with native gsc) and loaded the same reified state-machine snippets' compiled assemblies under both native and self-hosted gsc, walking `GetInterfaces()` and calling `.FullName` on each interface individually. Neither ever threw — the emitted interface metadata is byte-identical and correct in both cases.

It is a **cs2gs translator defect**: `CSharpToGSharpTranslator.Expressions.LambdaResultFlowsToNullableSink` (added by #4046 to keep a generic selector's result unasserted when its fluent call chain "collapses back to the same scalar type" as a nullable-tolerant terminal operator, e.g. `.Select(...).FirstOrDefault()`) only recognised that one shape. It never handled the sibling shape where the `Select` result flows **whole, as a collection**, into an ordinary argument position whose parameter itself accepts a nullable-element sequence — exactly `string.Join(string? separator, IEnumerable<string?> values)`. Its final `sinkType == resultType` equality check compared the *scalar* lambda result type against the *whole collection* parameter type, which can never match, so the function reported "does not flow to a nullable sink" and fell through to the general oblivious-forwarding bridge, which inserts a G# `!!` — a **runtime** assertion, unlike C#'s erased `!` — on `i.FullName`. Since `Type.FullName` legitimately returns `null` for these interfaces, the assertion throws.

Confirmed with a minimal, self-contained repro (no full self-hosted build needed to reproduce, once the mechanism was understood):
```csharp
string Describe(IEnumerable<Type> types) => string.Join(", ", types.Select(t => t.FullName));
```
translated (in an oblivious file, matching `test/Compiler.Tests.csproj`'s own `<Nullable>`-unset condition) to:
```
func Describe(types IEnumerable[Type]) string {
    return string.Join(", ", types.Select((t Type) -> t.FullName!!))
}
```
Compiling and running this with the real `gsc.dll` against `typeof(List<>).GetGenericArguments()[0]` (a genuinely null-`FullName` `Type`) reproduces the exact reported stack trace:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Default.Probe.<lambda_host_<lambda1>_1>.Invoke(Type t)
   at System.Linq.Enumerable.ArraySelectIterator`2.MoveNext()
   at System.String.Join(String separator, IEnumerable`1 values)
```

## Fix

Teach `LambdaResultFlowsToNullableSink` to also unwrap a single generic type argument from the sink parameter and compare element-to-element, matching when that element is already nullable-**annotated** (e.g. `string.Join`'s BCL-declared `IEnumerable<string?>`). This is scoped narrowly — it only skips the `!!` bridge when the sink itself proves, via its own BCL nullable annotation, that it tolerates a null element; it does not touch the general oblivious-forwarding bridge that this same mechanism (correctly) uses everywhere else.

## Scope note

The issue's 7th listed test, `CSharpImportedStructWithCustomEquality_NullableComparison_RunsAndVerifies` (`Issue2388NullableCustomEqualityEmitTests.cs`), does not share this call site or pattern at all — no `.Select`/`.FullName`/`string.Join` involved. It appears to have been grouped into "Cluster B" by stack-trace-shape heuristic rather than by an actual shared root cause; it is left untouched here as out of scope and will need its own investigation.

## Test plan

- [x] `dotnet build tools/cs2gs/Cs2Gs.Translator/Cs2Gs.Translator.csproj -c Release`
- [x] `dotnet test tools/cs2gs/Cs2Gs.Tests --filter "FullyQualifiedName~Issue4180"` — both new tests pass
- [x] Anti-vacuity: reverted the production hunk — both new tests fail, the functional one reproducing the exact reported `NullReferenceException` + stack trace; restored the fix — both pass again
- [x] `dotnet test tools/cs2gs/Cs2Gs.Tests -c Release` (full suite, 2907 tests) — all pass, no regressions
- [x] Re-translated the real `Issue1489GenericAsyncIteratorEmitTests.cs`, `Issue1481MapFunctionIteratorEmitTests.cs`, `Issue813TupleSequenceReturnEmitTests.cs` against the fixed translator — `!!` no longer appears on any `i.FullName` selector; diffed against the pre-fix translation to confirm it's the *only* change
- [x] `dotnet test test/Compiler.Tests --filter "FullyQualifiedName~Issue1489GenericAsyncIteratorEmitTests|FullyQualifiedName~Issue1481MapFunctionIteratorEmitTests|FullyQualifiedName~Issue813TupleSequenceReturnEmitTests"` (native) — all 25 pass, as expected (self-hosting-only bug; native was never affected)
- [x] Built a self-hosted `gsc.dll` (translate + compile `src/Core`, `src/Compiler`, `src/Sdk/Gsharp.Runtime.Channels`, `src/Analyzers/*` via `cs2gs migrate`) and confirmed the emitted state-machine interface metadata is correct under both native and self-hosted compilation for all 6 failing shapes — the crash is purely in the translated *test* code, never in gsc's emission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ptr4sovcAwpgaUEM4rEin
