### PR TITLE
cs2gs: fix __local_ regression — default-parameter cycle members wrongly excluded from SCC detection (#4197 follow-up)

### DIFF
--- a/tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs
@@ -319,4 +319,142 @@ namespace Demo
         // AddPatternSwitch(0): depth not > 0, stop. Final total = 28.
         LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(3)", "28");
     }
+
+    [Fact]
+    public void DefaultParameterCycleMember_KeepsRealNames_WholeGroupIncluded()
+    {
+        // Regression for the #4200 follow-up: the default-parameter carve-out
+        // that `DefaultParameterNonRecursiveDependency_StaysLiftedNotFolded`
+        // pins was applied to the SCC-detection graph itself, not just to the
+        // fold-BFS — so a default-parameter local function that is a CORE
+        // MEMBER of a cycle vanished from cycle detection, and the ENTIRE
+        // connected component (cycle members and their folded helpers alike)
+        // fell through to the `__local_` lift path.
+        //
+        // Real corpus shape, measured on the nightly gate after #4200 merged
+        // (`src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs`'s
+        // `ProjectRegionsForDefiniteReturn`): `void Add(BoundStatement, Action<BoundStatement>? routeTransfer = null)`
+        // is mutually recursive with `AddPatternSwitch`/`AddTry` and captures
+        // outer state — the ORIGINAL #3399 shape, correctly on the nullable
+        // scheme since long before #4197. Every one of its call sites already
+        // passes both arguments explicitly, so the default is never actually
+        // exercised by omission; declaring one was enough to lift all SEVEN
+        // functions in that method (`ControlFlowGraph.gs` went from 4
+        // `__local_` helpers to 7, breaching the corpus `liftedLocalCeiling`).
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+
+            void Add(int depth, int bonus = 10)
+            {
+                total += bonus + NewLabel(depth);
+                if (depth > 0)
+                {
+                    AddPatternSwitch(depth - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1, 0);
+                }
+            }
+
+            int NewLabel(int depth)
+            {
+                return depth * 2;
+            }
+
+            Add(seed, 5);
+            System.Console.WriteLine(total);
+            return total;
+        }
+    }
+}");
+
+        // The whole component keeps its real names: the two cycle members AND
+        // the non-recursive helper folded in behind them.
+        Assert.DoesNotContain("__local_", printed, StringComparison.Ordinal);
+        Assert.Contains("var Add", printed, StringComparison.Ordinal);
+        Assert.Contains("var AddPatternSwitch", printed, StringComparison.Ordinal);
+        Assert.Contains("var NewLabel", printed, StringComparison.Ordinal);
+        Assert.Contains("Add!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("AddPatternSwitch!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("NewLabel!!(", printed, StringComparison.Ordinal);
+
+        // Add(3, 5): total += 5 + NewLabel(3)=6 (total=11) ->
+        // AddPatternSwitch(2) -> Add(1, 0): total += 0 + NewLabel(1)=2
+        // (total=13) -> AddPatternSwitch(0): depth not > 0, stop. Total = 13.
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(3)", "13");
+    }
+
+    [Fact]
+    public void DefaultParameterCycleMember_OmittedArgumentIsMaterializedAtCallSite()
+    {
+        // The other half of the same fix: a claimed cycle member whose default
+        // IS relied upon by omission. `Name!!(args)` is a structural
+        // function-type invocation — gsc's arrow type carries parameter TYPES
+        // only, never defaults — so the omitted argument cannot fall back the
+        // way a real method call can (GS0144 "requires 2 arguments but was
+        // given 1"). Roslyn has already resolved the omission to the constant
+        // default, so the call site materializes it explicitly, exactly as the
+        // `__local_` lift path and the #1901 lambda-default path already do.
+        // A NAMED call site normalizes to the same positional form, since a
+        // structural arrow type has no parameter names to bind against.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+
+            void Add(int depth, int bonus = 10)
+            {
+                total += bonus;
+                if (depth > 0)
+                {
+                    AddPatternSwitch(depth - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1);
+                }
+            }
+
+            Add(seed, 5);
+            Add(depth: 0);
+            System.Console.WriteLine(total);
+            return total;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("__local_", printed, StringComparison.Ordinal);
+        Assert.Contains("var Add", printed, StringComparison.Ordinal);
+        Assert.Contains("var AddPatternSwitch", printed, StringComparison.Ordinal);
+
+        // Both omitting call sites carry the materialized default, and the
+        // named one is positional (no `depth:`/`bonus:` through the arrow).
+        Assert.Contains("Add!!(depth - 1, 10)", printed, StringComparison.Ordinal);
+        Assert.Contains("Add!!(0, 10)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("depth:", printed, StringComparison.Ordinal);
+
+        // Add(2, 5): total = 5 -> AddPatternSwitch(1) -> Add(0) [default 10]:
+        // total = 15, depth not > 0, stop. Then Add(depth: 0) [default 10]:
+        // total = 25.
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(2)", "25");
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs
@@ -666,4 +666,294 @@ namespace Demo
         // Add(2, 3, 4) = 7 + AddPatternSwitch(1) -> Add(0, 1, 2) = 3. Total 10.
         LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(2)", "10");
     }
+
+    [Fact]
+    public void RefParameterCycleMember_StaysOnLiftPath()
+    {
+        // PR #4211 review round 3 (Copilot), finding 1 — reported as an
+        // evaluation-order hazard in the claimed-cycle argument reassembly
+        // (`ref slots[NextIndex()]` moving relative to a spilled sibling).
+        // The reassembly is not where this breaks. A ref-kind parameter is a
+        // DECLARATION-side impossibility, exactly like `params` above:
+        // `ArrowTypeReference` carries parameter types only and has no
+        // ref-kind, so `AddGroupMember` declared
+        // `var Add ((int32, int32) -> void)?` for a literal that is really
+        // `func (depth int32, ref cell int32)` — `(int32, *int32) -> void`.
+        //
+        // Measured on this branch before the fix, gsc rejected it
+        // unconditionally:
+        //   Cannot convert type '(int32, int32) -> void'
+        //       to '((int32, int32) -> void)?'.
+        //   Cannot convert type '*int32' to 'int32'.   (x2, the `&x` call sites)
+        // for `ref`, `out` (`*?`) and `in` alike, with or without a default
+        // parameter and with or without a named call site. There is
+        // therefore no reachable "silently changing side effects": the program
+        // never compiles. The fix is the same carve-out `params` got, which
+        // additionally makes a ref-kind argument unreachable in
+        // `TranslateClaimedLocalFunctionArgumentsWithDefaults`.
+        //
+        // The call site below is Copilot's exact shape — a permuted named call
+        // passing `ref slots[Idx()]` alongside an omitted default. On the
+        // `__local_` path it now takes, the lift keeps the `name:` wrappers
+        // (a real method HAS parameter names), so the emitted call is
+        // `__local_Project_Add(cell: &slots[Idx()], a: Val(), 100)` and the
+        // binding is right: cell aliases slots[1], a = 5, b = 100 => 105.
+        //
+        // `order` prints 21, not C#'s 12, and that is a SEPARATE gsc-side gap
+        // with nothing to do with cs2gs: gsc evaluates an out-of-declared-order
+        // NAMED argument list in source order for by-value operands but
+        // evaluates a `&` operand at its PARAMETER position. Reduced to three
+        // SEPARATE hand-written G# programs, no translator involved, each with
+        // its own callee — `Idx`/`Val` fold a digit into `order`:
+        //   func Add(a int32, ref cell int32, b int32 = 100)
+        //     Add(cell: &slots[Idx()], a: Val(), 100)  => order 21  (WRONG)
+        //   func Add(a int32, c int32)
+        //     Add(c: Idx(), a: Val())                  => order 12  (by-value
+        //                                                            named, ok)
+        //   func RefFirst(ref cell int32, a int32)
+        //     RefFirst(&slots[Idx()], Val())           => order 12  (positional
+        //                                                            ref, ok)
+        // Pinned here as the tripwire for that follow-up: when gsc starts
+        // ordering `&` operands by source position this assertion flips to
+        // "105:12" and this comment comes out.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int order = 0;
+            int[] slots = new int[3];
+
+            int Idx()
+            {
+                order = (order * 10) + 1;
+                return 1;
+            }
+
+            int Val()
+            {
+                order = (order * 10) + 2;
+                return 5;
+            }
+
+            void Add(int a, ref int cell, int b = 100)
+            {
+                cell = a + b;
+                if (a > 1000)
+                {
+                    AddPatternSwitch(a - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    int t = 0;
+                    Add(depth - 1, ref t);
+                }
+            }
+
+            Add(cell: ref slots[Idx()], a: Val());
+            System.Console.WriteLine(slots[1] + "":"" + order);
+            return 0;
+        }
+    }
+}");
+
+        // The whole cycle stays on `__local_`, whose REAL method declaration
+        // carries `ref` natively — nothing ever declares an arrow type for it.
+        Assert.Contains("__local_Project_Add", printed, StringComparison.Ordinal);
+        Assert.Contains("__local_Project_AddPatternSwitch", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Add!!(", printed, StringComparison.Ordinal);
+        Assert.Contains("ref cell int32", printed, StringComparison.Ordinal);
+
+        // a = 5, b = 100 (default), cell = slots[1] = 105 — the binding this
+        // carve-out exists to get right. `order` is the gsc-side tripwire
+        // documented above; before the carve-out this snippet did not compile
+        // at all, so there was no order to get wrong.
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(0)", "105:21");
+    }
+
+    [Fact]
+    public void OutParameterCycleMember_StaysOnLiftPath()
+    {
+        // The `out` half of the carve-out above: the erased arrow type made the
+        // call sites fail as "Cannot convert type '*?' to 'int32'" (the `out`
+        // address form has no declared pointee yet at the call site), on top of
+        // the same declaration mismatch. Kept separate because an `out`
+        // argument also flows a DECLARATION expression (`out int t`) through
+        // the `__local_` lift rewrite.
+        //
+        // It also carries NO default parameter, which makes it the half of the
+        // gap that PREDATES this PR: it fails identically against pre-PR
+        // e815bb76. The ref-plus-default shape in the test above does NOT fail
+        // there, because the blanket `HasExplicitDefaultValue` exclusion that
+        // #4197's fix (e1c4c1d9) correctly removed used to keep it off the
+        // scheme by accident — removing it exposed that shape for the first
+        // time. One carve-out closes both halves.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+
+            void Add(int depth, out int cell)
+            {
+                cell = depth;
+                total += cell;
+                if (depth > 0)
+                {
+                    AddPatternSwitch(depth - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1, out int t);
+                }
+            }
+
+            Add(seed, out int c);
+            System.Console.WriteLine(total + "":"" + c);
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("__local_Project_Add", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Add!!(", printed, StringComparison.Ordinal);
+
+        // Add(2) -> total 2 -> AddPatternSwitch(1) -> Add(0) -> total 2. c = 2.
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(2)", "2:2");
+    }
+
+    [Fact]
+    public void DefaultParameterCycleMember_PermutedNamedArgumentsSnapshotBareIdentifiers()
+    {
+        // PR #4211 review round 3 (Copilot), finding 2 — and the one the
+        // previous round's spill genuinely missed. `SpillOperand` short-circuits
+        // on `IsTrivialOperand`, which answers "is DUPLICATING this safe?". That
+        // is the wrong question when the reassembly REORDERS instead of
+        // duplicating: `x` is still read exactly once, just at the wrong time.
+        //
+        // `Add(c: x, a: MutateX())` must read `x` (5) before `MutateX()` sets it
+        // to 99, so C# binds a = 1 (default), b = 2 (default), c = 5 => 125.
+        // Before the fix this branch emitted
+        //     let __spill0 = MutateX()
+        //     Add!!(__spill0, 2, x)
+        // which compiled, ran, and printed 219 (c = 99) — a silently wrong
+        // answer, the exact failure mode Copilot described. Every explicit
+        // operand that is not a literal or a type name is now snapshotted.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+            int x = 5;
+
+            int MutateX()
+            {
+                x = 99;
+                return 1;
+            }
+
+            void Add(int a = 1, int b = 2, int c = 3)
+            {
+                total = (total * 1000) + (a * 100) + (b * 10) + c;
+                if (a > 100)
+                {
+                    AddPatternSwitch(a - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1);
+                }
+            }
+
+            Add(c: x, a: MutateX());
+            System.Console.WriteLine(total);
+            return total;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("__local_", printed, StringComparison.Ordinal);
+
+        // `x` is snapshotted FIRST (source order), then `MutateX()`; the
+        // reassembled call references both spills and no bare `x`.
+        Assert.Contains("let __spill0 = x", printed, StringComparison.Ordinal);
+        Assert.Contains("let __spill1 = MutateX", printed, StringComparison.Ordinal);
+        Assert.Contains("Add!!(__spill1, 2, __spill0)", printed, StringComparison.Ordinal);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(0)", "125");
+    }
+
+    [Fact]
+    public void DefaultParameterCycleMember_PermutedNamedArgumentsKeepLiteralsEmbedded()
+    {
+        // The snapshot above is deliberately not universal: a literal cannot be
+        // observed changing, so it stays embedded and the output keeps only the
+        // temps it needs. `Add(c: 7, a: MutateX())` binds c = 7 regardless of
+        // when it is "read", so only `MutateX()` spills.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+            int x = 5;
+
+            int MutateX()
+            {
+                x = 99;
+                return 1;
+            }
+
+            void Add(int a = 1, int b = 2, int c = 3)
+            {
+                total = (total * 1000) + (a * 100) + (b * 10) + c;
+                if (a > 100)
+                {
+                    AddPatternSwitch(a - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1);
+                }
+            }
+
+            Add(c: 7, a: MutateX());
+            System.Console.WriteLine(total + "":"" + x);
+            return total;
+        }
+    }
+}");
+
+        Assert.Contains("Add!!(__spill0, 2, 7)", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("__spill1", printed, StringComparison.Ordinal);
+
+        // a = 1, b = 2, c = 7 => 127; `MutateX()` still ran (x = 99).
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(0)", "127:99");
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs
@@ -457,4 +457,213 @@ namespace Demo
         // total = 25.
         LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(2)", "25");
     }
+
+    [Fact]
+    public void DefaultParameterCycleMember_OutOfOrderNamedArgumentBindsByParameterOrdinal()
+    {
+        // PR #4211 review (Copilot). `IInvocationOperation.Arguments` is in
+        // EVALUATION order, not parameter order. Verified directly against this
+        // repo's Roslyn (Microsoft.CodeAnalysis.CSharp 5.6.0): for
+        // `void Add(int depth = 0, int bonus = 10)`, the call `Add(bonus: X)`
+        // arrives as
+        //   [0] param=bonus ordinal=1 kind=Explicit
+        //   [1] param=depth ordinal=0 kind=DefaultValue
+        // so the ORIGINAL positional walk emitted `Add!!(X, 10)` — silently
+        // binding the caller's value to `depth` and the `depth` default to
+        // `bonus`. Nothing failed to compile; only the answer was wrong.
+        // Slots are now addressed by `IParameterSymbol.Ordinal`.
+        //
+        // `Next()` is side-effecting so the run also pins that the reordering
+        // neither drops nor duplicates the caller's expression.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+            int ticks = 0;
+
+            int Next()
+            {
+                ticks++;
+                return 7;
+            }
+
+            void Add(int depth = 0, int bonus = 10)
+            {
+                total = (total * 100) + (depth * 10) + bonus;
+                if (depth > 0)
+                {
+                    AddPatternSwitch(depth - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1);
+                }
+            }
+
+            Add(bonus: Next());
+            System.Console.WriteLine(total + "":"" + ticks);
+            return total;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("__local_", printed, StringComparison.Ordinal);
+        Assert.Contains("var Add", printed, StringComparison.Ordinal);
+
+        // `Next()` lands in the `bonus` slot (ordinal 1), the omitted `depth`
+        // default in slot 0 — NOT the other way round.
+        Assert.Contains("Add!!(0, Next", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Add!!(Next", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("bonus:", printed, StringComparison.Ordinal);
+
+        // depth = 0 (default), bonus = 7 -> total = 7; `Next()` ran once.
+        // The pre-fix emission `Add!!(Next!!(), 10)` instead recursed from
+        // depth = 7 and printed a completely different total.
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(0)", "7:1");
+    }
+
+    [Fact]
+    public void DefaultParameterCycleMember_PermutedNamedArgumentsKeepSourceEvaluationOrder()
+    {
+        // The same fix's other half. Reassembling by ordinal is only half the
+        // job: when TWO explicit arguments are named out of declared order,
+        // emitting them straight into their ordinal slots would also swap the
+        // order in which they EVALUATE, and C# §12.6.2.2 fixes that to source
+        // order. Each non-trivial explicit operand is therefore spilled to a
+        // `let __spillN` in source order first, and the positional call site
+        // references the spills.
+        //
+        // The two printed numbers separate the two failure modes exactly:
+        //   total pins WHICH PARAMETER each value bound to,
+        //   ticks pins the ORDER the two `Next` calls ran in.
+        // Pre-fix (positional walk) printed "792:79" — right order, wrong
+        // binding. A naive ordinal sort with no spill would print "927:97" —
+        // right binding, reversed side effects. Only "927:79" is C#.
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int total = 0;
+            int ticks = 0;
+
+            int Next(int weight)
+            {
+                ticks = (ticks * 10) + weight;
+                return weight;
+            }
+
+            void Add(int a = 1, int b = 2, int c = 3)
+            {
+                total = (total * 1000) + (a * 100) + (b * 10) + c;
+                if (a > 100)
+                {
+                    AddPatternSwitch(a - 1);
+                }
+            }
+
+            void AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    Add(depth - 1);
+                }
+            }
+
+            Add(c: Next(7), a: Next(9));
+            System.Console.WriteLine(total + "":"" + ticks);
+            return total;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("__local_", printed, StringComparison.Ordinal);
+
+        // Spilled in SOURCE order (`Next(7)` first), then bound by ordinal:
+        // a = __spill1 (9), b = the omitted default 2, c = __spill0 (7).
+        Assert.Contains("__spill0 = Next", printed, StringComparison.Ordinal);
+        Assert.Contains("__spill1 = Next", printed, StringComparison.Ordinal);
+        Assert.Contains("Add!!(__spill1, 2, __spill0)", printed, StringComparison.Ordinal);
+
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(0)", "927:79");
+    }
+
+    [Fact]
+    public void VariadicCycleMember_StaysOnLiftPath()
+    {
+        // PR #4211 review (Copilot), the other finding. cs2gs's
+        // `ArrowTypeReference` carries parameter TYPES only — it has no
+        // variadic flag — and `MapParameter` maps a `params T[]` to its ELEMENT
+        // type behind a `...` carrier. So `AddGroupMember` would forward-declare
+        // `var Add ((int32, int32) -> void)?` for a literal that is really
+        // `func (depth int32, xs ...int32)`: two distinct gsc function types
+        // ("Cannot convert type '(int32, ...int32) -> void' to
+        // '((int32, int32) -> void)?'"), plus "Function 'Add!!' requires 2
+        // arguments but was given 3" at every expanded call site. Unlike a
+        // default parameter value this is not repairable at the call site — the
+        // DECLARATION is already the wrong type — so a variadic member keeps its
+        // whole cycle on the `__local_` lift path, whose real method declaration
+        // carries `params` natively.
+        //
+        // (gsc itself is not the limitation: a hand-written
+        // `var f ((int32, ...int32) -> void)? = nil` declares, binds and runs.
+        // Teaching `ArrowTypeReference` variadic shape is the follow-up.)
+        string printed = LocalFunctionHoistTranslationTests.TranslateUnit(@"
+namespace Demo
+{
+    public class Builder
+    {
+        public int Project(int seed)
+        {
+            int Add(int depth, params int[] xs)
+            {
+                int sum = 0;
+                foreach (int x in xs) { sum += x; }
+                if (depth > 0)
+                {
+                    sum += AddPatternSwitch(depth - 1);
+                }
+
+                return sum;
+            }
+
+            int AddPatternSwitch(int depth)
+            {
+                if (depth > 0)
+                {
+                    return Add(depth - 1, 1, 2);
+                }
+
+                return 0;
+            }
+
+            int result = Add(seed, 3, 4);
+            System.Console.WriteLine(result);
+            return result;
+        }
+    }
+}");
+
+        // The whole cycle stays on `__local_`, exactly as the generic and
+        // ref-returning carve-outs above do.
+        Assert.Contains("__local_Project_Add", printed, StringComparison.Ordinal);
+        Assert.Contains("__local_Project_AddPatternSwitch", printed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Add!!(", printed, StringComparison.Ordinal);
+
+        // The lifted real method keeps the variadic parameter natively.
+        Assert.Contains("xs ...int32", printed, StringComparison.Ordinal);
+
+        // Add(2, 3, 4) = 7 + AddPatternSwitch(1) -> Add(0, 1, 2) = 3. Total 10.
+        LocalFunctionHoistTranslationTests.CompileAndRun(printed, "Builder().Project(2)", "10");
+    }
 }

--- a/tools/cs2gs/Cs2Gs.Tests/Issue4211ConditionalArmElementAccessForgivenessTranslationTests.cs
+++ b/tools/cs2gs/Cs2Gs.Tests/Issue4211ConditionalArmElementAccessForgivenessTranslationTests.cs
@@ -1,0 +1,385 @@
+// <copyright file="Issue4211ConditionalArmElementAccessForgivenessTranslationTests.cs" company="GSharp">
+// Copyright (C) GSharp Authors. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Cs2Gs.CodeModel.Ast;
+using Cs2Gs.CodeModel.Printing;
+using Cs2Gs.CodeModel.RoundTrip;
+using Cs2Gs.Translator;
+using Cs2Gs.Translator.Loading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Cs2Gs.Tests;
+
+/// <summary>
+/// Translator-fidelity tests for the gap PR #4211's own hot-core translation
+/// guard surfaced: <c>GS0155 Cannot convert type 'GExpression?' to
+/// 'GExpression'</c> compiling cs2gs's own translated
+/// <c>CSharpToGSharpTranslator.Invocations.gs</c>.
+/// <para>
+/// Issue #2259 already bridges an element-access write whose right-hand side is
+/// a promoted-nullable value (<c>arr[i] = x</c> becomes <c>arr[i] = x!!</c>),
+/// because an element-access target — unlike a local/field/property/parameter —
+/// has no single declaration the whole-program taint fixpoint can widen. That
+/// rule asks <c>IsNullablePromotedValue</c> about the WHOLE right-hand side,
+/// and for a CONDITIONAL right-hand side that question routes through
+/// <c>IsNullableInitializer</c>, which recurses into the arms but reads only
+/// their DECLARED annotation — the taint fixpoint's promotion is invisible to
+/// it. So <c>slots[ordinal] = permutes ? this.SpillOperand(value, …) : value</c>
+/// (cs2gs's own <c>TranslateClaimedLocalFunctionArgumentsWithDefaults</c>,
+/// where <c>value</c> is a local the fixpoint promoted to <c>GExpression?</c>)
+/// emitted a bare <c>T?</c> arm into a <c>T</c> element slot.
+/// </para>
+/// <para>
+/// The fix answers per ARM instead — every conditional arm already translates
+/// through <c>TranslateValueWithNullForgiveness</c> — so exactly the arms that
+/// need the bridge get it and an already-non-null sibling arm stays byte for
+/// byte unchanged.
+/// </para>
+/// </summary>
+public class Issue4211ConditionalArmElementAccessForgivenessTranslationTests
+{
+    [Fact]
+    public void Oblivious_PromotedTernaryArms_AssignedToArrayElement_AssertEachNullableArm()
+    {
+        // The reduced corpus shape: an array allocated at the parameter count,
+        // filled by a loop, each slot written from a ternary whose arms carry a
+        // taint-promoted local. Both arms are `Node?` here, so both are bridged.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Node
+    {
+        public string Name;
+    }
+
+    public class C
+    {
+        private Node Produce(int i)
+        {
+            if (i < 0)
+            {
+                return null;
+            }
+
+            return new Node();
+        }
+
+        private Node Spill(Node operand, int marker)
+        {
+            return operand;
+        }
+
+        public Node[] Run(int count, bool permute)
+        {
+            var slots = new Node[count];
+            for (int i = 0; i < count; i++)
+            {
+                Node value = this.Produce(i);
+                slots[i] = permute ? this.Spill(value, i) : value;
+            }
+
+            return slots;
+        }
+    }
+}");
+
+        Assert.Contains("slots[i] = if permute { this.Spill(value, i)!! } else { value!! }", printed);
+    }
+
+    [Fact]
+    public void Oblivious_OnlyTheNullableArm_IsAsserted()
+    {
+        // The asymmetric half, which is what keeps this from being a blanket
+        // forgiveness: the `new Node()` arm is statically non-null and must stay
+        // bare, while the promoted local still needs its bridge.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class C
+    {
+        private Node Produce(int i)
+        {
+            if (i < 0)
+            {
+                return null;
+            }
+
+            return new Node();
+        }
+
+        public Node[] Run(int count, bool permute)
+        {
+            var slots = new Node[count];
+            for (int i = 0; i < count; i++)
+            {
+                Node value = this.Produce(i);
+                slots[i] = permute ? new Node() : value;
+            }
+
+            return slots;
+        }
+    }
+}");
+
+        Assert.Contains("slots[i] = if permute { Node() } else { value!! }", printed);
+    }
+
+    [Fact]
+    public void Oblivious_NestedTernaryArm_AssignedToIndexerWrite_IsAsserted()
+    {
+        // The sink generalizes past arrays to a user/BCL indexer write, and the
+        // arm walk sees through NESTED conditionals rather than only the
+        // outermost one.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    using System.Collections.Generic;
+
+    public class C
+    {
+        private string Produce(int i)
+        {
+            if (i < 0)
+            {
+                return null;
+            }
+
+            return ""x"";
+        }
+
+        public void Run(Dictionary<string, string> sink, string key, bool a, bool b, int i)
+        {
+            string value = this.Produce(i);
+            sink[key] = a ? (b ? value : ""lit"") : ""other"";
+        }
+    }
+}");
+
+        Assert.Contains(
+            @"sink[key] = if a { (if b { value!! } else { ""lit"" }) } else { ""other"" }",
+            printed);
+    }
+
+    [Fact]
+    public void Oblivious_SwitchExpressionArm_AssignedToArrayElement_IsAsserted()
+    {
+        // A switch-expression arm reaches the same seam: its arm expression is
+        // translated through `TranslateSwitchArmExpression` ->
+        // `TranslateConditionalValueBranch` ->
+        // `TranslateValueWithNullForgiveness`, exactly as a ternary arm is. The
+        // corpus shape was a ternary; this pins the sibling form so the rule's
+        // switch handling is exercised rather than assumed.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class C
+    {
+        private Node Produce(int i)
+        {
+            if (i < 0)
+            {
+                return null;
+            }
+
+            return new Node();
+        }
+
+        public Node[] Run(int count, int mode)
+        {
+            var slots = new Node[count];
+            for (int i = 0; i < count; i++)
+            {
+                Node value = this.Produce(i);
+                slots[i] = mode switch
+                {
+                    0 => new Node(),
+                    _ => value,
+                };
+            }
+
+            return slots;
+        }
+    }
+}");
+
+        Assert.Contains("value!!", printed);
+    }
+
+    [Fact]
+    public void Oblivious_GuardedArm_IsNotAsserted()
+    {
+        // gsc smart-casts a local narrowed by the conditional's own condition,
+        // so the guarded arm needs no assertion — only the unguarded sibling
+        // does. This is the boundary that keeps the rule from asserting values
+        // the emitted G# already knows are non-null.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class C
+    {
+        private Node Produce(int i)
+        {
+            if (i < 0)
+            {
+                return null;
+            }
+
+            return new Node();
+        }
+
+        public Node[] Run(int count)
+        {
+            var slots = new Node[count];
+            for (int i = 0; i < count; i++)
+            {
+                Node value = this.Produce(i);
+                Node fallback = this.Produce(0);
+                slots[i] = value != null ? value : fallback;
+            }
+
+            return slots;
+        }
+    }
+}");
+
+        Assert.Contains("slots[i] = if value != nil { value } else { fallback!! }", printed);
+    }
+
+    [Fact]
+    public void Oblivious_TernaryArmAssignedToOrdinaryLocal_IsNotAsserted()
+    {
+        // Only an ELEMENT-ACCESS sink qualifies. An ordinary local target is
+        // widened to `T?` at its own declaration by the taint fixpoint, so the
+        // arm must stay bare — asserting there would reintroduce a throw the
+        // original C# never took.
+        string printed = TranslateOblivious(@"
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class C
+    {
+        private Node Produce(int i)
+        {
+            if (i < 0)
+            {
+                return null;
+            }
+
+            return new Node();
+        }
+
+        public Node Run(int i, bool permute)
+        {
+            Node value = this.Produce(i);
+            Node result = null;
+            result = permute ? new Node() : value;
+            return result;
+        }
+    }
+}");
+
+        Assert.Contains("result = if permute { Node() } else { value }", printed);
+        Assert.DoesNotContain("value!!", printed);
+    }
+
+    [Fact]
+    public void Enabled_TernaryArmAssignedToArrayElement_IsUnchanged()
+    {
+        // A nullable-ENABLED compilation never runs the taint fixpoint, so this
+        // rule cannot fire there: the C# compiler already checked the contract
+        // and its own annotations are authoritative.
+        string printed = TranslateEnabled(@"
+namespace Demo
+{
+    public class Node
+    {
+    }
+
+    public class C
+    {
+        public Node?[] Run(int count, bool permute, Node? value)
+        {
+            var slots = new Node?[count];
+            for (int i = 0; i < count; i++)
+            {
+                slots[i] = permute ? null : value;
+            }
+
+            return slots;
+        }
+    }
+}");
+
+        Assert.DoesNotContain("value!!", printed);
+    }
+
+    private static string TranslateOblivious(string source)
+    {
+        LoadedCSharpProject project = CSharpProjectLoader.LoadInMemory(new[] { ("Snippet.cs", source) });
+        Assert.True(
+            project.BoundWithoutErrors,
+            "Snippet should bind with no C# errors: " +
+                string.Join(Environment.NewLine, project.ErrorDiagnostics));
+        Assert.Equal(
+            NullableContextOptions.Disable,
+            project.Compilation.Options.NullableContextOptions);
+
+        LoadedDocument document = Assert.Single(project.Documents);
+        var context = new TranslationContext(project.Compilation, document.SemanticModel, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string TranslateEnabled(string source)
+    {
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Latest);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, parseOptions, path: "Snippet.cs");
+        var compilation = CSharpCompilation.Create(
+            "Cs2Gs.EnabledInMemory",
+            new[] { tree },
+            CSharpProjectLoader.RuntimeReferences().Select(r => r).ToImmutableArray(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithNullableContextOptions(NullableContextOptions.Enable)
+                .WithAllowUnsafe(true));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(),
+            d => d.Severity == DiagnosticSeverity.Error);
+
+        SemanticModel model = compilation.GetSemanticModel(tree);
+        var document = new LoadedDocument("Snippet.cs", tree, model);
+        var context = new TranslationContext(compilation, model, document.FilePath);
+        return PrintAndValidate(new CSharpToGSharpTranslator().TranslateDocument(document, context));
+    }
+
+    private static string PrintAndValidate(CompilationUnit unit)
+    {
+        string printed = GSharpPrinter.Print(unit);
+        RoundTripResult result = TranslationTestValidation.AssertBinds(printed);
+        Assert.True(
+            result.Success,
+            "Translated G# must round-trip. Errors:\n" +
+                string.Join("\n", result.Errors) + "\n\nPrinted:\n" + printed);
+        return printed;
+    }
+}

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -2366,16 +2366,34 @@ public sealed partial class CSharpToGSharpTranslator
         // real name (see the fold-BFS below) instead of being lifted to
         // `__local_` by `RegisterRecursiveLocalFunctionLifts` purely because
         // it happened to be reachable. Only a cycle (or fold candidate) that
