### PR TITLE
cs2gs: fix for-loop parser desync and !!-bridge marker matching (#4190)

### DIFF
--- a/docs/cs2gs-analyzer-translation.md
+++ b/docs/cs2gs-analyzer-translation.md
@@ -309,6 +309,20 @@ with the ordinal measured in the equally re-spelled source so a repeated marker
 still lands on the right occurrence. A marker that still cannot be placed stays
 loud.
 
+**A tolerated `!!` bridge (issue #4190).** cs2gs's oblivious-mode nullable
+bridge inserts a runtime `!!` assertion on a reassigned receiver whose
+narrowing it cannot prove flow-sensitively — `current = current.BaseClass`
+prints as `current = current!!.BaseClass` — which is not a translation defect
+(a `do`/`while` loop's post-test guard narrows nothing G#'s own binder
+recognizes either, so the assertion is sometimes *required* for the
+translated code to bind, not merely conservative) but is exactly the kind of
+re-spelling neither plain ordinal placement nor the #3797 lexical rename can
+anticipate: the decision depends on flow analysis of the whole surrounding
+method, invisible from inside the marked region alone. Placement retries a
+third way — the marked text is matched with an *optional* `!!` tolerated
+after every identifier, every other character still an exact literal match —
+before a marker is finally dropped as unplaceable.
+
 ## Project and consumer transform
 
 `Cs2Gs.Pipeline/GSharpProjectTransformer.cs` gains an analyzer branch

--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -1276,14 +1276,25 @@ public partial class Parser
             // and desyncing the parser on whatever follows. A NON-empty struct
             // literal post (`result = Pt{X: i} { … }`) stays unaffected —
             // StructLiteralAllowedInSuppressedHeader still admits it.
+            //
+            // A for-clause post sits in the same "collection vs body" position
+            // as a for-range collection, not an if/while condition: an EMPTY
+            // struct literal immediately followed by a genuine body `{` should
+            // still be recognized as a struct literal (`result = Pt{} { }`), so
+            // allowEmptyStructLiteralInHeader is set here too (mirrors
+            // ParseExpressionInBodyHeader's save/set/restore for for-range
+            // callers, which pass allowEmptyStructLiteralCollection: true).
             suppressTrailingObjectInitializer++;
             suppressStructLiteral++;
+            var savedAllowEmptyStructLiteral = allowEmptyStructLiteralInHeader;
+            allowEmptyStructLiteralInHeader = true;
             try
             {
                 post = ParseSimpleStatement();
             }
             finally
             {
+                allowEmptyStructLiteralInHeader = savedAllowEmptyStructLiteral;
                 suppressTrailingObjectInitializer--;
                 suppressStructLiteral--;
             }

--- a/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
+++ b/src/Core/CodeAnalysis/Syntax/Parser.Statements.cs
@@ -1266,7 +1266,18 @@ public partial class Parser
             // `{`. Suppress trailing object-initializer wrapping so an indexer-
             // or call-tailed post (`s += arr[s] { … }`) does not consume the
             // loop body's opening brace as a composite literal.
+            //
+            // Issue #4177: also suppress the BARE struct-literal form (mirrors
+            // ParseExpressionInBodyHeader's #1575 fix for if/while/for-range
+            // headers). Without this, an assignment-expression post whose RHS
+            // ends in a plain member name immediately followed by an EMPTY loop
+            // body (`c = c.Next { }`) misparses `Next { }` as an empty struct
+            // literal applied to `Next`, swallowing the loop's own body brace
+            // and desyncing the parser on whatever follows. A NON-empty struct
+            // literal post (`result = Pt{X: i} { … }`) stays unaffected —
+            // StructLiteralAllowedInSuppressedHeader still admits it.
             suppressTrailingObjectInitializer++;
+            suppressStructLiteral++;
             try
             {
                 post = ParseSimpleStatement();
@@ -1274,6 +1285,7 @@ public partial class Parser
             finally
             {
                 suppressTrailingObjectInitializer--;
+                suppressStructLiteral--;
             }
         }
 

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue4177ForClauseBareMemberEmptyBodyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue4177ForClauseBareMemberEmptyBodyParserTests.cs
@@ -126,6 +126,53 @@ class C { func M() { for var i = 0; i < 3; result = Pt{X: i} { } } var result Pt
     }
 
     [Fact]
+    public void ForClause_Post_Empty_StructLiteral_With_EmptyBody_StillParses_AsStructLiteral()
+    {
+        // Copilot review follow-up on PR #4191: the EMPTY struct-literal
+        // counterpart to ForClause_Post_NonEmpty_StructLiteral_StillParses_
+        // AsStructLiteral. Suppressing the bare struct-literal form via
+        // suppressStructLiteral alone (without also honoring
+        // allowEmptyStructLiteralInHeader, mirroring for-range headers) would
+        // make StructLiteralAllowedInSuppressedHeader reject the EMPTY
+        // `Pt{}` post outright, so the first `{}` would be consumed as the
+        // loop body instead of the struct literal, leaving the real body `{ }`
+        // to desync the parser. An empty struct literal immediately followed
+        // by a genuine body `{` must still be recognized as a struct literal.
+        const string source = @"
+package p
+class Pt { var X int32 }
+class C { func M() { for var i = 0; i < 3; result = Pt{} { } } var result Pt }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Empty(((BlockStatementSyntax)forClause.Body).Statements);
+        Assert.Contains(Descendants(forClause.Post), n => n is StructLiteralExpressionSyntax);
+    }
+
+    [Fact]
+    public void ForClause_Post_Empty_StructLiteral_With_NonEmptyBody_StillParses_AsStructLiteral()
+    {
+        // Same shape as above, but with a non-empty body — locks in that the
+        // struct literal is recognized regardless of what the (separate)
+        // real body contains.
+        const string source = @"
+package p
+class Pt { var X int32 }
+class C { func M() { for var i = 0; i < 3; result = Pt{} { Console.WriteLine(1) } } var result Pt }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Single(((BlockStatementSyntax)forClause.Body).Statements);
+        Assert.Contains(Descendants(forClause.Post), n => n is StructLiteralExpressionSyntax);
+    }
+
+    [Fact]
     public void ForClause_Post_Indexer_Tailed_StillParses_AsIndexer()
     {
         // Regression guard for the pre-existing #1023 fix this shares a

--- a/test/Core.Tests/CodeAnalysis/Syntax/Issue4177ForClauseBareMemberEmptyBodyParserTests.cs
+++ b/test/Core.Tests/CodeAnalysis/Syntax/Issue4177ForClauseBareMemberEmptyBodyParserTests.cs
@@ -1,0 +1,146 @@
+// <copyright file="Issue4177ForClauseBareMemberEmptyBodyParserTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using GSharp.Core.CodeAnalysis.Syntax;
+using Xunit;
+
+namespace GSharp.Core.Tests.CodeAnalysis.Syntax;
+
+/// <summary>
+/// Issue #4177: a C-style <c>for</c> whose POST clause is an assignment
+/// expression ending in a bare member name (<c>c = c!!.Next</c>), immediately
+/// followed by an EMPTY loop body (<c>{ }</c>), must let the empty <c>{ }</c>
+/// open the loop body — it must NOT be mis-parsed as an empty struct literal
+/// applied to the member name (<c>Next{ }</c>).
+/// <para>
+/// <see cref="Parser.ParseForClauseStatement"/>'s post-clause already
+/// suppressed the composite-literal wrap (<c>suppressTrailingObjectInitializer</c>,
+/// issue #1023) for a CALL- or INDEXER-tailed post, but never suppressed the
+/// separate BARE struct-literal form (<c>suppressStructLiteral</c>) that a
+/// plain member-access-ending post can trigger — the same ambiguity
+/// <c>ParseExpressionInBodyHeader</c> already resolves for <c>if</c>/
+/// <c>while</c>/for-range headers (issue #1575). Without the fix, the empty
+/// <c>{ }</c> loop body brace pair is consumed as <c>Next{ }</c>, leaving the
+/// parser desynced on whatever follows (surfacing as an unrelated
+/// "expected &lt;IdentifierToken&gt;" diagnostic at the next real token).
+/// </para>
+/// <para>
+/// Found while migrating <c>test/InternalAnalyzers.Tests/BaseClassCycleUnsafeWalkAnalyzerTests.cs</c>
+/// (issue #4190): <c>for (var c = s.BaseClass; c != null; c = c.BaseClass) { }</c>
+/// translates to exactly this shape once cs2gs's nullable bridge inserts
+/// <c>!!</c> on the receiver.
+/// </para>
+/// </summary>
+public class Issue4177ForClauseBareMemberEmptyBodyParserTests
+{
+    private static IEnumerable<SyntaxNode> Descendants(SyntaxNode node)
+    {
+        foreach (var child in node.GetChildren())
+        {
+            yield return child;
+            foreach (var d in Descendants(child))
+            {
+                yield return d;
+            }
+        }
+    }
+
+    [Fact]
+    public void ForClause_Post_Ending_In_BareMember_With_EmptyBody_Parses_Without_Diagnostics()
+    {
+        // The canonical #4177 repro (post-fix, once the nullable bridge has
+        // already inserted `!!`).
+        const string source = @"
+package p
+class C { func M(s C) { for var c C? = s; c != nil; c = c!!.Next { } } var Next C }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.NotNull(forClause.Post);
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Empty(((BlockStatementSyntax)forClause.Body).Statements);
+
+        // No part of the post may have been reinterpreted as a struct literal.
+        Assert.Empty(Descendants(forClause.Post).OfType<StructLiteralExpressionSyntax>());
+    }
+
+    [Fact]
+    public void ForClause_Post_Ending_In_BareMember_Without_BangBang_With_EmptyBody_Parses_Without_Diagnostics()
+    {
+        // The same shape without the nullable-bridge `!!` — the ambiguity is
+        // about a bare member name directly abutting `{ }`, not about `!!`.
+        const string source = @"
+package p
+class C { func M(s C) { for var c = s; c != nil; c = c.Next { } } var Next C }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Empty(((BlockStatementSyntax)forClause.Body).Statements);
+        Assert.Empty(Descendants(forClause.Post).OfType<StructLiteralExpressionSyntax>());
+    }
+
+    [Fact]
+    public void ForClause_Post_Ending_In_BareMember_With_NonEmptyBody_Parses_Without_Diagnostics()
+    {
+        // A NON-empty body was never ambiguous (IsStructLiteralFollowingBrace
+        // requires an immediate `}`, spread, or `Identifier :`) — locks that
+        // in so the fix is understood as scoped to the empty-body collision.
+        const string source = @"
+package p
+class C { func M(s C) { for var c = s; c != nil; c = c.Next { Console.WriteLine(1) } } var Next C }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Single(((BlockStatementSyntax)forClause.Body).Statements);
+    }
+
+    [Fact]
+    public void ForClause_Post_NonEmpty_StructLiteral_StillParses_AsStructLiteral()
+    {
+        // Regression guard: StructLiteralAllowedInSuppressedHeader still
+        // admits a NON-empty struct literal post (unambiguous — `{ Ident :`
+        // can never open a body) — the fix must not blanket-suppress every
+        // struct literal in this position, only the empty/body-colliding one.
+        const string source = @"
+package p
+class Pt { var X int32 }
+class C { func M() { for var i = 0; i < 3; result = Pt{X: i} { } } var result Pt }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Contains(Descendants(forClause.Post), n => n is StructLiteralExpressionSyntax);
+    }
+
+    [Fact]
+    public void ForClause_Post_Indexer_Tailed_StillParses_AsIndexer()
+    {
+        // Regression guard for the pre-existing #1023 fix this shares a
+        // helper with: an indexer-tailed post must still bind the `[i]` as
+        // an indexer, not be disturbed by the new struct-literal suppression.
+        const string source = @"
+package p
+class C { func F(arr []int32) { for var s = 0; s < arr.Length; s += arr[s] { var x = 1 } } }
+";
+        var tree = SyntaxTree.Parse(source);
+        Assert.Empty(tree.Diagnostics);
+
+        var forClause = Descendants(tree.Root).OfType<ForClauseStatementSyntax>().Single();
+        Assert.IsType<BlockStatementSyntax>(forClause.Body);
+        Assert.Empty(Descendants(forClause.Post).OfType<StructLiteralExpressionSyntax>());
+        Assert.Contains(Descendants(forClause.Post), n => n is IndexExpressionSyntax);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.Translator.Loading;
 using Microsoft.CodeAnalysis;
@@ -164,6 +165,13 @@ public static class SnippetTranslator
                     index = NthOccurrence(printed, renamed.Text, renamedOrdinal);
                     length = renamed.Text.Length;
                 }
+            }
+
+            if (index < 0
+                && TryNullForgivingTolerantOccurrence(printed, marked.Text, ordinal, out int toleratedIndex, out int toleratedLength))
+            {
+                index = toleratedIndex;
+                length = toleratedLength;
             }
 
             if (index < 0)
@@ -353,6 +361,88 @@ public static class SnippetTranslator
         }
 
         return index;
+    }
+
+    /// <summary>
+    /// Issue #4190: retries placement tolerating a <c>!!</c> RUNTIME
+    /// null-assertion cs2gs inserts immediately after an identifier the
+    /// marked text reads — e.g. a guarded reassignment walk,
+    /// <c>current = current.BaseClass</c>, whose receiver's nullability
+    /// cs2gs's flow-sensitive analysis cannot always prove narrowed (a
+    /// <c>do</c>/<c>while</c> loop's post-test guard, in particular, narrows
+    /// nothing the G# binder itself recognizes — see
+    /// <c>StatementBinder.Loops.BindDoWhileStatementCore</c> — so the
+    /// bridging <c>!!</c> is not merely conservative there; it is required
+    /// for the translated G# to bind at all), prints as
+    /// <c>current = current!!.BaseClass</c>. Unlike <see cref="PredefinedRenaming"/>
+    /// (a lexical rename computed from the marked region's own syntax), the
+    /// `!!` decision depends on flow analysis of the FULL surrounding method
+    /// body, invisible from inside the marked region alone — so instead of
+    /// predicting the exact re-spelling, this searches for the marked text
+    /// with an OPTIONAL <c>!!</c> tolerated after every identifier, keeping
+    /// every other character an exact literal match. The same
+    /// occurrence-ordinal counted over the UNMODIFIED marker text in the
+    /// clean C# source (shared with the plain-match stage above) selects
+    /// which tolerant match is the right one, so a repeated marker still
+    /// lands on its own occurrence.
+    /// </summary>
+    /// <param name="printed">The printed G#.</param>
+    /// <param name="markedText">The marker's original C# text.</param>
+    /// <param name="ordinal">The zero-based occurrence to find.</param>
+    /// <param name="index">The matched span's start index, when found.</param>
+    /// <param name="length">The matched span's length, when found.</param>
+    /// <returns>True when a tolerant match was found.</returns>
+    private static bool TryNullForgivingTolerantOccurrence(
+        string printed, string markedText, int ordinal, out int index, out int length)
+    {
+        var pattern = new Regex(BuildNullForgivingTolerantPattern(markedText), RegexOptions.None);
+        var seen = 0;
+        for (Match match = pattern.Match(printed); match.Success; match = match.NextMatch())
+        {
+            if (seen == ordinal)
+            {
+                index = match.Index;
+                length = match.Length;
+                return true;
+            }
+
+            seen++;
+        }
+
+        index = -1;
+        length = 0;
+        return false;
+    }
+
+    // Builds a regex that matches `text` literally except that an optional
+    // `(?:!!)?` is tolerated immediately after every maximal identifier run —
+    // the one place cs2gs's runtime null-assertion can be inserted into an
+    // otherwise-verbatim expression.
+    private static string BuildNullForgivingTolerantPattern(string text)
+    {
+        var pattern = new StringBuilder(text.Length * 2);
+        var i = 0;
+        while (i < text.Length)
+        {
+            if (IsIdentifierChar(text[i]))
+            {
+                int start = i;
+                while (i < text.Length && IsIdentifierChar(text[i]))
+                {
+                    i++;
+                }
+
+                pattern.Append(Regex.Escape(text.Substring(start, i - start)));
+                pattern.Append("(?:!!)?");
+            }
+            else
+            {
+                pattern.Append(Regex.Escape(text[i].ToString()));
+                i++;
+            }
+        }
+
+        return pattern.ToString();
     }
 
     private static string StripMarkers(string source, List<MarkedText> markedTexts)

--- a/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
+++ b/tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs
@@ -139,12 +139,46 @@ public static class SnippetTranslator
             // is a fact about the C# node, and "is preceded by a declaration
             // keyword" is the printed G# counterpart, so the two ordinals are
             // counted over declarations only and agree again.
-            int index = DeclarationOrdinal(document, marked) is { } declarationOrdinal
-                ? NthDeclarationOccurrence(printed, marked.Text, declarationOrdinal)
+            int? declarationOrdinal = DeclarationOrdinal(document, marked);
+            int index = declarationOrdinal is { } d
+                ? NthDeclarationOccurrence(printed, marked.Text, d)
                 : -1;
             if (index < 0)
             {
-                index = NthOccurrence(printed, marked.Text, ordinal);
+                if (declarationOrdinal is null)
+                {
+                    // Issue #4191 (Copilot review of #4190): a NON-declaration
+                    // marker is placed by ONE unified exact-or-bridged ordinal
+                    // sequence, not by an exact-only search that falls back to
+                    // a wholly separate tolerant-only search only when the
+                    // exact search finds NOTHING. When translation inserts a
+                    // `!!` bridge on only SOME occurrences of the marked text
+                    // (e.g. a `do`-loop walk that needs it, alongside an
+                    // unrelated, narrowed `while`-loop walk of the same text
+                    // that stays exact), one occurrence "drops out" of the
+                    // exact-match sequence while the other does not, so the
+                    // exact-only ordinal computed from the C# source no longer
+                    // lines up with the exact-only ordinal in the printed G# —
+                    // and a plain exact search can then silently SUCCEED at
+                    // the wrong occurrence, never even reaching the tolerant
+                    // fallback below (which only runs once the exact search
+                    // returns -1). `TryNullForgivingTolerantOccurrence`'s
+                    // pattern already tolerates an optional `!!` after every
+                    // identifier — an exact occurrence matches it too, with
+                    // zero `!!`s — so using it here counts exact and bridged
+                    // forms together, in the one order they actually appear
+                    // in `printed`. `ordinal` itself (computed above via exact
+                    // matching over `cleanSource`) is unaffected by this: the
+                    // clean C# source never itself contains a `!!` bridge —
+                    // that is purely a translation artifact — so its exact
+                    // ordinal already agrees with what the tolerant matcher
+                    // would compute there.
+                    TryNullForgivingTolerantOccurrence(printed, marked.Text, ordinal, out index, out length);
+                }
+                else
+                {
+                    index = NthOccurrence(printed, marked.Text, ordinal);
+                }
             }
 
             if (index < 0)

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4190BaseClassWalkSnippetMarkerRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4190BaseClassWalkSnippetMarkerRegressionTests.cs
@@ -231,4 +231,82 @@ class Walker
 
         GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, result.GsWithMarkers, new[] { "GSA0006" });
     }
