### PR TITLE
cs2gs: stop forcing !! on an unobserved Task.Run lambda result (#4179)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
@@ -1,0 +1,439 @@
+// <copyright file="Issue4179UnobservedTaskRunResultRegressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4179 (split from #4129, umbrella #3501): 48 of #4129's test-parity
+/// failures for the migrated <c>test/Compiler.Tests</c> app all funneled
+/// through the SAME line, <c>Issue2891TryRegionFlowEmitTests.cs</c> /
+/// <c>Issue2906ExhaustiveSwitchReturnEmitTests.cs</c>'s shared
+/// <c>CompileVerifyLoadAndRun</c> helper:
+/// <code>
+/// var execution = Task.Run(
+///     () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty&lt;string&gt;() }));
+/// Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), $"{name} execution timed out");
+/// </code>
+/// <para>
+/// <c>test/Compiler.Tests.csproj</c> has no <c>&lt;Nullable&gt;</c> element, so
+/// it compiles nullable-OBLIVIOUS (<see cref="NullableContextOptions.Disable"/>)
+/// — the only mode <c>IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult</c>
+/// (issue #3644/#4046) operates in. That heuristic assumed EVERY runtime lambda
+/// handed to a generic call (<c>Task.Run&lt;TResult&gt;</c> included) sits under
+/// a non-null delegate-return CONTRACT the surrounding oblivious C# implicitly
+/// trusted, so it force-asserted the reflection-nullable
+/// <c>MethodInfo.Invoke(...)</c> result with <c>!!</c> — a G# RUNTIME null
+/// check (<c>MethodBodyEmitter.EmitUnary</c>: "`!!` is a runtime
+/// null-assertion"), unlike C#'s purely compile-time postfix <c>!</c>. Since
+/// <c>MethodInfo.Invoke</c> legitimately returns <see langword="null"/> for
+/// every void-returning method — which <c>&lt;Main&gt;$</c> always is — and
+/// nothing downstream ever reads <c>execution</c>'s wrapped value (only
+/// <c>.Wait(...)</c>, which never touches it), the assertion threw a
+/// <see cref="NullReferenceException"/> the instant the snippet's own emitted
+/// entry point ran, wrapped by <c>Task.Run</c>'s <see cref="AggregateException"/>
+/// — exactly the symptom the issue reports, on EVERY row of the two affected
+/// theories (the shape is shared by all of them; it has nothing to do with any
+/// individual snippet's switch/try/goto shape).
+/// </para>
+/// <para>
+/// Fix: <c>Task.Run</c>/<c>Task.Factory.StartNew</c>'s <c>TResult</c> is chosen
+/// SOLELY to carry the delegate's completion value back to whoever later reads
+/// <c>.Result</c> or awaits it — unlike a LINQ selector (<c>Select</c>,
+/// <c>Where</c>, ...), whose downstream enumeration DOES observe every
+/// projected element (the #3644 <c>PrepareTemporaryBuildProps</c> shape, which
+/// must keep asserting and does — see the negative-guard tests below). When
+/// nothing in scope ever unwraps the <c>Task&lt;TResult&gt;</c>,
+/// <c>LambdaResultFeedsUnobservedTaskRun</c> now recognizes the idiom and
+/// leaves the lambda result bare, matching the original C#'s own inferred
+/// <c>Task&lt;object?&gt;</c>.
+/// </para>
+/// </summary>
+public sealed class Issue4179UnobservedTaskRunResultRegressionTests
+{
+    /// <summary>
+    /// The exact shared-helper shape (issue #4179): a reflection
+    /// <c>MethodInfo.Invoke(...)</c> call — nullable per its BCL-annotated
+    /// signature — as the sole body of a lambda passed to <c>Task.Run</c>,
+    /// observed afterward only through <c>.Wait(...)</c>. Must NOT assert.
+    /// </summary>
+    [Fact]
+    public void TaskRun_ReflectionInvokeObservedOnlyThroughWait_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run(MethodInfo entry)
+        {
+            var execution = Task.Run(() => entry.Invoke(null, null));
+            bool completed = execution.Wait(TimeSpan.FromSeconds(10));
+            Console.WriteLine(completed);
+        }
+    }
+}");
+
+        Assert.Contains("entry.Invoke(nil, nil)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("entry.Invoke(nil, nil)!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The general shape underlying #4179, without reflection: ANY
+    /// nullable-returning call as an unobserved <c>Task.Run</c> lambda result
+    /// must stay bare, not just <c>MethodInfo.Invoke</c>.
+    /// </summary>
+    [Fact]
+    public void TaskRun_LocalNullableMethodObservedOnlyThroughWait_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run()
+        {
+            var execution = Task.Run(() => GetNullableObject());
+            execution.Wait(TimeSpan.FromSeconds(10));
+        }
+
+        private static object GetNullableObject() => null;
+    }
+}");
+
+        Assert.Contains("GetNullableObject()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetNullableObject()!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Precision guard: when the <c>Task.Run</c> result IS later unwrapped via
+    /// <c>.Result</c>, the assertion must still fire — #4179's fix is scoped to
+    /// values that are genuinely never observed, not to <c>Task.Run</c> as a
+    /// blanket exemption.
+    /// </summary>
+    [Fact]
+    public void TaskRun_ResultReadFromLocal_StillAssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run()
+        {
+            var execution = Task.Run(() => GetNullableObject());
+            object value = execution.Result;
+            Console.WriteLine(value);
+        }
+
+        private static object GetNullableObject() => null;
+    }
+}");
+
+        Assert.Contains("GetNullableObject()!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Precision guard: a fluent <c>.Result</c> directly off <c>Task.Run(...)</c>
+    /// (no intermediate local) must still assert.
+    /// </summary>
+    [Fact]
+    public void TaskRun_FluentResult_StillAssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run()
+        {
+            object value = Task.Run(() => GetNullableObject()).Result;
+            Console.WriteLine(value);
+        }
+
+        private static object GetNullableObject() => null;
+    }
+}");
+
+        Assert.Contains("GetNullableObject()!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Precision guard: an awaited <c>Task.Run(...)</c> must still assert —
+    /// <c>await</c> unwraps the value just as surely as <c>.Result</c> does.
+    /// </summary>
+    [Fact]
+    public void TaskRun_Awaited_StillAssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static async Task RunAsync()
+        {
+            object value = await Task.Run(() => GetNullableObject());
+            Console.WriteLine(value);
+        }
+
+        private static object GetNullableObject() => null;
+    }
+}");
+
+        Assert.Contains("GetNullableObject()!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Regression guard: #3644's own motivating shape — a LINQ selector
+    /// (generic, inferred <c>TResult</c>, exactly like <c>Task.Run</c>) whose
+    /// projected elements ARE observed by the downstream enumeration — must be
+    /// completely unaffected by #4179's fix. <c>LambdaResultFeedsUnobservedTaskRun</c>
+    /// is scoped to <c>Task.Run</c>/<c>Task.Factory.StartNew</c> specifically and
+    /// never even inspects a <c>Select</c> call.
+    /// </summary>
+    [Fact]
+    public void Select_FlatAnnotatedBclValue_StillAssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Demo
+{
+    public static class Props
+    {
+        public static void Prepare(IEnumerable<string> generatedProjectPaths)
+        {
+            foreach (string projectDirectory in generatedProjectPaths
+                .Select(path => Path.GetDirectoryName(Path.GetFullPath(path)))
+                .Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                Consume(projectDirectory);
+            }
+        }
+
+        private static void Consume(string directory)
+        {
+            Console.WriteLine(directory);
+        }
+    }
+}");
+
+        Assert.Contains("Path.GetDirectoryName(Path.GetFullPath(path))!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The functional proof that the FIXED shape actually runs cleanly under
+    /// the real <c>gsc.dll</c> emitter, and — for anti-vacuity — that the OLD
+    /// (buggy) shape genuinely throws the reported symptom rather than merely
+    /// "looking different" in printed text. Both programs are hand-written G#
+    /// (not re-derived from the translator) mirroring exactly what
+    /// <see cref="TaskRun_ReflectionInvokeObservedOnlyThroughWait_StaysBare"/>
+    /// proves the translator now emits (bare) versus emitted before this fix
+    /// (<c>!!</c>): a reflection <c>Invoke</c> of a VOID method (so the result
+    /// is genuinely null) wrapped in <c>Task.Run</c> and observed only through
+    /// <c>.Wait(...)</c> — precisely <c>CompileVerifyLoadAndRun</c>'s shape.
+    /// </summary>
+    [Fact]
+    public void SelfHostedShape_BareVersionRunsCleanly_BangBangVersionThrowsNre()
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        (int bareExit, string bareOutput) = CompileAndRun(compiler, BareSource);
+        Assert.True(bareExit == 0, "the bare (fixed) shape must run cleanly. Output:\n" + bareOutput);
+        Assert.Contains("done", bareOutput, StringComparison.Ordinal);
+
+        (int buggyExit, string buggyOutput) = CompileAndRun(compiler, BangBangSource);
+        Assert.True(
+            buggyExit != 0 && buggyOutput.Contains("NullReferenceException", StringComparison.Ordinal),
+            "the reverted (!!-asserted) shape must reproduce the reported NullReferenceException. Output:\n"
+                + buggyOutput);
+    }
+
+    private const string BareSource = """
+        package Issue4179.Bare
+
+        import System
+        import System.Reflection
+        import System.Threading.Tasks
+
+        class Runner {
+            shared {
+                func VoidMethod() {
+                }
+
+                func Main() {
+                    let entry = Runner().GetType().GetMethod(
+                        "VoidMethod",
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+                    )!!
+                    let execution = Task.Run(() -> entry.Invoke(nil, nil))
+                    let completed = execution.Wait(TimeSpan.FromSeconds(10))
+                    Console.WriteLine(if completed { "done" } else { "timed-out" })
+                }
+            }
+        }
+        """;
+
+    private const string BangBangSource = """
+        package Issue4179.BangBang
+
+        import System
+        import System.Reflection
+        import System.Threading.Tasks
+
+        class Runner {
+            shared {
+                func VoidMethod() {
+                }
+
+                func Main() {
+                    let entry = Runner().GetType().GetMethod(
+                        "VoidMethod",
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+                    )!!
+                    let execution = Task.Run(() -> entry.Invoke(nil, nil)!!)
+                    let completed = execution.Wait(TimeSpan.FromSeconds(10))
+                    Console.WriteLine(if completed { "done" } else { "timed-out" })
+                }
+            }
+        }
+        """;
+
+    private static (int Exit, string Output) CompileAndRun(string compiler, string source)
+    {
+        string workDir = Path.Combine(
+            AppContext.BaseDirectory,
+            nameof(Issue4179UnobservedTaskRunResultRegressionTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            string gsPath = Path.Combine(workDir, "Program.gs");
+            string dllPath = Path.Combine(workDir, "Program.dll");
+            File.WriteAllText(gsPath, source);
+
+            (int compileExit, string compileOutput) = RunDotnet(
+                $"\"{compiler}\" /target:exe /targetframework:net10.0 /out:\"{dllPath}\" \"{gsPath}\"");
+            Assert.True(compileExit == 0, "gsc must compile the self-hosted-shape probe. Output:\n" + compileOutput);
+
+            return RunDotnet($"\"{dllPath}\"");
+        }
+        finally
+        {
+            TryDelete(workDir);
+        }
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+
+    private static (int Exit, string Output) RunDotnet(string arguments)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("failed to start dotnet");
+        var output = new StringBuilder();
+        output.Append(process.StandardOutput.ReadToEnd());
+        output.Append(process.StandardError.ReadToEnd());
+        process.WaitForExit();
+        return (process.ExitCode, output.ToString());
+    }
+
+    private static string FindCompiler()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            foreach (string config in new[] { "Release", "Debug" })
+            {
+                string candidate = Path.Combine(directory.FullName, "out", "bin", config, "Compiler", "gsc.dll");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static void TryDelete(string directory)
+    {
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
@@ -127,6 +127,41 @@ namespace Demo
     }
 
     /// <summary>
+    /// The <c>Task.Factory.StartNew</c> sibling of
+    /// <see cref="TaskRun_LocalNullableMethodObservedOnlyThroughWait_StaysBare"/>.
+    /// <c>Task.Factory.StartNew</c> is a meaningfully different call shape than
+    /// <c>Task.Run</c> — a different containing type (<c>TaskFactory</c>, reached
+    /// through the <c>Task.Factory</c> static property rather than a direct
+    /// static method call) resolving to a distinct, heavily-overloaded method
+    /// group — so this exercises <c>IsTaskRunEntryPoint</c>'s <c>"TaskFactory"</c>
+    /// branch, which no prior test in this file touched.
+    /// </summary>
+    [Fact]
+    public void TaskFactoryStartNew_LocalNullableMethodObservedOnlyThroughWait_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run()
+        {
+            var execution = Task.Factory.StartNew(() => GetNullableObject());
+            execution.Wait(TimeSpan.FromSeconds(10));
+        }
+
+        private static object GetNullableObject() => null;
+    }
+}");
+
+        Assert.Contains("GetNullableObject()", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetNullableObject()!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Precision guard: when the <c>Task.Run</c> result IS later unwrapped via
     /// <c>.Result</c>, the assertion must still fire — #4179's fix is scoped to
     /// values that are genuinely never observed, not to <c>Task.Run</c> as a
@@ -146,6 +181,38 @@ namespace Demo
         public static void Run()
         {
             var execution = Task.Run(() => GetNullableObject());
+            object value = execution.Result;
+            Console.WriteLine(value);
+        }
+
+        private static object GetNullableObject() => null;
+    }
+}");
+
+        Assert.Contains("GetNullableObject()!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The <c>Task.Factory.StartNew</c> sibling of
+    /// <see cref="TaskRun_ResultReadFromLocal_StillAssertsNonNull"/>: proves the
+    /// exemption is properly scoped for this call shape too, not just
+    /// permissive — when the <c>StartNew</c> result IS unwrapped via
+    /// <c>.Result</c>, the assertion must still fire.
+    /// </summary>
+    [Fact]
+    public void TaskFactoryStartNew_ResultReadFromLocal_StillAssertsNonNull()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run()
+        {
+            var execution = Task.Factory.StartNew(() => GetNullableObject());
             object value = execution.Result;
             Console.WriteLine(value);
         }
@@ -282,6 +349,79 @@ namespace Demo
             "the reverted (!!-asserted) shape must reproduce the reported NullReferenceException. Output:\n"
                 + buggyOutput);
     }
