### PR TITLE
cs2gs: preserve nominal delegate identity in typeof(...) and explicit type arguments

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4113NominalDelegateIdentityInExpressionsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4113NominalDelegateIdentityInExpressionsTranslationTests.cs
@@ -113,6 +113,105 @@ namespace Demo
         Assert.Contains("typeof((object, EventArgs) -> void)", printed);
     }
 
+    [Fact]
+    public void TypeOfArrayOfNominalEventHandler_PreservesNominalIdentity()
+    {
+        // Copilot review of PR #4205: the top-level delegate check alone
+        // does not catch a nominal delegate one level down. MapExplicitType
+        // recurses into an array's element type instead of falling through
+        // to the general Map() pipeline for it.
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type F() => typeof(EventHandler[]);
+    }
+}");
+
+        Assert.Contains("typeof([]EventHandler)", printed);
+        Assert.DoesNotContain("EventArgs) -> void", printed);
+    }
+
+    [Fact]
+    public void TypeOfGenericListOfNominalEventHandler_PreservesNominalIdentity()
+    {
+        // Copilot review of PR #4205: same nesting gap, one generic type
+        // argument deep (`typeof(List<EventHandler>)`).
+        string printed = TranslateUnit(@"
+using System;
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type F() => typeof(List<EventHandler>);
+    }
+}");
+
+        Assert.Contains("typeof(List[EventHandler])", printed);
+        Assert.DoesNotContain("EventArgs) -> void", printed);
+    }
+
+    [Fact]
+    public void ExplicitGenericTypeArgumentOfGenericListOfNominalEventHandler_PreservesNominalIdentity()
+    {
+        // Copilot review of PR #4205: the same nesting gap reachable through
+        // MapTypeArguments (an explicit generic type argument on a call),
+        // not just MapTypeOf.
+        string printed = TranslateUnit(@"
+using System;
+using System.Collections.Generic;
+
+namespace Demo
+{
+    public class C
+    {
+        public bool F(object del) => Describe<List<EventHandler>>(del);
+
+        public bool Describe<T>(object value) => value is T;
+    }
+}");
+
+        Assert.Contains("Describe[List[EventHandler]](del)", printed);
+        Assert.DoesNotContain("Describe[List[(object", printed);
+    }
+
+    [Fact]
+    public void NullableValueTypeWrappingAnOrdinaryGenericType_IsNotDoublyWrapped()
+    {
+        // Regression guard found during PR #4205's own regression sweep, not
+        // by Copilot: Memory<int>? is Nullable<Memory<int>> — a generic named
+        // type (Nullable<T>) whose OWN single type argument is the WRAPPED
+        // type, not a sibling of the same shape as an ordinary List<T>/T[]
+        // nesting. Map() unwraps it specially (to Memory<int>'s own mapped
+        // shape, marked nullable) before ever reaching the generic tail the
+        // array/generic-argument recursion above mirrors, so blindly zipping
+        // Nullable<T>'s own type argument onto that already-unwrapped
+        // reference's type-argument list corrupted Memory<int>? into
+        // Memory[Memory[int32]]? — silently doubling the generic nesting on
+        // a declaration with no delegate anywhere in it.
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public void F()
+        {
+            Memory<int>? memory = new Memory<int>(new[] { 5, 6, 7, 8 });
+        }
+    }
+}");
+
+        Assert.Contains("Memory[int32]?", printed);
+        Assert.DoesNotContain("Memory[Memory", printed);
+    }
+
     private static string TranslateUnit(string source)
     {
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4113NominalDelegateIdentityInExpressionsTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4113NominalDelegateIdentityInExpressionsTranslationTests.cs
@@ -1,0 +1,136 @@
+// <copyright file="Issue4113NominalDelegateIdentityInExpressionsTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for issue #4113: a nominal CLR delegate
+/// (<c>EventHandler</c>, <c>EventHandler&lt;T&gt;</c>) referenced from a
+/// <c>typeof(...)</c> operand or an explicit generic type argument must keep
+/// its nominal identity, exactly like <c>MapExplicitType</c> already
+/// preserves it for a variable's declared type (issue #2835/#3841).
+/// <para>
+/// Before this fix, <c>MapTypeOf</c> (the <c>typeof(...)</c> operand mapper)
+/// and <c>MapTypeArguments</c> (the explicit-type-argument mapper) both
+/// routed through the general, structurally-canonicalizing <c>Map</c>
+/// pipeline, which silently rewrote <c>typeof(EventHandler)</c> into
+/// <c>typeof(Action&lt;object, EventArgs&gt;)</c> — a DIFFERENT runtime
+/// <see cref="Type"/>. That is invisible at the printed-G#-source level only
+/// if you don't check it, but it defeats any test (or, once this exact
+/// translator source is itself self-hosted, any compiler logic — see
+/// <c>MemberLookup.CanonicalizeWellKnownEventHandler</c>) that relies on
+/// <c>typeof(EventHandler)</c> actually meaning <c>System.EventHandler</c>.
+/// </para>
+/// </summary>
+public class Issue4113NominalDelegateIdentityInExpressionsTranslationTests
+{
+    [Fact]
+    public void TypeOfNominalEventHandler_PreservesNominalIdentity()
+    {
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type F() => typeof(EventHandler);
+    }
+}");
+
+        Assert.Contains("typeof(EventHandler)", printed);
+        Assert.DoesNotContain("EventArgs) -> void", printed);
+    }
+
+    [Fact]
+    public void TypeOfClosedGenericNominalEventHandler_PreservesNominalIdentity()
+    {
+        string printed = TranslateUnit(@"
+using System;
+using System.ComponentModel;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type F() => typeof(EventHandler<PropertyChangedEventArgs>);
+    }
+}");
+
+        Assert.Contains("typeof(EventHandler[PropertyChangedEventArgs])", printed);
+        Assert.DoesNotContain("EventArgs) -> void", printed);
+    }
+
+    [Fact]
+    public void ExplicitGenericTypeArgumentOfNominalEventHandler_PreservesNominalIdentity()
+    {
+        // The exact shape behind EventEmitTests' `Assert.IsType<EventHandler>(del)`
+        // (#4113): an explicit type argument on a generic method call.
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public bool F(object del) => Describe<EventHandler>(del);
+
+        public bool Describe<T>(object value) => value is T;
+    }
+}");
+
+        Assert.Contains("Describe[EventHandler](del)", printed);
+        Assert.DoesNotContain("Describe[(object", printed);
+    }
+
+    [Fact]
+    public void TypeOfOrdinaryActionDelegate_StillCanonicalizesToStructuralForm()
+    {
+        // Precision guard: Func/Action/Predicate are the canonical structural
+        // spelling's own identity (issue #2835's own exclusion) — typeof over
+        // one of those must keep collapsing to the arrow form, unlike
+        // EventHandler above.
+        string printed = TranslateUnit(@"
+using System;
+
+namespace Demo
+{
+    public class C
+    {
+        public Type F() => typeof(Action<object, EventArgs>);
+    }
+}");
+
+        Assert.Contains("typeof((object, EventArgs) -> void)", printed);
+    }
+
+    private static string TranslateUnit(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip and bind. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -3767,8 +3767,17 @@ public sealed partial class CSharpToGSharpTranslator
                 ITypeSymbol symbol = i < boundTypeArguments.Length
                     ? boundTypeArguments[i]
                     : this.context.GetTypeInfo(argument).Type;
+
+                // Issue #4113: an explicit type argument (`Assert.IsType<EventHandler>(x)`)
+                // is, like a variable's declared type, an EXPLICITLY WRITTEN source
+                // type — MapExplicitType's named-CLR-delegate-identity rule
+                // (issue #2835/#3841) applies here for the same reason: the general
+                // Map() pipeline's structural-arrow canonicalization silently
+                // rewrote `IsType<EventHandler>` into `IsType<Action<object,
+                // EventArgs>>`, a different runtime type, defeating exactly the
+                // identity check the call was making.
                 result.Add(symbol != null
-                    ? this.typeMapper.Map(symbol, this.context, argument.GetLocation())
+                    ? this.typeMapper.MapExplicitType(symbol, this.context, argument.GetLocation())
                     : new NamedTypeReference(argument.ToString()));
             }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -561,6 +561,70 @@ public sealed class CSharpTypeMapper
                 : mapped;
         }
 
