### PR TITLE
Fix false VS Code diagnostics during workspace startup

### DIFF
--- a/src/LanguageServer/DocumentSyncHandler.cs
+++ b/src/LanguageServer/DocumentSyncHandler.cs
@@ -115,19 +115,19 @@ public static class DocumentSyncHandler
             diagnostics.Add(BuildDiagnostic("Syntax", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
         }
 
-        foreach (var d in compilation.GlobalScope.Diagnostics)
-        {
-            // Only report diagnostics that originate from this file's syntax tree.
-            if (useProject && d.Location.Text != syntaxTree.Text)
-            {
-                continue;
-            }
-
-            diagnostics.Add(BuildDiagnostic("Semantic", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
-        }
-
         if (!skipBinding)
         {
+            foreach (var d in compilation.GlobalScope.Diagnostics)
+            {
+                // Only report diagnostics that originate from this file's syntax tree.
+                if (useProject && d.Location.Text != syntaxTree.Text)
+                {
+                    continue;
+                }
+
+                diagnostics.Add(BuildDiagnostic("Semantic", d.Message, d.Location.Span.Start, d.Location.Span.End, syntaxTree.Text));
+            }
+
             var program = compilation.BoundProgram;
             foreach (var d in program.Diagnostics)
             {

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -60,6 +60,7 @@ public sealed class LspServer
     private LanguageServerInitializationOptions initializationOptions = new LanguageServerInitializationOptions();
     private string pendingWorkspaceRootPath;
     private CancellationTokenSource backgroundLoadCts;
+    private bool workspaceDiscoveryPending;
 
     public LspServer(DocumentContentService documentContentService, WorkspaceState workspaceState, ILogger logger = null)
     {
@@ -83,6 +84,7 @@ public sealed class LspServer
     public Task<InitializeResult> InitializeAsync(InitializeParams request)
     {
         this.pendingWorkspaceRootPath = request?.RootPath ?? request?.RootUri?.GetFileSystemPath();
+        this.workspaceDiscoveryPending = !string.IsNullOrEmpty(this.pendingWorkspaceRootPath);
         this.DetectClientDiagnosticCapabilities(request?.Capabilities ?? default);
         this.initializationOptions = request?.InitializationOptions ?? new LanguageServerInitializationOptions();
 
@@ -141,42 +143,42 @@ public sealed class LspServer
                         {
                             this.gate.Release();
                         }
-                    });
+                    },
+                    waitForWarmUp: true);
 
-                // Discovery can (and on a cold start typically does) finish *after* the client
-                // has already opened files: the editor sends didOpen the moment the window
-                // restores, racing the background load kicked off just above. Those files were
-                // bound against a project-less compilation (no project references), so every
-                // imported symbol — the project's own types and referenced-assembly types alike
-                // — was reported "could not be found" (e.g. GS0198 on xunit's @Fact). Now that
-                // projects and their references are known, refresh diagnostics for every open
-                // document so those spurious squiggles clear without the user having to edit the
-                // file to trigger a re-bind (issue: persistent import squiggles after scaffolding
-                // a multi-project workspace).
-                cts.Token.ThrowIfCancellationRequested();
-                this.gate.Wait(cts.Token);
-                try
-                {
-                    this.RefreshOpenDocumentDiagnosticsAfterDiscovery();
-                }
-                finally
-                {
-                    this.gate.Release();
-                }
             }
             catch (OperationCanceledException)
             {
                 // Shutdown raced the background load; nothing left to do.
+                return;
             }
             catch (ObjectDisposedException)
             {
                 // Shutdown disposed the CTS while the load observed its token; benign.
+                return;
             }
             catch (Exception ex)
             {
                 // Workspace discovery is best-effort; single-file editing still works without
                 // it, but a failed load should be debuggable rather than silently degraded.
                 this.logger?.LogError($"Background workspace load failed: {ex.GetType().FullName}: {ex.Message}", ex);
+                return;
+            }
+
+            // Discovery can (and on a cold start typically does) finish *after* the client
+            // has already opened files. Until this point diagnostics stay syntax-only rather
+            // than binding against a project-less compilation and reporting every BCL/imported
+            // symbol as missing. Mark discovery complete before refreshing so the re-pull/full
+            // push bind uses the now-registered projects and references.
+            this.gate.Wait(cts.Token);
+            try
+            {
+                this.workspaceDiscoveryPending = false;
+                this.RefreshOpenDocumentDiagnosticsAfterDiscovery();
+            }
+            finally
+            {
+                this.gate.Release();
             }
         });
     }
@@ -324,9 +326,11 @@ public sealed class LspServer
         SyntaxTree syntaxTree = null;
         string filePath = null;
         ProjectState project = null;