+
+    // Copilot review follow-up on PR #4191: TWO occurrences of the exact same
+    // marker text (`Path.GetFullPath(x.F)`), where translation bridges only
+    // the FIRST with `!!` (x.F is `string?` on NullHolder) and leaves the
+    // SECOND, later occurrence exact (x.F is non-null `string` on
+    // NonNullHolder — a different, unrelated declaration, so nothing narrows
+    // it, it is simply never nullable). This is the mixed-context shape the
+    // review flagged: the earlier occurrence "drops out" of the exact-text
+    // sequence once bridged, while the later one does not, so an exact-only
+    // ordinal search computed from the C# source no longer lines up with an
+    // exact-only search over the printed G#.
+    private const string MixedBridgedAndExactBaseClassAccess = """
+    using System.IO;
+
+    class NullHolder
+    {
+        public string? F;
+    }
+
+    class NonNullHolder
+    {
+        public string F = "";
+    }
+
+    class Walker
+    {
+        public void M1(NullHolder x)
+        {
+            [|Path.GetFullPath(x.F)|].ToString();
+        }
+
+        public void M2(NonNullHolder x)
+        {
+            [|Path.GetFullPath(x.F)|].ToString();
+        }
+    }
+    """;
+
+    /// <summary>
+    /// Before the fix, the plain exact-only search silently SUCCEEDS at the
+    /// wrong occurrence instead of failing over to the tolerant fallback:
+    /// the FIRST marker (M1, whose own occurrence gets bridged) steals the
+    /// SECOND marker's (M2's) exact span via <c>NthOccurrence</c>, and the
+    /// SECOND marker then also resolves onto M2's span via the tolerant
+    /// fallback — both markers land on the SAME (M2's) span, nested
+    /// (<c>[|[|Path.GetFullPath(x.|]F)|]</c>), and M1's own occurrence gets
+    /// no marker at all. The fix (a single unified exact-or-tolerant ordinal
+    /// sequence for non-declaration markers) must place each marker on its
+    /// own, distinct, correct span instead.
+    /// </summary>
+    [Fact]
+    public void MixedBridgedAndExactOccurrences_PlaceEachMarkerOnItsOwnDistinctSpan()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(MixedBridgedAndExactBaseClassAccess);
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            d => d.DiagnosticId == SnippetTranslator.SnippetDiagnosticId
+                && d.Message.Contains("does not survive translation verbatim", StringComparison.Ordinal));
+
+        // Exactly two markers, each wrapping its own method's call — never
+        // both wrapping the same span, and never nested/overlapping.
+        int m1Index = result.GsWithMarkers.IndexOf("func M1(", StringComparison.Ordinal);
+        int m2Index = result.GsWithMarkers.IndexOf("func M2(", StringComparison.Ordinal);
+        Assert.True(m1Index >= 0 && m2Index > m1Index);
+
+        string m1Body = result.GsWithMarkers.Substring(m1Index, m2Index - m1Index);
+        string m2Body = result.GsWithMarkers.Substring(m2Index);
+
+        Assert.Contains("[|Path.GetFullPath(x.F!!)|]", m1Body);
+        Assert.Contains("[|Path.GetFullPath(x.F)|]", m2Body);
+
+        // M2's span (the non-bridged one) must never itself contain a `!!` —
+        // the bug's symptom was M1's marker stealing M2's un-bridged span.
+        Assert.DoesNotContain("!!", m2Body.Substring(0, m2Body.IndexOf("].ToString()", StringComparison.Ordinal)));
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4190BaseClassWalkSnippetMarkerRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4190BaseClassWalkSnippetMarkerRegressionTests.cs
@@ -1,0 +1,234 @@
+// <copyright file="Issue4190BaseClassWalkSnippetMarkerRegressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Analyzers;
+using Cs2Gs.Translator.Loading;
+using GSharp.CodeAnalysis.Analyzers.Testing;
+using GSharp.Core.CodeAnalysis;
+using GSharp.Core.CodeAnalysis.Analyzers;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4190: <c>test/InternalAnalyzers.Tests</c> dropped from fully green
+/// (translate/compile/ilverify/test-parity) back to a translate-stage failure
+/// after PR #4172 added <c>BaseClassCycleUnsafeWalkAnalyzerTests.cs</c>, whose
+/// three <c>[|…|]</c>-marked snippets (<c>ReportsForLoopWalk</c>,
+/// <c>ReportsWhileLoopWalk</c>, <c>ReportsDoWhileLoopWalk</c>) all failed to
+/// re-place their marker after translation.
+///
+/// <para>
+/// <b>Two distinct root causes, both real bugs, fixed independently:</b>
+/// </para>
+/// <para>
+/// <b>#4177 (parser).</b> <c>ReportsForLoopWalk</c>'s translated G# was
+/// outright UNPARSEABLE (<c>GS0005: Unexpected token &lt;CloseBraceToken&gt;,
+/// expected &lt;IdentifierToken&gt;</c>), so the marker text obviously could
+/// not survive verbatim inside garbage. Root cause:
+/// <c>Parser.ParseForClauseStatement</c>'s post-clause suppressed the
+/// composite-literal wrap (<c>suppressTrailingObjectInitializer</c>, issue
+/// #1023) but never the separate BARE struct-literal form
+/// (<c>suppressStructLiteral</c>). A post-clause ending in a bare member name
+/// immediately followed by an EMPTY loop body — exactly
+/// <c>c = c!!.Next { }</c> — misparsed <c>Next { }</c> as an empty struct
+/// literal, swallowing the loop's own body brace and desyncing the parser.
+/// Fixed by also suppressing <c>suppressStructLiteral</c> around the
+/// post-clause parse, mirroring <c>ParseExpressionInBodyHeader</c>'s existing
+/// #1575 fix for <c>if</c>/<c>while</c>/for-range headers.
+/// </para>
+/// <para>
+/// <b>#4190 residual (marker matching).</b> Once #4177 was fixed, all three
+/// snippets translate to VALID G# — but the marker text still failed to
+/// re-place, because cs2gs's oblivious-mode nullable bridge inserts a runtime
+/// <c>!!</c> assertion on the reassigned receiver
+/// (<c>current = current.BaseClass</c> prints as
+/// <c>current = current!!.BaseClass</c>). This is not a translation defect:
+/// <c>BaseClassCycleUnsafeWalkAnalyzer.GetBaseClassAccess</c> already
+/// documents and unwraps exactly this shape (issue #4173), and for the
+/// <c>do</c>/<c>while</c> case the assertion is not merely conservative —
+/// G#'s own <c>do</c>/<c>while</c> binder
+/// (<c>StatementBinder.Loops.BindDoWhileStatementCore</c>) applies no
+/// post-test narrowing at all, so the bridging <c>!!</c> is REQUIRED for the
+/// translated code to bind. <c>SnippetTranslator</c>'s exact-text marker
+/// placement (issue #3778) and its one lexical-rename retry (issue #3797)
+/// could not anticipate a flow-sensitive insertion invisible from inside the
+/// marked region alone, so it is fixed the same way #3797 was: a new
+/// tolerant-match fallback (<see cref="SnippetTranslator"/>'s
+/// <c>TryNullForgivingTolerantOccurrence</c>) that accepts the marked text
+/// with an optional <c>!!</c> tolerated after every identifier, keeping every
+/// other character an exact literal match.
+/// </para>
+/// <para>
+/// Every assertion here EXECUTES the real path: the real snippets (copied
+/// verbatim from <c>BaseClassCycleUnsafeWalkAnalyzerTests.cs</c>) are
+/// translated by the real <see cref="SnippetTranslator"/>, and the real
+/// GSA0006 analyzer — translated and compiled by the real G# compiler — is
+/// run by <see cref="GSharpAnalyzerVerifier"/> over the re-placed markers,
+/// mirroring <c>Issue3794AnalyzerSnippetPackageSplitTests</c>.
+/// </para>
+/// </summary>
+public sealed class Issue4190BaseClassWalkSnippetMarkerRegressionTests : IDisposable
+{
+    // Copied verbatim from
+    // test/InternalAnalyzers.Tests/BaseClassCycleUnsafeWalkAnalyzerTests.cs's
+    // ReportsForLoopWalk.
+    private const string ForLoopWalk = """
+class StructSymbol
+{
+    public StructSymbol? BaseClass;
+}
+
+class Walker
+{
+    void Walk(StructSymbol s)
+    {
+        for (var c = s.BaseClass; c != null; [|c = c.BaseClass|])
+        {
+        }
+    }
+}
+""";
+
+    // Copied verbatim from ReportsWhileLoopWalk.
+    private const string WhileLoopWalk = """
+class StructSymbol
+{
+    public StructSymbol? BaseClass;
+}
+
+class Walker
+{
+    void Walk(StructSymbol s)
+    {
+        var current = s;
+        while (current != null)
+        {
+            [|current = current.BaseClass|];
+        }
+    }
+}
+""";
+
+    // Copied verbatim from ReportsDoWhileLoopWalk.
+    private const string DoWhileLoopWalk = """
+class StructSymbol
+{
+    public StructSymbol? BaseClass;
+}
+
+class Walker
+{
+    void Walk(StructSymbol s)
+    {
+        var current = s;
+        do
+        {
+            [|current = current.BaseClass|];
+        }
+        while (current != null);
+    }
+}
+""";
+
+    private readonly DirectoryInfo workDirectory =
+        Directory.CreateTempSubdirectory("cs2gs-issue4190-baseclass-walk");
+
+    public void Dispose()
+    {
+        try
+        {
+            workDirectory.Delete(recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    [Theory]
+    [InlineData(ForLoopWalk)]
+    [InlineData(WhileLoopWalk)]
+    [InlineData(DoWhileLoopWalk)]
+    public void Marker_SurvivesTranslation_WithNoUnplacedMarkerDiagnostic(string markedSnippet)
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(markedSnippet);
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            d => d.DiagnosticId == SnippetTranslator.SnippetDiagnosticId
+                && d.Message.Contains("does not survive translation verbatim", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(ForLoopWalk)]
+    [InlineData(WhileLoopWalk)]
+    [InlineData(DoWhileLoopWalk)]
+    public void TranslatedSnippet_IsValidG_AndRoundTrips(string markedSnippet)
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(markedSnippet);
+        Assert.NotNull(result.GsWithMarkers);
+
+        // Markers are test-harness syntax, not G# — strip them before parsing,
+        // exactly as GSharpAnalyzerVerifier does.
+        string withoutMarkers = result.GsWithMarkers.Replace("[|", string.Empty).Replace("|]", string.Empty);
+        TranslationTestValidation.AssertBinds(withoutMarkers);
+    }
+
+    /// <summary>
+    /// The translated <c>ReportsForLoopWalk</c> shape still needs the `!!`
+    /// bridge cs2gs's oblivious nullable analysis inserts — this is #4190's
+    /// point, not #4177's: #4177 made the shape PARSEABLE, it did not (and
+    /// must not) remove the bridging assertion.
+    /// </summary>
+    [Fact]
+    public void ForLoopWalk_TranslatesWithBangBangBridge_OnTheReassignedReceiver()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(ForLoopWalk);
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Contains("c!!.BaseClass", result.GsWithMarkers, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(WhileLoopWalk)]
+    [InlineData(DoWhileLoopWalk)]
+    public void LoopWalk_TranslatesWithBangBangBridge_OnTheReassignedReceiver(string markedSnippet)
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(markedSnippet);
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Contains("current!!.BaseClass", result.GsWithMarkers, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// End to end, the whole reason the marker must survive: the real
+    /// GSA0006 analyzer, translated and compiled by the real G# compiler,
+    /// reports at exactly the re-placed marker for all three loop shapes.
+    /// </summary>
+    /// <param name="markedSnippet">The C# snippet with its marker.</param>
+    [Theory]
+    [InlineData(ForLoopWalk)]
+    [InlineData(WhileLoopWalk)]
+    [InlineData(DoWhileLoopWalk)]
+    public void TranslatedGsa0006_FiresAtTheRePlacedMarker(string markedSnippet)
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(markedSnippet);
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.Empty(result.UnplacedMarkers);
+
+        string analyzerDll = Adr0169TranslatedAnalyzerHarness.CompileTranslatedAnalyzer(
+            workDirectory.FullName, "BaseClassCycleUnsafeWalkAnalyzer.cs", "TranslatedGsa0006");
+        ImmutableArray<GSharpDiagnosticAnalyzer> analyzers =
+            GSharpAnalyzerHost.Load(new[] { analyzerDll }, out ImmutableArray<Diagnostic> hostDiagnostics);
+        Assert.Empty(hostDiagnostics);
+        GSharpDiagnosticAnalyzer analyzer = Assert.Single(analyzers);
+
+        GSharpAnalyzerVerifier.VerifyAnalyzer(analyzer, result.GsWithMarkers, new[] { "GSA0006" });
+    }
+}


### PR DESCRIPTION
## Summary

Restores `test/InternalAnalyzers.Tests` to fully translating after PR #4172's `BaseClassCycleUnsafeWalkAnalyzerTests.cs` took the whole selfmig app back from green (`PPPP`) to a translate-stage failure (#4190). Two independent root causes were found and fixed, and #4177 is closed as a side effect.

### Root cause 1 — #4177 (parser desync, `ReportsForLoopWalk`)

`ReportsForLoopWalk`'s translated G# was outright **unparseable**:
```
GS0005: Unexpected token <CloseBraceToken>, expected <IdentifierToken>.
```
Traced to `Parser.ParseForClauseStatement`: the post-clause suppressed the composite-literal wrap (`suppressTrailingObjectInitializer`, issue #1023) but never the separate **bare struct-literal** form (`suppressStructLiteral`). A C-style `for`'s post-clause ending in a bare member name immediately followed by an **empty** loop body — exactly `c = c!!.Next { }` — misparsed `Next { }` as an empty struct literal applied to `Next`, swallowing the loop's own body brace and desyncing the parser on whatever followed.

Fix: also suppress `suppressStructLiteral` around the post-clause parse, mirroring `ParseExpressionInBodyHeader`'s existing #1575 fix for `if`/`while`/for-range headers. A **non-empty** struct-literal post (`result = Pt{X: i} { … }`) stays unaffected — `StructLiteralAllowedInSuppressedHeader` still admits it.

### Root cause 2 — #4190 residual (marker matching, all three shapes)

Once #4177 was fixed, all three `BaseClassCycleUnsafeWalk` snippets translate to **valid** G# — but `SnippetTranslator`'s exact-text marker re-placement still failed for all three, because cs2gs's oblivious-mode nullable bridge inserts a runtime `!!` on the reassigned receiver: `current = current.BaseClass` prints as `current = current!!.BaseClass`.

This is not a translation defect to "fix away": `BaseClassCycleUnsafeWalkAnalyzer.GetBaseClassAccess` already documents and explicitly unwraps exactly this shape (issue #4173). More importantly, for the `do`/`while` shape the assertion is **required**, not merely conservative — G#'s own `do`/`while` binder (`StatementBinder.Loops.BindDoWhileStatementCore`) applies no post-test narrowing at all, so removing the `!!` would produce G# that fails to bind. For the plain `while` shape, G#'s binder *does* narrow within the loop body (`ComputeConditionNarrowing`), but extending cs2gs's oblivious-mode guard detection (`IsDominatedByNullCheckGuard`) to recognize loop conditions is a much larger, riskier change to a heavily-shared function with wide blast radius across other green selfmig apps — not justified just to avoid a redundant-but-harmless runtime check.

Fixed in `SnippetTranslator` instead, following the precedent #3797 set (a lexical-rename retry for C#'s predefined-type-keyword rename): a new tolerant-match fallback searches for the marked text with an *optional* `!!` tolerated after every identifier, keeping every other character an exact literal match, using the same occurrence-ordinal convention as the existing two placement stages.

## Fixes

- `src/Core/CodeAnalysis/Syntax/Parser.Statements.cs` — suppress `suppressStructLiteral` in `ParseForClauseStatement`'s post-clause (closes #4177).
- `tools/cs2gs/Cs2Gs.ProjectLoading/Analyzers/SnippetTranslator.cs` — new `TryNullForgivingTolerantOccurrence` marker-placement fallback.
- `docs/cs2gs-analyzer-translation.md` — documents the new tolerant-match fallback alongside the existing #3797 write-up.

## Test plan

- [x] New `test/Core.Tests/CodeAnalysis/Syntax/Issue4177ForClauseBareMemberEmptyBodyParserTests.cs` (5 tests): the exact repro shape (with and without `!!`), a non-empty-body guard, a non-empty-struct-literal-post guard, and an indexer-tailed-post guard (shares the #1023 helper).
- [x] New `tools/cs2gs/Cs2Gs.Tests/Issue4190BaseClassWalkSnippetMarkerRegressionTests.cs` (12 tests): the three real snippets (copied verbatim from `BaseClassCycleUnsafeWalkAnalyzerTests.cs`) translated by the real `SnippetTranslator`, asserting no unplaced markers, valid/round-tripping G#, the expected `!!` bridge is still present (proving the fix doesn't remove required safety), and — end to end — the real GSA0006 analyzer (translated and compiled by the real G# compiler) fires at the re-placed marker via `GSharpAnalyzerVerifier`.
- [x] Anti-vacuity: reverted each fix independently.
  - Reverting the parser fix reproduces the exact original `GS0005` error for the `#4177` repro and the empty-body cases; the non-empty-body/indexer/struct-literal guard tests are unaffected, confirming the fix is precisely scoped.
  - Reverting the `SnippetTranslator` fix reproduces the exact original unplaced-marker symptom (`"c = c.BaseClass"` / `"current = current.BaseClass"`) for all three shapes.
  - Restored: all new tests green again.
- [x] `dotnet test test/InternalAnalyzers.Tests/InternalAnalyzers.Tests.csproj`: all 26 native tests pass (this is the real, un-translated C# test suite — confirms nothing in the analyzer or its tests regressed).
- [x] Full regression suites, both clean modulo pre-existing environment gaps unrelated to this change:
  - `dotnet test test/Core.Tests/Core.Tests.csproj`: **9074/9076** passed — the 2 failures (`Issue3755PinningShapeTargetFrameworkTests`) require a `NETStandard.Library.Ref` targeting pack not installed on this machine.
  - `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj`: **2936/2937** passed — the 1 failure (`Issue2819_SameVersionPackedToolAndSdk_CompileTranslatedPatternVariable`) requires a locally-built Release `cs2gs`/`Gsharp.NET.Sdk` `.nupkg` pair that doesn't exist in this Debug-only build environment.

Per issue #4190's scope, `tools/cs2gs/selfmig-baseline.json` is deliberately **not** touched here — re-banking `test/InternalAnalyzers.Tests` into `greenApps` should happen only after a full selfmig gate run confirms the fix end-to-end in CI.

Closes #4177. Part of #3501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ptr4sovcAwpgaUEM4rEin