+        // Issue #4113 follow-up (Copilot review of PR #4205): the delegate
+        // check above only catches a nominal delegate written DIRECTLY as
+        // the explicit type. One nested one level down — an array element
+        // (`typeof(EventHandler[])`) or a non-tuple generic type argument
+        // (`Observe<List<EventHandler>>()`) — still fell through to the
+        // general Map() pipeline for that nested position, which collapses
+        // it to the structural arrow form the same way the top-level case
+        // used to. Map() first gives the CORRECT baseline shape (name,
+        // namespace qualification, nested-containing-type handling, arity —
+        // none of that changes here), and only the nested slot(s) are
+        // rebuilt through MapExplicitType instead of Map.
+        //
+        // The guards on the generic branch are deliberate and each closes a
+        // measured false-positive, not a hypothetical one: `Nullable<T>`
+        // (`Memory<int>?`) is ITSELF a generic named type whose own single
+        // type argument is the WRAPPED type, not a sibling type argument
+        // list of the same shape — Map() special-cases it by unwrapping to
+        // `T`'s own mapped shape before ever reaching the generic tail this
+        // branch mirrors, so `structural` here is `T`'s reference (e.g.
+        // `Memory[int32]`), and its TypeArguments correspond to `T`'s OWN
+        // arguments, not `Nullable<T>`'s. Blindly zipping
+        // `genericNamed.TypeArguments` (`[Memory<int>]`, Nullable's own
+        // argument) onto that unrelated list — the count coincidentally
+        // matched, both being length 1 — silently produced
+        // `Memory[Memory[int32]]?`, corrupting an unrelated, correctly-typed
+        // declaration. The `structural.Name` suffix check is the general
+        // form of this same defense: it holds whenever Map() actually built
+        // `structural` FROM `genericNamed`'s own qualified name (the
+        // ordinary generic tail this substitution assumes), and fails
+        // whenever Map() took some OTHER special-cased early exit (Nullable
+        // unwrapping being the one this fix measured, not necessarily the
+        // only one) that produced a reference naming a different type
+        // entirely.
+        //
+        // A NESTED generic type (`Outer<T>.Inner<U>`) is excluded by the
+        // count guard for a related reason: it splits its arguments between
+        // TypeArguments and ContainingType in a way this substitution does
+        // not attempt to reproduce, so it is skipped (falls through
+        // unchanged) rather than risk zipping arguments against the wrong
+        // slot — narrower coverage than a fully general fix, but never
+        // wrong.
+        if (type is IArrayTypeSymbol array)
+        {
+            GTypeReference explicitElement = this.MapExplicitType(array.ElementType, context, location);
+            return new ArrayTypeReference(explicitElement, array.Rank) { IsNullable = type.NullableAnnotation == NullableAnnotation.Annotated };
+        }
+
+        if (type is INamedTypeSymbol genericNamed
+            && genericNamed.IsGenericType
+            && !genericNamed.IsTupleType
+            && !genericNamed.IsAnonymousType
+            && genericNamed.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T
+            && this.Map(type, context, location) is NamedTypeReference structural
+            && structural.Name.EndsWith(genericNamed.Name, System.StringComparison.Ordinal)
+            && structural.TypeArguments.Count == genericNamed.TypeArguments.Length)
+        {
+            List<GTypeReference> explicitArgs = genericNamed.TypeArguments
+                .Select(a => this.MapExplicitType(a, context, location))
+                .ToList();
+            return explicitArgs.SequenceEqual(structural.TypeArguments)
+                ? structural
+                : new NamedTypeReference(structural.Name, explicitArgs, structural.ContainingType) { IsNullable = structural.IsNullable };
+        }
+
         return this.Map(type, context, location);
     }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpTypeMapper.cs