+        bool skipBinding;
         await this.gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
+            skipBinding = this.workspaceDiscoveryPending;
             filePath = uri.GetFileSystemPath();
             project = !string.IsNullOrEmpty(filePath) ? this.workspaceState.GetProjectForFile(filePath) : null;
             if (this.documentContentService.TryGet(uri.ToString(), out var content))
@@ -349,7 +353,7 @@ public sealed class LspServer
         DiagnosticComputationResult result;
         try
         {
-            result = DocumentSyncHandler.ComputeDiagnosticsForSnapshot(syntaxTree, skipBinding: false, project, filePath, this.workspaceState);
+            result = DocumentSyncHandler.ComputeDiagnosticsForSnapshot(syntaxTree, skipBinding, project, filePath, this.workspaceState);
         }
         catch (OperationCanceledException)
         {
@@ -1140,7 +1144,7 @@ public sealed class LspServer
     /// </summary>
     private void SchedulePushDiagnosticsBind(DocumentUri uri, DiagnosticComputationResult parseResult)
     {
-        if (this.clientSupportsPullDiagnostics)
+        if (this.clientSupportsPullDiagnostics || this.workspaceDiscoveryPending)
         {
             return;
         }

--- a/src/LanguageServer/Server/LspServer.cs
+++ b/src/LanguageServer/Server/LspServer.cs
@@ -48,6 +48,8 @@ public sealed class LspServer
     internal Action<DocumentUri, DiagnosticComputationResult> TestOnBindResult;
     internal Action<DocumentUri, IReadOnlyList<Diagnostic>> TestOnPublish;
     internal Action TestOnDiagnosticRefreshAfterDiscovery;
+    internal Action TestBeforeWorkspaceDiscovery;
+    internal Action TestBeforeWorkspaceDiscoveryCompletion;
     internal Func<CancellationToken, Task> TestPushBindDelay;
     private readonly TaskCompletionSource<int> exitSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly object refreshLock = new object();
@@ -127,58 +129,61 @@ public sealed class LspServer
         {
             try
             {
-                WorkspaceInitializer.Initialize(
-                    this.workspaceState,
-                    rootPath,
-                    cts.Token,
-                    tryGetOpenBuffer: file => this.workspaceState.TryGetOpenBuffer(file, out var text) ? text : null,
-                    withGate: mutate =>
-                    {
-                        this.gate.Wait(cts.Token);
-                        try
+                try
+                {
+                    this.TestBeforeWorkspaceDiscovery?.Invoke();
+                    WorkspaceInitializer.Initialize(
+                        this.workspaceState,
+                        rootPath,
+                        cts.Token,
+                        tryGetOpenBuffer: file => this.workspaceState.TryGetOpenBuffer(file, out var text) ? text : null,
+                        withGate: mutate =>
                         {
-                            mutate();
-                        }
-                        finally
-                        {
-                            this.gate.Release();
-                        }
-                    },
-                    waitForWarmUp: true);
+                            this.gate.Wait(cts.Token);
+                            try
+                            {
+                                mutate();
+                            }
+                            finally
+                            {
+                                this.gate.Release();
+                            }
+                        },
+                        waitForWarmUp: true);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not ObjectDisposedException)
+                {
+                    // Workspace discovery is best-effort; single-file editing still works
+                    // without it, but a failed load should be debuggable rather than silently
+                    // degraded.
+                    this.logger?.LogError($"Background workspace load failed: {ex.GetType().FullName}: {ex.Message}", ex);
+                }
 
+                // Discovery can (and on a cold start typically does) finish *after* the client
+                // has already opened files. Until this point diagnostics stay syntax-only rather
+                // than binding against a project-less compilation and reporting every BCL/imported
+                // symbol as missing. Mark discovery complete before refreshing so the re-pull/full
+                // push bind uses the now-registered projects and references.
+                this.TestBeforeWorkspaceDiscoveryCompletion?.Invoke();
+                cts.Token.ThrowIfCancellationRequested();
+                this.gate.Wait(cts.Token);
+                try
+                {
+                    this.workspaceDiscoveryPending = false;
+                    this.RefreshOpenDocumentDiagnosticsAfterDiscovery();
+                }
+                finally
+                {
+                    this.gate.Release();
+                }
             }
             catch (OperationCanceledException)
             {
                 // Shutdown raced the background load; nothing left to do.
-                return;
             }
             catch (ObjectDisposedException)
             {
                 // Shutdown disposed the CTS while the load observed its token; benign.
-                return;
-            }
-            catch (Exception ex)
-            {
-                // Workspace discovery is best-effort; single-file editing still works without
-                // it, but a failed load should be debuggable rather than silently degraded.
-                this.logger?.LogError($"Background workspace load failed: {ex.GetType().FullName}: {ex.Message}", ex);
-                return;
-            }
-
-            // Discovery can (and on a cold start typically does) finish *after* the client
-            // has already opened files. Until this point diagnostics stay syntax-only rather
-            // than binding against a project-less compilation and reporting every BCL/imported
-            // symbol as missing. Mark discovery complete before refreshing so the re-pull/full
-            // push bind uses the now-registered projects and references.
-            this.gate.Wait(cts.Token);
-            try
-            {
-                this.workspaceDiscoveryPending = false;
-                this.RefreshOpenDocumentDiagnosticsAfterDiscovery();
-            }
-            finally
-            {
-                this.gate.Release();
             }
         });
     }

