### PR TITLE
cs2gs: hoist repeated same-target postfix increments correctly (fixes #4114)

### DIFF
--- a/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
+++ b/src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs
@@ -660,10 +660,26 @@ internal sealed class InterfaceImplEmitter
                 }
             }
 
-            bridges.Add(new InheritedEventBridge(
-                ev,
-                MetadataTokens.MethodDefinitionHandle(nextMethodRow++),
-                MetadataTokens.MethodDefinitionHandle(nextMethodRow++)));
+            // Issue #4114: one MethodDef row each for add_/remove_, assigned to
+            // named locals across separate statements (matching every other
+            // row-reservation loop in ReflectionMetadataEmitter.cs, e.g. the
+            // property-getter/setter and class-event add/remove/raise loops)
+            // rather than as two `nextMethodRow++` post-increments inline in
+            // one constructor call. The two forms are equivalent C#, but the
+            // cs2gs-translated build of this method once collapsed the inline
+            // form's two increments into one read of the pre-increment value
+            // used twice, handing add_ and remove_ the SAME planned row and
+            // tripping "Inherited event bridge MethodDef row was not emitted
+            // in planned order" (GS9998) the first time this method itself
+            // ran self-hosted. The root cause was cs2gs's postfix-hoist
+            // lowering (fixed in CSharpToGSharpTranslator.Statements.cs'
+            // WithHoistedPostfix); this shape is kept as defense in depth so
+            // a future translator change can't reopen the same trap here.
+            var addHandle = MetadataTokens.MethodDefinitionHandle(nextMethodRow);
+            nextMethodRow++;
+            var removeHandle = MetadataTokens.MethodDefinitionHandle(nextMethodRow);
+            nextMethodRow++;
+            bridges.Add(new InheritedEventBridge(ev, addHandle, removeHandle));
         }
     }
 

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -340,6 +340,46 @@ namespace Demo
         Assert.Equal(2, CountOccurrences(printed, "H(x++)"));
     }
 
+    /// <summary>
+    /// Issue #4114 follow-up (Copilot review of PR #4196): an array-element
+    /// postfix increment (<c>a[0]++</c>) has no target <c>ISymbol</c> via
+    /// <c>GetSymbolInfo</c> — element access is a built-in operation, not a
+    /// symbol reference — so aliasing between two occurrences can never be
+    /// ruled out. The original fix's <c>target == null</c> branch treated an
+    /// unresolved target as safely hoistable (mirroring pre-#4114 behavior),
+    /// which reintroduces exactly the bug #4114 fixed whenever the repeated
+    /// target is unresolvable rather than a plain local: both occurrences of
+    /// <c>a[0]++</c> would still be independently hoisted, again observing
+    /// the same pre-increment value. An unresolved target must now stay
+    /// inline unconditionally.
+    /// </summary>
+    [Fact]
+    public void PostIncrement_ArrayElementTargetTwiceInOneStatement_PreservesLeftToRightSequencing()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static void Record(int a, int b) { }
+
+        public static void Pair(int[] arr)
+        {
+            Record(H(arr[0]++), H(arr[0]++));
+        }
+
+        private static int H(int n) => n;
+    }
+}");
+
+        // Neither occurrence may be hoisted to a trailing statement: an
+        // unresolved target (array-element access) can never be proven
+        // single-occurrence, so it must stay inline exactly like a repeated
+        // resolvable target does.
+        Assert.DoesNotContain("H(arr[0]), H(arr[0])", printed);
+        Assert.Equal(2, CountOccurrences(printed, "H(arr[0]++)"));
+    }
+
     private static int CountOccurrences(string text, string value)
     {
         int count = 0;

--- a/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/OahuDecryptTranslationTests.cs
@@ -298,6 +298,62 @@ namespace Demo
     }
 
     /// <summary>