@@ -1205,11 +1205,23 @@ public sealed class CSharpTypeMapper
     internal static string StripGlobalPrefix(string name) =>
         name.StartsWith("global::", System.StringComparison.Ordinal) ? name.Substring("global::".Length) : name;
 
+    // Issue #4113: a `typeof(...)` operand observes the CLR's actual runtime
+    // Type identity, so it needs the same "preserve named-delegate identity"
+    // treatment MapExplicitType already applies to an explicitly-typed
+    // declaration (issue #2835/#3841) — not the general Map() pipeline, whose
+    // structural-arrow canonicalization is a style choice appropriate for a
+    // *declaration*, not for an expression whose entire purpose is to name an
+    // exact runtime type. Routing through the general mapper silently turned
+    // `typeof(EventHandler)` into `typeof(Action<object, EventArgs>)`: a
+    // different CLR type, breaking every runtime identity comparison against
+    // it (reflection-based ABI assertions, and — once this very method's own
+    // source is self-hosted — gsc's own CanonicalizeWellKnownEventHandler,
+    // which returns `TypeSymbol.FromClrType(typeof(EventHandler))`).
     internal GTypeReference MapTypeOf(ITypeSymbol type, TranslationContext context, Location location)
     {
         return IsSystemIndexOrRange(type)
             ? this.MapCore(type, context, location)
-            : this.Map(type, context, location);
+            : this.MapExplicitType(type, context, location);
     }
 
     internal GTypeReference MapNominalDelegate(


### PR DESCRIPTION
Fixes #4113.

`CSharpTypeMapper.MapTypeOf` (`typeof(...)` operands) and `CSharpToGSharpTranslator.MapTypeArguments` (explicit generic type arguments) both routed through the general, structurally-canonicalizing `Map()` pipeline instead of `MapExplicitType`, the rule that already preserves a nominal CLR delegate's identity (`System.EventHandler`) for an explicitly-written declaration (issue #2835/#3841).

This silently mistranslated `typeof(EventHandler)` into `typeof((object?, EventArgs) -> void)`, which materializes as `typeof(Action<object, EventArgs>)` at runtime — a **different** CLR type, breaking every identity comparison against it. This affected both test assertions (`Assert.IsType<EventHandler>(del)`, `typeof(EventHandler)` in `EventEmitTests` and `Issue2726NominalEventDelegateEmitTests`) and gsc's own `MemberLookup.CanonicalizeWellKnownEventHandler`, which itself calls `typeof(EventHandler)`/`typeof(EventHandler<EventArgs>)` to build its return value — so once `src/Core` is self-hosted, the migrated compiler canonicalizes events to `Action<object,EventArgs>` instead of real `EventHandler`, producing ILVerify `MissingMethod` failures for any real-C#-compiled consumer that expects `EventHandler` accessors.

All 8 of issue #4113's listed failures trace to this one bug: 5 directly from the `typeof`/`IsType` mistranslation, 3 more (ILVerify `MissingMethod` failures) from `MemberLookup`'s own corrupted canonicalization once self-hosted.

## Fix

Both sites now call `MapExplicitType` instead of `Map`, reusing the existing nominal-delegate-preservation rule rather than duplicating it.

## Verified

- New `Issue4113NominalDelegateIdentityInExpressionsTranslationTests` (4 tests, including a precision guard confirming `Action`/`Func`/`Predicate` still canonicalize to the structural arrow form) is red without the fix (3/4 fail via anti-vacuity revert) and green with it.
- Full `Cs2Gs.Tests` suite: 2945/2945 pass.
- Native `test/Compiler.Tests` `EventEmitTests` + `Issue2726NominalEventDelegateEmitTests`: 50/50 pass, unchanged — `src/Core` itself was not touched.
