### PR TITLE
gsc: fix GetHierarchy() accessibility in an analyzer-snippet test (#4201)

### DIFF
--- a/test/InternalAnalyzers.Tests/BaseClassCycleUnsafeWalkAnalyzerTests.cs
+++ b/test/InternalAnalyzers.Tests/BaseClassCycleUnsafeWalkAnalyzerTests.cs
@@ -209,7 +209,7 @@ class StructSymbol
 {
     public StructSymbol? BaseClass;
 
-    List<StructSymbol> GetHierarchy()
+    public List<StructSymbol> GetHierarchy()
     {
         var hierarchy = new List<StructSymbol>();
         StructSymbol? current = this;

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4201GetHierarchyAccessibilitySnippetRegressionTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4201GetHierarchyAccessibilitySnippetRegressionTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="Issue4201GetHierarchyAccessibilitySnippetRegressionTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Linq;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Analyzers;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4201: <c>test/InternalAnalyzers.Tests/BaseClassCycleUnsafeWalkAnalyzerTests.cs</c>'s
+/// <c>IgnoresGuardedWalkThroughHierarchyHelper</c> snippet (added by #4172) declared
+/// <c>StructSymbol.GetHierarchy()</c> with no access modifier — defaulting to
+/// <c>private</c> in C# — while calling it from the sibling <c>Walker</c> class. That is a
+/// genuine CS0122 compile error in the embedded snippet, invisible to
+/// <c>dotnet test</c> (Roslyn's analyzer-testing infrastructure still runs the analyzer
+/// and checks its diagnostics even when the snippet fails to compile), but fatal to
+/// <c>SnippetTranslator</c>, which requires <c>project.BoundWithoutErrors</c> before it
+/// will attempt translation at all. That one compile error blocked the ENTIRE
+/// <c>test/InternalAnalyzers.Tests</c> app from translating in the selfmig pipeline.
+///
+/// <para>
+/// The fix is a one-word accessibility change (add <c>public</c>) in the fixture
+/// itself. This test pins the translator-level failure mode by exercising
+/// <see cref="SnippetTranslator.Translate(string)"/> directly on both the fixed shape
+/// (copied verbatim from the corrected fixture) and the original broken shape — it
+/// documents exactly what breaks and how, in a fast unit test that does not need a
+/// whole-repo selfmig run to demonstrate. It is not a substitute for the live fixture:
+/// if <c>BaseClassCycleUnsafeWalkAnalyzerTests.cs</c> itself regresses this way again,
+/// the nightly cs2gs-selfmig gate (not this test) is what will catch it.
+/// </para>
+/// </summary>
+public sealed class Issue4201GetHierarchyAccessibilitySnippetRegressionTests
+{
+    // Copied verbatim (post-fix) from
+    // test/InternalAnalyzers.Tests/BaseClassCycleUnsafeWalkAnalyzerTests.cs's
+    // IgnoresGuardedWalkThroughHierarchyHelper.
+    private const string FixedSnippet = """
+using System.Collections.Generic;
+
+class StructSymbol
+{
+    public StructSymbol? BaseClass;
+
+    public List<StructSymbol> GetHierarchy()
+    {
+        var hierarchy = new List<StructSymbol>();
+        StructSymbol? current = this;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseClass;
+        }
+
+        return hierarchy;
+    }
+}
+
+class Walker
+{
+    bool FindAncestor(StructSymbol container, StructSymbol target)
+    {
+        var chain = container.GetHierarchy();
+        for (var i = 1; i < chain.Count; i++)
+        {
+            if (chain[i] == target)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+""";
+
+    // The pre-fix shape: `GetHierarchy()` carries no access modifier, so it defaults to
+    // `private` and `Walker.FindAncestor`'s cross-class call is a CS0122 compile error.
+    private const string BrokenSnippet = """
+using System.Collections.Generic;
+
+class StructSymbol
+{
+    public StructSymbol? BaseClass;
+
+    List<StructSymbol> GetHierarchy()
+    {
+        var hierarchy = new List<StructSymbol>();
+        StructSymbol? current = this;
+        while (current != null)
+        {
+            hierarchy.Add(current);
+            current = current.BaseClass;
+        }
+
+        return hierarchy;
+    }
+}
+
+class Walker
+{
+    bool FindAncestor(StructSymbol container, StructSymbol target)
+    {
+        var chain = container.GetHierarchy();
+        for (var i = 1; i < chain.Count; i++)
+        {
+            if (chain[i] == target)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+""";
+
+    [Fact]
+    public void FixedSnippet_TranslatesCleanly_WithNoAnalyzerSnippetDiagnostic()
+    {
+        SnippetTranslationResult result = SnippetTranslator.Translate(FixedSnippet);
+
+        Assert.NotNull(result.GsWithMarkers);
+        Assert.DoesNotContain(
+            result.Diagnostics,
+            d => d.Message.Contains("does not compile", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BrokenSnippet_FailsToTranslate_WithCs0122InTheDiagnosticMessage()
+    {
+        // Anti-vacuity (#4201): reverting the one-word `public` fix reproduces exactly
+        // this translate-stage failure; restoring it (FixedSnippet, above) fixes it.
+        SnippetTranslationResult result = SnippetTranslator.Translate(BrokenSnippet);
+
+        Assert.Null(result.GsWithMarkers);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Message.Contains("does not compile", StringComparison.Ordinal)
+                && d.Message.Contains("CS0122", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4201. `BaseClassCycleUnsafeWalkAnalyzerTests.cs`'s `IgnoresGuardedWalkThroughHierarchyHelper` test (added by #4172) embeds a C# analyzer-test snippet where `StructSymbol.GetHierarchy()` had no access modifier — defaulting to `private` — while the sibling `Walker` class called it across the class boundary. That's a genuine CS0122 compile error inside the snippet.

`dotnet test` stayed green because Roslyn's analyzer-testing infrastructure runs the analyzer and checks its diagnostics even when the snippet has a compile error alongside. But cs2gs's `SnippetTranslator` requires `project.BoundWithoutErrors` before attempting translation at all, so this one compile error blocked the entire `test/InternalAnalyzers.Tests` app from translating in the selfmig pipeline.

Fix: add `public` to `GetHierarchy()`'s declaration. One-line test-fixture change; no translator/compiler code touched.

## Verification

- Native test still passes identically: `dotnet test test/InternalAnalyzers.Tests/InternalAnalyzers.Tests.csproj -c Release --filter "FullyQualifiedName~IgnoresGuardedWalkThroughHierarchyHelper"` -> 1/1 passed.
- Full `test/InternalAnalyzers.Tests` suite: 26/26 passed, zero regressions.
- Added `tools/cs2gs/Cs2Gs.Tests/Issue4201GetHierarchyAccessibilitySnippetRegressionTests.cs`, exercising `SnippetTranslator.Translate` directly:
  - the fixed snippet (verbatim from the corrected fixture) translates cleanly with no `CS2GS-ANALYZER-SNIPPET`/"does not compile" diagnostic;
  - the pre-fix broken snippet reproduces the exact failure (`does not compile` + `CS0122`) — anti-vacuity: reverting the one-word fix reproduces the failure, restoring it fixes it.
Part of #3501.
