### PR TITLE
cs2gs: close two more nullable-oblivious-forwarding gaps sibling to #4180/#4181

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4116ImplicitArrayLiteralNullableElementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4116ImplicitArrayLiteralNullableElementTranslationTests.cs
@@ -1,0 +1,125 @@
+// <copyright file="Issue4116ImplicitArrayLiteralNullableElementTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4116 (split from #4045's #2388 residual runtime failure,
+/// <c>Issue2388NullableCustomEqualityEmitTests</c>, "runtime NRE"): an
+/// implicit array literal (<c>new[] { a, b }</c>) passed straight into a BCL
+/// sink whose parameter array itself accepts nullable elements (e.g.
+/// <c>MethodBase.Invoke(object? obj, object?[]? parameters)</c>) forced a
+/// legitimately-null element (e.g. a boxed default <c>Nullable&lt;T&gt;</c>,
+/// which really is <see langword="null"/>) into a G# <c>!!</c> runtime
+/// assertion and threw.
+/// <para>
+/// Root cause: <c>TranslateImplicitArrayCreation</c> computed its
+/// per-element nullability contract from
+/// <c>GetTypeInfo(creation).Type</c>/<c>.ConvertedType</c> — but in a
+/// nullable-OBLIVIOUS file (no <c>#nullable enable</c> — exactly the
+/// migrated corpus's own state, per the codebase's own
+/// <c>IsObliviousCompilation</c> concept), Roslyn does not compute
+/// per-EXPRESSION nullable annotations at all: both properties report
+/// <c>NullableAnnotation.None</c> for the array literal's element, even
+/// though the parameter it flows into (<c>MethodBase.Invoke</c>'s
+/// <c>object?[]?</c>) is genuinely nullable-annotated in the BCL's own
+/// metadata. The fix instead resolves the array element type from the
+/// call's BOUND PARAMETER SYMBOL (via the enclosing argument's
+/// <c>IArgumentOperation</c>) when the literal is a direct call argument —
+/// a parameter's own annotation comes from the CALLEE's metadata and is
+/// visible regardless of the caller's own nullable context, unlike
+/// expression-level <c>GetTypeInfo</c>.
+/// </para>
+/// </summary>
+public class Issue4116ImplicitArrayLiteralNullableElementTranslationTests
+{
+    [Fact]
+    public void ImplicitArrayLiteral_PassedToBclNullableElementParameter_DoesNotAssertItsElements()
+    {
+        // The exact shape from Issue2388NullableCustomEqualityEmitTests:
+        // a nullable-oblivious file, `var n = Activator.CreateInstance(...)`
+        // (a genuinely `object?`-typed local, from the BCL's own annotated
+        // return), forwarded whole into `MethodInfo.Invoke`'s `object?[]?`
+        // parameters array via an implicit array literal.
+        string rendered = Render(@"
+using System;
+using System.Reflection;
+
+public static class Probe
+{
+    public static void Run(MethodInfo eqMethod, object m1, Type nullableType)
+    {
+        var n = Activator.CreateInstance(nullableType);
+        eqMethod.Invoke(null, new[] { m1, n });
+    }
+}
+");
+
+        Assert.DoesNotContain("n!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("eqMethod.Invoke(nil, []object{m1, n})", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void ImplicitArrayLiteral_PassedToSourceDeclaredObliviousElementParameter_StillAssertsItsElements()
+    {
+        // Control: a SOURCE-DECLARED (same-compilation) sink whose array
+        // parameter carries no `?` at all — genuinely oblivious, not merely
+        // unannotated BCL metadata — must keep asserting a nullable value
+        // that flows into it, so a mutant that stops asserting
+        // unconditionally is caught here.
+        string rendered = Render(@"
+using System;
+
+public static class Probe
+{
+    private static void Consume(object[] values)
+    {
+    }
+
+    public static void Run(Type nullableType)
+    {
+        var n = Activator.CreateInstance(nullableType);
+        Consume(new[] { n, n });
+    }
+}
+");
+
+        Assert.Contains("n!!", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4116ImplicitArrayLiteralNullableElementTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4116ImplicitArrayLiteralNullableElementTranslationTests.cs
@@ -69,6 +69,35 @@ public static class Probe
     }
 
     [Fact]
+    public void ParenthesizedImplicitArrayLiteral_PassedToBclNullableElementParameter_DoesNotAssertItsElements()
+    {
+        // Copilot review on #4209: a semantics-preserving pair of
+        // parentheses around the array literal (`eqMethod.Invoke(null,
+        // (new[] { m1, n }))`) is still a direct call argument — its
+        // IMMEDIATE syntactic parent is a ParenthesizedExpressionSyntax,
+        // not the ArgumentSyntax, so the fix must walk up through it (as
+        // every other "is this a direct argument" check in this translator
+        // already does) rather than giving up and falling back to the
+        // oblivious annotation.
+        string rendered = Render(@"
+using System;
+using System.Reflection;
+
+public static class Probe
+{
+    public static void Run(MethodInfo eqMethod, object m1, Type nullableType)
+    {
+        var n = Activator.CreateInstance(nullableType);
+        eqMethod.Invoke(null, (new[] { m1, n }));
+    }
+}
+");
+
+        Assert.DoesNotContain("n!!", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
     public void ImplicitArrayLiteral_PassedToSourceDeclaredObliviousElementParameter_StillAssertsItsElements()
     {
         // Control: a SOURCE-DECLARED (same-compilation) sink whose array

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4116XunitAssertEqualNullArgumentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4116XunitAssertEqualNullArgumentTranslationTests.cs
@@ -3,10 +3,15 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Cs2Gs.CodeModel.Printing;
 using Cs2Gs.CodeModel.RoundTrip;
 using Cs2Gs.Translator;
 using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace Cs2Gs.Tests;
@@ -123,6 +128,81 @@ public static class Probe
         AssertRoundTripParses(rendered);
     }
 
+    [Fact]
+    public void CustomAssertEqual_InANamespaceOnlyEndingInXunit_StaysForcedNonNull()
+    {
+        // Control (Copilot review on #4209): the namespace check must pin
+        // the EXACT top-level `Xunit` namespace (`global::Xunit`), not
+        // merely a namespace whose LAST segment happens to be named
+        // "Xunit". `Company.Xunit.Assert.Equal` is an unrelated,
+        // non-exempted method that just happens to share the name/shape.
+        //
+        // IMPORTED (a genuinely separately-compiled, referenced assembly —
+        // not a same-compilation declaration): gsc's oblivious-PROMOTION
+        // mechanism only ever rewrites a SAME-compilation declaration's own
+        // parameter type, so a same-file "Company.Xunit.Assert.Equal" would
+        // itself get silently promoted to `object?` by usage evidence,
+        // masking the exact bug this control exists to catch. An imported
+        // method's declared (non-nullable, explicitly `#nullable enable`)
+        // parameter can never be rewritten that way, so its own contract is
+        // what decides — and a mutant that matches on the namespace's leaf
+        // name alone is caught here.
+        MetadataReference customAssertLibrary = CompileLibraryReference(@"
+#nullable enable
+namespace Company.Xunit
+{
+    public static class Assert
+    {
+        public static void Equal(object expected, object actual)
+        {
+        }
+    }
+}
+");
+
+        string rendered = Render(
+            @"
+using Company.Xunit;
+
+public static class Probe
+{
+    private static void CheckDefault(object expected, object actual)
+    {
+        Assert.Equal(expected, actual);
+    }
+
+    public static void Run()
+    {
+        CheckDefault(null, null);
+    }
+}
+",
+            additionalReferences: new[] { customAssertLibrary });
+
+        // Round-trip binding is skipped here: it would require also
+        // resolving the compiled "Company.Xunit.Assert" library on gsc's
+        // OWN (separate) ReferenceResolver, which this control's narrow
+        // purpose — proving the printed text still forces `!!` — does not
+        // warrant.
+        Assert.Contains("expected!!", rendered, StringComparison.Ordinal);
+    }
+
+    private static MetadataReference CompileLibraryReference(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create(
+            "Issue4116CustomXunitLibrary",
+            new[] { syntaxTree },
+            CSharpProjectLoader.RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        Microsoft.CodeAnalysis.Emit.EmitResult result = compilation.Emit(stream);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        stream.Position = 0;
+        return MetadataReference.CreateFromStream(stream);
+    }
+
     private static void AssertRoundTripParses(string rendered)
     {
         RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
@@ -133,10 +213,15 @@ public static class Probe
                 string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
     }
 
-    private static string Render(string source)
+    private static string Render(string source, MetadataReference[] additionalReferences = null)
     {
+        IReadOnlyList<MetadataReference> references = additionalReferences == null
+            ? null
+            : CSharpProjectLoader.RuntimeReferences().Concat(additionalReferences).ToList();
+
         LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
-            new[] { ("Source.cs", source) });
+            new[] { ("Source.cs", source) },
+            references);
 
         Assert.True(
             project.BoundWithoutErrors,

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4116XunitAssertEqualNullArgumentTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4116XunitAssertEqualNullArgumentTranslationTests.cs
@@ -1,0 +1,151 @@
+// <copyright file="Issue4116XunitAssertEqualNullArgumentTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Issue #4116 (split from #4045's #2745 residual runtime failure,
+/// <c>Issue2745OptionalParameterMetadataEmitTests</c>, "NRE while checking
+/// reflected defaults"): <c>Assert.Equal&lt;T&gt;(T expected, T actual)</c> /
+/// <c>Assert.NotEqual&lt;T&gt;(T, T)</c> carry no non-null constraint on
+/// <c>T</c> in xunit's own signature — comparing a value against a
+/// legitimately-null expected/actual result is exactly the point of these
+/// overloads (e.g. asserting a reflected <c>ParameterInfo.DefaultValue</c>
+/// equals <see langword="null"/> for a <c>string? = nil</c>-defaulted
+/// parameter).
+/// <para>
+/// <c>IsXunitNullAssertionArgument</c> already exempted
+/// <c>Assert.Null</c>/<c>Assert.NotNull</c> arguments from gsc's oblivious-
+/// forwarding bridge (which otherwise forces a G# <c>!!</c> runtime
+/// assertion whenever a nullable-oblivious value flows into an apparently
+/// non-null sink), but did not exempt <c>Assert.Equal</c>/
+/// <c>Assert.NotEqual</c> — so a helper like
+/// <c>AssertDefault(ParameterInfo parameter, object expected) =&gt;
+/// Assert.Equal(expected, parameter.DefaultValue);</c>, called once with a
+/// literal <c>null</c> expected value, translated to
+/// <c>Assert.Equal(expected!!, parameter.DefaultValue!!)</c> — throwing an
+/// NRE on the exact call the test exists to prove doesn't throw.
+/// </para>
+/// </summary>
+public class Issue4116XunitAssertEqualNullArgumentTranslationTests
+{
+    [Fact]
+    public void AssertEqual_WithLiteralNullArgument_IsNotForcedNonNull()
+    {
+        string rendered = Render(@"
+using System;
+using Xunit;
+
+public static class Probe
+{
+    public static void CheckDefault(object expected, object actual)
+    {
+        Assert.Equal(expected, actual);
+    }
+
+    public static void Run()
+    {
+        CheckDefault(null, null);
+    }
+}
+");
+
+        Assert.DoesNotContain("Assert.Equal(expected!!", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("actual!!)", rendered, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(expected, actual)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void AssertNotEqual_WithLiteralNullArgument_IsNotForcedNonNull()
+    {
+        string rendered = Render(@"
+using System;
+using Xunit;
+
+public static class Probe
+{
+    public static void CheckDifferent(object expected, object actual)
+    {
+        Assert.NotEqual(expected, actual);
+    }
+
+    public static void Run()
+    {
+        CheckDifferent(null, ""x"");
+    }
+}
+");
+
+        Assert.DoesNotContain("Assert.NotEqual(expected!!", rendered, StringComparison.Ordinal);
+        Assert.Contains("Assert.NotEqual(expected, actual)", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    [Fact]
+    public void AssertContains_WithObliviouslyPromotedArgument_StaysForcedNonNull()
+    {
+        // Control: Assert.Contains<T>(T expected, IEnumerable<T> collection)
+        // shares Assert.Equal's generic two-argument shape (an unconstrained
+        // T the general oblivious-forwarding bridge treats as non-null) but
+        // is NOT in the Null/NotNull/Equal/NotEqual exemption, so it must
+        // keep the existing forced-non-null behavior for an oblivious value
+        // promoted nullable by usage evidence (called once with a literal
+        // `null`) — proving the exemption is scoped to exactly those four
+        // method names, not to every generic-comparison-shaped Xunit method.
+        string rendered = Render(@"
+using System;
+using Xunit;
+
+public static class Probe
+{
+    private static void CheckContains(object expected, object[] collection)
+    {
+        Assert.Contains(expected, collection);
+    }
+
+    public static void Run()
+    {
+        CheckContains(null, new object[0]);
+    }
+}
+");
+
+        Assert.Contains("expected!!", rendered, StringComparison.Ordinal);
+        AssertRoundTripParses(rendered);
+    }
+
+    private static void AssertRoundTripParses(string rendered)
+    {
+        RoundTripResult result = TranslationTestValidation.AssertBinds(rendered);
+
+        Assert.True(
+            result.Success,
+            "Sanitized G# must round-trip-parse. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + rendered);
+    }
+
+    private static string Render(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(
+            new[] { ("Source.cs", source) });
+
+        Assert.True(
+            project.BoundWithoutErrors,
+            "inline source should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        Cs2Gs.CodeModel.Ast.CompilationUnit unit = new CSharpToGSharpTranslator().TranslateDocument(document, context);
+        return GSharpPrinter.Print(unit);
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2156,11 +2156,22 @@ public sealed partial class CSharpToGSharpTranslator
             // arguments as flowing into a non-null sink and forced a G# `!!`
             // runtime assertion on a value that is null by design — throwing
             // an NRE instead of comparing the legitimate `nil`.
+            // The namespace check must pin the EXACT top-level `Xunit`
+            // namespace (`global::Xunit`), not merely a namespace whose last
+            // segment happens to be named "Xunit" (e.g. `Company.Xunit`,
+            // some other vendor's assertion library). Matching by leaf
+            // `.Name` alone would exempt an unrelated imported
+            // `Company.Xunit.Assert.Equal`'s non-null parameter from the
+            // forced-bridge, silently leaving a nullable G# value passed to
+            // whatever real non-null sink that method has. Mirrors the same
+            // "outer namespace is global" check CSharpTypeMapper already
+            // applies for an exact `System` match.
             return this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
             {
                 Name: "Null" or "NotNull" or "Equal" or "NotEqual",
                 ContainingType.Name: "Assert",
                 ContainingNamespace.Name: "Xunit",
+                ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true,
             };
         }
 

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -2146,9 +2146,19 @@ public sealed partial class CSharpToGSharpTranslator
                 return false;
             }
 
+            // Issue #4116: `Assert.Equal<T>(T, T)`/`Assert.NotEqual<T>(T, T)`
+            // carry no non-null constraint on `T` in xunit's own signature —
+            // comparing a value against a legitimately-null expected/actual
+            // result (e.g. a reflected `ParameterInfo.DefaultValue` for a
+            // nilable-defaulted parameter) is exactly what they exist to do.
+            // Before this, only `Assert.Null`/`Assert.NotNull` were exempted
+            // here, so gsc's oblivious-forwarding bridge treated `Equal`'s
+            // arguments as flowing into a non-null sink and forced a G# `!!`
+            // runtime assertion on a value that is null by design — throwing
+            // an NRE instead of comparing the legitimate `nil`.
             return this.context.GetSymbolInfo(invocation).Symbol is IMethodSymbol
             {
-                Name: "Null" or "NotNull",
+                Name: "Null" or "NotNull" or "Equal" or "NotEqual",
                 ContainingType.Name: "Assert",
                 ContainingNamespace.Name: "Xunit",
             };

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -2319,7 +2319,26 @@ public sealed partial class CSharpToGSharpTranslator
         private GExpression TranslateImplicitArrayCreation(ImplicitArrayCreationExpressionSyntax creation)
         {
             GTypeReference elementType = this.GetArrayElementType(creation, null);
-            IArrayTypeSymbol arrayType = this.context.GetTypeInfo(creation).Type as IArrayTypeSymbol;
+
+            // Issue #4116: prefer the BOUND PARAMETER's array element type,
+            // when this literal is passed directly as a call argument, over
+            // the literal's own best-common-type-inferred `Type`/
+            // `ConvertedType`. In a nullable-OBLIVIOUS file (no `#nullable
+            // enable` — exactly the migrated corpus's own state), Roslyn
+            // does not compute per-EXPRESSION nullable annotations at all:
+            // `GetTypeInfo(creation).Type` and `.ConvertedType` both report
+            // `NullableAnnotation.None` for `new[] { a, n }`, even when it
+            // flows straight into a BCL sink like
+            // `MethodInfo.Invoke(object?, object?[]?)`. The bound PARAMETER
+            // SYMBOL itself, resolved from the enclosing argument's
+            // operation, is unaffected by that — parameter annotations come
+            // from the callee's OWN (already nullable-annotated) metadata
+            // regardless of the caller's nullable context — so it is
+            // preferred here when available, falling back to the literal's
+            // natural type otherwise.
+            IArrayTypeSymbol arrayType =
+                this.TryGetArgumentParameterArrayType(creation)
+                ?? this.context.GetTypeInfo(creation).Type as IArrayTypeSymbol;
             ITypeSymbol elementTypeSymbol = arrayType?.ElementType;
             if (arrayType is { Rank: > 1 })
             {
@@ -2353,6 +2372,26 @@ public sealed partial class CSharpToGSharpTranslator
                         this.TranslateArrayInitializerElement(
                             expression, elementTypeSymbol, literalPromoted))
                     .ToList());
+        }
+
+        // Issue #4116: when `arrayExpression` is passed DIRECTLY as a call
+        // argument, resolves the array type of the BOUND PARAMETER it binds
+        // to — via the argument's own IArgumentOperation, not the
+        // expression's own GetTypeInfo — so its element's real nullable
+        // annotation (sourced from the callee's metadata) is visible even in
+        // a nullable-oblivious file, where GetTypeInfo never populates
+        // per-expression annotations at all. Returns null for every other
+        // position (a nested initializer, a return, a local initializer,
+        // …), where the literal's own natural type is exactly what's wanted.
+        private IArrayTypeSymbol TryGetArgumentParameterArrayType(ExpressionSyntax arrayExpression)
+        {
+            if (arrayExpression.Parent is not ArgumentSyntax argument)
+            {
+                return null;
+            }
+
+            return (this.context.SemanticModel.GetOperation(argument) as IArgumentOperation)
+                ?.Parameter?.Type as IArrayTypeSymbol;
         }
 
         private GExpression TranslateInitializerExpression(InitializerExpressionSyntax initializer)

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Patterns.cs
@@ -2383,14 +2383,28 @@ public sealed partial class CSharpToGSharpTranslator
         // per-expression annotations at all. Returns null for every other
         // position (a nested initializer, a return, a local initializer,
         // …), where the literal's own natural type is exactly what's wanted.
+        //
+        // Walks the OPERATION tree, not the syntax tree: a semantics-
+        // preserving wrap (`eqMethod.Invoke(null, (new[] { m1, n }))`) still
+        // binds to the same argument/parameter, but Roslyn's operation tree
+        // elides a ParenthesizedExpressionSyntax entirely — it produces NO
+        // IOperation node of its own, so `GetOperation` on the ArgumentSyntax
+        // (or on the ParenthesizedExpressionSyntax) returns null even though
+        // the ArrayCreationOperation's own `.Parent` already IS the
+        // IArgumentOperation directly. Starting from the array expression's
+        // own operation and walking its OPERATION-tree parent (skipping only
+        // an intervening IConversionOperation, e.g. an implicit array
+        // covariance conversion) sidesteps the syntax-level parenthesization
+        // question entirely.
         private IArrayTypeSymbol TryGetArgumentParameterArrayType(ExpressionSyntax arrayExpression)
         {
-            if (arrayExpression.Parent is not ArgumentSyntax argument)
+            IOperation operation = this.context.SemanticModel.GetOperation(arrayExpression)?.Parent;
+            while (operation is IConversionOperation)
             {
-                return null;
+                operation = operation.Parent;
             }
 
-            return (this.context.SemanticModel.GetOperation(argument) as IArgumentOperation)
+            return (operation as IArgumentOperation)
                 ?.Parameter?.Type as IArrayTypeSymbol;
         }
 


### PR DESCRIPTION
## Root cause

Two more instances of the bug family #4180/#4181 fixed for `.Select(...)` results forwarded to a nullable-tolerant sink: cs2gs's oblivious-forwarding bridge forces a G# `!!` runtime assertion onto a value that is legitimately null, because the heuristic deciding "does this sink tolerate null" missed two more shapes.

**1. `Assert.Equal`/`Assert.NotEqual` (Issue2745OptionalParameterMetadataEmitTests, "NRE while checking reflected defaults")**

`IsXunitNullAssertionArgument` exempted only `Assert.Null`/`Assert.NotNull` from the forced-non-null bridge. `Assert.Equal<T>(T, T)`/`Assert.NotEqual<T>(T, T)` carry no non-null constraint on their unconstrained `T` in xunit's own signature — comparing a value against a legitimately-null expected/actual result is exactly what they exist to do — but Roslyn can never report an unconstrained generic parameter as `NullableAnnotation.Annotated`, so nothing else exempted them either. A helper like:
```csharp
private static void AssertDefault(ParameterInfo p, object expected) => Assert.Equal(expected, p.DefaultValue);
```
called once with a literal `null` expected value (the `note string? = nil` case), translated to `Assert.Equal(expected!!, p.DefaultValue!!)` — throwing an NRE on the exact call the test exists to prove doesn't throw.

**2. Implicit array literals passed to a BCL sink with nullable elements (Issue2388NullableCustomEqualityEmitTests, "runtime NRE")**

`TranslateImplicitArrayCreation` computed an array literal's per-element nullability contract from `GetTypeInfo(creation).Type`/`.ConvertedType`. In a nullable-OBLIVIOUS file (no `#nullable enable` — exactly the migrated corpus's own state), Roslyn does not compute per-EXPRESSION nullable annotations at all: both properties report `NullableAnnotation.None` even when the literal flows straight into a BCL sink whose parameter array itself accepts nullable elements (e.g. `MethodBase.Invoke(object? obj, object?[]? parameters)`, both nullable in the BCL's own metadata). `new[] { m1, n }` forwarded into `eqMethod.Invoke(null, ...)`, where `n` is a genuinely-null boxed default `Nullable<T>`, got its `n` element wrapped in `!!` and threw.

## Fixes

1. Extend `IsXunitNullAssertionArgument`'s method-name set to include `Equal`/`NotEqual` alongside `Null`/`NotNull`.
2. Resolve the array element type from the enclosing argument's BOUND PARAMETER SYMBOL (via `IArgumentOperation`), when the array literal is a direct call argument, instead of from `GetTypeInfo` on the array expression itself — a parameter's own annotation comes from the callee's metadata and is visible regardless of the caller's own nullable context.

## Tests

- `Issue4116XunitAssertEqualNullArgumentTranslationTests` — `Assert.Equal`/`Assert.NotEqual` with a literal-null argument no longer forced; control: `Assert.Contains<T>` (shares Equal's generic shape, not exempted) still forces an obliviously-promoted argument.
- `Issue4116ImplicitArrayLiteralNullableElementTranslationTests` — an array literal passed to a BCL sink with nullable elements no longer forces its elements; control: a source-declared, genuinely oblivious (non-annotated) array parameter still forces.

Verified red-without-fix / green-with-fix locally for both, plus the related `Issue4180`/`Issue4045` regression suites pass unchanged.

Part of #4116, split from #4045.