--- a/src/LanguageServer/WorkspaceInitializer.cs
+++ b/src/LanguageServer/WorkspaceInitializer.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,12 +27,14 @@ public static class WorkspaceInitializer
     /// <param name="withGate">Runs a single file's registration under the same gate used by
     /// didOpen/didChange/didSave, so registration and buffer edits never interleave and
     /// clobber each other. Callers that run single-threaded (tests) can omit it.</param>
+    /// <param name="waitForWarmUp">Waits for project binding warm-up before returning.</param>
     public static void Initialize(
         WorkspaceState workspaceState,
         string rootPath,
         CancellationToken cancellationToken = default,
         Func<string, string?>? tryGetOpenBuffer = null,
-        Action<Action>? withGate = null)
+        Action<Action>? withGate = null,
+        bool waitForWarmUp = false)
     {
         if (string.IsNullOrEmpty(rootPath))
         {
@@ -88,12 +91,10 @@ public static class WorkspaceInitializer
         // Warm up each project's compilation on the thread pool so the first
         // user-facing request (file open → diagnostics) doesn't pay the full
         // cold-bind cost (typically ~500ms for a project with a large reference
-        // graph). Fire-and-forget is fine — every public consumer goes through
-        // ProjectState.GetCompilation which locks and lazy-initializes, so the
-        // background warm-up just races with the first real request to populate
-        // the cache. If discovery turns up an unbindable project the binder
-        // surfaces those diagnostics through the normal path; we swallow any
-        // exception here so warm-up never crashes the LSP startup path.
+        // graph). The LSP waits for these tasks before enabling semantic
+        // diagnostics so a cold pull cannot race a warm-up bind of the same
+        // compilation. Direct callers retain the existing fire-and-forget behavior.
+        var warmUps = new List<Task>();
         foreach (var disc in discovered)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -104,7 +105,7 @@ public static class WorkspaceInitializer
             var project = workspaceState.GetProject(disc.ProjectFilePath);
             if (project != null)
             {
-                _ = Task.Run(() =>
+                warmUps.Add(Task.Run(() =>
                 {
                     try
                     {
@@ -124,8 +125,13 @@ public static class WorkspaceInitializer
                     catch
                     {
                     }
-                });
+                }));
             }
+        }
+
+        if (waitForWarmUp)
+        {
+            Task.WaitAll(warmUps.ToArray(), cancellationToken);
         }
     }
 }

--- a/test/LanguageServer.Tests/DocumentSyncHandlerTests.cs
+++ b/test/LanguageServer.Tests/DocumentSyncHandlerTests.cs
@@ -23,6 +23,17 @@ public class DocumentSyncHandlerTests
     }
 
     [Fact]
+    public void ComputeDiagnostics_SkipBindingReportsOnlySyntaxDiagnostics()
+    {
+        const string source = "import System\n\nfunc F(value MissingType) {\n";
+
+        var diagnostics = DocumentSyncHandler.ComputeDiagnostics(source, skipBinding: true).Diagnostics;
+
+        Assert.NotEmpty(diagnostics);
+        Assert.All(diagnostics, d => Assert.Equal("Syntax", d.Code.Value));
+    }
+
+    [Fact]
     public void ComputeDiagnostics_PassesProjectReferencesToBindProgram()
     {
         // Regression: previously DocumentSyncHandler called Binder.BindProgram(GlobalScope)

--- a/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
+++ b/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
@@ -88,6 +88,70 @@ public class WorkspaceDiscoveryDiagnosticRefreshTests
         }
     }
 