-        // itself passes through a generic, ref-returning, or default-
-        // parameter-carrying local function stays on the `__local_` path
-        // (those members never enter the `functions`/`edges` graph below, so
-        // this pass never even sees the cycle — see the carve-out further
-        // down). PR #4200's CI run found the default-parameter gap: a
-        // non-recursive callee folded into a group has every call site
-        // rewritten to `Name!!(args)`, and a delegate-typed call site cannot
-        // fall back to a default the way a real method call can, so a caller
-        // that relied on the C#-level default would end up short an argument
-        // (GS0144).
+        // itself passes through a generic or ref-returning local function
+        // stays on the `__local_` path (those members never enter the
+        // `functions`/`edges` graph below, so this pass never even sees the
+        // cycle — see the carve-out further down).
+        //
+        // A DEFAULT PARAMETER VALUE is deliberately NOT one of those graph
+        // carve-outs, and the distinction is the point (issue #4197
+        // follow-up). Generic and ref-returning are DECLARATION-side
+        // impossibilities: the arrow type `((Params) -> R)?` cannot express a
+        // type parameter or a `ref` return at all, so the whole cycle has to
+        // stay off the scheme. A default is declaration-EXPRESSIBLE — the
+        // arrow type simply drops it — and only breaks at a CALL SITE that
+        // omitted the defaulted argument, since the rewritten `Name!!(args)`
+        // is a delegate-typed invocation that cannot fall back to a default
+        // the way a real method call can (PR #4200's CI run found exactly
+        // that: GS0144 "requires 3 arguments but was given 2"). Call sites of
+        // a claimed member are entirely translator-controlled, so that gap is
+        // closed where it lives — `TranslateCallArguments` materializes the
+        // omitted default explicitly, exactly as the `__local_` lift path
+        // already does for its own rewritten call sites. Excluding a
+        // default-carrying local function from this graph instead would erase
+        // it from cycle detection, and with it any cycle it is a CORE MEMBER
+        // of: `ControlFlowGraph.cs`'s `ProjectRegionsForDefiniteReturn` lost
+        // its whole `Add`/`AddPatternSwitch`/`AddTry` group (7 lifted helpers
+        // where 0 were wanted) that way. The fold-BFS below still skips a
+        // default-carrying candidate, because THERE the `__local_` lift is a
+        // strictly better answer — a real method declaration carries the
+        // default natively — and no cycle is sacrificed by declining it.
         private void RegisterCapturingRecursiveLocalFunctions(IReadOnlyList<StatementSyntax> statements)
         {
             // `DescendantNodes()` excludes the node itself — local functions that
@@ -2398,25 +2416,16 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     // A generic local function's type parameters cannot be
-                    // expressed on a function-typed local, a ref-returning
-                    // local is an unsupported gap either way, and a
-                    // DEFAULT PARAMETER VALUE has no expression on a
-                    // function-typed local either — `(Params) -> R)?` is a
-                    // structural arrow/delegate type, not a full method
-                    // declaration, so it cannot carry a default. Once a
-                    // function is rewritten to that shape, every call site
-                    // is rewritten to `Name!!(args)` too — a call site that
-                    // relied on the C#-level default (supplying fewer
-                    // arguments than the parameter list) would then be
-                    // missing a required argument (GS0144), since a
-                    // delegate-typed call site cannot fall back to a
-                    // default the way a real method call can. All three
-                    // carve-outs stay on the existing `__local_` lift path,
-                    // which lifts to a REAL method declaration that natively
-                    // supports default parameter values.
+                    // expressed on a function-typed local, and a
+                    // ref-returning local is an unsupported gap either way.
+                    // Both carve-outs stay on the existing `__local_` lift
+                    // path, which lifts to a REAL method declaration. A
+                    // default parameter value is NOT a carve-out here — see
+                    // the header comment: it is expressible on the
+                    // declaration side and only constrains call sites, which
+                    // this scheme fully controls.
                     if (localFunction.TypeParameterList != null
-                        || symbol.ReturnsByRef
-                        || symbol.Parameters.Any(parameter => parameter.HasExplicitDefaultValue))
+                        || symbol.ReturnsByRef)
                     {
                         continue;
                     }
