### PR TITLE
cs2gs: pin the ternary-argument Task.Run shape from #4111's harness line

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
@@ -97,6 +97,46 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #4111 (a subset of #4179's 48 rows: the "AcceptedFiniteShape_
+    /// VerifiesLoadsAndRuns — 30 rows" line item): the REAL
+    /// <c>CompileVerifyLoadAndRun</c> helper does not pass a bare
+    /// <see langword="null"/> as <c>MethodInfo.Invoke</c>'s second argument —
+    /// it passes a conditional (ternary) expression,
+    /// <c>entry.GetParameters().Length == 0 ? null : new object[] { ... }</c>.
+    /// The positive test above only pins the bare-<see langword="null"/>
+    /// shape, so a future regression in how
+    /// <c>LambdaResultFeedsUnobservedTaskRun</c> handles a non-trivial
+    /// argument expression at the call site would not be caught by it. This
+    /// test pins the actual shape verbatim, closing that gap.
+    /// </summary>
+    [Fact]
+    public void TaskRun_ReflectionInvokeWithConditionalArgumentObservedOnlyThroughWait_StaysBare()
+    {
+        string printed = TranslateOblivious(@"
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Demo
+{
+    public static class Runner
+    {
+        public static void Run(MethodInfo entry)
+        {
+            var execution = Task.Run(
+                () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() }));
+            bool completed = execution.Wait(TimeSpan.FromSeconds(10));
+            Console.WriteLine(completed);
+        }
+    }
+}");
+
+        Assert.Contains("entry.Invoke(", printed, StringComparison.Ordinal);
+        Assert.Contains("GetParameters().Length == 0", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain(")!!", printed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The general shape underlying #4179, without reflection: ANY
     /// nullable-returning call as an unobserved <c>Task.Run</c> lambda result
     /// must stay bare, not just <c>MethodInfo.Invoke</c>.


### PR DESCRIPTION
Fixes #4111

## Summary

#4111's 30 `Issue2891TryRegionFlowEmitTests.AcceptedFiniteShape_VerifiesLoadsAndRuns` failures are the exact same bug as issue #4179 (split from #4129, CLOSED): the "AcceptedFiniteShape_VerifiesLoadsAndRuns — 30 rows" line item in #4179's own failure inventory. Both issues describe the identical symptom against the identical helper line in `test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs`'s `CompileVerifyLoadAndRun`:

```csharp
var execution = Task.Run(
    () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() }));
Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), $"{name} execution timed out");
```

#4179 was already root-caused and fixed by #4182 (merged as `9cafdbd9`, already on `main` and in this branch's history): `test/Compiler.Tests.csproj` compiles nullable-oblivious, and cs2gs's `IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult` heuristic force-asserted the reflection-nullable `MethodInfo.Invoke(...)` result with `!!` inside the unobserved `Task.Run` lambda. `<Main>$` is void, so `Invoke` legitimately returns `null` every time, and the forced `!!` threw the instant the migrated snippet's entry point ran -- wrapped by `Task.Run`'s `AggregateException`, exactly the "async compile/run wrapper faults with NullReferenceException" symptom #4111 reports. #4182's own investigation directly disproves the "gsc emitter miscompiles switch/try/goto" framing #4111's title implies: it built a self-hosted `gsc`/`GSharp.Core.dll` and ran every snippet body from the affected test files through it directly -- every snippet ran correctly, so the failure is 100% attributable to the shared harness line, independent of any individual try-region shape.

**This PR contains no compiler or translator fix** -- there is nothing left to fix; #4182 already fixed it. It adds the one piece of regression coverage #4179/#4182 did not pin: their positive tests only cover the bare `entry.Invoke(null, null)` shape. The *actual* `CompileVerifyLoadAndRun` helper passes a conditional (ternary) second argument, not a bare `null`, so a future regression in how `LambdaResultFeedsUnobservedTaskRun` handles a non-trivial argument expression at the call site would not have been caught. This adds that exact shape, verbatim, as its own test.

## Evidence

- Ran a fresh whole-repository `cs2gs migrate --translate-only` on top of latest `main` (commit `964a50a6`, which already includes #4182's fix). The migrated `test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.gs` at lines 580-589 shows `entry.Invoke(...)` with **no `!!`**:
  ```
  let execution = Task.Run(
      () -> entry.Invoke(
          nil,
          if entry.GetParameters().Length == 0 {
              default([]?object)
          } else {
              []object{Array.Empty[string]()}
          }
      )
  )
  Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), "$name execution timed out")
  ```
- Anti-vacuity: reverted #4182's production hunk in `CSharpToGSharpTranslator.Expressions.cs` and reran both the existing bare-null positive test and this PR's new ternary-argument test -- **both fail**, each reproducing the exact `)!!` insertion (`entry.Invoke(nil, nil)!!` and `...Array.Empty[string]()} })!!` respectively -- at different string positions, proving the new test discriminates the argument-expression shape and isn't just textually matching `Invoke(nil, nil)`. Restored the fix: both green again.
- `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue4179UnobservedTaskRunResultRegressionTests"`: **11 passed, 0 failed** (10 existing + 1 new).
- Ran `cs2gs validate --app test/Compiler.Tests/Compiler.Tests.csproj` against the fresh migrated tree to get a targeted before/after test-parity count for the 30 rows. `test/Compiler.Tests` is one of the largest apps in the corpus (5,468 tests) and its compile+ILVerify+test-parity stages are known to take on the order of an hour (#4045 measured ~55 min for a full run). After ~27 minutes it was still in the `compile` stage with no transition to `ilverify`/`test-parity`, so I stopped it at the local session's time budget rather than let it run unattended. Consistent with #4182's own precedent for this exact app ("I did NOT run the full sharded self-migration gate end-to-end... judged out of scope for local verification given the machine-time cost"), an unfinished local validate run is not treated as a blocker here -- the translated-source diff plus the anti-vacuity witness above (which directly demonstrates the fix discriminates and fires on the real harness shape) is the deliverable, matching the standard #4182 itself was held to and merged under.

## Test plan

- [x] New `TaskRun_ReflectionInvokeWithConditionalArgumentObservedOnlyThroughWait_StaysBare` in `tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs`, tightened with an assertion that the ternary condition itself survives translation (`GetParameters().Length == 0`), not just that some `Invoke` call is present.
- [x] Anti-vacuity: reverting #4182's fix reproduces the exact bug for both the bare-null and ternary-argument shapes; restoring the fix returns both to green.
- [x] `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue4179UnobservedTaskRunResultRegressionTests"`: 11 passed, 0 failed.
- [x] Re-translated the real `test/Compiler.Tests/Emit/Issue2891TryRegionFlowEmitTests.cs` via a fresh whole-repo `cs2gs migrate --translate-only`: confirmed no `!!` on `entry.Invoke(...)`.
- [ ] Full `cs2gs validate --app test/Compiler.Tests/Compiler.Tests.csproj` (compile/ILVerify/test-parity): stopped after ~27 min still in the `compile` stage, at the local session's time budget. Not a blocker per #4182's own precedent for this same app -- CI/a future run can complete it.

## Note

This work happened in a worktree the harness assigned as `agent-ae54a24e04fc7c2e5` rather than the `.claude/worktrees/issue-4111` path named in the original task brief (a separate worktree on branch `fix/issue-4111-try-region-emit-nre`, at `964a50a6` when this session started), hence the different branch name here.

## Copilot review

Copilot's automated review recommended approval with no findings and no inline comment threads (test-only diff, no production-code risk). Nothing to address.
