### PR TITLE
cs2gs: record that #4195's ternary-argument test also pins #4112's 18 rows

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
@@ -108,6 +108,25 @@ namespace Demo
     /// <c>LambdaResultFeedsUnobservedTaskRun</c> handles a non-trivial
     /// argument expression at the call site would not be caught by it. This
     /// test pins the actual shape verbatim, closing that gap.
+    /// <para>
+    /// Issue #4112 is the REMAINING 18 of #4179's 48 rows, and this one test
+    /// covers those too — the four line items
+    /// <c>ExhaustiveSwitch_VerifiesLoadsAndRuns</c> (11 rows),
+    /// <c>ExhaustiveSwitchStatement_UnmatchedValueFallsThrough</c> (5), and
+    /// <c>ExhaustiveEnum_UnnamedRuntimeValue_ThrowsDefensively</c> /
+    /// <c>ExhaustiveEnum_UnnamedValueWithFixedReturn_ThrowsDefensively</c>
+    /// (1 each), so 30 + 18 = 48. They live in a SECOND test class, but no
+    /// second test is needed here: the faulting line in
+    /// <c>Issue2906ExhaustiveSwitchReturnEmitTests.cs</c> (lines 364-366) is
+    /// BYTE-IDENTICAL to the <c>Issue2891TryRegionFlowEmitTests.cs</c> line
+    /// (644-646) reproduced verbatim below, so the assertion already pins
+    /// both. The two <c>CompileVerifyLoadAndRun</c> helpers differ only in
+    /// Issue2906's two optional <c>IlVerifier</c> parameters and Issue2891's
+    /// <c>try</c>/<c>catch</c> around <c>Emit</c> — neither is reachable by
+    /// this heuristic. Recorded here because #4112's title blames gsc's
+    /// exhaustive-switch emit path, which #4182 exonerated by running all 46
+    /// snippet bodies from both files under a self-hosted gsc.
+    /// </para>
     /// </summary>
     [Fact]
     public void TaskRun_ReflectionInvokeWithConditionalArgumentObservedOnlyThroughWait_StaysBare()

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4179UnobservedTaskRunResultRegressionTests.cs
@@ -120,10 +120,14 @@ namespace Demo
     /// <c>Issue2906ExhaustiveSwitchReturnEmitTests.cs</c> (lines 364-366) is
     /// BYTE-IDENTICAL to the <c>Issue2891TryRegionFlowEmitTests.cs</c> line
     /// (644-646) reproduced verbatim below, so the assertion already pins
-    /// both. The two <c>CompileVerifyLoadAndRun</c> helpers differ only in
-    /// Issue2906's two optional <c>IlVerifier</c> parameters and Issue2891's
-    /// <c>try</c>/<c>catch</c> around <c>Emit</c> — neither is reachable by
-    /// this heuristic. Recorded here because #4112's title blames gsc's
+    /// both. The two <c>CompileVerifyLoadAndRun</c> helpers do differ
+    /// elsewhere — Issue2906 takes two optional <c>IlVerifier</c> parameters,
+    /// Issue2891 wraps <c>Emit</c> in <c>try</c>/<c>catch</c>, they format
+    /// diagnostics differently, and they use different temporary-assembly name
+    /// prefixes — but every one of those is surrounding context this heuristic
+    /// never inspects: it keys on the lambda result flowing into an unobserved
+    /// <c>Task.Run</c>, and that expression is common to both.
+    /// Recorded here because #4112's title blames gsc's
     /// exhaustive-switch emit path, which #4182 exonerated by running all 46
     /// snippet bodies from both files under a self-hosted gsc.
     /// </para>


### PR DESCRIPTION
## Summary

Closes the paper trail for #4112. **There is no defect left to fix** — #4112's 18 failures are the remaining 18 of the 48 rows #4179 enumerates, already fixed by #4182 (`9cafdbd9`), exactly as #4111 was for the other 30. This PR is a comment-only amendment; no production code and no test behaviour changes.

## Root cause (already fixed)

#4179's body lists its 48 failing rows by name, across **two** test classes that share one helper:

```
AcceptedFiniteShape_VerifiesLoadsAndRuns                      - 30 rows   <- #4111
ExhaustiveSwitch_VerifiesLoadsAndRuns                         - 11 rows   \
ExhaustiveSwitchStatement_UnmatchedValueFallsThrough          -  5 rows    |  = 18 = #4112
ExhaustiveEnum_UnnamedRuntimeValue_ThrowsDefensively          -  1 row     |
ExhaustiveEnum_UnnamedValueWithFixedReturn_ThrowsDefensively  -  1 row    /
```

