### PR TITLE
cs2gs: record that #4180's fix also closes #4115's 6 selfmig iterator NRE rows

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
@@ -52,6 +52,29 @@ namespace Cs2Gs.Tests;
 /// matching when that element is already nullable-ANNOTATED (e.g. the
 /// BCL-declared <c>IEnumerable&lt;string?&gt;</c> <c>string.Join</c> accepts).
 /// </para>
+/// <para>
+/// Issue #4115 ("selfmig: generic iterator state-machine metadata
+/// inspection throws NRE (6 parity failures)", split from #4045) is the
+/// SAME six rows as #4180 (split from #4129) — both parity measurements
+/// independently surfaced the identical
+/// <c>StateMachine_BareElement_IsGeneric_ImplementsAsyncEnumerableOfVar0</c>,
+/// <c>StateMachine_MapElement_ImplementsAsyncEnumerableOfReifiedDictionary</c>,
+/// <c>StateMachine_FunctionElement_ImplementsAsyncEnumerableOfReifiedFunc</c>,
+/// <c>StateMachineClass_MapElement_ImplementsIEnumerableOfReifiedDictionary</c>,
+/// <c>StateMachineClass_FunctionElement_ImplementsIEnumerableOfReifiedFunc</c>,
+/// and <c>StateMachineClass_TupleElement_ImplementsIEnumerableOfValueTuple</c>
+/// failures, in the same three files, with the same
+/// <c>NullReferenceException</c>-inside-<c>.Select(i =&gt; i.FullName)</c>
+/// signature. There is no defect left to fix for #4115 either — this class's
+/// two <c>!!</c>-on-<c>FullName</c> tests already pin the exact translator
+/// defect, and <c>test/Compiler.Tests</c>' 25 native tests across
+/// <c>Issue1481MapFunctionIteratorEmitTests</c>,
+/// <c>Issue1489GenericAsyncIteratorEmitTests</c>, and
+/// <c>Issue813TupleSequenceReturnEmitTests</c> were never affected (native
+/// gsc never hits this bug — it is purely a self-hosting translation-fidelity
+/// issue). This provenance note is the same shape #4199 used to record that
+/// #4195's regression test also pinned #4112's rows.
+/// </para>
 /// </summary>
 public sealed class Issue4180NullableSelectResultRegressionTests
 {

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
@@ -54,26 +54,35 @@ namespace Cs2Gs.Tests;
 /// </para>
 /// <para>
 /// Issue #4115 ("selfmig: generic iterator state-machine metadata
-/// inspection throws NRE (6 parity failures)", split from #4045) is the
-/// SAME six rows as #4180 (split from #4129) — both parity measurements
-/// independently surfaced the identical
-/// <c>StateMachine_BareElement_IsGeneric_ImplementsAsyncEnumerableOfVar0</c>,
-/// <c>StateMachine_MapElement_ImplementsAsyncEnumerableOfReifiedDictionary</c>,
-/// <c>StateMachine_FunctionElement_ImplementsAsyncEnumerableOfReifiedFunc</c>,
-/// <c>StateMachineClass_MapElement_ImplementsIEnumerableOfReifiedDictionary</c>,
-/// <c>StateMachineClass_FunctionElement_ImplementsIEnumerableOfReifiedFunc</c>,
-/// and <c>StateMachineClass_TupleElement_ImplementsIEnumerableOfValueTuple</c>
-/// failures, in the same three files, with the same
-/// <c>NullReferenceException</c>-inside-<c>.Select(i =&gt; i.FullName)</c>
-/// signature. There is no defect left to fix for #4115 either — this class's
-/// two <c>!!</c>-on-<c>FullName</c> tests already pin the exact translator
-/// defect, and <c>test/Compiler.Tests</c>' 25 native tests across
+/// inspection throws NRE (6 parity failures)", split from #4045) describes
+/// this exact same defect against the same three files
+/// (<c>Issue1489GenericAsyncIteratorEmitTests.cs</c>,
+/// <c>Issue1481MapFunctionIteratorEmitTests.cs</c>,
+/// <c>Issue813TupleSequenceReturnEmitTests.cs</c>) with the same
+/// <c>NullReferenceException</c>-while-inspecting-the-generated-interfaces
+/// signature, and the same count: of those three files' seven
+/// <c>AssertImplementsGenericOf</c>/<c>AssertImplementsEnumerableOf</c>
+/// reflection tests, exactly six assert an interface row closed over the
+/// state machine's own unresolved Var(0) type parameter (so
+/// <see cref="Type.FullName"/> is null on that row and the stray <c>!!</c>
+/// throws); the seventh —
+/// <c>StateMachineClass_MapOfListElement_StaysErased_AndVerifies</c> —
+/// asserts a fully-closed, erased row (<c>Dictionary&lt;string,
+/// List&lt;object&gt;&gt;</c>) whose <c>FullName</c> is never null, so it
+/// was never among the failures. There is no defect left to fix for #4115
+/// either — this class's <c>TranslatedSnippet_*</c> and
+/// <c>SelfHostedNullableSelectResult_*</c> tests (four in total, two
+/// shapes) already pin the exact translator defect, and
+/// <c>test/Compiler.Tests</c>' 25 native tests across
 /// <c>Issue1481MapFunctionIteratorEmitTests</c>,
 /// <c>Issue1489GenericAsyncIteratorEmitTests</c>, and
 /// <c>Issue813TupleSequenceReturnEmitTests</c> were never affected (native
 /// gsc never hits this bug — it is purely a self-hosting translation-fidelity
-/// issue). This provenance note is the same shape #4199 used to record that
-/// #4195's regression test also pinned #4112's rows.
+/// issue; see #4180's PR description for the documented re-translation of
+/// these exact three files confirming no <c>!!</c> remains on any
+/// <c>i.FullName</c> selector). This provenance note is the same shape
+/// #4199 used to record that #4195's regression test also pinned #4112's
+/// rows.
 /// </para>
 /// </summary>
 public sealed class Issue4180NullableSelectResultRegressionTests

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs
@@ -60,14 +60,21 @@ namespace Cs2Gs.Tests;
 /// <c>Issue1481MapFunctionIteratorEmitTests.cs</c>,
 /// <c>Issue813TupleSequenceReturnEmitTests.cs</c>) with the same
 /// <c>NullReferenceException</c>-while-inspecting-the-generated-interfaces
-/// signature, and the same count: of those three files' seven
-/// <c>AssertImplementsGenericOf</c>/<c>AssertImplementsEnumerableOf</c>
-/// reflection tests, exactly six assert an interface row closed over the
-/// state machine's own unresolved Var(0) type parameter (so
-/// <see cref="Type.FullName"/> is null on that row and the stray <c>!!</c>
-/// throws); the seventh —
-/// <c>StateMachineClass_MapOfListElement_StaysErased_AndVerifies</c> —
-/// asserts a fully-closed, erased row (<c>Dictionary&lt;string,
+/// signature, and the same count: of those three files' seven reflection
+/// tests — six sharing the <c>AssertImplementsGenericOf</c> helper
+/// (<c>Issue1489GenericAsyncIteratorEmitTests.cs</c>, three tests) /
+/// <c>AssertImplementsEnumerableOf</c> helper
+/// (<c>Issue1481MapFunctionIteratorEmitTests.cs</c>, three tests), plus a
+/// seventh in <c>Issue813TupleSequenceReturnEmitTests.cs</c>
+/// (<c>StateMachineClass_TupleElement_ImplementsIEnumerableOfValueTuple</c>)
+/// that performs the equivalent <c>smType.GetInterfaces()</c> scan inline
+/// rather than through either shared helper — exactly six assert an
+/// interface row closed over the state machine's own unresolved Var(0)
+/// type parameter (so <see cref="Type.FullName"/> is null on that row and
+/// the stray <c>!!</c> throws); the seventh —
+/// <c>StateMachineClass_MapOfListElement_StaysErased_AndVerifies</c>, one
+/// of the <c>AssertImplementsEnumerableOf</c>-based three — asserts a
+/// fully-closed, erased row (<c>Dictionary&lt;string,
 /// List&lt;object&gt;&gt;</c>) whose <c>FullName</c> is never null, so it
 /// was never among the failures. There is no defect left to fix for #4115
 /// either — this class's <c>TranslatedSnippet_*</c> and


### PR DESCRIPTION
## Summary

Closes the paper trail for #4115. **There is no defect left to fix** — #4115's 6 test-parity failures are the exact same rows as #4180 (already fixed by #4181, commit `964a50a6`, already on `main`). This PR is a comment-only amendment; no production code and no test behaviour changes.

## Investigation

Per the issue's own instructions, I first checked whether #4115 shared #4111/#4112's root cause (the #4179/#4182 unobserved-`Task.Run` `!!` heuristic on `CompileVerifyLoadAndRun`). It does not: none of `Issue1481MapFunctionIteratorEmitTests.cs`, `Issue1489GenericAsyncIteratorEmitTests.cs`, or `Issue813TupleSequenceReturnEmitTests.cs` use `CompileVerifyLoadAndRun` or an unobserved `Task.Run` — they compile via a direct in-process `Program.Main` call and reflect on `smType.GetInterfaces()` directly.

Reading those three files closely surfaced a sharper match: they are **exactly** the three files and the same shape of failure (`NullReferenceException` "while inspecting the generated state-machine interfaces") already described and fixed by #4180/#4181:

- cs2gs's `LambdaResultFlowsToNullableSink` only recognised a `.Select(...)` result that chains into a further scalar-returning call (e.g. `.Select(...).FirstOrDefault()`). It didn't recognise the sibling shape where the `Select` result flows **whole, as a collection**, into an argument position whose parameter itself accepts a nullable-element sequence — exactly `string.Join(string?, IEnumerable<string?>)`, which every one of these tests' `AssertImplementsGenericOf`/`AssertImplementsEnumerableOf` helpers builds as their `Assert.True` failure message: `string.Join(", ", smType.GetInterfaces().Select(i => i.FullName))`.
- Falling through to the general oblivious-forwarding bridge inserted a G# `!!` on `i.FullName`. `Type.FullName` legitimately returns `null` for a reified generic interface row closed over an unresolved type parameter (`IEnumerable<Dictionary<string,T>>` closed over the SM's own `Var(0)`) — exactly the shape 6 of these 7 reflection tests construct. The 7th, `StateMachineClass_MapOfListElement_StaysErased_AndVerifies`, asserts a fully-closed, erased row (`Dictionary<string, List<object>>`) whose `FullName` is never null — which is why it was never among the 6 failures.
- This is **not a gsc emitter defect**: #4180's investigation (and the assertion messages themselves, which only evaluate lazily-necessary on failure) confirm the emitted state-machine interface metadata is correct under both native and self-hosted gsc. It is purely a self-hosting **translation-fidelity** issue in the test's own reflection code.

## Why no new production fix

The fix for this exact defect (`CSharpToGSharpTranslator.Expressions.cs`'s `LambdaResultFlowsToNullableSink` unwrapping a sink's single generic type argument and comparing element-to-element) already merged in #4181 (commit `964a50a6`), which is already on `main` in this worktree. What was missing is provenance connecting #4115 (split from #4045) to that fix (which was filed as #4180, split from #4129) — the same gap #4199 closed for #4112 against #4179/#4182. This PR adds that note to `tools/cs2gs/Cs2Gs.Tests/Issue4180NullableSelectResultRegressionTests.cs`, in the same shape.

I also checked `tools/cs2gs/selfmig-test-allowlist.json` — none of these test names or #4115/#4180/#4129 appear there, so there is no allow-list entry to remove.

## Verification

**Green, on current `main` (already past `964a50a6`):**

```
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue4180"
Passed! - Failed: 0, Passed: 4, Skipped: 0, Total: 4

dotnet test test/Compiler.Tests/Compiler.Tests.csproj -c Release --filter "FullyQualifiedName~Issue1481MapFunctionIteratorEmitTests|FullyQualifiedName~Issue1489GenericAsyncIteratorEmitTests|FullyQualifiedName~Issue813TupleSequenceReturnEmitTests"
Passed! - Failed: 0, Passed: 25, Skipped: 0, Total: 25
```

(Native tests were never affected — native gsc never hits this translator-only bug, matching #4180's own documentation of re-translating these exact three files with no `!!` left on any `i.FullName` selector.)

**Red, by anti-vacuity** (reverted just #4180/#4181's translator hunk in `CSharpToGSharpTranslator.Expressions.cs`, comparing the commit before and after `964a50a6`):

```
dotnet test tools/cs2gs/Cs2Gs.Tests/Cs2Gs.Tests.csproj -c Release --filter "FullyQualifiedName~Issue4180"
Failed! - Failed: 4, Passed: 0, Total: 4

Assert.DoesNotContain() Failure: Sub-string found
Found:  "t.FullName!!"

System.NullReferenceException: Object reference not set to an instance of an object.
   at Default.Probe.<lambda_host_<lambda1>_1>.Invoke(Type t)
   at System.Linq.Enumerable.ArraySelectIterator`2.MoveNext()
   at System.String.Join(String separator, IEnumerable`1 values)
```

— reproducing the exact reported crash shape and stack trace. Restored the fix afterward and re-confirmed green (4/4).

Part of #3501. Fixes #4115.