@@ -2651,6 +2660,25 @@ public sealed partial class CSharpToGSharpTranslator
                             || foldSymbols.Contains(symbol)
                             || sccMembers.Contains(symbol)
                             || this.state.RecursiveLocalFunctionGroups.ContainsKey(symbol))
+                        {
+                            continue;
+                        }
+
+                        // PR #4200's CI run: a fold candidate that declares a
+                        // DEFAULT PARAMETER VALUE is left on the `__local_`
+                        // lift path on purpose (`Binder.cs`'s
+                        // `FindTopLevelBaseIndex`, whose `AddBaseFirst` call
+                        // site omits the third argument). Folding is an
+                        // optional readability win, never a correctness
+                        // requirement, and the lift produces a REAL method
+                        // declaration that carries the default natively —
+                        // strictly better than a delegate-typed local whose
+                        // every call site has to have the default
+                        // materialized back in. A cycle member is the
+                        // opposite case and stays claimed: declining it would
+                        // cost the whole cycle its real names (see the header
+                        // comment).
+                        if (symbol.Parameters.Any(parameter => parameter.HasExplicitDefaultValue))
                         {
                             continue;
                         }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -2366,10 +2366,10 @@ public sealed partial class CSharpToGSharpTranslator
         // real name (see the fold-BFS below) instead of being lifted to
         // `__local_` by `RegisterRecursiveLocalFunctionLifts` purely because
         // it happened to be reachable. Only a cycle (or fold candidate) that