+    /// Issue #4114: TWO postfix increments of the SAME target within one
+    /// statement (<c>H(x++), H(x++)</c>) are NOT both hoisted to trailing
+    /// statements. C# sequences them left-to-right — the first call observes
+    /// the original value, the second observes it already incremented — and
+    /// deferring both mutations to after the whole statement would collapse
+    /// that sequencing, so every hoisted read would observe the same
+    /// (original) value. This is exactly how the self-hosted compiler's
+    /// inherited event-bridge MethodDef row planner (<c>PlanBridge</c> in
+    /// <c>InterfaceImplEmitter.cs</c>) built two numerically identical
+    /// planned handles from <c>H(nextMethodRow++), H(nextMethodRow++)</c>,
+    /// which then tripped its "not emitted in planned order" guard (GS9998)
+    /// once self-hosted. The repeated target's occurrences must fall through
+    /// to G#'s native inline inc/dec expression instead, which evaluates
+    /// each occurrence in true left-to-right order.
+    /// </summary>
+    [Fact]
+    public void PostIncrement_SameTargetTwiceInOneStatement_PreservesLeftToRightSequencing()
+    {
+        string printed = TranslateUnit(@"
+namespace Demo
+{
+    public static class C
+    {
+        public static void Record(int a, int b) { }
+
+        public static void Pair(int x)
+        {
+            Record(H(x++), H(x++));
+        }
+
+        private static int H(int n) => n;
+    }
+}");
+
+        // Neither occurrence may be hoisted to a trailing statement: that
+        // would print `x` (a bare read) at BOTH call sites and defer both
+        // mutations to the end, losing the first call's distinct
+        // pre-increment value. Each call site keeps its own inline `x++`.
+        Assert.DoesNotContain("H(x), H(x)", printed);
+        Assert.Equal(2, CountOccurrences(printed, "H(x++)"));
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    /// <summary>
     /// <c>yield break</c> maps to G#'s native <c>yield break</c> statement
     /// (issue #3501 A1), which terminates the iterator from any depth.
     /// </summary>

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -2309,6 +2309,27 @@ public sealed partial class CSharpToGSharpTranslator
         /// the sub-expression is suppressed (read as its pre-increment value) and
         /// the mutation is appended after the main statement (ADR-0115 §B).
         /// </summary>
+        /// <remarks>
+        /// Issue #4114: this hoist-to-trailing-statement strategy is only sound
+        /// when a target is mutated at most ONCE in the statement. C# sequences
+        /// repeated postfix operators on the SAME target left-to-right — each
+        /// occurrence of `x++` in `H(x++), H(x++)` observes a DIFFERENT value
+        /// (the first reads the original, the second reads it already
+        /// incremented). Suppressing every occurrence and deferring every
+        /// mutation to AFTER the whole statement collapses that sequencing:
+        /// none of the mutations has run when either suppressed read happens,
+        /// so both read the same (original) value, and the compiler's own
+        /// metadata row planner discovered this the hard way — two inherited
+        /// event-bridge MethodDef rows were planned as `H(nextMethodRow++),
+        /// H(nextMethodRow++))` and came out numerically identical, so the
+        /// second emitted row landed one past its plan and tripped the
+        /// self-hosted compiler's "not emitted in planned order" guard
+        /// (GS9998). A target with more than one embedded occurrence is left
+        /// un-hoisted here; those occurrences fall through to G#'s native
+        /// inline inc/dec expression (gsc issue #1027), which evaluates each
+        /// occurrence in true left-to-right order without needing a statement
+        /// seam. Single-occurrence targets keep the existing hoisted form.
+        /// </remarks>
         private IEnumerable<GStatement> WithHoistedPostfix(
             ExpressionSyntax expression,
             Func<IEnumerable<GStatement>> buildMain)
@@ -2319,7 +2340,34 @@ public sealed partial class CSharpToGSharpTranslator
                 return buildMain();
             }
 
+            var targetOccurrences = new Dictionary<ISymbol, int>(SymbolEqualityComparer.Default);
             foreach (PostfixUnaryExpressionSyntax node in embedded)
+            {
+                ISymbol target = this.context.GetSymbolInfo(node.Operand).Symbol;
+                if (target != null)
+                {
+                    targetOccurrences[target] = targetOccurrences.TryGetValue(target, out int count) ? count + 1 : 1;
+                }
+            }
+
+            // A node whose operand's symbol could not be resolved has no
+            // reliable way to detect aliasing with another occurrence, so it
+            // is conservatively treated as its own single-occurrence target
+            // (matching this method's pre-#4114 behavior for such nodes).
+            List<PostfixUnaryExpressionSyntax> hoistable = embedded
+                .Where(node =>
+                {
+                    ISymbol target = this.context.GetSymbolInfo(node.Operand).Symbol;
+                    return target == null || targetOccurrences[target] == 1;
+                })
+                .ToList();
+
+            if (hoistable.Count == 0)
+            {
+                return buildMain();
+            }
+
+            foreach (PostfixUnaryExpressionSyntax node in hoistable)
             {
                 this.state.SuppressedPostfix.Add(node);
             }
@@ -2331,13 +2379,13 @@ public sealed partial class CSharpToGSharpTranslator
             }
             finally
             {
-                foreach (PostfixUnaryExpressionSyntax node in embedded)
+                foreach (PostfixUnaryExpressionSyntax node in hoistable)
                 {
                     this.state.SuppressedPostfix.Remove(node);
                 }
             }
 
