### PR TITLE
cs2gs: preserve delegate identity for a var-typed local's delegate-creation initializer

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4116VarDelegateLocalIdentityTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4116VarDelegateLocalIdentityTranslationTests.cs
@@ -1,0 +1,181 @@
+// <copyright file="Issue4116VarDelegateLocalIdentityTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4116 (split from #4045's #2519 residual runtime failure,
+/// <c>Issue2519SourceClassConstraintOrderingEmitTests</c>): a `var`-typed C#
+/// local initialized by a delegate-creation expression
+/// (<c>var handler = new Action(() =&gt; counter++);</c>) loses its nominal
+/// delegate identity entirely.
+/// <para>
+/// <c>TranslateObjectCreation</c> unwraps <c>new SomeDelegate(lambda)</c>
+/// straight to the bare lambda argument (G# has no delegate-wrapper
+/// constructor to keep). An EXPLICITLY typed local (<c>Action handler =
+/// ...</c>) survives this because the declared-type-preservation branch
+/// (issue #4045) still emits an explicit type clause. A `var` local has no
+/// such anchor, so G# was left to infer the bare arrow lambda's type from
+/// its own body — and since G# models <c>++</c>/<c>--</c> as a VALUE-
+/// PRODUCING expression (ADR-0115 §B / gsc issue #1027), <c>() -&gt;
+/// counter++</c> naturally infers <c>Func&lt;int32&gt;</c> instead of the
+/// source's <c>Action</c>. A reflection-based <c>MethodInfo.Invoke</c> against
+/// the real <c>Action</c>-typed parameter then rejects it outright — "Func`1
+/// passed where Action is required" — exactly
+/// <c>Issue2519SourceClassConstraintOrderingEmitTests</c>' migrated-pipeline
+/// failure mode.
+/// </para>
+/// <para>
+/// The emitted annotation is the structural arrow spelling (<c>() -&gt;
+/// void</c>), not the nominal name <c>Action</c>: <c>MapExplicitType</c>
+/// (issue #2835/#3841/#4113/#4205) treats <c>Func</c>/<c>Action</c>/
+/// <c>Predicate</c> as the structural spelling's own canonical identity and
+/// still canonicalizes them, unlike a genuinely distinct nominal delegate
+/// such as <c>EventHandler</c>. What matters for correctness here is only
+/// that an explicit type clause exists at all, so gsc target-types the
+/// lambda against it — exactly as it already does for an explicitly-typed
+/// C# local (issue #4045's <c>EventHandler handler = (_, _) =&gt; hits++;</c>,
+/// covered by <c>Issue4045CompilerTestsParityRegressionTests</c>) — instead
+/// of inferring the lambda's type from its own body with no target at all.
+/// </para>
+/// </summary>
+public class Issue4116VarDelegateLocalIdentityTranslationTests
+{
+    [Fact]
+    public void VarActionLocal_FromDelegateCreationWithIncrementBody_GetsAnExplicitVoidType()
+    {
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue4116
+{
+    public class Holder
+    {
+        public Action MakeCounter(int[] box)
+        {
+            var handler = new Action(() => box[0]++);
+            return handler;
+        }
+    }
+}
+");
+
+        Assert.Contains("let handler () -> void = () -> box[0]++", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void VarFuncLocal_FromDelegateCreationWithIncrementBody_GetsAnExplicitReturnType()
+    {
+        // A non-void delegate target needs the annotation too: without it,
+        // nothing is broken here (the natural inference already matches), but
+        // the fix must still apply uniformly to every var-typed delegate
+        // local per the shared nominal-identity rule (issue #4113/#4205),
+        // not conditionally based on ReturnsVoid.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue4116
+{
+    public class Holder
+    {
+        public Func<int> MakeCounter(int[] box)
+        {
+            var handler = new Func<int>(() => box[0]++);
+            return handler;
+        }
+    }
+}
+");
+
+        Assert.Contains("let handler () -> int32 = () -> box[0]++", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void VarEventHandlerLocal_FromDelegateCreationWithIncrementBody_KeepsNominalDelegateType()
+    {
+        // A genuinely nominal (non-Func/Action/Predicate) delegate must keep
+        // its own name, not collapse to the structural spelling — the same
+        // distinction issue #4113/#4205 draws for typeof(...) operands and
+        // explicit generic type arguments.
+        string rendered = Render(@"
+using System;
+
+namespace Corpus.Issue4116
+{
+    public class Holder
+    {
+        public void Subscribe(int[] box)
+        {
+            var handler = new EventHandler((sender, args) => box[0]++);
+            handler(null, EventArgs.Empty);
+        }
+    }
+}
+");
+
+        Assert.Contains("let handler EventHandler = (", rendered, StringComparison.Ordinal);
+        Assert.Contains("-> box[0]++", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void VarIntLocal_StaysUnannotated()
+    {
+        // Control: an ordinary non-delegate `var` local must not gain a
+        // spurious type clause, so a mutant that annotates every `var` local
+        // is caught here.
+        string rendered = Render(@"
+namespace Corpus.Issue4116
+{
+    public class Holder
+    {
+        public int Compute()
+        {
+            var value = 1 + 2;
+            return value;
+        }
+    }
+}
+");
+
+        Assert.Contains("let value = 1 + 2", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        Assert.Empty(context.Diagnostics);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -230,6 +230,47 @@ public sealed partial class CSharpToGSharpTranslator
                     type = MakeNullable(this.typeMapper.MapEventType(
                         inferredLocal.Type, this.context, declaration.Type.GetLocation()));
                 }
+                else if (initializer != null &&
+                    declarator.Initializer.Value is BaseObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: 1 } &&
+                    this.context.GetDeclaredSymbol(declarator) is ILocalSymbol { Type: INamedTypeSymbol { TypeKind: TypeKind.Delegate } } delegateInferredLocal)
+                {
+                    // Issue #4116: a `var`-typed local initialized by a
+                    // delegate-CREATION expression (`var handler = new
+                    // Action(() => counter++);`) can lose its C# delegate
+                    // identity entirely. TranslateObjectCreation unwraps
+                    // `new SomeDelegate(lambda)` straight to the bare lambda
+                    // argument (G# has no delegate-wrapper constructor to
+                    // keep), and a `var` local — unlike an EXPLICITLY typed
+                    // one (`EventHandler handler = ...`, issue #4045, handled
+                    // by the `hasExplicitType` branch above) — has no OTHER
+                    // place in the emitted G# that still carries the C#
+                    // delegate type forward. Left un-annotated, G# infers the
+                    // arrow lambda's type from its own BODY instead: a VOID
+                    // delegate whose lambda body is a value-producing
+                    // expression (e.g. `counter++` — G# models
+                    // increment/decrement as value-producing, ADR-0115 §B /
+                    // gsc issue #1027) infers a non-void `Func&lt;T&gt;`
+                    // rather than the source's `Action`, and a
+                    // reflection-based `MethodInfo.Invoke` against the real
+                    // (`Action`-typed) parameter then rejects it outright.
+                    // This is the same nominal-identity-preservation rule
+                    // already applied to an explicit local's declared type, a
+                    // `typeof(...)` operand (issue #4113), and an explicit
+                    // generic type argument (issue #4113) — MapExplicitType,
+                    // not the general structurally-canonicalizing Map.
+                    //
+                    // Scoped to exactly this shape (an object-CREATION
+                    // initializer, the one TranslateObjectCreation unwraps):
+                    // a `var` local initialized by a BARE lambda (`var f = (x
+                    // int32 = 10) => x * 2;`, no wrapping delegate
+                    // constructor at all) loses nothing — there is no unwrap
+                    // step to discard information — and must keep the
+                    // idiomatic unannotated arrow form (issue #1901's own
+                    // coverage pins this; a broader condition here
+                    // regressed it).
+                    type = this.typeMapper.MapExplicitType(
+                        delegateInferredLocal.Type, this.context, declaration.Type.GetLocation());
+                }
 
                 results.Add(new LocalDeclarationStatement(
                     binding,

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -232,8 +232,30 @@ public sealed partial class CSharpToGSharpTranslator
                 }
                 else if (initializer != null &&
                     declarator.Initializer.Value is BaseObjectCreationExpressionSyntax { ArgumentList.Arguments.Count: 1 } &&
-                    this.context.GetDeclaredSymbol(declarator) is ILocalSymbol { Type: INamedTypeSymbol { TypeKind: TypeKind.Delegate } } delegateInferredLocal)
+                    this.context.GetDeclaredSymbol(declarator) is ILocalSymbol delegateInferredLocal &&
+                    delegateInferredLocal.Type is INamedTypeSymbol namedDelegateLocalType &&
+                    namedDelegateLocalType.TypeKind == TypeKind.Delegate)
                 {
+                    // Issue #4127/#4129 (self-hosting regression, #3501):
+                    // decomposed into a designation (`is ILocalSymbol
+                    // delegateInferredLocal`) plus a separate, PLAIN enum
+                    // comparison (`namedDelegateLocalType.TypeKind ==
+                    // TypeKind.Delegate`) — not a nested `{ Type:
+                    // INamedTypeSymbol { TypeKind: TypeKind.Delegate } }`
+                    // property pattern — because gsc's pattern matcher does
+                    // not reliably evaluate a property pattern containing an
+                    // enum-constant sub-pattern against an
+                    // imported-interface-typed scrutinee (`ILocalSymbol.Type`
+                    // is declared `ITypeSymbol`) once this exact translator
+                    // source is itself translated to G# and compiled by gsc
+                    // — the self-hosting pipeline issue #4116 exists to fix.
+                    // See CSharpTypeMapper.MapEventType and
+                    // CSharpToGSharpTranslator.Constructors.cs's
+                    // `explicitlyNamedDelegate` for the same workaround
+                    // already applied elsewhere in this translator (issue
+                    // #4153's own repro isolates the trigger to the enum
+                    // sub-pattern alone).
+                    //
                     // Issue #4116: a `var`-typed local initialized by a
                     // delegate-CREATION expression (`var handler = new
                     // Action(() => counter++);`) can lose its C# delegate
@@ -269,7 +291,7 @@ public sealed partial class CSharpToGSharpTranslator
                     // coverage pins this; a broader condition here
                     // regressed it).
                     type = this.typeMapper.MapExplicitType(
-                        delegateInferredLocal.Type, this.context, declaration.Type.GetLocation());
+                        namedDelegateLocalType, this.context, declaration.Type.GetLocation());
                 }
 
                 results.Add(new LocalDeclarationStatement(


### PR DESCRIPTION
## Root cause

A `var`-typed local initialized by a delegate-creation expression (`var handler = new Action(() => counter++);`) can lose its C# delegate identity entirely.

`TranslateObjectCreation` unwraps `new SomeDelegate(lambda)` straight to the bare lambda argument — G# has no delegate-wrapper constructor to keep, so the wrapping `new Action(...)` is redundant and dropped. An explicitly-typed local (`EventHandler handler = ...`, issue #4045) survives this because the existing declared-type-preservation branch still emits an explicit type clause. A `var` local has no such anchor: nothing else in the emitted G# carries the C# delegate type forward.

Left un-annotated, G# infers the arrow lambda's type from its own body instead. Since G# models `++`/`--` as a value-producing expression (ADR-0115 §B / gsc issue #1027), `() -> counter++` naturally infers `Func<int32>` rather than the source's `Action` — and a reflection-based `MethodInfo.Invoke` against the real `Action`-typed parameter then rejects it outright: "Func`1[Int32] passed where Action is required". This is exactly `Issue2519SourceClassConstraintOrderingEmitTests`' migrated-pipeline failure mode (2 of #4116's 8 named cases).

## Fix

For a `var`-typed local whose initializer is specifically a delegate-creation expression (`new SomeDelegate(argument)`, one argument, delegate-typed) AND whose Roslyn-inferred type is a delegate, emit an explicit type annotation via `MapExplicitType` — the same nominal-identity-preservation rule issue #4045/#4113/#4205 already apply for an explicit local's declared type, a `typeof(...)` operand, and an explicit generic type argument.

Scoped narrowly to exactly that initializer shape (an object-*creation* expression, the one `TranslateObjectCreation` unwraps) — **not** to every `var`-typed local whose Roslyn type happens to be a delegate. A `var` local initialized by a BARE lambda (`var f = (int x = 10) => x * 2;`, no wrapping delegate constructor at all) loses no information — there's no unwrap step discarding anything — and must keep its idiomatic unannotated arrow form. An earlier, broader version of this fix regressed exactly that shape (`Issue1901LambdaDefaultsTranslationTests`); this PR's version passes that suite unchanged.

The emitted annotation is the structural arrow spelling (e.g. `() -> void` for `Action`) rather than the nominal name: `MapExplicitType` treats `Func`/`Action`/`Predicate` as the structural spelling's own canonical identity (issue #2835's own exclusion) and still canonicalizes them — what matters for correctness is only that an explicit type clause exists at all, so gsc target-types the lambda against it (discarding the increment's value for a void target), exactly as it already does for an explicitly-typed C# local.

## Tests

`Issue4116VarDelegateLocalIdentityTranslationTests` — 4 cases: `var` + `Action`-creation with an increment body gets an explicit `() -> void` annotation; `var` + `Func<int>`-creation gets an explicit `() -> int32` annotation; a genuinely nominal (non-Func/Action) delegate like `EventHandler` keeps its own name; an ordinary non-delegate `var` local stays unannotated (control).

Verified red-without-fix / green-with-fix locally, plus a full `Cs2Gs.Tests` regression sweep (2958 tests) after narrowing the condition — the only two regressions from an earlier broader version (`Issue1901LambdaDefaultsTranslationTests`) are green again, and `Issue4045CompilerTestsParityRegressionTests` (the explicitly-typed `EventHandler` sibling shape) is unaffected.

Part of #4116, split from #4045.