-        // itself passes through a generic or ref-returning local function
-        // stays on the `__local_` path (those members never enter the
-        // `functions`/`edges` graph below, so this pass never even sees the
-        // cycle — see the carve-out further down).
+        // itself passes through a generic, ref-returning, or VARIADIC
+        // (`params`) local function stays on the `__local_` path (those
+        // members never enter the `functions`/`edges` graph below, so this
+        // pass never even sees the cycle — see the carve-out further down).
         //
         // A DEFAULT PARAMETER VALUE is deliberately NOT one of those graph
         // carve-outs, and the distinction is the point (issue #4197
@@ -2394,6 +2394,25 @@ public sealed partial class CSharpToGSharpTranslator
         // default-carrying candidate, because THERE the `__local_` lift is a
         // strictly better answer — a real method declaration carries the
         // default natively — and no cycle is sacrificed by declining it.
+        //
+        // A `params` PARAMETER, by contrast, IS a declaration-side carve-out —
+        // PR #4211's review found it, and the gap predates that PR (the old
+        // exclusion keyed on `HasExplicitDefaultValue` alone, so a
+        // `params`-only member was already admitted). gsc itself models a
+        // variadic function type fine (`((int32, ...int32) -> void)?` declares,
+        // binds and runs), but cs2gs's `ArrowTypeReference` carries parameter
+        // TYPES only and has no variadic flag, while `MapParameter` maps a
+        // `params T[]` to the ELEMENT type behind a `...` carrier. So
+        // `AddGroupMember` would declare `Add ((int32, int32) -> void)?` for a
+        // literal that is really `func (depth int32, xs ...int32)` — two
+        // distinct gsc function types ("Cannot convert type
+        // '(int32, ...int32) -> void' to '((int32, int32) -> void)?'"), and
+        // every expanded call site would overflow the declared arity
+        // ("Function 'Add!!' requires 2 arguments but was given 3"). Unlike the
+        // default-value case there is no call-site-only repair: the DECLARATION
+        // is already wrong. Until `ArrowTypeReference` models variadic shape,
+        // a variadic member keeps its whole cycle on the `__local_` path, whose
+        // real method declaration carries `params` natively.
         private void RegisterCapturingRecursiveLocalFunctions(IReadOnlyList<StatementSyntax> statements)
         {
             // `DescendantNodes()` excludes the node itself — local functions that
@@ -2416,16 +2435,21 @@ public sealed partial class CSharpToGSharpTranslator
                     }
 
                     // A generic local function's type parameters cannot be