-            foreach (PostfixUnaryExpressionSyntax node in embedded)
+            foreach (PostfixUnaryExpressionSyntax node in hoistable)
             {
                 statements.Add(new IncrementDecrementStatement(
                     this.TranslateExpression(node.Operand),

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -2350,15 +2350,20 @@ public sealed partial class CSharpToGSharpTranslator
                 }
             }
 
-            // A node whose operand's symbol could not be resolved has no
+            // A node whose operand's symbol could not be resolved (e.g. an
+            // array-element access like `a[0]++` — a built-in indexer
+            // operation with no target symbol via GetSymbolInfo) has no
             // reliable way to detect aliasing with another occurrence, so it
-            // is conservatively treated as its own single-occurrence target
-            // (matching this method's pre-#4114 behavior for such nodes).
+            // must stay inline rather than be hoisted: hoisting is only safe
+            // once a repeat is ruled out, and an unresolved target can never
+            // rule one out. `Record(a[0]++, a[0]++)` therefore falls through
+            // to G#'s native inline postfix, which evaluates each occurrence
+            // in true left-to-right order regardless of aliasing.
             List<PostfixUnaryExpressionSyntax> hoistable = embedded
                 .Where(node =>
                 {
                     ISymbol target = this.context.GetSymbolInfo(node.Operand).Symbol;
-                    return target == null || targetOccurrences[target] == 1;
+                    return target != null && targetOccurrences[target] == 1;
                 })
                 .ToList();
 


### PR DESCRIPTION
## Root cause

`InterfaceImplEmitter.PlanBridge` (`src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs`) plans two MethodDef rows for an inherited event bridge:

```csharp
bridges.Add(new InheritedEventBridge(
    ev,
    MetadataTokens.MethodDefinitionHandle(nextMethodRow++),
    MetadataTokens.MethodDefinitionHandle(nextMethodRow++)));
```

This is completely ordinary C#: the first argument reads `nextMethodRow` then increments it, the second reads the now-incremented value then increments again, so `add_` and `remove_` get distinct, sequential rows.

`cs2gs`'s translator models `++`/`--` as a *statement*, not a value-producing expression, in the common case. When a postfix increment appears in expression position (`WithHoistedPostfix` in `tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs`), it is "hoisted": the read is replaced by a bare read of the pre-increment value and the mutation is deferred to a trailing statement after the whole expression-statement. That hoist was applied to **every** embedded postfix node independently, with no check for whether the same target repeated. For `H(nextMethodRow++), H(nextMethodRow++))`, both occurrences got suppressed to a bare read of `nextMethodRow` (the *same*, pre-increment value), and both increments were deferred to *after* the statement — collapsing the two-step sequencing C# requires.

I confirmed this directly by reading the translated `.gs` output for `PlanBridge` from a whole-repo `cs2gs migrate --translate-only` pass:

```
InheritedEventBridge(
    ev,
    MetadataTokens.MethodDefinitionHandle(nextMethodRow),
    MetadataTokens.MethodDefinitionHandle(nextMethodRow)
)
nextMethodRow++
nextMethodRow++
```

Both handles came out numerically identical. `add_` then gets emitted at the row that was actually free (matching the plan), but `remove_` lands one row later than its (wrong, duplicate) planned handle, tripping `InterfaceImplEmitter.EmitInheritedEventBridge`'s own defensive check:

```
error GS9998: InvalidOperationException: Inherited event bridge MethodDef row was not emitted in planned order.
```

This only manifests once `InterfaceImplEmitter.cs` itself is translated and self-hosted (the native C# build of the same algorithm is unaffected), which is exactly why this only shows up under `test/Compiler.Tests`' self-migration run and not natively.

## Fix

1. **Primary (`tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs`)**: `WithHoistedPostfix` now only hoists a postfix node to a trailing statement when its target has exactly one occurrence in the statement. A target occurring more than once is left un-hoisted; those occurrences fall through to G#'s native inline inc/dec expression (gsc issue #1027), which evaluates each occurrence in true left-to-right order and needs no statement seam.
2. **Hardening (`src/Core/CodeAnalysis/Emit/InterfaceImplEmitter.cs`)**: `PlanBridge` now assigns `add_`/`remove_` handles from separate statements (one `nextMethodRow++` each), matching every other row-reservation loop already in `ReflectionMetadataEmitter.cs` (property getter/setter, event add/remove/raise, etc.). This is defense in depth so the same trap can't reopen here even if the translator regresses.

I scanned the C# corpus that gets self-migrated for any other statement containing the same target incremented twice (`grep`-based multi-line scan across `src/Core`, `src/Compiler`, `tools/cs2gs/Cs2Gs.Translator`, `src/LanguageServer`, `src/Repl`, `src/Formatting`, `tools/gsgen`) — `PlanBridge` was the only hit, so the blast radius is fully contained to this one spot.

## Regression coverage

Added `Cs2Gs.Tests.OahuDecryptTranslationTests.PostIncrement_SameTargetTwiceInOneStatement_PreservesLeftToRightSequencing`, asserting `Record(H(x++), H(x++))` translates with two distinct inline `H(x++)` call sites rather than collapsing to `Record(H(x), H(x))` with both mutations deferred. Verified it fails without the translator fix and passes with it.

## Red → green witness

**Targeted unit tests**, before/after the fix (native build, both green — the translator/unit-test level red witness is described above):
- `Cs2Gs.Tests` (`OahuDecryptTranslationTests`, 33 tests incl. the new one): pass
- `Compiler.Tests` (`Issue2742InheritedInterfaceEventEmitTests`, 3 tests): pass natively both before and after (native gsc never hit this bug — it's purely a self-hosting translation-fidelity issue)

**Self-migration `validate --app test/Compiler.Tests/Compiler.Tests.csproj`** (whole-repo `cs2gs migrate --translate-only` + `validate`, `GS_DEBUG_STACK=1`):

Before the fix:
```
error GS9998: InvalidOperationException: Inherited event bridge MethodDef row was not emitted in planned order.
  at ...MultiLevelInheritedCustomEvent_TypeLoadsDispatchesAndIlVerifies()
  at ...OahuDownloadSettings_InheritedFieldLikeEvent_TypeLoadsDispatchesAndIlVerifies()
  at ...ImportedInterface_InheritedFieldLikeEvent_TypeLoadsAndIlVerifies()

Failed!  - Failed: 37, Passed: 5789, Skipped: 0, Total: 5826, Duration: 50 m 25 s
```

After the fix (fresh whole-repo translate + validate, since the fix touches `src/Core` itself):
```
Failed!  - Failed: 35, Passed: 5791, Skipped: 0, Total: 5826, Duration: 51 m 4 s
```

- `MultiLevelInheritedCustomEvent_TypeLoadsDispatchesAndIlVerifies`: now passes.
- `ImportedInterface_InheritedFieldLikeEvent_TypeLoadsAndIlVerifies`: now passes.
- `OahuDownloadSettings_InheritedFieldLikeEvent_TypeLoadsDispatchesAndIlVerifies`: the GS9998 crash is gone; compilation now proceeds past metadata-row planning and the test reaches its *load/dispatch* stage, where it fails on `System.ArgumentException: Object of type 'System.EventHandler' cannot be converted to type 'System.Action\`2[System.Object,System.EventArgs]'` — this is the already-tracked, separate structural/nominal event-handler ABI mismatch (issue #4113, "structural event metadata is inconsistent across emitted contracts and consumers"), which #4114 explicitly scoped out ("distinct from the structural/nominal event ABI mismatch because compilation aborts in metadata row planning before load/dispatch checks"). Confirmed #4113 is open and explicitly lists this exact failure shape ("4 EventEmitTests cases expect Action<object, EventArgs> but observe EventHandler").

All 3 of #4114's originally-listed GS9998 crashes are gone; 2 of the 3 tests are fully green, and the 3rd now fails under a different, already-tracked issue outside this PR's scope.

Part of #3501. Fixes #4114.