+
+    /// <summary>
+    /// The <c>Task.Factory.StartNew</c> sibling of
+    /// <see cref="SelfHostedShape_BareVersionRunsCleanly_BangBangVersionThrowsNre"/>,
+    /// proving <c>IsTaskRunEntryPoint</c>'s <c>"TaskFactory"</c> branch holds up
+    /// under the real emitter/runtime, not just in printed-text assertions.
+    /// </summary>
+    [Fact]
+    public void SelfHostedShape_StartNew_BareVersionRunsCleanly_BangBangVersionThrowsNre()
+    {
+        string compiler = FindCompiler();
+        Assert.True(compiler != null, "gsc.dll must be built (dotnet build GSharp.sln) before running this test.");
+
+        (int bareExit, string bareOutput) = CompileAndRun(compiler, StartNewBareSource);
+        Assert.True(bareExit == 0, "the bare (fixed) shape must run cleanly. Output:\n" + bareOutput);
+        Assert.Contains("done", bareOutput, StringComparison.Ordinal);
+
+        (int buggyExit, string buggyOutput) = CompileAndRun(compiler, StartNewBangBangSource);
+        Assert.True(
+            buggyExit != 0 && buggyOutput.Contains("NullReferenceException", StringComparison.Ordinal),
+            "the reverted (!!-asserted) shape must reproduce the reported NullReferenceException. Output:\n"
+                + buggyOutput);
+    }
+
+    private const string StartNewBareSource = """
+        package Issue4179.StartNewBare
+
+        import System
+        import System.Reflection
+        import System.Threading.Tasks
+
+        class Runner {
+            shared {
+                func VoidMethod() {
+                }
+
+                func Main() {
+                    let entry = Runner().GetType().GetMethod(
+                        "VoidMethod",
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+                    )!!
+                    let execution = Task.Factory.StartNew(() -> entry.Invoke(nil, nil))
+                    let completed = execution.Wait(TimeSpan.FromSeconds(10))
+                    Console.WriteLine(if completed { "done" } else { "timed-out" })
+                }
+            }
+        }
+        """;
+
+    private const string StartNewBangBangSource = """
+        package Issue4179.StartNewBangBang
+
+        import System
+        import System.Reflection
+        import System.Threading.Tasks
+
+        class Runner {
+            shared {
+                func VoidMethod() {
+                }
+
+                func Main() {
+                    let entry = Runner().GetType().GetMethod(
+                        "VoidMethod",
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+                    )!!
+                    let execution = Task.Factory.StartNew(() -> entry.Invoke(nil, nil)!!)
+                    let completed = execution.Wait(TimeSpan.FromSeconds(10))
+                    Console.WriteLine(if completed { "done" } else { "timed-out" })
+                }
+            }
+        }
+        """;
 
     private const string BareSource = """
         package Issue4179.Bare

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -3397,6 +3397,7 @@ public sealed partial class CSharpToGSharpTranslator
                 || this.LambdaResultFeedsNullableObservedInvocation(use)
                 || this.FindResultLambda(use) is not { } lambda
                 || this.LambdaResultFlowsToNullableSink(lambda)
+                || this.LambdaResultFeedsUnobservedTaskRun(use)
                 || this.GetLambdaTargetDelegateType(lambda) is not { DelegateInvokeMethod: { } invoke }
                 || invoke.ReturnType is not { IsReferenceType: true }
                 || invoke.ReturnType.NullableAnnotation == NullableAnnotation.Annotated)
@@ -3415,6 +3416,97 @@ public sealed partial class CSharpToGSharpTranslator
             return this.IsNullablePromotedValue(use)
                 || this.IsImportedObliviousNullableMember(this.context.GetSymbolInfo(use).Symbol);
         }
+
+        // Issue #4179: `Task.Run<TResult>(Func<TResult> function)` (and its
+        // `Task.Factory.StartNew` sibling) infers TResult purely to carry the
+        // delegate's completion value back to whoever later reads `.Result` /
+        // awaits it. When nothing in scope ever does — the "run this on the
+        // thread pool, synchronize only via Wait()" idiom the self-hosting
+        // emit-test harnesses use to drive a freshly compiled assembly's entry
+        // point through `MethodInfo.Invoke` — TResult's nullability was never
+        // load-bearing for the original C#, which happily produced e.g.
+        // `Task<object?>` with nobody the wiser: a void-returning `Invoke`
+        // legitimately returns null every time. Forcing `!!` at the lambda's
+        // own result seam here throws the instant the delegate returns null, a
+        // risk the un-migrated program never took. This is narrower than (and
+        // does not touch) #3644/#4046's LINQ-selector reasoning: a `Select`/
+        // `Where` result IS observed by its downstream enumeration, so that
+        // family keeps asserting — only the two BCL entry points whose entire
+        // contract is "run this", not "project this", are exempted here.
+        private bool LambdaResultFeedsUnobservedTaskRun(ExpressionSyntax use)
+        {
+            if (this.FindResultLambda(use) is not { } lambda)
+            {
+                return false;
+            }
+
+            SyntaxNode node = lambda;
+            while (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+            {
+                node = node.Parent;
+            }
+
+            return node.Parent is ArgumentSyntax argument
+                && argument.Parent?.Parent is InvocationExpressionSyntax invocation
+                && this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol method
+                && IsTaskRunEntryPoint(method)
+                && !this.TaskInvocationResultIsEverUnwrapped(invocation);
+        }
+
+        private static bool IsTaskRunEntryPoint(IMethodSymbol method)
+        {
+            IMethodSymbol original = method.OriginalDefinition;
+            return original.Name is "Run" or "StartNew"
+                && original.ContainingType is { Name: "Task" or "TaskFactory" } containingType
+                && containingType.ContainingNamespace?.ToDisplayString() == "System.Threading.Tasks";
+        }
+
+        // True when the `Task<TResult>`/`ValueTask<TResult>` produced by
+        // <paramref name="invocation"/> is ever unwrapped — a direct fluent
+        // `.Result`/`.GetAwaiter()` off the call, an `await` of it, or (once
+        // bound to a local via <see cref="ResolveValueSink"/>) the same off
+        // that local anywhere in its declaring block. A sink this translator
+        // cannot trace (fire-and-forget as a bare statement, forwarded as an
+        // argument, etc.) is treated conservatively as unwrapped, so the
+        // exemption only ever fires for the narrow, syntactically provable
+        // "declared, then only Wait()/observed for completion" shape.
+        private bool TaskInvocationResultIsEverUnwrapped(InvocationExpressionSyntax invocation)
+        {
+            SyntaxNode value = invocation;
+            while (value.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+            {
+                value = value.Parent;
+            }
+
+            if (value.Parent is AwaitExpressionSyntax
+                || (value.Parent is MemberAccessExpressionSyntax fluentAccess
+                    && fluentAccess.Expression == value
+                    && IsTaskResultUnwrapMember(fluentAccess.Name.Identifier.Text)))
+            {
+                return true;
+            }
+
+            if (this.ResolveValueSink(invocation) is not ILocalSymbol local)
+            {
+                return true;
+            }
+
+            SyntaxNode scope = this.GetNullabilityScope(local);
+            if (scope == null)
+            {
+                return true;
+            }
+
+            return scope.DescendantNodes()
+                    .OfType<MemberAccessExpressionSyntax>()
+                    .Any(member => this.BindsTo(member.Expression, local)
+                        && IsTaskResultUnwrapMember(member.Name.Identifier.Text))
+                || scope.DescendantNodes()
+                    .OfType<AwaitExpressionSyntax>()
+                    .Any(awaitExpression => this.BindsTo(awaitExpression.Expression, local));
+        }
+
+        private static bool IsTaskResultUnwrapMember(string name) => name is "Result" or "GetAwaiter";
 
         private bool LambdaResultFlowsToNullableSink(AnonymousFunctionExpressionSyntax lambda)
         {


### PR DESCRIPTION
## Summary

- Root cause of #4179 (split from #4129, umbrella #3501): 48 of #4129's ~79-88 test-parity failures for the migrated `test/Compiler.Tests` app all funneled through the SAME line — `Issue2891TryRegionFlowEmitTests.cs` / `Issue2906ExhaustiveSwitchReturnEmitTests.cs`'s shared `CompileVerifyLoadAndRun` helper:
  ```csharp
  var execution = Task.Run(
      () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() }));
  Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), $"{name} execution timed out");
  ```
- `test/Compiler.Tests.csproj` has no `<Nullable>` element, so it compiles nullable-**oblivious**. `IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult` (#3644/#4046) — the only heuristic that fires in that mode — assumed every runtime lambda handed to a generic call (`Task.Run<TResult>` included) sits under a non-null delegate-return **contract** the surrounding oblivious C# implicitly trusted, so it force-asserted the reflection-nullable `MethodInfo.Invoke(...)` result with `!!`. `!!` is a G# **runtime** null check (`MethodBodyEmitter.EmitUnary`: *"`!!` is a runtime null-assertion"*) — unlike C#'s purely compile-time postfix `!`, which the original source didn't even use here.
- `MethodInfo.Invoke` legitimately returns `null` for every void-returning method — which the emitted snippet's `<Main>$` always is — and nothing downstream ever reads `execution`'s wrapped value (only `.Wait(...)`, which never touches it). The force-asserted `!!` threw a `NullReferenceException` the instant the snippet's own freshly emitted entry point ran, wrapped by `Task.Run`'s `AggregateException` — exactly #4179's reported symptom, on every row of both theories, because the shape is shared by the helper itself, not by any individual snippet's switch/try/goto body (that's why the bug hit 100% of those rows regardless of shape — a hypothesis this PR's repro directly disproves the "gsc emitter miscompiles switch/try/goto" alternative for).

## Root cause and evidence (repro path)

- Built a self-hosted `gsc.dll`/`GSharp.Core.dll` (translated `src/Core` + `src/Compiler` with `cs2gs`, compiled by a native `gsc`) and ran every `FiniteCases`/`Cases`/`FallthroughCases` body from both affected test files through it directly (compile via the self-hosted `Compilation` API, load into a collectible `AssemblyLoadContext`, invoke `<Main>$` via reflection wrapped in `Task.Run` — i.e. exactly `CompileVerifyLoadAndRun`'s own mechanism) — **every snippet ran correctly**. This rules out a self-hosted gsc emitter defect for the switch/try/goto shapes named in the issue.
- Translated the *actual* `test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs` (and the 2906 sibling) with the production `cs2gs` translator (what self-migration does) and found `entry.Invoke(...)` — the reflection call, not any snippet body — carrying an erroneous `!!`:
  ```
  let execution = Task.Run(
      () -> entry.Invoke(
          nil,
          if entry.GetParameters().Length == 0 { default([]?object) } else { []object{Array.Empty[string]()} }
      )!!
  )
  ```
  Since `<Main>$` is void, `entry.Invoke(...)` always returns `null`, so this `!!` throws every time — reproducing #4179's `AggregateException`-wrapped `NullReferenceException` exactly.
- Traced the insertion to `IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult` in `CSharpToGSharpTranslator.Expressions.cs`, confirmed with a minimal standalone corpus repro (`cs2gs migrate --diagnostic-run`) isolating the shape down to: any nullable-returning call (reflection or a plain same-project method) as the sole body of a lambda passed to `Task.Run`, in an oblivious project.

## Which side: cs2gs translator, not gsc's emitter

This is a **cs2gs translator** defect (in `tools/cs2gs/Cs2Gs.Translator/`), not a gsc emitter defect (`src/Core/CodeAnalysis/Emit/`): gsc's `!!` emission is textbook-correct (it *is* a runtime null check, by design) for whatever G# it's handed — the translator handed it the wrong G# for this C# input. This is the same class as #3644/#4046 (a translator correctness bug for a given C# input shape), **not** the same class as #4157/#4167 (a bug that only manifests because the translator's own source was itself fed through self-hosting). Confirmed the switch/try/goto snippets named in the issue are innocent bystanders — the failure is 100% attributable to the shared harness line, independent of gsc's build provenance.

## Fix

`Task.Run<TResult>`/`Task.Factory.StartNew<TResult>`'s `TResult` is chosen solely to carry the delegate's completion value back to whoever later reads `.Result` or awaits it — unlike a LINQ selector (`Select`, `Where`, ...), whose downstream enumeration DOES observe every projected element (the #3644 `PrepareTemporaryBuildProps` shape, which must keep asserting, and still does). `LambdaResultFeedsUnobservedTaskRun` recognizes the "run this, synchronize only via `Wait()`" idiom — scoped narrowly to `Task.Run`/`Task.Factory.StartNew`, and only when the result is never unwrapped anywhere in scope (`.Result`, `.GetAwaiter()`, or `await`, fluent or via a local) — and leaves the lambda result bare, matching the original C#'s own inferred `Task<object?>`.

## Test plan

- [x] New `tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs`:
  - Two positive tests (reflection `MethodInfo.Invoke`, and a plain same-project nullable-returning method) proving the unobserved-`Task.Run` shape now stays bare.
  - Three negative/precision guards proving `Task.Run(...).Result`, a later `.Result` read off the local, and `await Task.Run(...)` all **still** assert — the fix is scoped to genuinely-unobserved values only.
  - A regression guard replaying #3644's own `Select(path => Path.GetDirectoryName(...))` motivating shape verbatim, confirming it is completely untouched (still asserts).
  - A functional proof: hand-written G# mirroring the fixed (bare) vs. reverted (`!!`) shape, compiled and run by the **real** `gsc.dll` — the bare version runs cleanly, the `!!` version reproduces the exact `NullReferenceException`.
- [x] Anti-vacuity: reverted the production hunk — the two positive tests fail with the exact bug reproduced (`Assert.DoesNotContain` finds `entry.Invoke(nil, nil)!!` / `GetNullableObject()!!`); the five shape-guard/negative/functional tests are unaffected, as expected (the functional test uses a hand-kept mirror, not a translation, matching the #4167 precedent). Restored: all 7 green again.
- [x] `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Debug` (full suite): **2918 passed, 0 failed** — no regressions anywhere, including every #3644/#4046/#2113/#2164/#2202/#4045/#4167 nullable-bridging family.
- [x] Re-translated the actual `test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs` and `Issue2906ExhaustiveSwitchReturnEmitTests.cs` with the fixed translator (via `cs2gs migrate --translate-only`, scoped to `src/Core` + `src/Compiler` + `test/Compiler.Tests` and their direct dependencies): `entry.Invoke(...)` no longer carries `!!` in either file — confirmed directly against the real affected source, not just a synthetic repro.
- [x] Built a self-hosted `gsc.dll` (translate + native-gsc-compile of `src/Core`/`src/Compiler`) and ran all 46 real switch/try/goto snippet bodies from both affected test files through it directly (compile, load into a collectible ALC, reflection-`Invoke` via `Task.Run`, exactly mirroring the test harness) — all passed, confirming the self-hosted **emitter** was never at fault. (The remaining 3 of 49 extracted cases fail only because my minimal native harness didn't wire up the `Gsharp.Runtime.Channels` reference the `scope`/`select` constructs need — a harness gap, not a gsc or translator defect; not pursued further since it doesn't bear on the failure cluster's actual root cause.)

Note on verification honesty: the *translation* fix is proven against the real affected files and the real self-hosted-pipeline mechanism (translate-only over the real corpus), and independently against a full native `Cs2Gs.Tests` run. I did **not** run the full sharded self-migration gate end-to-end (building self-hosted `test/Compiler.Tests` itself and executing its xunit suite) — that was judged out of scope for local verification given the machine-time cost, consistent with #4157's precedent. The mechanism-level fix plus the two independent repro angles (translated-text diff on the real file, and a real-`gsc`-compiled-and-run functional proof of the exact before/after runtime behavior) is the deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ptr4sovcAwpgaUEM4rEin