-                    // expressed on a function-typed local, and a
-                    // ref-returning local is an unsupported gap either way.
-                    // Both carve-outs stay on the existing `__local_` lift
-                    // path, which lifts to a REAL method declaration. A
-                    // default parameter value is NOT a carve-out here — see
-                    // the header comment: it is expressible on the
-                    // declaration side and only constrains call sites, which
-                    // this scheme fully controls.
+                    // expressed on a function-typed local, a ref-returning
+                    // local is an unsupported gap either way, and a `params`
+                    // parameter has no representation on cs2gs's
+                    // `ArrowTypeReference` (which carries parameter types
+                    // only), so the forward declaration and the function
+                    // literal assigned to it would be two different gsc
+                    // function types. All three carve-outs stay on the
+                    // existing `__local_` lift path, which lifts to a REAL
+                    // method declaration. A default parameter value is NOT a
+                    // carve-out here — see the header comment: it is
+                    // expressible on the declaration side and only constrains
+                    // call sites, which this scheme fully controls.
                     if (localFunction.TypeParameterList != null
-                        || symbol.ReturnsByRef)
+                        || symbol.ReturnsByRef
+                        || symbol.Parameters.Any(IsVariadicCarrierParameter))
                     {
                         continue;
                     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Constructors.cs
@@ -2413,6 +2413,36 @@ public sealed partial class CSharpToGSharpTranslator
         // is already wrong. Until `ArrowTypeReference` models variadic shape,
         // a variadic member keeps its whole cycle on the `__local_` path, whose
         // real method declaration carries `params` natively.
+        //
+        // A `ref`/`out`/`in` PARAMETER is a third declaration-side carve-out,
+        // for exactly the same reason and found the same way (PR #4211's third
+        // review round). `ArrowTypeReference` carries parameter
+        // types only and has no ref-kind, so `AddGroupMember` declares
+        // `var Add ((int32, int32) -> void)?` for a literal that is really
+        // `func (depth int32, ref cell int32)`, i.e. `(int32, *int32) -> void`.
+        // gsc rejects the whole shape loudly and unconditionally — "Cannot
+        // convert type '(int32, int32) -> void' to '((int32, int32) -> void)?'"
+        // on the assignment plus "Cannot convert type '*int32' to 'int32'" at
+        // every `&x` call site (`*?` for `out`) — for `ref`, `out` and `in`
+        // alike, with or without a default parameter and with or without a
+        // named call site.
+        //
+        // Half of that is older than this PR and half is this PR's own: a
+        // ref-kind member WITHOUT a default was already claimed (and already
+        // broken) at e815bb76, while one WITH a default used to be kept out of
+        // the whole scheme by the blanket `HasExplicitDefaultValue` exclusion
+        // that #4197's fix (e1c4c1d9) correctly removed — so removing it
+        // exposed this shape for the first time. Either way the answer is the
+        // same, and it is the one `params` got: there is no call-site-only
+        // repair, because the DECLARATION is already the wrong function type.
+        // Such a member keeps its whole cycle on the `__local_` lift path,
+        // whose real method declaration carries the ref-kind natively. That
+        // path also preserves the `name:` wrappers (a real method HAS parameter
+        // names), so the call site binds correctly. This also makes a
+        // ref-kind argument unreachable in
+        // <see cref="TranslateClaimedLocalFunctionArgumentsWithDefaults"/>,
+        // which is why that method's evaluation-order spill only ever has
+        // by-value operands to consider.
         private void RegisterCapturingRecursiveLocalFunctions(IReadOnlyList<StatementSyntax> statements)
         {
             // `DescendantNodes()` excludes the node itself — local functions that
@@ -2436,20 +2466,22 @@ public sealed partial class CSharpToGSharpTranslator
 
                     // A generic local function's type parameters cannot be
                     // expressed on a function-typed local, a ref-returning
-                    // local is an unsupported gap either way, and a `params`
-                    // parameter has no representation on cs2gs's
-                    // `ArrowTypeReference` (which carries parameter types
-                    // only), so the forward declaration and the function
-                    // literal assigned to it would be two different gsc
-                    // function types. All three carve-outs stay on the
-                    // existing `__local_` lift path, which lifts to a REAL
-                    // method declaration. A default parameter value is NOT a
-                    // carve-out here — see the header comment: it is
-                    // expressible on the declaration side and only constrains
-                    // call sites, which this scheme fully controls.
+                    // local is an unsupported gap either way, and neither a
+                    // `params` parameter nor a `ref`/`out`/`in` parameter has
+                    // any representation on cs2gs's `ArrowTypeReference`
+                    // (which carries parameter types only), so the forward
+                    // declaration and the function literal assigned to it
+                    // would be two different gsc function types. All four
+                    // carve-outs stay on the existing `__local_` lift path,
+                    // which lifts to a REAL method declaration. A default
+                    // parameter value is NOT a carve-out here — see the header
+                    // comment: it is expressible on the declaration side and
+                    // only constrains call sites, which this scheme fully
+                    // controls.
                     if (localFunction.TypeParameterList != null
                         || symbol.ReturnsByRef
-                        || symbol.Parameters.Any(IsVariadicCarrierParameter))
+                        || symbol.Parameters.Any(IsVariadicCarrierParameter)
+                        || symbol.Parameters.Any(parameter => parameter.RefKind != RefKind.None))
                     {
                         continue;
                     }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Deconstruction.cs
@@ -1285,14 +1285,27 @@ public sealed partial class CSharpToGSharpTranslator
         // see <see cref="TranslateLambda"/>/<see cref="TranslateLocalFunction"/>)
         // the operand is conservatively left embedded as-is rather than spilled
         // into an unrelated scope.
-        private GExpression SpillOperand(GExpression operand) => this.SpillOperand(operand, this.state.PendingSpillPrologue);
+        private GExpression SpillOperand(GExpression operand, bool forceNonTrivial = false) =>
+            this.SpillOperand(operand, this.state.PendingSpillPrologue, forceNonTrivial);
 
         // As above, but retains a loud fallback for a future expression-only
         // site that fails to open either a statement seam or issue #3355's
         // native block-expression seam.
-        private GExpression SpillOperand(GExpression operand, SyntaxNode operandSyntaxForDiagnostic)
+        //
+        // `forceNonTrivial` suppresses the <see cref="IsTrivialOperand"/>
+        // shortcut. That shortcut answers "is duplicating this expression
+        // safe?", which is the wrong question for a caller that is REORDERING
+        // evaluation rather than duplicating it: a bare identifier is safe to
+        // read twice, but it is NOT safe to read it LATER than written when
+        // another operand that moved ahead of it can mutate what it names
+        // (PR #4211's third review round — see
+        // <see cref="SnapshotPermutedArgumentOperand"/>).
+        private GExpression SpillOperand(
+            GExpression operand,
+            SyntaxNode operandSyntaxForDiagnostic,
+            bool forceNonTrivial = false)
         {
-            if (IsTrivialOperand(operand))
+            if (!forceNonTrivial && IsTrivialOperand(operand))
             {
                 return operand;
             }
@@ -1304,12 +1317,13 @@ public sealed partial class CSharpToGSharpTranslator
 
             if (this.state.PendingSpillPrologue != null)
             {
-                return this.SpillOperand(operand);
+                return this.SpillOperand(operand, forceNonTrivial);
             }
 
             string message =
                 "a non-trivial operand reached an expression-only translation site without opening " +
-                "a native block-expression spill seam; emitting it would evaluate it more than once.";
+                "a native block-expression spill seam; emitting it in place would evaluate it more " +
+                "than once, or out of source order.";
             this.context.ReportUnsupported(operandSyntaxForDiagnostic, message);
             return operand;
         }
@@ -1446,9 +1460,12 @@ public sealed partial class CSharpToGSharpTranslator
         // <see cref="FlattenChainedAssignment"/>) that already build their own
         // ordered statement list and know exactly where the spill must land,
         // independent of whatever statement seam happens to be active.
-        private GExpression SpillOperand(GExpression operand, List<GStatement> prologue)
+        private GExpression SpillOperand(
+            GExpression operand,
+            List<GStatement> prologue,
+            bool forceNonTrivial = false)
         {
-            if (IsTrivialOperand(operand) || prologue == null)
+            if ((!forceNonTrivial && IsTrivialOperand(operand)) || prologue == null)
             {
                 return operand;
             }

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Expressions.cs
@@ -2564,6 +2564,25 @@ public sealed partial class CSharpToGSharpTranslator
                 return true;
             }
 
+            // Issue #4211: the ELEMENT-ACCESS-SINK sibling of the rule just
+            // above. #2259 already bridges `arr[i] = <promoted nullable>` with
+            // `!!` — but only when the WHOLE right-hand side is recognizably
+            // promoted. A conditional/switch RHS is not: `IsNullablePromotedValue`
+            // routes a ternary through `IsNullableInitializer`, which recurses
+            // into the arms but consults only their DECLARED annotations, never
+            // the whole-program taint fixpoint — so `arr[i] = cond ? a : b` with
+            // a taint-promoted arm was invisible to the sink rule and emitted a
+            // bare `T?` arm into a `T` element slot (GS0155). Each arm is
+            // translated through `TranslateValueWithNullForgiveness`, so
+            // answering per-arm here bridges exactly the arms that need it and
+            // leaves an already-non-null sibling arm byte-identical — the same
+            // shape the return-preserving rule above uses, pointed at the one
+            // other sink the taint fixpoint structurally cannot widen.
+            if (this.IsNullableTaintedArmOfElementAccessAssignment(recv))
+            {
+                return true;
+            }
+
             // Issue #2432: an UNCONDITIONAL (no ternary/switch, no null-check
             // guard) forward of a same-project promoted-nullable field / property
             // / local / parameter / method as the ENTIRE (possibly parenthesized)
@@ -3214,6 +3233,114 @@ public sealed partial class CSharpToGSharpTranslator
             // return type must NOT be promoted to nullable by the oblivious
             // analyzer (i.e., it was deliberately kept non-null).
             return this.IsBodyOfReturnPreservingMember(conditional);
+        }
+
+        /// <summary>
+        /// Issue #4211: true when <paramref name="use"/> is a promoted-nullable
+        /// value read as an ARM of a conditional/switch expression whose result
+        /// is assigned into an element-access target that genuinely requires a
+        /// non-null reference (<see cref="ElementAccessAssignmentRequiresNonNullReference"/>).
+        /// </summary>
+        /// <remarks>
+        /// This is the arm-level completion of issue #2259's element-access sink
+        /// rule. That rule asks <c>IsNullablePromotedValue</c> about the WHOLE
+        /// right-hand side; for a ternary that question is answered by
+        /// <c>IsNullableInitializer</c>, which recurses into the arms but only
+        /// ever reads their DECLARED annotation — the taint fixpoint's promotion
+        /// is invisible to it. So the exact corpus shape
+        /// <c>slots[ordinal] = permutes ? this.SpillOperand(value, …) : value</c>
+        /// (cs2gs's own <c>TranslateClaimedLocalFunctionArgumentsWithDefaults</c>,
+        /// where <c>value</c> is a local the fixpoint promoted to
+        /// <c>GExpression?</c>) emitted a bare <c>T?</c> arm into a <c>T</c>
+        /// element slot and failed to compile with GS0155.
+        /// <para>
+        /// Scoping, mirroring
+        /// <see cref="IsNullableTaintedArmOfReturnPreservingConditional"/>:
+        /// oblivious compilations only; the use must really be an ARM (the walk
+        /// requires at least one conditional/switch level, so a DIRECT RHS keeps
+        /// flowing through #2259's whole-RHS rule and stays byte-identical); the
+        /// sink must be an element access the taint fixpoint structurally cannot
+        /// widen (unlike a local/field/property/parameter target, which it widens
+        /// at the target's own declaration); and a local/parameter narrowed by a
+        /// dominating null-check guard is skipped because gsc's own Kotlin-style
+        /// smart-cast — including the conditional's own condition when it guards
+        /// that arm — has already made the read non-null.
+        /// </para>
+        /// </remarks>
+        private bool IsNullableTaintedArmOfElementAccessAssignment(ExpressionSyntax use)
+        {
+            if (!this.IsObliviousCompilation()
+                || !TryGetElementAccessAssignmentThroughConditionalArms(
+                    use,
+                    out AssignmentExpressionSyntax assignment)
+                || !this.ElementAccessAssignmentRequiresNonNullReference(assignment))
+            {
+                return false;
+            }
+
+            ISymbol symbol = this.context.GetSymbolInfo(use).Symbol;
+            if (symbol is ILocalSymbol or IParameterSymbol
+                && this.IsDominatedByNullCheckGuard(use, symbol))
+            {
+                return false;
+            }
+
+            return this.IsNullablePromotedValue(use);
+        }
+
+        // Walks outward from a conditional/switch ARM (through parentheses and
+        // any number of NESTED conditional/switch levels) to the simple
+        // assignment whose right-hand side that conditional ultimately is.
+        // Requires at least one conditional/switch level to have been crossed:
+        // a direct, unwrapped assignment RHS is issue #2259's whole-RHS rule's
+        // business and is deliberately left alone here. A use sitting in a
+        // conditional's CONDITION (rather than an arm) stops the walk, as does
+        // any other intervening expression — this is not a general "does this
+        // value eventually reach an element write" dataflow question.
+        private static bool TryGetElementAccessAssignmentThroughConditionalArms(
+            ExpressionSyntax use,
+            out AssignmentExpressionSyntax assignment)
+        {
+            assignment = null;
+            SyntaxNode current = use;
+            bool crossedConditional = false;
+
+            while (current != null)
+            {
+                switch (current.Parent)
+                {
+                    case ParenthesizedExpressionSyntax parenthesized:
+                        current = parenthesized;
+                        continue;
+
+                    case ConditionalExpressionSyntax ternary
+                        when current == ternary.WhenTrue || current == ternary.WhenFalse:
+                        crossedConditional = true;
+                        current = ternary;
+                        continue;
+
+                    case SwitchExpressionArmSyntax arm
+                        when current == arm.Expression
+                            && arm.Parent is SwitchExpressionSyntax switchExpression:
+                        crossedConditional = true;
+                        current = switchExpression;
+                        continue;
+
+                    case AssignmentExpressionSyntax candidate when current == candidate.Right:
+                        if (!crossedConditional)
+                        {
+                            return false;
+                        }
+
+                        assignment = candidate;
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+
+            return false;
         }
 
         // Issue #2432: true when <paramref name="use"/> is a same-project

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1212,6 +1212,28 @@ public sealed partial class CSharpToGSharpTranslator
                 return this.TranslateDelegateInvokeArgumentsWithDefaults(callSyntax, arguments, operationArguments);
             }
 
+            // Issue #4197 follow-up: a local function claimed by the #3399
+            // nullable-function-local scheme is called as `Name!!(args)` — a
+            // structural function-type invocation that, exactly like the
+            // delegate-invoke case above, cannot fall back to a C#-level
+            // default (GS0144 "requires N arguments but was given M"). Roslyn
+            // has already resolved the omitted argument to its constant
+            // default, so materialize it here rather than dropping it. Only a
+            // call site that actually OMITTED something takes this path, so a
+            // claimed member called at full arity keeps its existing output
+            // byte for byte.
+            if (targetMethod is { MethodKind: MethodKind.LocalFunction }
+                && this.state.RecursiveLocalFunctionGroups.TryGetValue(
+                    targetMethod, out RecursiveLocalFunctionGroup claimedGroup)
+                && claimedGroup.Members.Contains(targetMethod, SymbolEqualityComparer.Default)
+                && operationArguments.Any(a => a.ArgumentKind == ArgumentKind.DefaultValue)
+                && operationArguments.All(a => a.ArgumentKind == ArgumentKind.DefaultValue
+                    || (a.ArgumentKind == ArgumentKind.Explicit && a.Syntax is ArgumentSyntax)))
+            {
+                return this.TranslateClaimedLocalFunctionArgumentsWithDefaults(
+                    callSyntax, operationArguments);
+            }
+
             IArgumentOperation paramsCollectionArg =
                 operationArguments.FirstOrDefault(a => a.ArgumentKind == ArgumentKind.ParamCollection);
 
@@ -1419,6 +1441,58 @@ public sealed partial class CSharpToGSharpTranslator
 
                 result.Add(this.TranslateArgument(arguments[nextSyntaxArgument]));
                 nextSyntaxArgument++;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Rebuilds the full argument list of a call to a local function claimed
+        /// by the #3399 nullable-function-local scheme (issue #4197 follow-up),
+        /// when the C# call site omitted a defaulted argument. Roslyn's
+        /// <paramref name="operationArguments"/> are already in PARAMETER order,
+        /// so walking them positionally both materializes the omitted default
+        /// (which the rewritten `Name!!(…)` function-type call has no other way
+        /// to supply) and normalizes a named-argument call site into the
+        /// positional form that call shape requires — a named argument carries
+        /// no meaning through a structural arrow type, whose parameters have
+        /// types but no names. The argument VALUE is translated (never the
+        /// `name:` wrapper) for that reason; `ref`/`out` argument forms are
+        /// unaffected, since they live on the value translation.
+        /// </summary>
+        /// <remarks>
+        /// Re-ordering an out-of-order named-argument call site evaluates its
+        /// arguments in parameter order rather than source order, which is
+        /// observable only when two arguments of one such call site both have
+        /// side effects. That is strictly rarer than the GS0144 this closes, and
+        /// the alternative — keeping the source order — would emit arguments
+        /// against the wrong parameters entirely.
+        /// </remarks>
+        private List<GExpression> TranslateClaimedLocalFunctionArgumentsWithDefaults(
+            SyntaxNode callSyntax,
+            ImmutableArray<IArgumentOperation> operationArguments)
+        {
+            var result = new List<GExpression>(operationArguments.Length);
+            foreach (IArgumentOperation argumentOperation in operationArguments)
+            {
+                if (argumentOperation.ArgumentKind == ArgumentKind.DefaultValue)
+                {
+                    // Not coerced to the parameter type: `MapConstantValue`
+                    // already maps the constant AGAINST that type, and the
+                    // target here is a structural arrow whose parameter types
+                    // are exactly the declaration's — the same reasoning that
+                    // keeps the delegate-invoke path above uncoerced, and
+                    // what makes a `nil` default print as `nil` rather than a
+                    // `default(((T) -> R)?)` envelope.
+                    result.Add(this.TranslateOperationDefaultArgument(
+                        callSyntax,
+                        argumentOperation,
+                        "local function parameter",
+                        coerceToParameterType: false));
+                    continue;
+                }
+
+                result.Add(this.TranslateArgumentValue((ArgumentSyntax)argumentOperation.Syntax));
             }
 
             return result;

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1221,14 +1221,18 @@ public sealed partial class CSharpToGSharpTranslator
             // default, so materialize it here rather than dropping it. Only a
             // call site that actually OMITTED something takes this path, so a
             // claimed member called at full arity keeps its existing output
-            // byte for byte.
+            // byte for byte. Every argument must also NAME the parameter it
+            // binds to, because the reassembly addresses slots by
+            // `Parameter.Ordinal` — `IInvocationOperation.Arguments` is in
+            // EVALUATION order, not parameter order (PR #4211 review).
             if (targetMethod is { MethodKind: MethodKind.LocalFunction }
                 && this.state.RecursiveLocalFunctionGroups.TryGetValue(
                     targetMethod, out RecursiveLocalFunctionGroup claimedGroup)
                 && claimedGroup.Members.Contains(targetMethod, SymbolEqualityComparer.Default)
                 && operationArguments.Any(a => a.ArgumentKind == ArgumentKind.DefaultValue)
-                && operationArguments.All(a => a.ArgumentKind == ArgumentKind.DefaultValue
-                    || (a.ArgumentKind == ArgumentKind.Explicit && a.Syntax is ArgumentSyntax)))
+                && operationArguments.All(a => a.Parameter != null
+                    && (a.ArgumentKind == ArgumentKind.DefaultValue
+                        || (a.ArgumentKind == ArgumentKind.Explicit && a.Syntax is ArgumentSyntax))))
             {
                 return this.TranslateClaimedLocalFunctionArgumentsWithDefaults(
                     callSyntax, operationArguments);
@@ -1415,11 +1419,22 @@ public sealed partial class CSharpToGSharpTranslator
         /// numeric coercion/spill behavior is unchanged), and a <c>DefaultValue</c>
         /// slot materializes that parameter's constant default directly — the
         /// explicit value gsc's structural function-type call has no other way to
-        /// supply. Named arguments are excluded up front: C# forbids a named
-        /// argument through a delegate/lambda invocation entirely (no parameter
-        /// names survive the natural delegate type), so <paramref name="arguments"/>
-        /// is always in positional/Explicit order already.
+        /// supply.
         /// </summary>
+        /// <remarks>
+        /// The "parameter order" above holds for a POSITIONAL call site only.
+        /// This comment used to assert that C# forbids a named argument through
+        /// a delegate invocation; it does not — a delegate DECLARATION keeps its
+        /// parameter names, so `D d; d(b: 5);` is legal C# and reaches here with
+        /// `Arguments` in EVALUATION order (`[b Explicit, a DefaultValue]`), the
+        /// same shape PR #4211's review found on the local-function path below.
+        /// The consequence differs though: this path keeps the `name:` wrapper
+        /// (<c>TranslateArgument</c>), so a named delegate-invoke call site emits
+        /// `f(b: 5, 10)` and gsc rejects it loudly ("Named argument 'b' does not
+        /// match any parameter") rather than binding the wrong parameter
+        /// silently. Left as a separate follow-up: the shape is unrepresented in
+        /// the corpus and the fix belongs with its own test, not with #4197's.
+        /// </remarks>
         private List<GExpression> TranslateDelegateInvokeArgumentsWithDefaults(
             SyntaxNode callSyntax,
             SeparatedSyntaxList<ArgumentSyntax> arguments,
@@ -1449,32 +1464,52 @@ public sealed partial class CSharpToGSharpTranslator
         /// <summary>
         /// Rebuilds the full argument list of a call to a local function claimed
         /// by the #3399 nullable-function-local scheme (issue #4197 follow-up),
-        /// when the C# call site omitted a defaulted argument. Roslyn's
-        /// <paramref name="operationArguments"/> are already in PARAMETER order,
-        /// so walking them positionally both materializes the omitted default
-        /// (which the rewritten `Name!!(…)` function-type call has no other way
-        /// to supply) and normalizes a named-argument call site into the
-        /// positional form that call shape requires — a named argument carries
-        /// no meaning through a structural arrow type, whose parameters have
-        /// types but no names. The argument VALUE is translated (never the
+        /// when the C# call site omitted a defaulted argument. Every argument is
+        /// placed in the slot named by its own
+        /// <see cref="IParameterSymbol.Ordinal"/>: that both materializes the
+        /// omitted default (which the rewritten `Name!!(…)` function-type call
+        /// has no other way to supply) and normalizes a named-argument call site
+        /// into the positional form that call shape requires — a named argument
+        /// carries no meaning through a structural arrow type, whose parameters
+        /// have types but no names. The argument VALUE is translated (never the
         /// `name:` wrapper) for that reason; `ref`/`out` argument forms are
         /// unaffected, since they live on the value translation.
         /// </summary>
         /// <remarks>
-        /// Re-ordering an out-of-order named-argument call site evaluates its
-        /// arguments in parameter order rather than source order, which is
-        /// observable only when two arguments of one such call site both have
-        /// side effects. That is strictly rarer than the GS0144 this closes, and
-        /// the alternative — keeping the source order — would emit arguments
-        /// against the wrong parameters entirely.
+        /// <para>
+        /// <see cref="IInvocationOperation.Arguments"/> is in EVALUATION order,
+        /// not parameter order — PR #4211's review (Copilot) caught the original
+        /// version of this method assuming the opposite. For
+        /// <c>void Add(int a = 10, int b = 20)</c>, the call <c>Add(b: X())</c>
+        /// arrives as <c>[b Explicit, a DefaultValue]</c>, so a positional walk
+        /// emitted <c>Add!!(X(), 10)</c> — silently binding <c>X()</c> to
+        /// <c>a</c> and <c>10</c> to <c>b</c>. Addressing each slot by ordinal
+        /// is what makes the result correct regardless of source order.
+        /// </para>
+        /// <para>
+        /// Explicit operands are still TRANSLATED in the array's (source)
+        /// order, so any spill they hoist keeps its relative position. When the
+        /// ordinal permutation would additionally move one explicit operand
+        /// before another that was written first, each non-trivial explicit
+        /// operand is spilled to a `let __spillN` in the enclosing statement
+        /// seam, so the emitted program still EVALUATES them in source order
+        /// (C# §12.6.2.2) and only the already-constant defaults move. A call
+        /// site whose explicit ordinals are already ascending — which includes
+        /// every purely POSITIONAL call site, the overwhelming majority — never
+        /// permutes and so spills nothing; those keep their previous output
+        /// byte for byte. A NAMED call site's output does change, because the
+        /// previous output was wrong.
+        /// </para>
         /// </remarks>
         private List<GExpression> TranslateClaimedLocalFunctionArgumentsWithDefaults(
             SyntaxNode callSyntax,
             ImmutableArray<IArgumentOperation> operationArguments)
         {
-            var result = new List<GExpression>(operationArguments.Length);
+            bool permutesExplicitArguments = PermutesExplicitArguments(operationArguments);
+            var slots = new GExpression[operationArguments.Length];
             foreach (IArgumentOperation argumentOperation in operationArguments)
             {
+                int ordinal = argumentOperation.Parameter.Ordinal;
                 if (argumentOperation.ArgumentKind == ArgumentKind.DefaultValue)
                 {
                     // Not coerced to the parameter type: `MapConstantValue`
@@ -1484,18 +1519,58 @@ public sealed partial class CSharpToGSharpTranslator
                     // keeps the delegate-invoke path above uncoerced, and
                     // what makes a `nil` default print as `nil` rather than a
                     // `default(((T) -> R)?)` envelope.
-                    result.Add(this.TranslateOperationDefaultArgument(
+                    slots[ordinal] = this.TranslateOperationDefaultArgument(
                         callSyntax,
                         argumentOperation,
                         "local function parameter",
-                        coerceToParameterType: false));
+                        coerceToParameterType: false);
                     continue;
                 }
 
-                result.Add(this.TranslateArgumentValue((ArgumentSyntax)argumentOperation.Syntax));
+                var argumentSyntax = (ArgumentSyntax)argumentOperation.Syntax;
+                GExpression value = this.TranslateArgumentValue(argumentSyntax);
+
+                // A `ref`/`out` argument is never spilled: its translation is an
+                // ADDRESS form (`&x` / `out x`), and binding that to a
+                // `let __spillN` would hand the callee the temp instead of the
+                // caller's variable. Such an argument is a plain lvalue with no
+                // evaluation side effect of its own, so leaving it in place
+                // cannot reorder anything observable.
+                slots[ordinal] = permutesExplicitArguments
+                    && argumentSyntax.RefKindKeyword.IsKind(SyntaxKind.None)
+                    ? this.SpillOperand(value, argumentOperation.Syntax)
+                    : value;
             }
 
-            return result;
+            return slots.ToList();
+        }
+
+        // True when reassembling `operationArguments` by parameter ordinal
+        // would emit two EXPLICIT operands in an order other than the one they
+        // were written in — i.e. the explicit arguments'
+        // ordinals are not ascending along the (evaluation-ordered) array.
+        // Omitted `DefaultValue` slots never count: Roslyn resolves them to a
+        // constant, which has no side effect to reorder.
+        private static bool PermutesExplicitArguments(
+            ImmutableArray<IArgumentOperation> operationArguments)
+        {
+            var previousOrdinal = -1;
+            foreach (IArgumentOperation argumentOperation in operationArguments)
+            {
+                if (argumentOperation.ArgumentKind == ArgumentKind.DefaultValue)
+                {
+                    continue;
+                }
+
+                if (argumentOperation.Parameter.Ordinal < previousOrdinal)
+                {
+                    return true;
+                }
+
+                previousOrdinal = argumentOperation.Parameter.Ordinal;
+            }
+
+            return false;
         }
 
         private GExpression TranslateOperationDefaultArgument(

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Invocations.cs
@@ -1472,8 +1472,10 @@ public sealed partial class CSharpToGSharpTranslator
         /// into the positional form that call shape requires — a named argument
         /// carries no meaning through a structural arrow type, whose parameters
         /// have types but no names. The argument VALUE is translated (never the
-        /// `name:` wrapper) for that reason; `ref`/`out` argument forms are
-        /// unaffected, since they live on the value translation.
+        /// `name:` wrapper) for that reason. A ref-kind argument cannot occur
+        /// here at all: a local function with a `ref`/`out`/`in` parameter is
+        /// carved out of the scheme at registration time, since
+        /// `ArrowTypeReference` cannot declare a ref-kind.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -1490,8 +1492,11 @@ public sealed partial class CSharpToGSharpTranslator
         /// Explicit operands are still TRANSLATED in the array's (source)
         /// order, so any spill they hoist keeps its relative position. When the
         /// ordinal permutation would additionally move one explicit operand
-        /// before another that was written first, each non-trivial explicit
-        /// operand is spilled to a `let __spillN` in the enclosing statement
+        /// before another that was written first, EVERY explicit operand that
+        /// is not a literal or type name — a bare identifier very much
+        /// included, see
+        /// <see cref="SnapshotPermutedArgumentOperand"/> — is spilled to a
+        /// `let __spillN` in the enclosing statement
         /// seam, so the emitted program still EVALUATES them in source order
         /// (C# §12.6.2.2) and only the already-constant defaults move. A call
         /// site whose explicit ordinals are already ascending — which includes
@@ -1530,20 +1535,53 @@ public sealed partial class CSharpToGSharpTranslator
                 var argumentSyntax = (ArgumentSyntax)argumentOperation.Syntax;
                 GExpression value = this.TranslateArgumentValue(argumentSyntax);
 
-                // A `ref`/`out` argument is never spilled: its translation is an
-                // ADDRESS form (`&x` / `out x`), and binding that to a
+                // A `ref`/`out`/`in` argument is left in place. Its translation
+                // is an ADDRESS form (`&x`), and binding that to a
                 // `let __spillN` would hand the callee the temp instead of the
-                // caller's variable. Such an argument is a plain lvalue with no
-                // evaluation side effect of its own, so leaving it in place
-                // cannot reorder anything observable.
+                // caller's variable. The branch is inert rather than a
+                // judgement call: a local function with ANY ref-kind parameter
+                // is carved out of the claimed-cycle scheme entirely
+                // (`RegisterCapturingRecursiveLocalFunctions`), because
+                // `ArrowTypeReference` has no ref-kind to declare — so no
+                // ref-kind argument ever reaches this method. It is kept as a
+                // guard so that loosening the carve-out cannot silently start
+                // rebinding an address to a temp. (PR #4211 review: the earlier
+                // claim here — that a ref lvalue "has no evaluation side effect
+                // of its own" — was simply false, e.g. `ref slots[Next()]`;
+                // the carve-out, not that claim, is what makes this safe.)
                 slots[ordinal] = permutesExplicitArguments
                     && argumentSyntax.RefKindKeyword.IsKind(SyntaxKind.None)
-                    ? this.SpillOperand(value, argumentOperation.Syntax)
+                    ? this.SnapshotPermutedArgumentOperand(value, argumentOperation.Syntax)
                     : value;
             }
 
             return slots.ToList();
         }
+
+        // Evaluates one explicit by-value operand of a PERMUTED claimed-cycle
+        // call into a `let __spillN` so that the emitted program still runs the
+        // explicit operands in source order (C# §12.6.2.2) even though the
+        // reassembled call lists them in parameter order.
+        //
+        // Unlike an ordinary spill this does NOT honor
+        // `IsTrivialOperand`. That shortcut exists for DUPLICATION ("reading
+        // this twice is the same as reading it once"), and duplication is not
+        // what happens here: the operand is read exactly once, but at a
+        // different POINT IN TIME relative to the other operands. A bare
+        // identifier is the exact shape that breaks — `Add(c: x, a: MutateX())`
+        // must read `x` before `MutateX()` runs, and leaving `x` embedded in
+        // the reassembled call `Add!!(__spill0, 2, x)` reads it after
+        // (PR #4211 review, verified end to end: the call printed 219 where C#
+        // prints 125).
+        //
+        // A literal or a type name is genuinely immune — nothing can change
+        // what it denotes — so those stay embedded and keep the output free of
+        // pointless temps. `this` is NOT assumed immune: a struct receiver is a
+        // value, and a later operand can mutate its fields.
+        private GExpression SnapshotPermutedArgumentOperand(GExpression value, SyntaxNode operandSyntax) =>
+            value is LiteralExpression or TypeExpression
+                ? value
+                : this.SpillOperand(value, operandSyntax, forceNonTrivial: true);
 
         // True when reassembling `operationArguments` by parameter ordinal
         // would emit two EXPLICIT operands in an order other than the one they

--- a/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
+++ b/tools/cs2gs/Cs2Gs.Translator/CSharpToGSharpTranslator.Statements.cs
@@ -638,29 +638,45 @@ public sealed partial class CSharpToGSharpTranslator
             AssignmentExpressionSyntax assignment, GExpression translatedRhs)
         {
             if (!this.IsObliviousCompilation()
-                || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
                 || translatedRhs is NonNullAssertionExpression
                 || IsNullOrSuppressedNull(assignment.Right)
-                || assignment.Left is not ElementAccessExpressionSyntax
+                || !this.ElementAccessAssignmentRequiresNonNullReference(assignment)
                 || !this.IsNullablePromotedValue(assignment.Right))
             {
                 return translatedRhs;
+            }
+
+            return EnsureNonNullAssertion(translatedRhs);
+        }
+
+        // Issue #4211: the SINK half of the #2259 rule above, factored out so the
+        // whole-RHS rule and its per-ARM sibling
+        // (<see cref="IsNullableTaintedArmOfElementAccessAssignment"/>) share a
+        // single definition of "this element-access write genuinely demands a
+        // non-null reference": a SIMPLE assignment into an element-access target
+        // whose own type is a non-annotated reference type and whose resolved
+        // indexer (arrays resolve to no symbol at all) is not itself promoted to
+        // `T?` by the taint fixpoint. An already-nullable sink has nothing to
+        // forgive, and a compound assignment is a different shape entirely.
+        private bool ElementAccessAssignmentRequiresNonNullReference(
+            AssignmentExpressionSyntax assignment)
+        {
+            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+                || assignment.Left is not ElementAccessExpressionSyntax)
+            {
+                return false;
             }
 
             ITypeSymbol leftType = this.context.GetTypeInfo(assignment.Left).Type;
             if (leftType is not { IsReferenceType: true }
                 || leftType.NullableAnnotation == NullableAnnotation.Annotated)
             {
-                return translatedRhs;
+                return false;
             }
 
-            if (this.context.GetSymbolInfo(assignment.Left).Symbol is IPropertySymbol indexer
-                && this.ShouldPromoteToNullableReference(indexer))
-            {
-                return translatedRhs;
-            }
-
-            return EnsureNonNullAssertion(translatedRhs);
+            return this.context.GetSymbolInfo(assignment.Left).Symbol
+                    is not IPropertySymbol indexer
+                || !this.ShouldPromoteToNullableReference(indexer);
         }
 
         // Issue #2427 (oblivious sink): a plain REASSIGNMENT (`path = (pathStub +