30 + 18 = 48. All four issues (#4045, #4111, #4112, #4179) were measured on the same pre-fix run (5,393 passed / 75 failed / 5,468 total).

cs2gs's `IsUnguardedForwardOfTaintedValueAsRuntimeLambdaResult` force-asserted the reflection-nullable `MethodInfo.Invoke(...)` result with `!!` inside an unobserved `Task.Run` lambda. `<Main>$` is void, so `Invoke` legitimately returns `null` and the runtime `!!` threw on every row, surfacing through `.Wait()` as the reported `NullReferenceException`.

**The "exhaustive-switch emit path" in #4112's title is a red herring.** #4182 ran all 46 real snippet bodies from both affected files through a self-hosted gsc and every one executed correctly. I independently swept `ExhaustivenessAnalyzer`, `BoundPatternSwitchStatement`, `StatementBinder.Blocks`, `PatternBinder`, `Lowerer`'s switch lowering, `MethodBodyEmitter`'s switch / `NonVoidFallthroughGuard` emit and `ControlFlowGraph`, comparing each native `.cs` against its migrated `.gs`: all faithful. All 18 rows fail together precisely because they share the one harness line, not because of any switch shape.

## Why no new test

`Issue2906ExhaustiveSwitchReturnEmitTests.cs:364-366` is **byte-identical** to `Issue2891TryRegionFlowEmitTests.cs:644-646`:

```csharp
var execution = Task.Run(
    () => entry.Invoke(null, entry.GetParameters().Length == 0 ? null : new object[] { Array.Empty<string>() }));
Assert.True(execution.Wait(TimeSpan.FromSeconds(10)), $"{name} execution timed out");
```

#4195's `TaskRun_ReflectionInvokeWithConditionalArgumentObservedOnlyThroughWait_StaysBare` already reproduces that line verbatim and asserts `DoesNotContain(")!!")`, so it pins both classes. The two `CompileVerifyLoadAndRun` helpers differ only in Issue2906's two optional `IlVerifier` parameters and Issue2891's `try`/`catch` around `Emit` — neither is reachable by the heuristic. A second test would be duplication, not coverage.

What *was* missing is provenance: `grep 4112` over the repo returned nothing, so a reader of that test had no way to know it guards those 18 rows. This PR adds that, in the same shape #4195 used for #4111.

## Verification

**Green, end-to-end self-hosted (the leg #4182 explicitly did not run).** Reusing a whole-repo `cs2gs migrate --translate-only` tree translated at gsc `0.4.616+964a50a6b8` (post-#4182), I ran `validate --app test/Compiler.Tests/Compiler.Tests.csproj` to build the migrated test assembly against the migrated `GSharp.Core`, then filtered to the class:

```
$ dotnet test GSharp.Compiler.Tests.dll \
    --filter "FullyQualifiedName~Issue2906ExhaustiveSwitchReturnEmitTests"
Passed!  - Failed: 0, Passed: 18, Skipped: 0, Total: 18, Duration: 8 s
```

18/18, gsc `0.4.622+214c1c8ddd`. Honesty note: this is the stage-2 initial-compile output; the `!!`-polish pass had not run — that pass only ever *removes* assertions, so it cannot mask a `!!` that is already absent.

**Red, by anti-vacuity.** Removing the single clause #4182 added at `CSharpToGSharpTranslator.Expressions.cs:3400` (`|| this.LambdaResultFeedsUnobservedTaskRun(use)`):

| step | Issue4179 suite |
| --- | --- |
| fix present | Passed 11, Failed 0 |
| clause removed | Passed 7, **Failed 4** |
| restored | Passed 11, Failed 0 |

The failure that matters is #4195's ternary test — the one this PR documents:

```
Assert.DoesNotContain() Failure: Sub-string found
String: ..."y.Empty[string]()} })!!)\n            let "...
Found:  ")!!"
```

That is `!!` back on `entry.Invoke(...)`: the exact NullReferenceException source for #4112's 18 rows. The originally observed red is #4179's gate run 34370082359 (gsc `0.4.604`, pre-fix).

**This PR's own change:** `dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue4179UnobservedTaskRunResultRegressionTests"` — 11 passed, 0 failed.

## Follow-up candidate (not this PR)

Both helpers mask the real failure: a faulted `Task.Run` surfaces only `AggregateException: ... (Object reference not set to an instance of an object.)` with no throw site. #4179 flagged this ("unwrap `.InnerException` or `.Flatten()`"), and it is the main reason this cluster was expensive to diagnose. Worth its own issue against the two test helpers.