+    [Fact]
+    public async Task PullClient_DiscoveryFailure_RestoresSemanticDiagnostics()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+            var fooPath = Path.Combine(rootDir, "Demo", "Foo.gs");
+            var uri = DocumentUri.FromFileSystemPath(fooPath);
+            var refreshRequested = false;
+            server.TestBeforeWorkspaceDiscovery = () => throw new InvalidOperationException("Injected discovery failure.");
+            server.TestOnDiagnosticRefreshAfterDiscovery = () => refreshRequested = true;
+
+            await server.InitializeAsync(new InitializeParams { RootPath = rootDir, Capabilities = PullClientCapabilities() });
+            await server.DidOpenAsync(new DidOpenTextDocumentParams
+            {
+                TextDocument = new TextDocumentItem { Uri = uri, Text = FooSource },
+            });
+
+            Assert.Empty(await PullDiagnosticsAsync(server, uri));
+
+            using var doc = JsonDocument.Parse("{}");
+            server.Initialized(doc.RootElement.Clone());
+            await WaitForAsync(() => refreshRequested);
+
+            Assert.NotEmpty(await PullDiagnosticsAsync(server, uri));
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PullClient_ShutdownBeforeDiscoveryCompletion_DoesNotRefresh()
+    {
+        var rootDir = CreateSampleWorkspace();
+        try
+        {
+            var server = new LspServer(new DocumentContentService(), new WorkspaceState());
+            var completionReached = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var refreshRequested = false;
+            server.TestBeforeWorkspaceDiscoveryCompletion = () =>
+            {
+                server.Shutdown();
+                completionReached.TrySetResult(true);
+            };
+            server.TestOnDiagnosticRefreshAfterDiscovery = () => refreshRequested = true;
+
+            await server.InitializeAsync(new InitializeParams { RootPath = rootDir, Capabilities = PullClientCapabilities() });
+            using var doc = JsonDocument.Parse("{}");
+            server.Initialized(doc.RootElement.Clone());
+
+            await completionReached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await Task.Delay(100);
+
+            Assert.False(refreshRequested);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
     private static JsonElement PullClientCapabilities()
     {
         // Advertise textDocument/diagnostic (pull) and workspace diagnostic refreshSupport so the

--- a/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
+++ b/test/LanguageServer.Tests/WorkspaceDiscoveryDiagnosticRefreshTests.cs
@@ -17,12 +17,10 @@ namespace GSharp.LanguageServer.Tests;
 /// <summary>
 /// Background workspace discovery (kicked off in "initialized") races the editor's didOpen:
 /// on a cold start the client opens visible files before discovery has registered any project,
-/// so a pull-diagnostics client (e.g. VS Code) that pulls diagnostics during the race gets a
-/// file bound against a project-less compilation — with none of the project's references or
-/// sibling source files. Every imported symbol then reported "could not be found" (e.g. GS0198
-/// on xunit's <c>@Fact</c>, or a sibling type/function in the same project), and the squiggles
-/// persisted because nothing re-pulled the file once discovery finished — the user had to edit
-/// the file to trigger a refresh.
+/// so a pull-diagnostics client (e.g. VS Code) can pull diagnostics before the file has an owning
+/// project. Binding such a file against a project-less compilation reports every imported/BCL
+/// symbol as missing. While discovery is pending the server must therefore return syntax-only
+/// diagnostics, then refresh and perform the full project-aware bind once discovery completes.
 ///
 /// This test locks in the fix: once background discovery completes, the server replaces each
 /// open document snapshot with one attached to its now-discovered project and asks the client
@@ -57,11 +55,11 @@ public class WorkspaceDiscoveryDiagnosticRefreshTests
                 TextDocument = new TextDocumentItem { Uri = uri, Text = FooSource },
             });
 
-            // A pull that lands before background discovery registers the project binds the file
-            // project-less: the sibling symbols in Bar.gs are invisible and reported missing.
+            // A pull that lands before background discovery registers the project must not bind
+            // project-less and flash false missing-symbol diagnostics.
             var beforeDiscovery = await PullDiagnosticsAsync(server, uri);
             Assert.Null(workspace.GetProjectForFile(fooPath));
-            Assert.NotEmpty(beforeDiscovery);
+            Assert.Empty(beforeDiscovery);
 
             // Discovery runs in the background; when it completes the server asks the client to
             // refresh (re-pull) diagnostics for its open documents.


### PR DESCRIPTION
## Summary
- keep diagnostics syntax-only while workspace projects and references are being discovered
- wait for compilation warm-up before enabling semantic diagnostics
- refresh open documents once project-aware diagnostics are ready
- add regressions for clean pre-discovery pulls and syntax-only diagnostic mode

## Validation
- live installed VS Code against Oahu: 3 consecutive fresh-process cold starts, 5 representative files, no transient or final errors over 30 seconds
- targeted LanguageServer tests: 9 passed
- VS Code unit tests: 80 passed
- VS Code ESLint: passed