### PR DESCRIPTION
## Summary

Follow-up to #4197 / PR #4200. **This is a regression found in the actual nightly self-migration gate after #4200 merged**, not a theoretical one: `liftedLocalCeiling` in `tools/cs2gs/selfmig-baseline.json` went 31 → 37 and the gate failed.

PR #4200 landed a review fix for a real bug its own CI found: a non-recursive callee folded into a nullable-function-local group has every call site rewritten to `Name!!(args)`, and that delegate-typed call site cannot fall back to a C#-level default the way a real method call can — `GS0144: Function 'FindTopLevelBaseIndex!!' requires 3 arguments but was given 2` (`src/Core/CodeAnalysis/Binding/Binder.cs`'s `FindTopLevelBaseIndex`, whose `AddBaseFirst` call site omits the third argument). The fix excluded any local function declaring a default parameter from the `functions` list inside `RegisterCapturingRecursiveLocalFunctions`.

That list feeds **two** things: the SCC/cycle detection graph *and* the fold-BFS that pulls non-recursive dependents into a claimed group. The exclusion was only needed for the second, but it was applied to both — so a default-parameter local function that is a **core member of a genuine cycle** disappeared from cycle detection entirely, and the whole connected component fell through to the `__local_` lift path.

`src/Core/CodeAnalysis/Binding/ControlFlowGraph.cs`'s `ProjectRegionsForDefiniteReturn` is exactly that shape:

```csharp
void Add(BoundStatement current, Action<BoundStatement>? routeTransfer = null) { … }   // ← declares a default
void AddPatternSwitch(BoundPatternSwitchStatement switchStatement, Action<BoundStatement>? routeTransfer) { … }
void AddTry(BoundTryStatement tryStatement, Action<BoundStatement>? outerRoute) { … }
```

`Add`/`AddPatternSwitch`/`AddTry` are mutually recursive AND capture outer state — the original #3399 shape, correctly on the nullable-function-local scheme with real names since long before #4197. Every one of `Add`'s call sites already passes both arguments explicitly, so its default is never exercised by omission; merely *declaring* one was enough to lose the cycle. The result was **worse than the pre-#4197 baseline**: all seven local functions in that method lifted (the three cycle members plus the four helpers `CollectLabels`/`CloneWithFreshLabels`/`NewLabel`/`NewChoice`), where pre-#4197 only the four helpers did and post-#4200-first-commit none did.

## Fix

The two carve-outs are not the same kind of thing, and the fix makes that explicit:

- **Generic / ref-returning are DECLARATION-side impossibilities.** The arrow type `((Params) -> R)?` cannot express a type parameter or a `ref` return at all, so those must keep the whole cycle off the scheme — unchanged, still excluded from the `functions`/`edges` graph.
- **A default parameter is declaration-EXPRESSIBLE** (the arrow type simply drops it) and only constrains **call sites** — which, for a claimed member, are entirely translator-controlled. So it is no longer a graph carve-out, and the gap is closed where it actually lives.

Three changes:

1. `CSharpToGSharpTranslator.Constructors.cs` — `RegisterCapturingRecursiveLocalFunctions` no longer excludes a default-parameter local function from the `functions`/`edges` graph, so a cycle it is a core member of is detected again. (`callers` was already computed over the full `allFunctionPairs` inventory, so caller analysis is unaffected by the graph change.)
2. Same file — the **fold-BFS** keeps the exclusion, now stated as the deliberate preference it is: for a *fold candidate* the `__local_` lift is a strictly better answer (a real method declaration carries the default natively) and declining to fold costs nothing. For a *cycle member* declining costs the whole cycle its real names. `Binder.cs`'s `FindTopLevelBaseIndex` is a pure fold candidate and keeps lifting exactly as #4200 made it.
3. `CSharpToGSharpTranslator.Invocations.cs` — `TranslateCallArguments` materializes an omitted default at a claimed member's call site, walking Roslyn's already-resolved argument operations in parameter order, exactly as the `__local_` lift path (`BuildOptionalParameterDefault` padding) and the #1901 lambda-default path (`TranslateDelegateInvokeArgumentsWithDefaults`) already do. A named call site normalizes to positional in the process, since a structural arrow type has no parameter names to bind against. The branch is gated on *some argument actually having been omitted*, so a claimed member called at full arity keeps its existing output byte for byte — this makes the graph change safe corpus-wide rather than relying on "no corpus call site happens to omit".

## Verification

Built `gsc.dll`/`cs2gs.dll` Release and ran `cs2gs migrate --translate-only` over `src/Core` + `src/Analyzers/InternalAnalyzers` (everything else `--exclude`d), before and after:

| | before (this branch's base) | after |
|---|---|---|
| `ControlFlowGraph.gs` `__local_` occurrences | **49** across 7 distinct helpers (`_Add`, `_AddPatternSwitch`, `_AddTry`, `_CollectLabels`, `_CloneWithFreshLabels`, `_NewLabel`, `_NewChoice`) | **0** — all seven on the nullable scheme with real names (`var Add ((BoundStatement, ((BoundStatement) -> void)?) -> void)? = nil`, `Add!!(nested, routeTransfer)`, …) |
| `Binder.gs` `__local_BindGlobalScope_FindTopLevelBaseIndex` | 4 | **4 — unchanged**, no GS0144 reopened |
| whole migrated tree (843 `.gs` files) | — | `diff -rq` reports **exactly one** differing file: `ControlFlowGraph.gs` |
| translate stage | 2/2 apps PASS | 2/2 apps PASS |

`tools/cs2gs/selfmig-baseline.json` is untouched: `liftedLocalCeiling` is a ceiling and this change only removes `__local_` occurrences, so it cannot take the gate red; re-measuring and ratcheting belongs to the first post-merge gate run.

### Tests

Two new cases in `tools/cs2gs/Cs2Gs.Tests/Issue4197CapturingRecursiveLocalFunctionWideningTests.cs`, both `TranslateUnit` + real-`gsc` `CompileAndRun`:

- `DefaultParameterCycleMember_KeepsRealNames_WholeGroupIncluded` — the `ControlFlowGraph.cs` shape reduced: a default-parameter cycle member whose call sites all pass full arity. Asserts zero `__local_` and that the cycle members *and* the helper folded in behind them keep real names; runs and prints the traced result.
- `DefaultParameterCycleMember_OmittedArgumentIsMaterializedAtCallSite` — the other half: a claimed cycle member whose default **is** relied upon, at both an in-cycle call site and a named outer one. Asserts the materialized `Add!!(depth - 1, 10)` / `Add!!(0, 10)` and the absence of `depth:`; runs and checks the value.

This is the gap that let the regression through: #4200's own `DefaultParameterNonRecursiveDependency_StaysLiftedNotFolded` only exercised a default-parameter function as a **leaf fold candidate**, never as a cycle member. That test is unchanged and still green — the fold-candidate behaviour it pins is deliberately preserved.

### Anti-vacuity (ADR-0154 witness)

- **Mutant A** — re-add `|| symbol.Parameters.Any(p => p.HasExplicitDefaultValue)` to the `functions` filter, rebuild: both new tests go red with `Assert.DoesNotContain() Failure: Sub-string found … "__local_Project_Add"` / `"__local_Project_NewLabel"` — the exact corpus symptom.
- **Mutant B** — disable the new call-site materialization branch only, rebuild: `DefaultParameterCycleMember_OmittedArgumentIsMaterializedAtCallSite` goes red with `Function 'Add!!' requires 2 arguments but was given 1.` — the exact GS0144 shape #4200's review fix was written for, now proven to be handled rather than avoided.
- Restore both: all 7 tests in the file pass.

Full `Cs2Gs.Tests` suite: `Passed! - Failed: 0, Passed: 2951, Skipped: 0, Total: 2951, Duration: 22 m 41 s`. Zero regressions — no existing test needed its expectations changed.

## Update 1 — Copilot review: argument-ordinal binding and a variadic carve-out (commit `ab247e3e`)

Copilot found two real gaps in the argument-materialization logic above (point 3).

**Silent argument mis-binding (the serious one).** `TranslateCallArguments`'s reassembly assumed `operationArguments` (Roslyn's `ImmutableArray<IArgumentOperation>`) was already in parameter order. It is not — `IInvocationOperation.Arguments` is in **evaluation order**. For `void Add(int a = 10, int b = 20)`, the call `Add(b: X())` arrives as `[b Explicit, a DefaultValue]`. Walking it positionally emitted `Add!!(X(), 10)` — silently binding `X()`'s result to `a` and `10` to `b`. Confirmed by probing Roslyn directly (Microsoft.CodeAnalysis.CSharp 5.6.0, this repo's pinned version) and by an end-to-end repro: `Add(bonus: 7)` against `Add(int depth = 0, int bonus = 10)` emitted `Add!!(7, 0)`, compiled, ran, and returned the wrong answer.

Fix: each argument is now placed in the slot named by its own `Parameter.Ordinal`, not its array position. Explicit operands are still *translated* in the array's (evaluation) order, so a non-trivial operand's side effect keeps its place — when the ordinal permutation would move one explicit operand ahead of another written earlier (detected by `PermutesExplicitArguments`), each such operand is spilled through the existing `SpillOperand` seam (`let __spillN = …`) so the emitted program still evaluates them in C# §12.6.2.2 source order and only the constant defaults move. A purely positional call site — the overwhelming majority — never permutes and its output is unchanged byte for byte.

**Variadic (`params`) cycle members.** A cycle member with a `params` parameter can't join the nullable-function-local scheme: gsc itself models variadic function types fine, but cs2gs's `ArrowTypeReference` carries parameter *types* only, with no variadic flag, and `MapParameter` maps `params T[]` to its element type behind a `...` carrier — so the forward declaration and the assigned literal would be two different gsc function types. Confirmed this gap **predates** this PR (the original exclusion keyed on `HasExplicitDefaultValue` alone, so a `params`-only member was already admitted and already broken before this PR touched anything) — this PR only widened it to `params` *+ default*. Fix: `symbol.Parameters.Any(IsVariadicCarrierParameter)` (an existing helper, reused) joins the two pre-existing declaration-side carve-outs (generic, ref-returning) in the SCC graph exclusion.

New tests in `Issue4197CapturingRecursiveLocalFunctionWideningTests.cs`: `DefaultParameterCycleMember_OutOfOrderNamedArgumentBindsByParameterOrdinal`, `DefaultParameterCycleMember_PermutedNamedArgumentsKeepSourceEvaluationOrder` (asserts both correct binding *and* preserved side-effect order), `VariadicCycleMember_StaysOnLiftPath`.

A third, narrower gap Copilot's review also surfaced — the sibling delegate-invoke path (`TranslateDelegateInvokeArgumentsWithDefaults`) makes the same evaluation-order assumption, but fails **loudly** (gsc rejects a mis-shaped named argument) rather than silently mis-binding, and a full-arity out-of-order named call site at a claimed member doesn't reach the new branch at all (same loud-rejection outcome) — tracked separately as #4212 rather than folded into this PR, since both degrade safely and neither shows up in the current corpus.

Verified: full `Cs2Gs.Tests` suite green (`Failed: 0, Passed: 2951`), anti-vacuity on both fixes (reverting reproduces the exact mis-binding / re-broken `params` shape; restoring passes), CI green including `hot-core translation guard`.

## Update 2 — hot-core translation guard: a genuine cs2gs capability fix, not a workaround (commit `17ea0535e`)

Update 1's own new method (`TranslateClaimedLocalFunctionArgumentsWithDefaults`) failed CI's `hot-core translation guard` — the job that checks cs2gs can translate *and compile* its own source. `gsc` rejected the translated `CSharpToGSharpTranslator.Invocations.gs` with `GS0155: Cannot convert type 'GExpression?' to 'GExpression'`.

The first hypothesis — that cs2gs's array-element nullability tracking couldn't prove a pre-sized `GExpression[]` array was fully populated by the fill loop before `.ToList()` — was investigated and **disproven**: `Cs2Gs.Translator` compiles with `Nullable=disable`, so C#'s own NRT analysis never looked at this code, and the emitted array's element type was already correctly non-nullable.

The real root cause: cs2gs's existing "oblivious taint fixpoint" `!!`-bridging (issue #2259) already handles `arr[i] = <promoted-nullable RHS>` — but only by asking whether the *whole* right-hand side is a recognizably-promoted value. For a ternary RHS, that question routes through `IsNullableInitializer`, which recurses into the arms but reads only their *declared* annotation, never the taint fixpoint's promotion — so `slots[ordinal] = permutesExplicitArguments ? this.SpillOperand(value, …) : value` (this PR's own new code, where `value` is a local the fixpoint promotes to `GExpression?`) emitted a bare `T?` arm into a `T` element slot, invisible to the existing sink rule.

Fix: a per-arm sibling of the existing rule, `IsNullableTaintedArmOfElementAccessAssignment`, mirroring the already-existing `IsNullableTaintedArmOfReturnPreservingConditional` pattern used for return-position ternaries — the same "ask per-arm, not per-whole-expression" shape, now pointed at the one other sink (element-access assignment) the taint fixpoint structurally cannot widen at the target's own declaration. Scoped to oblivious compilations only; requires crossing at least one conditional/switch level (a direct RHS keeps flowing through #2259's existing whole-RHS rule, unchanged); stops at a conditional's condition position; skips a local/parameter already narrowed by a dominating null-check guard (gsc's own smart-cast already makes that read non-null).

**`CSharpToGSharpTranslator.Invocations.cs` — the method that triggered this — is untouched by this commit.** This is a capability fix to cs2gs's own nullable-bridging machinery, not a rewrite of the C# that exposed the gap.

Verified: a 4-app hot-core guard closure (InternalAnalyzers, Core, Cs2Gs.CodeModel, **Cs2Gs.Translator**) run locally — translate/compile/ilverify/test-parity all PASS, including the compile stage that previously emitted `GS0155`. A corpus-wide `--translate-only` ripple diff across all 8 hot-core projects (954 `.gs` files) shows **exactly one** differing line: `Invocations.gs:1330`, `value` → `value!!` — the precise CI coordinates, nothing else moved. Full `Cs2Gs.Tests` suite: `Failed: 0, Passed: 2960`. Anti-vacuity: reverting this commit's changes fails exactly 5 of the 7 new tests (the 2 unaffected are true negative controls — a non-element sink, and a nullable-enabled compilation where this fixpoint doesn't apply); restoring passes all 7. Net effect on the `!!` readability counter: +1 corpus-wide (well inside the existing `nullAssertionCeiling` margin) — a real, tiny cost of correctness, not drift.

New tests: `Issue4211ConditionalArmElementAccessForgivenessTranslationTests.cs` (7 cases — reduced corpus shape, asymmetric arms, switch-expression arm, nested ternary into an indexer write, guarded arm stays unasserted, ordinary-local sink unaffected, nullable-enabled unaffected), each validated through the real gsc binder (`AssertBinds`/`GSharpRoundTrip.Validate` — a genuine `GS0155` oracle, not a string match).
